### PR TITLE
Update references to parents in modules not-built by default

### DIFF
--- a/addons/security/pom.xml
+++ b/addons/security/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-addons</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-security</artifactId>

--- a/db/couch/pom.xml
+++ b/db/couch/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-db</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-db-couch</artifactId>

--- a/db/infinispan/pom.xml
+++ b/db/infinispan/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-db</artifactId>
-    <version>0.6-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-db-infinispan</artifactId>

--- a/subsys/infinispan/pom.xml
+++ b/subsys/infinispan/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>org.commonjava.aprox</groupId>
     <artifactId>aprox-subsystems</artifactId>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-subsys-infinispan</artifactId>

--- a/wars/rest-sec/pom.xml
+++ b/wars/rest-sec/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.commonjava.aprox.wars</groupId>
     <artifactId>aprox-wars</artifactId>
-    <version>0.4-SNAPSHOT</version>
+    <version>0.9.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>aprox-rest-sec</artifactId>


### PR DESCRIPTION
Most of them are not still buildable (which was my initial goal to set it all up in eclipse, then I realized that these modules are not needed) but at least the parent references in pom files are fixed.
