### PR TITLE
fix two bugs, plus one potential bug

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
@@ -15,13 +15,11 @@
  */
 package org.commonjava.indy.content.index;
 
-import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 
-import javax.annotation.Nonnull;
 import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectInput;
@@ -50,7 +48,7 @@ public class IndexedStorePath
     @Field
     private String path;
 
-    public IndexedStorePath( @Nonnull StoreKey storeKey, @Nonnull StoreKey origin, @Nonnull String path )
+    public IndexedStorePath( StoreKey storeKey, StoreKey origin, String path )
     {
         this.storeType = storeKey.getType();
         this.storeName = storeKey.getName();

--- a/addons/folo/model-java/pom.xml
+++ b/addons/folo/model-java/pom.xml
@@ -43,6 +43,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-search-orm</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -15,13 +15,16 @@
  */
 package org.commonjava.indy.promote.data;
 
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.audit.ChangeSummary;
-import org.commonjava.indy.content.IndyLocationExpander;
 import org.commonjava.indy.content.ContentGenerator;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.DownloadManager;
+import org.commonjava.indy.content.IndyLocationExpander;
 import org.commonjava.indy.core.content.DefaultContentManager;
 import org.commonjava.indy.core.content.DefaultDownloadManager;
+import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -41,14 +44,24 @@ import org.commonjava.maven.galley.maven.rel.MavenModelProcessor;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.testing.maven.GalleyMavenFixture;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collections;
+import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -77,6 +90,8 @@ public class PromotionManagerTest
 
     private PromotionValidator validator;
 
+    private Executor executor;
+
     @Before
     public void setup()
             throws Exception
@@ -102,14 +117,236 @@ public class PromotionManagerTest
                                             new PromotionValidationTools( contentManager, storeManager,
                                                                           galleyParts.getPomReader(),
                                                                           galleyParts.getMavenMetadataReader(),
-                                                                          modelProcessor,
-                                                                          galleyParts.getTypeMapper(),
+                                                                          modelProcessor, galleyParts.getTypeMapper(),
                                                                           galleyParts.getTransferManager() ) );
         manager = new PromotionManager( validator, contentManager, downloadManager, storeManager );
+
+        executor = Executors.newCachedThreadPool();
+    }
+
+    /**
+     * On collision, the promotion manager should skip the second file to be promoted (instead of overwriting the
+     * existing one). This assumes no overwrite attribute is available for setting in the promotion request (or that
+     * it is available but isn't set...and defaults to false).
+     * @throws Exception
+     */
+    @Test
+    public void promoteAllByPath_CollidingPaths_VerifySecondSkipped()
+            throws Exception
+    {
+        final HostedRepository source1 = new HostedRepository( "source1" );
+        final HostedRepository source2 = new HostedRepository( "source2" );
+        storeManager.storeArtifactStore( source1, new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" ),
+                                         new EventMetadata() );
+        storeManager.storeArtifactStore( source2, new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" ),
+                                         new EventMetadata() );
+
+        String originalString = "This is a test";
+
+        final String path = "/path/path";
+        contentManager.store( source1, path, new ByteArrayInputStream( originalString.getBytes() ),
+                              TransferOperation.UPLOAD, new EventMetadata() );
+
+        contentManager.store( source2, path, new ByteArrayInputStream( "This is another test".getBytes() ),
+                              TransferOperation.UPLOAD, new EventMetadata() );
+
+        final HostedRepository target = new HostedRepository( "target" );
+        storeManager.storeArtifactStore( target, new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" ),
+                                         new EventMetadata() );
+
+        PathsPromoteResult result =
+                manager.promotePaths( new PathsPromoteRequest( source1.getKey(), target.getKey(), path ) );
+
+        assertThat( result.getRequest().getSource(), equalTo( source1.getKey() ) );
+        assertThat( result.getRequest().getTarget(), equalTo( target.getKey() ) );
+
+        Set<String> pending = result.getPendingPaths();
+        assertThat( pending == null || pending.isEmpty(), equalTo( true ) );
+
+        Set<String> skipped = result.getSkippedPaths();
+        assertThat( skipped == null || skipped.isEmpty(), equalTo( true ) );
+
+        Set<String> completed = result.getCompletedPaths();
+        assertThat( completed, notNullValue() );
+        assertThat( completed.size(), equalTo( 1 ) );
+
+        assertThat( result.getError(), nullValue() );
+
+        Transfer ref = downloadManager.getStorageReference( target, path );
+        assertThat( ref.exists(), equalTo( true ) );
+        try (InputStream in = ref.openInputStream())
+        {
+            String value = IOUtils.toString( in );
+            assertThat( value, equalTo( originalString ) );
+        }
+
+        result = manager.promotePaths( new PathsPromoteRequest( source1.getKey(), target.getKey(), path ) );
+
+        assertThat( result.getRequest().getSource(), equalTo( source1.getKey() ) );
+        assertThat( result.getRequest().getTarget(), equalTo( target.getKey() ) );
+
+        pending = result.getPendingPaths();
+        assertThat( pending == null || pending.isEmpty(), equalTo( true ) );
+
+        skipped = result.getSkippedPaths();
+        assertThat( skipped, notNullValue() );
+        assertThat( skipped.size(), equalTo( 1 ) );
+
+        completed = result.getCompletedPaths();
+        assertThat( completed == null || completed.isEmpty(), equalTo( true ) );
+
+        assertThat( result.getError(), nullValue() );
+
+        ref = downloadManager.getStorageReference( target, path );
+        assertThat( ref.exists(), equalTo( true ) );
+        try (InputStream in = ref.openInputStream())
+        {
+            String value = IOUtils.toString( in );
+            assertThat( value, equalTo( originalString ) );
+        }
     }
 
     @Test
-    public void promoteAll_PushTwoArtifactsToHostedRepo_VerifyCopiedToOtherHostedRepo()
+    public void promoteAllByPath_RaceToPromote_FirstLocksTargetStore()
+            throws Exception
+    {
+        Random rand = new Random();
+        final HostedRepository[] sources = { new HostedRepository( "source1" ), new HostedRepository( "source2" ) };
+        final String[] paths = { "/path/path1", "/path/path2", "/path3", "/path/path/4" };
+        Stream.of( sources ).forEach( ( source ) -> {
+            try
+            {
+                storeManager.storeArtifactStore( source, new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" ),
+                                                 new EventMetadata() );
+
+                Stream.of( paths ).forEach( ( path ) -> {
+                    byte[] buf = new byte[1024 * 1024 * 2];
+                    rand.nextBytes( buf );
+                    try
+                    {
+                        contentManager.store( source, path, new ByteArrayInputStream( buf ), TransferOperation.UPLOAD,
+                                              new EventMetadata() );
+                    }
+                    catch ( IndyWorkflowException e )
+                    {
+                        e.printStackTrace();
+                        Assert.fail( "failed to store generated file to: " + source + path );
+                    }
+                } );
+            }
+            catch ( IndyDataException e )
+            {
+                e.printStackTrace();
+                Assert.fail( "failed to store hosted repository: " + source );
+            }
+        } );
+
+        final HostedRepository target = new HostedRepository( "target" );
+        storeManager.storeArtifactStore( target, new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" ),
+                                         new EventMetadata() );
+
+        PathsPromoteResult[] results = new PathsPromoteResult[2];
+        CountDownLatch cdl = new CountDownLatch( 2 );
+
+        AtomicInteger counter = new AtomicInteger( 0 );
+        Stream.of( sources ).forEach( ( source ) -> {
+            int idx = counter.getAndIncrement();
+            executor.execute( () -> {
+                try
+                {
+                    results[idx] =
+                            manager.promotePaths( new PathsPromoteRequest( source.getKey(), target.getKey(), paths ) );
+                }
+                catch ( Exception e )
+                {
+                    e.printStackTrace();
+                    Assert.fail( "Promotion from source: " + source + " failed." );
+                }
+                finally
+                {
+                    cdl.countDown();
+                }
+            } );
+
+            try
+            {
+                Thread.sleep( 25 );
+            }
+            catch ( InterruptedException e )
+            {
+                Assert.fail( "Test interrupted" );
+            }
+        } );
+
+        assertThat( "Promotions failed to finish.", cdl.await( 30, TimeUnit.SECONDS ), equalTo( true ) );
+
+        // first one should succeed.
+        PathsPromoteResult result = results[0];
+        assertThat( result.getRequest().getSource(), equalTo( sources[0].getKey() ) );
+        assertThat( result.getRequest().getTarget(), equalTo( target.getKey() ) );
+
+        Set<String> pending = result.getPendingPaths();
+        assertThat( pending == null || pending.isEmpty(), equalTo( true ) );
+
+        Set<String> skipped = result.getSkippedPaths();
+        assertThat( skipped == null || skipped.isEmpty(), equalTo( true ) );
+
+        Set<String> completed = result.getCompletedPaths();
+        assertThat( completed, notNullValue() );
+        assertThat( completed.size(), equalTo( paths.length ) );
+
+        assertThat( result.getError(), nullValue() );
+
+        Stream.of( paths ).forEach( ( path ) -> {
+            HostedRepository src = sources[0];
+            Transfer sourceRef = downloadManager.getStorageReference( src, path );
+            Transfer targetRef = downloadManager.getStorageReference( target, path );
+            assertThat( targetRef.exists(), equalTo( true ) );
+            try (InputStream sourceIn = sourceRef.openInputStream();
+                 InputStream targetIn = targetRef.openInputStream())
+            {
+                int s = -1, t = -1;
+                while ( ( s = sourceIn.read() ) == ( t = targetIn.read() ) )
+                {
+                    if ( s == -1 )
+                    {
+                        break;
+                    }
+                }
+
+                if ( s != -1 && s != t )
+                {
+                    Assert.fail( path + " doesn't match between source: " + src + " and target: " + target );
+                }
+            }
+            catch ( IOException e )
+            {
+                e.printStackTrace();
+                Assert.fail( "Failed to compare contents of: " + path + " between source: " + src + " and target: "
+                                     + target );
+            }
+        } );
+
+        // second one should be completely skipped.
+        result = results[1];
+        assertThat( result.getRequest().getSource(), equalTo( sources[1].getKey() ) );
+        assertThat( result.getRequest().getTarget(), equalTo( target.getKey() ) );
+
+        pending = result.getPendingPaths();
+        assertThat( pending == null || pending.isEmpty(), equalTo( true ) );
+
+        skipped = result.getSkippedPaths();
+        assertThat( skipped, notNullValue() );
+        assertThat( skipped.size(), equalTo( paths.length ) );
+
+        completed = result.getCompletedPaths();
+        assertThat( completed == null || completed.isEmpty(), equalTo( true ) );
+
+        assertThat( result.getError(), nullValue() );
+    }
+
+    @Test
+    public void promoteAllByPath_PushTwoArtifactsToHostedRepo_VerifyCopiedToOtherHostedRepo()
             throws Exception
     {
         final HostedRepository source = new HostedRepository( "source" );
@@ -151,7 +388,7 @@ public class PromotionManagerTest
     }
 
     @Test
-    public void promoteAll_PushTwoArtifactsToHostedRepo_DryRun_VerifyPendingPathsPopulated()
+    public void promoteAllByPath_PushTwoArtifactsToHostedRepo_DryRun_VerifyPendingPathsPopulated()
             throws Exception
     {
         final HostedRepository source = new HostedRepository( "source" );
@@ -193,7 +430,7 @@ public class PromotionManagerTest
     }
 
     @Test
-    public void promoteAll_PurgeSource_PushTwoArtifactsToHostedRepo_VerifyCopiedToOtherHostedRepo()
+    public void promoteAllByPath_PurgeSource_PushTwoArtifactsToHostedRepo_VerifyCopiedToOtherHostedRepo()
             throws Exception
     {
         final HostedRepository source = new HostedRepository( "source" );

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteResult.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteResult.java
@@ -34,6 +34,8 @@ public class PathsPromoteResult
 
     private Set<String> completedPaths;
 
+    private Set<String> skippedPaths;
+
     private ValidationResult validations;
 
     private String error;
@@ -43,20 +45,22 @@ public class PathsPromoteResult
     }
 
     public PathsPromoteResult( final PathsPromoteRequest request, final Set<String> pending, final Set<String> complete,
-                               final String error )
+                               final Set<String> skipped, final String error )
     {
         this.request = request;
         this.pendingPaths = pending;
         this.completedPaths = complete;
+        this.skippedPaths = skipped;
         this.error = error;
     }
 
     public PathsPromoteResult( final PathsPromoteRequest request, final Set<String> pending, final Set<String> complete,
-                               final ValidationResult validations )
+                               final Set<String> skipped, final ValidationResult validations )
     {
         this.request = request;
         this.pendingPaths = pending;
         this.completedPaths = complete;
+        this.skippedPaths = skipped;
         this.validations = validations;
         this.error = null;
     }
@@ -91,6 +95,16 @@ public class PathsPromoteResult
         this.completedPaths = completedPaths;
     }
 
+    public Set<String> getSkippedPaths()
+    {
+        return skippedPaths;
+    }
+
+    public void setSkippedPaths( Set<String> skippedPaths )
+    {
+        this.skippedPaths = skippedPaths;
+    }
+
     public String getError()
     {
         return error;
@@ -114,8 +128,8 @@ public class PathsPromoteResult
     @Override
     public String toString()
     {
-        return String.format( "PathsPromoteResult [\n  request=%s\n  pendingPaths=%s\n  completedPaths=%s\n  error=%s\n  validations:\n  %s\n]",
-                              request, pendingPaths, completedPaths, error, validations );
+        return String.format( "PathsPromoteResult [\n  request=%s\n  pendingPaths=%s\n  completedPaths=%s\n  skippedPaths=%s\n  error=%s\n  validations:\n  %s\n]",
+                              request, pendingPaths, completedPaths, skippedPaths, error, validations );
     }
 
 }

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/PathsPromoteResultTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/PathsPromoteResultTest.java
@@ -39,7 +39,7 @@ public class PathsPromoteResultTest
         final PathsPromoteResult in =
             new PathsPromoteResult( new PathsPromoteRequest( new StoreKey( StoreType.hosted, "source" ),
                                                    new StoreKey( StoreType.hosted, "target" ) ),
-                               Collections.<String> emptySet(), new HashSet<String>( Arrays.asList( "/path/one",
+                               Collections.emptySet(), Collections.emptySet(), new HashSet<String>( Arrays.asList( "/path/one",
                                                                                                     "/path/two" ) ),
                                new ValidationResult() );
 
@@ -64,8 +64,8 @@ public class PathsPromoteResultTest
         final PathsPromoteResult in =
             new PathsPromoteResult( new PathsPromoteRequest( new StoreKey( StoreType.hosted, "source" ),
                                                    new StoreKey( StoreType.hosted, "target" ) ),
-                               new HashSet<String>( Arrays.asList( "/path/one", "/path/two" ) ),
-                               Collections.<String> emptySet(), "Something stupid happened" );
+                               new HashSet<>( Arrays.asList( "/path/one", "/path/two" ) ),
+                               Collections.emptySet(), Collections.emptySet(), "Something stupid happened" );
 
         final String json = mapper.writeValueAsString( in );
 
@@ -88,8 +88,8 @@ public class PathsPromoteResultTest
         final PathsPromoteResult in =
             new PathsPromoteResult( new PathsPromoteRequest( new StoreKey( StoreType.hosted, "source" ),
                                                    new StoreKey( StoreType.hosted, "target" ) ),
-                               new HashSet<String>( Arrays.asList( "/path/one", "/path/two" ) ),
-                               new HashSet<String>( Collections.singletonList( "/path/three" ) ), "Something stupid happened" );
+                               new HashSet<>( Arrays.asList( "/path/one", "/path/two" ) ),
+                               new HashSet<>( Collections.singletonList( "/path/three" ) ), Collections.emptySet(), "Something stupid happened" );
 
         final String json = mapper.writeValueAsString( in );
 

--- a/models/core-java/pom.xml
+++ b/models/core-java/pom.xml
@@ -57,6 +57,7 @@
     <dependency>
       <groupId>com.wordnik</groupId>
       <artifactId>swagger-jaxrs_2.10</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <resteasyVersion>3.0.9.Final</resteasyVersion>
     <undertowVersion>1.1.2.Final</undertowVersion>
     <xnioVersion>3.3.0.Final</xnioVersion>
-    <partylineVersion>1.5</partylineVersion>
+    <partylineVersion>1.6</partylineVersion>
     <keycloakVersion>1.2.0.Final</keycloakVersion>
     <jhttpcVersion>1.1</jhttpcVersion>
     


### PR DESCRIPTION
* race condition in by-path promotion (now synchronizing on target key to force competing promotions to wait on the running promotion)
* classpath of client includes jboss-logging and swagger, which can cause deployment issues in JBoss containers (jboss-logging mostly)
* overwriting a file with smaller content than the existing version didn't truncate the resulting file to the bounds of the new content.