### PR TITLE
update to cartographer snapshot

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloPomDownloadListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloPomDownloadListener.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author pkocandr
  */
-public class FoloPomDonwloadListener
+public class FoloPomDownloadListener
 {
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
@@ -109,7 +109,7 @@ public class FoloPomDonwloadListener
         }
         try
         {
-            contentManager.retrieve( store, pomResource.getPath() );
+            contentManager.retrieve( store, pomResource.getPath(), event.getEventMetadata() );
         }
         catch ( final IndyWorkflowException ex )
         {

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <slf4j-version>1.6.1</slf4j-version>
     <atlasVersion>0.16.0</atlasVersion>
     <galleyVersion>0.11.0</galleyVersion>
-    <cartoVersion>0.10.3</cartoVersion>
+    <cartoVersion>0.10.4-SNAPSHOT</cartoVersion>
     <bomVersion>17</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <resteasyVersion>3.0.9.Final</resteasyVersion>


### PR DESCRIPTION
This fixes an issue where something like org.scala-lang:scala-library:2.10.0 as the root of the graph was coming up missing because it only has the terminal-parent relationship in the runtime scope, and the terminal-parent relationship wasn't being added to the graph db...leaving the graph db with the impression scala-library was missing.