### PR TITLE
Fix workspace deletion

### DIFF
--- a/addons/depgraph/vertx/src/main/java/org/commonjava/aprox/depgraph/vertx/WorkspaceResource.java
+++ b/addons/depgraph/vertx/src/main/java/org/commonjava/aprox/depgraph/vertx/WorkspaceResource.java
@@ -50,11 +50,11 @@ public class WorkspaceResource
     public void delete( final HttpServerRequest request )
     {
         final String id = request.params()
-                                 .get( p_wsid.name() );
+                                 .get( p_wsid.key() );
         try
         {
             controller.delete( id );
-            setStatus( ApplicationStatus.OK, request );
+            setStatus( ApplicationStatus.OK, request ).end();
         }
         catch ( final AproxWorkflowException e )
         {
@@ -79,7 +79,7 @@ public class WorkspaceResource
             }
             else
             {
-                setStatus( ApplicationStatus.NOT_MODIFIED, request );
+                setStatus( ApplicationStatus.NOT_MODIFIED, request ).end();
             }
         }
         catch ( final AproxWorkflowException e )
@@ -104,7 +104,7 @@ public class WorkspaceResource
             }
             else
             {
-                setStatus( ApplicationStatus.NOT_MODIFIED, request );
+                setStatus( ApplicationStatus.NOT_MODIFIED, request ).end();
             }
         }
         catch ( final AproxWorkflowException e )
@@ -130,7 +130,7 @@ public class WorkspaceResource
             }
             else
             {
-                setStatus( ApplicationStatus.NOT_MODIFIED, request );
+                setStatus( ApplicationStatus.NOT_MODIFIED, request ).end();
             }
         }
         catch ( final AproxWorkflowException e )
@@ -150,7 +150,7 @@ public class WorkspaceResource
             final String json = controller.get( id );
             if ( json == null )
             {
-                setStatus( ApplicationStatus.NOT_FOUND, request );
+                setStatus( ApplicationStatus.NOT_FOUND, request ).end();
             }
             else
             {
@@ -170,7 +170,7 @@ public class WorkspaceResource
         final String json = controller.list();
         if ( json == null )
         {
-            setStatus( ApplicationStatus.NOT_FOUND, request );
+            setStatus( ApplicationStatus.NOT_FOUND, request ).end();
         }
         else
         {

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
     <arquillian-version>1.0.1.Final</arquillian-version>
     <qarqas-version>0.3</qarqas-version>
     <shelflife-version>0.6.3</shelflife-version>
-    <atlasVersion>0.13.2</atlasVersion>
-    <galleyVersion>0.6.3</galleyVersion>
-    <cartoVersion>0.7.1</cartoVersion>
+    <atlasVersion>0.13.4-SNAPSHOT</atlasVersion>
+    <galleyVersion>0.6.5-SNAPSHOT</galleyVersion>
+    <cartoVersion>0.7.2-SNAPSHOT</cartoVersion>
     <bomVersion>12</bomVersion>
     <webdavVersion>3.1.1</webdavVersion>
     <vabrVersion>1.8</vabrVersion>


### PR DESCRIPTION
- use fixed version of atlas
- fix read of vsid param
- end requests in WorkspaceResource properly

Also uses snapshot versions of cartographer and galley, which should use the same atlas version (I guess there are not worth a separate PRs).
Without the requests ending client waited for response forever.

The fix is intended to allow re-use of a wsid when deleted (i.e. use a workspace, delete it and then use workspace with the same wsid), but I still get org.apache.lucene.store.LockObtainFailedException even with this, but before this commit it behaved much worse :-)
