### PR TITLE
Remove copyright header from json config files, comments are not allowed...

### DIFF
--- a/launchers/easyprox/src/main/resources/etc/aprox/autoprox.json
+++ b/launchers/easyprox/src/main/resources/etc/aprox/autoprox.json
@@ -1,13 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2014 Red Hat, Inc..
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the GNU Public License v3.0
-# which accompanies this distribution, and is available at
-# http://www.gnu.org/licenses/gpl.html
-# 
-# Contributors:
-#     Red Hat, Inc. - initial API and implementation
-#-------------------------------------------------------------------------------
 {
   "repo": {
       "url":"http://repository.jboss.org/nexus/content/repositories/${name}/",

--- a/launchers/savant/src/main/resources/etc/aprox/autoprox.json
+++ b/launchers/savant/src/main/resources/etc/aprox/autoprox.json
@@ -1,13 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2014 Red Hat, Inc..
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of the GNU Public License v3.0
-# which accompanies this distribution, and is available at
-# http://www.gnu.org/licenses/gpl.html
-# 
-# Contributors:
-#     Red Hat, Inc. - initial API and implementation
-#-------------------------------------------------------------------------------
 {
   "repo": {
       "url":"http://repository.jboss.org/nexus/content/repositories/${name}/",


### PR DESCRIPTION
... in json

When running aprox-launcher with the comment included, the first http request
ends with an exception:

```
Caused by: groovy.json.JsonException: Lexing failed on line: 1, column: 1, while reading '#', no possible valid JSON value or punctuation could be recognized.
    at groovy.json.JsonLexer.nextToken(JsonLexer.java:82)
    at groovy.json.JsonSlurper.parse(JsonSlurper.java:75)
    at groovy.json.JsonSlurper.parseFile(JsonSlurper.java:124)
    at groovy.json.JsonSlurper.parse(JsonSlurper.java:101)
    at groovy.json.JsonSlurper$parse.call(Unknown Source)
    at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
    at LegacyFactory.<init>(legacy-factory.groovy:26)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
    at java.lang.Class.newInstance(Class.java:374)
    at org.commonjava.aprox.subsys.template.ScriptEngine.parseScriptInstance(ScriptEngine.java:36)
    at org.commonjava.aprox.subsys.template.ScriptEngine$Proxy$_$$_WeldClientProxy.parseScriptInstance(Unknown Source)
    at org.commonjava.aprox.autoprox.conf.AutoProxConfigurator.buildFactories(AutoProxConfigurator.java:170)
    at org.commonjava.aprox.autoprox.conf.AutoProxConfigurator.getConfig(AutoProxConfigurator.java:124)
    ...
```

and the client does not get a response, i.e. waiting for it forever.
