### PR TITLE
Ensure that pom is downloaded to every artifact coming from a remote …

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloPomDonwloadListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloPomDonwloadListener.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.folo.change;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.content.ContentManager;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.maven.atlas.ident.util.ArtifactPathInfo;
+import org.commonjava.maven.galley.event.FileStorageEvent;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is a listener that tracks file storage events. If a non-pom artifact download occurs it ensures that also
+ * associated pom artifact gets downloaded even if it was not requested.
+ *
+ * @author pkocandr
+ */
+public class FoloPomDonwloadListener
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private ContentManager contentManager;
+
+    @Inject
+    private CacheProvider cacheProvider;
+
+    @Inject
+    private StoreDataManager storeManager;
+
+    public void onFileUpload( @Observes final FileStorageEvent event )
+    {
+        // check for a TransferOperation of DOWNLOAD
+        final TransferOperation op = event.getType();
+        if ( op != TransferOperation.DOWNLOAD )
+        {
+            logger.trace( "Not a download transfer operation. No pom existence check performed." );
+            return;
+        }
+
+        // check if it is a path that doesn't end in with ".pom"
+        final Transfer transfer = event.getTransfer();
+        if ( transfer == null )
+        {
+            logger.trace( "No transfer. No pom existence check performed." );
+            return;
+        }
+
+        String txfrPath = transfer.getPath();
+        if ( txfrPath.endsWith( ".pom" ) )
+        {
+            logger.trace( "This is a pom download." );
+            return;
+        }
+
+        // use ArtifactPathInfo to parse into a GAV, just to verify that it's looking at an artifact download
+        ArtifactPathInfo artPathInfo = ArtifactPathInfo.parse( txfrPath );
+        if ( artPathInfo == null )
+        {
+            logger.trace( "Not an artifact download ({}). No pom existence check performed.", txfrPath );
+            return;
+        }
+
+        // verify that the associated .pom file exists
+        String pomFilename = String.format( "%s-%s.pom", artPathInfo.getArtifactId(), artPathInfo.getVersion() );
+        ConcreteResource pomResource = transfer.getResource().getParent().getChild( pomFilename );
+        if ( cacheProvider.exists( pomResource ) )
+        {
+            logger.trace( "Pom {} already exists.", cacheProvider.getFilePath( pomResource ) );
+            return;
+        }
+
+        // trigger pom download by requesting it from the same repository as the original artifact
+        StoreKey storeKey = StoreKey.fromString( transfer.getLocation().getName() );
+        ArtifactStore store;
+        try
+        {
+            store = storeManager.getArtifactStore( storeKey );
+        }
+        catch ( final IndyDataException ex )
+        {
+            logger.error( "Error retrieving artifactStore with key " + storeKey, ex );
+            return;
+        }
+        try
+        {
+            contentManager.retrieve( store, pomResource.getPath() );
+        }
+        catch ( final IndyWorkflowException ex )
+        {
+            logger.error( "Error while retrieving pom artifact " + pomResource.getPath() + " from store " + store, ex );
+            return;
+        }
+    }
+
+}

--- a/addons/folo/ftests/pom.xml
+++ b/addons/folo/ftests/pom.xml
@@ -70,5 +70,10 @@
       <artifactId>indy-test-fixtures-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy.boot</groupId>
+      <artifactId>indy-booter-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/AutomaticPomDownloadTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/AutomaticPomDownloadTest.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.folo.ftest.content;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+import java.io.InputStream;
+import java.util.Date;
+
+import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Test checking that a pom is downloaded automatically without requesting it. The test runs an http server that expects
+ * download of /org/foo/bar/1.0/bar-1.0.jar and /org/foo/bar/1.0/bar-1.0.pom. Then the test ensures that the pom does
+ * not exist, downloads the jar and after a timeout it checks that the pom exists.
+ *
+ * @author pkocandr
+ */
+public class AutomaticPomDownloadTest
+    extends AbstractFoloContentManagementTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    @Test
+    public void downloadJarAndCheckIfPomWasDownloaded()
+        throws Exception
+    {
+        final String repoId = "test-repo";
+        final String pathFormat = "/org/foo/bar/1.0/bar-1.0.%s";
+        final String jarPath = server.formatUrl( repoId, String.format( pathFormat, "jar" ) );
+        final String pomPath = server.formatUrl( repoId, String.format( pathFormat, "pom" ) );
+
+        // mocking up a http server that expects access to both a .jar and the accompanying .pom
+        String datetime = ( new Date() ).toString();
+        server.expect( pomPath, 200, String.format( "pom %s", datetime ) );
+        server.expect( jarPath, 200, String.format( "jar %s", datetime ) );
+
+        // set up remote repository pointing to the test http server
+        final String changelog = "Setup: " + name.getMethodName();
+        client.stores().create( new RemoteRepository( repoId, server.formatUrl( repoId ) ), changelog,
+                                RemoteRepository.class );
+
+        // ensure the pom does not exist before the jar download
+        IndyFoloContentClientModule clientModule = client.module( IndyFoloContentClientModule.class );
+        assertThat( clientModule.exists( newName(), remote, repoId, pomPath ), equalTo( false ) );
+
+        // download the .jar
+        final InputStream result = clientModule.get( newName(), remote, repoId, jarPath );
+        assertThat( result, notNullValue() );
+
+        result.close();
+
+        // verify the existence of the .pom file after 1 seconds of Thread.sleep()
+        Thread.sleep( 1000 );
+        assertThat( clientModule.exists( newName(), remote, repoId, pomPath ), equalTo( true ) );
+    }
+
+}


### PR DESCRIPTION
…repository

It detects downloads of artifacts from remote repositories and check, if
associated pom already exists. If not it triggers its download.

Follows https://github.com/Commonjava/galley/pull/89