### PR TITLE
Working on improving content-index responses to events in Indy

### DIFF
--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreEnablementEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreEnablementEvent.java
@@ -1,0 +1,73 @@
+package org.commonjava.indy.change.event;
+
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.maven.galley.event.EventMetadata;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+
+/**
+ * Created by jdcasey on 5/2/16.
+ */
+public class ArtifactStoreEnablementEvent
+    implements IndyStoreEvent
+{
+
+    private final EventMetadata eventMetadata;
+
+    private final boolean disabling;
+
+    private Set<ArtifactStore> stores;
+
+    private final boolean preprocessing;
+
+    public ArtifactStoreEnablementEvent( boolean preprocessing, EventMetadata eventMetadata, boolean disabling, ArtifactStore... stores )
+    {
+        this.preprocessing = preprocessing;
+        this.eventMetadata = eventMetadata;
+        this.disabling = disabling;
+        this.stores = new HashSet<>( Arrays.asList( stores ) );
+    }
+
+    public EventMetadata getEventMetadata()
+    {
+        return eventMetadata;
+    }
+
+    public boolean isDisabling()
+    {
+        return disabling;
+    }
+
+    public boolean isPreprocessing()
+    {
+        return preprocessing;
+    }
+
+    public Set<ArtifactStore> getStores()
+    {
+        return stores;
+    }
+
+    @Override
+    public Iterator<ArtifactStore> iterator()
+    {
+        return stores.iterator();
+    }
+
+    @Override
+    public void forEach( Consumer<? super ArtifactStore> action )
+    {
+        stores.forEach( action::accept );
+    }
+
+    @Override
+    public Spliterator<ArtifactStore> spliterator()
+    {
+        return stores.spliterator();
+    }
+}

--- a/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
+++ b/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
@@ -3,6 +3,7 @@ package org.commonjava.indy.content;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
@@ -44,6 +45,19 @@ public interface DirectContentAccess
      * @return A suitable transfer object (not null; those cases result in an exception) NOTE: the returned transfer may not exist!
      */
     Transfer getTransfer( final ArtifactStore store, final String path )
+            throws IndyWorkflowException;
+
+    /**
+     * Retrieve a {@link Transfer} object suitable for use in the specified operation. This method handles the selection logic in the event the store
+     * is a {@link Group}, and doesn't fire any events (the returned {@link Transfer} object handles that in this case).<br/>
+     * <b>No content generators are called in this method.</b>
+     *
+     * @param storeKey The key to the store in which the Transfer should reside
+     * @param path The path of the Transfer inside the store
+     * @return A suitable transfer object (not null; those cases result in an exception) NOTE: the returned transfer may not exist!
+     * @throws IndyWorkflowException in case no suitable storage location can be found
+     */
+    Transfer getTransfer( StoreKey storeKey, String path )
             throws IndyWorkflowException;
 
     List<StoreResource> listRaw( ArtifactStore store, String parentPath )

--- a/api/src/main/java/org/commonjava/indy/data/NoOpStoreEventDispatcher.java
+++ b/api/src/main/java/org/commonjava/indy/data/NoOpStoreEventDispatcher.java
@@ -52,4 +52,28 @@ public class NoOpStoreEventDispatcher
     {
     }
 
+    @Override
+    public void enabling( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+
+    }
+
+    @Override
+    public void enabled( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+
+    }
+
+    @Override
+    public void disabling( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+
+    }
+
+    @Override
+    public void disabled( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+
+    }
+
 }

--- a/api/src/main/java/org/commonjava/indy/data/StoreEventDispatcher.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreEventDispatcher.java
@@ -36,4 +36,13 @@ public interface StoreEventDispatcher
     void updating( final ArtifactStoreUpdateType type, final EventMetadata eventMetadata, final Map<ArtifactStore, ArtifactStore> stores );
 
     void updated( final ArtifactStoreUpdateType type, final EventMetadata eventMetadata, final Map<ArtifactStore, ArtifactStore> stores );
+
+    void enabling( final EventMetadata eventMetadata, final ArtifactStore...stores );
+
+    void enabled( final EventMetadata eventMetadata, final ArtifactStore...stores );
+
+    void disabling( final EventMetadata eventMetadata, final ArtifactStore... stores );
+
+    void disabled( final EventMetadata eventMetadata, final ArtifactStore...stores );
+
 }

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
@@ -41,7 +41,7 @@ import java.io.IOException;
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 @ApplicationScoped
-public class StoreEnablementListener
+public class StoreEnablementManager
 {
 
     public static final String DISABLE_TIMEOUT = "Disable-Timeout";
@@ -58,6 +58,7 @@ public class StoreEnablementListener
     @Inject
     private IndyConfiguration config;
 
+    //FIXME: Convert to using ArtifactStoreEnablementEvent.
     public void onStoreUpdate( @Observes ArtifactStorePostUpdateEvent event )
     {
         for ( ArtifactStore store : event )
@@ -111,6 +112,7 @@ public class StoreEnablementListener
             logger.warn( "{} has been disabled due to store-level error: {}\n Will re-enable in {} seconds.", key,
                          error, config.getStoreDisableTimeoutSeconds() );
 
+            // TODO: How is it this doesn't duplicate the event handler method onStoreUpdate()...we're updating the store just above here.
             setReEnablementTimeout( key, config.getStoreDisableTimeoutSeconds() );
         }
         catch ( IndyDataException e )

--- a/core/src/main/java/org/commonjava/indy/core/change/event/DefaultStoreEventDispatcher.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/event/DefaultStoreEventDispatcher.java
@@ -19,6 +19,7 @@ import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.change.event.ArtifactStoreDeletePostEvent;
 import org.commonjava.indy.change.event.ArtifactStoreDeletePreEvent;
+import org.commonjava.indy.change.event.ArtifactStoreEnablementEvent;
 import org.commonjava.indy.change.event.ArtifactStorePostUpdateEvent;
 import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
@@ -51,6 +52,9 @@ public class DefaultStoreEventDispatcher
 
     @Inject
     private Event<ArtifactStoreDeletePostEvent> postDelEvent;
+
+    @Inject
+    private Event<ArtifactStoreEnablementEvent> enablementEvent;
 
     @Inject
     @WeftManaged
@@ -142,6 +146,42 @@ public class DefaultStoreEventDispatcher
                         new ArtifactStorePostUpdateEvent( type, eventMetadata, changeMap );
                 updatePostEvent.fire( event );
             } );
+        }
+    }
+
+    @Override
+    public void enabling( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+        fireEnablement( true, eventMetadata, false, stores );
+    }
+
+    @Override
+    public void enabled( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+        fireEnablement( false, eventMetadata, false, stores );
+    }
+
+    @Override
+    public void disabling( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+        fireEnablement( true, eventMetadata, true, stores );
+    }
+
+    @Override
+    public void disabled( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+        fireEnablement( false, eventMetadata, true, stores );
+    }
+
+    private void fireEnablement( boolean preprocess, EventMetadata eventMetadata, boolean disabling,
+                                 ArtifactStore... stores )
+    {
+        if ( enablementEvent != null )
+        {
+            executor.execute( ()->{
+                final ArtifactStoreEnablementEvent event = new ArtifactStoreEnablementEvent( preprocess, eventMetadata, disabling, stores );
+                enablementEvent.fire( event );
+            });
         }
     }
 

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
@@ -5,6 +5,7 @@ import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 import org.slf4j.Logger;
@@ -72,6 +73,13 @@ public class DefaultDirectContentAccess
             throws IndyWorkflowException
     {
         return downloadManager.getStorageReference( store, path );
+    }
+
+    @Override
+    public Transfer getTransfer( final StoreKey key, final String path )
+            throws IndyWorkflowException
+    {
+        return downloadManager.getStorageReference( key, path );
     }
 
     @Override

--- a/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
@@ -16,7 +16,7 @@
 package org.commonjava.indy.core.ctl;
 
 import org.commonjava.indy.IndyWorkflowException;
-import org.commonjava.indy.core.change.StoreEnablementListener;
+import org.commonjava.indy.core.change.StoreEnablementManager;
 import org.commonjava.indy.core.expire.Expiration;
 import org.commonjava.indy.core.expire.ExpirationSet;
 import org.commonjava.indy.core.expire.IndySchedulerException;
@@ -30,7 +30,6 @@ import org.quartz.impl.matchers.GroupMatcher;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.Date;
 
 @ApplicationScoped
 public class SchedulerController
@@ -57,7 +56,7 @@ public class SchedulerController
         try
         {
             Expiration expiration = scheduleManager.findSingleExpiration(
-                    new StoreKeyMatcher( storeKey, StoreEnablementListener.DISABLE_TIMEOUT ) );
+                    new StoreKeyMatcher( storeKey, StoreEnablementManager.DISABLE_TIMEOUT ) );
 
             if ( expiration == null )
             {
@@ -86,8 +85,9 @@ public class SchedulerController
         try
         {
             ExpirationSet expirations = scheduleManager.findMatchingExpirations(
-                    GroupMatcher.groupEndsWith( StoreEnablementListener.DISABLE_TIMEOUT ) );
+                    GroupMatcher.groupEndsWith( StoreEnablementManager.DISABLE_TIMEOUT ) );
 
+            // TODO: This seems REALLY inefficient...
             storeDataManager.getAllArtifactStores().forEach( (store)->{
                 if ( store.isDisabled() )
                 {
@@ -109,7 +109,7 @@ public class SchedulerController
 
     private Expiration indefiniteDisable( ArtifactStore store )
     {
-        return new Expiration( ScheduleManager.groupName( store.getKey(), StoreEnablementListener.DISABLE_TIMEOUT ), StoreEnablementListener.DISABLE_TIMEOUT );
+        return new Expiration( ScheduleManager.groupName( store.getKey(), StoreEnablementManager.DISABLE_TIMEOUT ), StoreEnablementManager.DISABLE_TIMEOUT );
     }
 
 }

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -377,6 +377,18 @@ public class MemoryStoreDataManager
         {
             dispatcher.updating( exists ? ArtifactStoreUpdateType.UPDATE : ArtifactStoreUpdateType.ADD, eventMetadata,
                                  Collections.singletonMap( store, original ) );
+
+            if ( exists )
+            {
+                if ( store.isDisabled() && !original.isDisabled() )
+                {
+                    dispatcher.disabling( eventMetadata, store );
+                }
+                else if ( !store.isDisabled() && original.isDisabled() )
+                {
+                    dispatcher.enabling( eventMetadata, store );
+                }
+            }
         }
     }
 
@@ -388,6 +400,18 @@ public class MemoryStoreDataManager
         {
             dispatcher.updated( exists ? ArtifactStoreUpdateType.UPDATE : ArtifactStoreUpdateType.ADD, eventMetadata,
                                 Collections.singletonMap( store, original ) );
+
+            if ( exists )
+            {
+                if ( store.isDisabled() && !original.isDisabled() )
+                {
+                    dispatcher.disabled( eventMetadata, store );
+                }
+                else if ( !store.isDisabled() && original.isDisabled() )
+                {
+                    dispatcher.enabled( eventMetadata, store );
+                }
+            }
         }
     }
 

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -37,6 +37,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -223,7 +224,7 @@ public class MemoryStoreDataManager
             throws IndyDataException
     {
         Set<Group> groups = reverseGroupMemberships.get( repo );
-        return groups == null ? Collections.emptySet() : new HashSet<>( groups );
+        return groups == null ? Collections.emptySet() : Collections.unmodifiableSet( groups );
     }
 
     private boolean groupContains( final Group g, final StoreKey key )
@@ -341,15 +342,14 @@ public class MemoryStoreDataManager
                         Set<Group> memberIn = reverseGroupMemberships.get( memberKey );
                         if ( memberIn == null )
                         {
-                            memberIn = Collections.singleton( g );
+                            memberIn = new HashSet<>( Arrays.asList( g ) );
                         }
                         else
                         {
-                            memberIn = new HashSet<>( memberIn );
                             memberIn.add( g );
                         }
 
-                        reverseGroupMemberships.put( memberKey, Collections.unmodifiableSet( memberIn ) );
+                        reverseGroupMemberships.put( memberKey, memberIn );
                     }
                 });
             }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractContentTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractContentTimeoutWorkingTest.java
@@ -41,11 +41,11 @@ public abstract class AbstractContentTimeoutWorkingTest
         return false;
     }
 
-    private String pomFilePath;
+    private File pomFile;
 
-    protected static final int TIMEOUT_SECONDS = 2;
+    protected static final int TIMEOUT_SECONDS = 1;
 
-    protected static final int TIMEOUT_WAITING_MILLISECONDS = ( TIMEOUT_SECONDS + 2 ) * 1000;
+    protected static final int TIMEOUT_WAITING_MILLISECONDS = 2000;
 
     @Before
     public void setupRepo()
@@ -69,9 +69,11 @@ public abstract class AbstractContentTimeoutWorkingTest
         final PathInfo result = client.content().getInfo( remote, repoId, pomPath );
         assertThat( "no result", result, notNullValue() );
         assertThat( "doesn't exist", result.exists(), equalTo( true ) );
-        pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
+
+        String pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
                                      remote.name(), repoId, pomPath );
-        final File pomFile = new File( pomFilePath );
+
+        pomFile = new File( pomFilePath );
         assertThat( "pom doesn't exist", pomFile.exists(), equalTo( true ) );
 
     }
@@ -83,7 +85,6 @@ public abstract class AbstractContentTimeoutWorkingTest
         Thread.sleep( TIMEOUT_WAITING_MILLISECONDS );
         logger.debug( "Timeout time {}s passed!", TIMEOUT_SECONDS );
 
-        final File pomFile = new File( pomFilePath );
         assertThat( "artifact should be removed when timeout", pomFile.exists(), equalTo( false ) );
     }
 

--- a/test/db/src/main/java/org/commonjava/indy/core/data/testutil/StoreEventDispatcherStub.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/testutil/StoreEventDispatcherStub.java
@@ -48,4 +48,28 @@ public class StoreEventDispatcherStub
     {
     }
 
+    @Override
+    public void enabling( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+
+    }
+
+    @Override
+    public void enabled( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+
+    }
+
+    @Override
+    public void disabling( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+
+    }
+
+    @Override
+    public void disabled( EventMetadata eventMetadata, ArtifactStore... stores )
+    {
+
+    }
+
 }


### PR DESCRIPTION
Working on improving content-indexer responses to events in the system, and formalizing the enable/disable event set so we can listen to it.

This is still under some development, with ContentIndexObserver and StoreEnablementListener in need of some uncommenting / debugging. I believe the concepts are sound though (the ones I have commented in those classes).

@pkocandr I wanted to submit this as a PR anyway to show where I was planning to go with the work, and see if you think it looks like a sound approach. In particular, I was planning to make StoreEnablementManager respond to ArtifactStoreEnablementEvent instead of the ArtifactStoreUpdateEvent that it uses to set the disabled timeout...and even more importantly, the ContentIndexObserver, which has a bunch of commented out code. Those commented sections were causing test failures, and I didn't want to leave this work on my localhost, so I took them out temporarily. You should find // FIXME comments in places I intend to get back to.

This PR isn't necessarily something I mean to merge as-is...it's more to provide you with my current progress.