### PR TITLE
Content timeout testing fixes

### DIFF
--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -177,8 +177,19 @@ public abstract class AbstractIndyFunctionalTest
     protected void initBaseTestConfig( CoreServerFixture fixture )
             throws IOException
     {
-        writeConfigFile( "conf.d/scheduler.conf", "[scheduler]\nenabled=false" );
-        writeConfigFile( "conf.d/indexer.conf", "[indexer]\nenabled=false" );
+        if ( isSchedulerEnabled() )
+        {
+            writeConfigFile( "conf.d/scheduler.conf", readTestResource( "default-test-scheduler.conf" ) );
+        }
+        else
+        {
+            writeConfigFile( "conf.d/scheduler.conf", "[scheduler]\nenabled=false" );
+        }
+    }
+
+    protected boolean isSchedulerEnabled()
+    {
+        return false;
     }
 
     protected String readTestResource( String resource )

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -189,7 +189,7 @@ public abstract class AbstractIndyFunctionalTest
 
     protected boolean isSchedulerEnabled()
     {
-        return false;
+        return true;
     }
 
     protected String readTestResource( String resource )

--- a/ftests/common/src/main/resources/default-test-main.conf
+++ b/ftests/common/src/main/resources/default-test-main.conf
@@ -1,0 +1,25 @@
+[flatfiles]
+
+# This is where configurations and persistent state related to both the core
+# functions of Indy and its addons are stored.
+data.dir=${indy.home}/var/lib/indy/data
+
+# This is where temporary files used in various calculations for addon functions
+# are stored.
+work.dir=${indy.home}/var/lib/indy/work
+
+[storage-default]
+
+# This is the location where proxied / uploaded / generated repository
+# content is stored. It is distinct from configuration state and other
+# persistent data related to addons.
+storage.dir=${indy.home}/var/lib/indy/storage
+
+[ui]
+
+# UI files are stored here, for easy access to allow customization.
+ui.dir=${indy.home}/var/lib/indy/ui
+
+
+Include conf.d/*.conf
+

--- a/ftests/common/src/main/resources/default-test-scheduler.conf
+++ b/ftests/common/src/main/resources/default-test-scheduler.conf
@@ -1,0 +1,31 @@
+[scheduler]
+ddl=scheduler/quartz-h2.sql
+
+org.quartz.dataSource.ds.driver = org.h2.Driver
+org.quartz.dataSource.ds.URL = jdbc:h2:mem:scheduler;DB_CLOSE_DELAY=-1
+#org.quartz.dataSource.ds.user = sa
+#org.quartz.dataSource.ds.password =
+org.quartz.dataSource.ds.maxConnections = 9
+
+### --------------------------------------------------------------------
+### DANGER ZONE:
+### You probably don't need to change anything below this point.
+### --------------------------------------------------------------------
+org.quartz.scheduler.skipUpdateCheck: true
+org.quartz.scheduler.instanceName = INDY_SCHEDULER
+org.quartz.threadPool.class = org.quartz.simpl.SimpleThreadPool
+org.quartz.threadPool.threadCount = 4
+org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread = true
+
+#specify the jobstore used
+org.quartz.jobStore.class = org.quartz.impl.jdbcjobstore.JobStoreTX
+org.quartz.jobStore.driverDelegateClass = org.quartz.impl.jdbcjobstore.StdJDBCDelegate
+org.quartz.jobStore.useProperties = false
+
+#The datasource for the jobstore that is to be used
+org.quartz.jobStore.dataSource = ds
+
+#quartz table prefixes in the database
+org.quartz.jobStore.tablePrefix = qrtz_
+org.quartz.jobStore.misfireThreshold = 60000
+org.quartz.jobStore.isClustered = false

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentPassthroughTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentPassthroughTimeoutWorkingTest.java
@@ -97,12 +97,6 @@ public class ContentPassthroughTimeoutWorkingTest
     }
 
     @Override
-    protected boolean isSchedulerEnabled()
-    {
-        return true;
-    }
-
-    @Override
     protected void initTestConfig( CoreServerFixture fixture )
             throws IOException
     {

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentPassthroughTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentPassthroughTimeoutWorkingTest.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.helper.PathInfo;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ContentPassthroughTimeoutWorkingTest
+        extends AbstractContentManagementTest
+{
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "repos" );
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+
+    private String repoId;
+
+    private String pomPath;
+
+    private String pomFilePath;
+
+    public static final int TIMEOUT_SECONDS = 2;
+
+    public static final int TIMEOUT_WAITING_MILLISECONDS = ( TIMEOUT_SECONDS + 2 ) * 1000;
+
+    @Before
+    public void setupRepo()
+            throws Exception
+    {
+        repoId = "test-repo";
+        pomPath = "org/foo/bar/1.0/bar-1.0.pom";
+        final String pomUrl = server.formatUrl( repoId, pomPath );
+
+        // mocking up a http server that expects access to a .pom
+        final String datetime = ( new Date() ).toString();
+        server.expect( pomUrl, 200, String.format( "pom %s", datetime ) );
+
+        // set up remote repository pointing to the test http server, and timeout little later
+        final String changelog = "Timeout Testing: " + name.getMethodName();
+        final RemoteRepository repository = new RemoteRepository( repoId, server.formatUrl( repoId ) );
+        repository.setPassthrough( true );
+
+        client.stores().create( repository, changelog, RemoteRepository.class );
+
+        // ensure the pom exist before the timeout checking
+        final PathInfo result = client.content().getInfo( remote, repoId, pomPath );
+        assertThat( "no result", result, notNullValue() );
+        assertThat( "doesn't exist", result.exists(), equalTo( true ) );
+        pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
+                                     remote.name(), repoId, pomPath );
+        final File pomFile = new File( pomFilePath );
+        assertThat( "pom doesn't exist", pomFile.exists(), equalTo( true ) );
+
+    }
+
+    @Test
+    public void quartzBasedTimeoutArtifact()
+            throws Exception
+    {
+        // make sure the repo timout
+        Thread.sleep( TIMEOUT_WAITING_MILLISECONDS );
+        logger.debug( "Timeout time {}s passed!", TIMEOUT_SECONDS );
+
+        final File pomFile = new File( pomFilePath );
+        assertThat( "artifact should be removed when timeout", pomFile.exists(), equalTo( false ) );
+    }
+
+    @Override
+    protected boolean isSchedulerEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "main.conf", "passthrough.timeout=" + TIMEOUT_SECONDS + "\n" + readTestResource(
+                "default-test-main.conf" ) );
+    }
+
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentTimeoutWorkingTest.java
@@ -70,7 +70,7 @@ public class ContentTimeoutWorkingTest
         // set up remote repository pointing to the test http server, and timeout little later
         final String changelog = "Timeout Testing: " + name.getMethodName();
         final RemoteRepository repository = new RemoteRepository( repoId, server.formatUrl( repoId ) );
-        repository.setTimeoutSeconds( TIMEOUT_SECONDS );
+        repository.setCacheTimeoutSeconds( TIMEOUT_SECONDS );
 
         client.stores().create( repository, changelog, RemoteRepository.class );
 
@@ -85,7 +85,6 @@ public class ContentTimeoutWorkingTest
 
     }
 
-    @Ignore
     @Test
     public void quartzBasedTimeoutArtifact()
             throws Exception
@@ -98,25 +97,10 @@ public class ContentTimeoutWorkingTest
         assertThat( "artifact should be removed when timeout", pomFile.exists(), equalTo( false ) );
     }
 
-    @Ignore
-    @Test
-    public void cacheProviderBasedTimeoutArtifact()
-            throws Exception
+    @Override
+    protected boolean isSchedulerEnabled()
     {
-        final File pomFile = new File( pomFilePath );
-        final long pomLastModified = pomFile.lastModified();
-
-        // make sure the repo timout
-        Thread.sleep( TIMEOUT_WAITING_MILLISECONDS );
-        logger.debug( "Timeout time {}s passed!", TIMEOUT_SECONDS );
-
-        final Boolean contentExists = client.content().exists( remote, repoId, pomPath );
-        final File pomFileAgain = new File( pomFilePath );
-        if ( contentExists && pomFileAgain.exists() )
-        {
-            assertThat( "cache timout not working, artifact not removed and not changed", pomFileAgain.lastModified(),
-                        is( not( pomLastModified ) ) );
-        }
+        return true;
     }
 
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentTimeoutWorkingTest.java
@@ -97,10 +97,4 @@ public class ContentTimeoutWorkingTest
         assertThat( "artifact should be removed when timeout", pomFile.exists(), equalTo( false ) );
     }
 
-    @Override
-    protected boolean isSchedulerEnabled()
-    {
-        return true;
-    }
-
 }


### PR DESCRIPTION
There were a few problems with the content timeout tests (actually the abstract base ftest class):

* Overwriting main.conf (to set passthrough.timeout, for example) removed a lot of configuration that would have been in the default config file...now we have a default-test-main.conf to append to custom overrides like this.
* Overwriting scheduler.conf to enable wasn't enough; we needed a default-test-scheduler.conf that contained all the quartz properties...to make this speedier, I made the URL an in-memory db.
* The scheduler DB used to be so slow that I disabled it for functional testing...which was causing @ligangty 's tests to fail.
* I added an override-able method to the abstract base ftest to allow a ftest to say that it wanted the scheduler enabled or disabled. As of the last commit, it's enabled by default (since the in-memory db is fast enough)
* I added a new ftest to check that the passthrough timeout works.