### PR TITLE
Fix #277: NPE in MavenMetadataGenerator

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/MavenMetadataGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/MavenMetadataGenerator.java
@@ -351,7 +351,7 @@ public class MavenMetadataGenerator
     {
         ArtifactPathInfo samplePomInfo = null;
 
-        // first level will contain version directories...for each directory, we need to verify the presence of a .pom file before including 
+        // first level will contain version directories...for each directory, we need to verify the presence of a .pom file before including
         // as a valid version
         final List<SingleVersion> versions = new ArrayList<SingleVersion>();
         nextTopResource: for ( final StoreResource topResource : firstLevelFiles )
@@ -365,13 +365,18 @@ public class MavenMetadataGenerator
                     if ( fileResource.getPath()
                                      .endsWith( ".pom" ) )
                     {
-                        versions.add( VersionUtils.createSingleVersion( new File( topPath ).getName() ) );
-                        if ( samplePomInfo == null )
+                        ArtifactPathInfo filePomInfo = ArtifactPathInfo.parse( fileResource.getPath() );
+                        // check if the pom is valid for the path
+                        if ( filePomInfo != null )
                         {
-                            samplePomInfo = ArtifactPathInfo.parse( fileResource.getPath() );
-                        }
+                            versions.add( VersionUtils.createSingleVersion( new File( topPath ).getName() ) );
+                            if ( samplePomInfo == null )
+                            {
+                                samplePomInfo = filePomInfo;
+                            }
 
-                        continue nextTopResource;
+                            continue nextTopResource;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The issue was caused by manual pom upload in a wrong path, specifically
twitter4j-core-4.0.4.redhat-2.pom into version 4.0.4.redhat-2 but in
artifactId twitter4j. The ArtifactPathInfo cannot be parsed from the
path, but the version was still included.

The fix prevents a version inclusion if there is not the correct pom present.