### PR TITLE
MAJOR performance improvements, minor bugfixes

### DIFF
--- a/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/AutoProxCalculationTest.java
+++ b/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/AutoProxCalculationTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.autoprox.rest.dto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/CatalogDTOTest.java
+++ b/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/CatalogDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.autoprox.rest.dto;
 
 import org.apache.commons.io.IOUtils;

--- a/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/RuleDTOTest.java
+++ b/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/RuleDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.autoprox.rest.dto;
 
 import org.apache.commons.io.IOUtils;

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -24,6 +24,7 @@ import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.infinispan.Cache;
@@ -149,146 +150,161 @@ public class ContentIndexManager
 
     public void removeIndexedStorePath( String path, StoreKey key, Consumer<IndexedStorePath> pathConsumer )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-
-        QueryFactory queryFactory = Search.getQueryFactory( contentIndex );
-
-        QueryBuilder<Query> queryBuilder = queryFactory.from( IndexedStorePath.class )
-                                                       .having( "storeType" )
-                                                       .eq( key.getType() )
-                                                       .and()
-                                                       .having( "storeName" )
-                                                       .eq( key.getName() )
-                                                       .and()
-                                                       .having( "path" )
-                                                       .eq( path )
-                                                       .toBuilder();
-
-        List<IndexedStorePath> paths = queryBuilder.build().list();
-        paths.forEach( ( indexedStorePath ) -> {
-            logger.debug( "Removing: {}", indexedStorePath );
-            contentIndex.remove( indexedStorePath );
-            if ( pathConsumer != null )
-            {
-                pathConsumer.accept( indexedStorePath );
-            }
-        } );
+//        Logger logger = LoggerFactory.getLogger( getClass() );
+        IndexedStorePath topPath = new IndexedStorePath( key, path );
+        if ( contentIndex.remove( topPath ) != null && pathConsumer != null )
+        {
+            pathConsumer.accept( topPath );
+        }
+//
+//        QueryFactory queryFactory = Search.getQueryFactory( contentIndex );
+//
+//        QueryBuilder<Query> queryBuilder = queryFactory.from( IndexedStorePath.class )
+//                                                       .having( "storeType" )
+//                                                       .eq( key.getType() )
+//                                                       .and()
+//                                                       .having( "storeName" )
+//                                                       .eq( key.getName() )
+//                                                       .and()
+//                                                       .having( "path" )
+//                                                       .eq( path )
+//                                                       .toBuilder();
+//
+//        List<IndexedStorePath> paths = queryBuilder.build().list();
+//        paths.forEach( ( indexedStorePath ) -> {
+//            logger.debug( "Removing: {}", indexedStorePath );
+//            contentIndex.remove( indexedStorePath );
+//            if ( pathConsumer != null )
+//            {
+//                pathConsumer.accept( indexedStorePath );
+//            }
+//        } );
     }
 
-    public List<IndexedStorePath> lookupIndexedPathByTopKey( final StoreKey key, final String path )
-    {
-        QueryFactory queryFactory = Search.getQueryFactory( contentIndex );
-        QueryBuilder<Query> queryBuilder = queryFactory.from( IndexedStorePath.class )
-                                                       .having( "storeType" )
-                                                       .eq( key.getType() )
-                                                       .and()
-                                                       .having( "storeName" )
-                                                       .eq( key.getName() )
-                                                       .and()
-                                                       .having( "path" )
-                                                       .eq( path )
-                                                       .toBuilder();
+//    public List<IndexedStorePath> lookupIndexedPathByTopKey( final StoreKey key, final String path )
+//    {
+//        QueryFactory queryFactory = Search.getQueryFactory( contentIndex );
+//        QueryBuilder<Query> queryBuilder = queryFactory.from( IndexedStorePath.class )
+//                                                       .having( "storeType" )
+//                                                       .eq( key.getType() )
+//                                                       .and()
+//                                                       .having( "storeName" )
+//                                                       .eq( key.getName() )
+//                                                       .and()
+//                                                       .having( "path" )
+//                                                       .eq( path )
+//                                                       .toBuilder();
+//
+//        return queryBuilder.build().list();
+//    }
 
-        return queryBuilder.build().list();
-    }
-
-    public List<IndexedStorePath> lookupIndexedSubPathsByTopKey( final StoreKey key, final String superPath )
-    {
-        QueryFactory queryFactory = Search.getQueryFactory( contentIndex );
-        QueryBuilder<Query> queryBuilder = queryFactory.from( IndexedStorePath.class )
-                                                       .having( "storeType" )
-                                                       .eq( key.getType() )
-                                                       .and()
-                                                       .having( "storeName" )
-                                                       .eq( key.getName() )
-                                                       .and()
-                                                       .having( "path" )
-                                                       .like( superPath + "%" )
-                                                       .toBuilder();
-
-        return queryBuilder.build().list();
-    }
+//    public List<IndexedStorePath> lookupIndexedSubPathsByTopKey( final StoreKey key, final String superPath )
+//    {
+//        QueryFactory queryFactory = Search.getQueryFactory( contentIndex );
+//        QueryBuilder<Query> queryBuilder = queryFactory.from( IndexedStorePath.class )
+//                                                       .having( "storeType" )
+//                                                       .eq( key.getType() )
+//                                                       .and()
+//                                                       .having( "storeName" )
+//                                                       .eq( key.getName() )
+//                                                       .and()
+//                                                       .having( "path" )
+//                                                       .like( superPath + "%" )
+//                                                       .toBuilder();
+//
+//        return queryBuilder.build().list();
+//    }
 
     public void deIndexStorePath( final StoreKey key, final String path )
     {
         executor.execute( () -> {
-            contentIndex.remove( new IndexedStorePath( key, key, path ) );
+            IndexedStorePath toRemove = new IndexedStorePath( key, path );
+            contentIndex.remove( toRemove );
 
-            try
-            {
-                Set<Group> groups = storeDataManager.getGroupsContaining( key );
-                if ( groups != null )
-                {
-                    groups.forEach( ( group ) -> contentIndex.remove( new IndexedStorePath( group.getKey(), key, path ),
-                                                                      Boolean.TRUE ) );
-                }
-            }
-            catch ( IndyDataException e )
-            {
-                Logger logger = LoggerFactory.getLogger( getClass() );
-                logger.error(
-                        String.format( "Cannot lookup groups containing: %s for content indexing. Reason: %s", key,
-                                       e.getMessage() ), e );
-            }
-
-            if ( StoreType.group == key.getType() )
-            {
-                try
-                {
-                    List<ArtifactStore> members = storeDataManager.getOrderedConcreteStoresInGroup( key.getName() );
-                    if ( members != null )
-                    {
-                        members.forEach( ( member ) -> {
-                            contentIndex.remove( new IndexedStorePath( key, member.getKey(), path ) );
-
-                            contentIndex.remove( new IndexedStorePath( member.getKey(), member.getKey(), path ) );
-                        } );
-                    }
-                }
-                catch ( IndyDataException e )
-                {
-                    Logger logger = LoggerFactory.getLogger( getClass() );
-                    logger.error( String.format(
-                            "Cannot lookup concrete membership of group: %s for content indexing. Reason: %s", key,
-                            e.getMessage() ), e );
-                }
-            }
+            // TODO: Can we really make this lazy?
+//            try
+//            {
+//                Set<Group> groups = storeDataManager.getGroupsContaining( key );
+//                if ( groups != null )
+//                {
+//                    groups.forEach( ( group ) -> {
+//                        IndexedStorePath groupToRemove = new IndexedStorePath( group.getKey(), path );
+//                        contentIndex.remove( groupToRemove );
+//                        byTopKey.remove( groupToRemove );
+//                    } );
+//                }
+//            }
+//            catch ( IndyDataException e )
+//            {
+//                Logger logger = LoggerFactory.getLogger( getClass() );
+//                logger.error(
+//                        String.format( "Cannot lookup groups containing: %s for content indexing. Reason: %s", key,
+//                                       e.getMessage() ), e );
+//            }
+//
+//            if ( StoreType.group == key.getType() )
+//            {
+//                try
+//                {
+//                    List<ArtifactStore> members = storeDataManager.getOrderedConcreteStoresInGroup( key.getName() );
+//                    if ( members != null )
+//                    {
+//                        members.forEach( ( member ) -> {
+//                            contentIndex.remove( new IndexedStorePath( key, member.getKey(), path ) );
+//
+//                            contentIndex.remove( new IndexedStorePath( member.getKey(), member.getKey(), path ) );
+//                        } );
+//                    }
+//                }
+//                catch ( IndyDataException e )
+//                {
+//                    Logger logger = LoggerFactory.getLogger( getClass() );
+//                    logger.error( String.format(
+//                            "Cannot lookup concrete membership of group: %s for content indexing. Reason: %s", key,
+//                            e.getMessage() ), e );
+//                }
+//            }
         } );
     }
 
     public IndexedStorePath getIndexedStorePath( final StoreKey key, final String path )
             throws IndyWorkflowException
     {
-        List<IndexedStorePath> matches = lookupIndexedPathByTopKey( key, path );
-        Logger logger = LoggerFactory.getLogger( getClass() );
-        logger.debug( "Found index hits for: {} in store: {}:\n  {}", path, key, matches );
+        return contentIndex.get( new IndexedStorePath( key, path ) );
 
-        if ( !matches.isEmpty() )
-        {
-            return matches.get( 0 );
-        }
-
-        return null;
+//        List<IndexedStorePath> matches = lookupIndexedPathByTopKey( key, path );
+//        Logger logger = LoggerFactory.getLogger( getClass() );
+//        logger.debug( "Found index hits for: {} in store: {}:\n  {}", path, key, matches );
+//
+//        if ( !matches.isEmpty() )
+//        {
+//            return matches.get( 0 );
+//        }
+//
+//        return null;
     }
 
-    public void indexTransferIn( Transfer transfer, StoreKey...keys )
+    public void indexTransferIn( Transfer transfer, StoreKey...topKeys )
     {
         if ( transfer != null && transfer.exists() )
         {
-            indexPathInStores( transfer.getPath(), keys );
+            indexPathInStores( transfer.getPath(), LocationUtils.getKey( transfer ), topKeys );
         }
     }
 
     /**
      * When we store or retrieve content, index it for faster reference next time.
      */
-    public void indexPathInStores( String path, StoreKey... keys )
+    public void indexPathInStores( String path, StoreKey originKey, StoreKey... topKeys )
     {
         executor.execute( () -> {
-            Set<StoreKey> keySet = new HashSet<>( Arrays.asList( keys ) );
+            IndexedStorePath origin = new IndexedStorePath( originKey, path );
+            contentIndex.put( origin, origin );
+
+            Set<StoreKey> keySet = new HashSet<>( Arrays.asList( topKeys ) );
             keySet.forEach( (key)->{
-                IndexedStorePath isp = new IndexedStorePath( key, key, path );
-                contentIndex.put( isp, isp );
+                IndexedStorePath isp = new IndexedStorePath( key, originKey, path );
+                contentIndex.put( isp, origin );
             } );
         } );
     }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.content.index;
 
 import org.commonjava.cdi.util.weft.ExecutorConfig;

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -280,25 +280,27 @@ public class ContentIndexManager
 
     public void clearIndexedPathFrom( String path, Set<Group> groups, Consumer<IndexedStorePath> pathConsumer )
     {
-        Set<Group> nextGroups = new HashSet<>();
-        if ( groups != null )
+        if ( groups == null || groups.isEmpty() )
         {
-            groups.forEach( (group)->{
-                removeIndexedStorePath( path, group.getKey(), pathConsumer );
-                try
-                {
-                    nextGroups.addAll( storeDataManager.getGroupsContaining( group.getKey() ) );
-                }
-                catch ( IndyDataException e )
-                {
-                    Logger logger = LoggerFactory.getLogger( getClass() );
-                    logger.error( String.format( "Failed to lookup groups containing: %s. Reason: %s", group.getKey(), e.getMessage() ),
-                                  e );
-                }
-            } );
-
-            nextGroups.removeAll( groups );
+            return;
         }
+
+        Set<Group> nextGroups = new HashSet<>();
+        groups.forEach( (group)->{
+            removeIndexedStorePath( path, group.getKey(), pathConsumer );
+            try
+            {
+                nextGroups.addAll( storeDataManager.getGroupsContaining( group.getKey() ) );
+            }
+            catch ( IndyDataException e )
+            {
+                Logger logger = LoggerFactory.getLogger( getClass() );
+                logger.error( String.format( "Failed to lookup groups containing: %s. Reason: %s", group.getKey(), e.getMessage() ),
+                              e );
+            }
+        } );
+
+        nextGroups.removeAll( groups );
 
         clearIndexedPathFrom( path, nextGroups, pathConsumer );
     }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexObserver.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexObserver.java
@@ -209,6 +209,7 @@ public class ContentIndexObserver
         }
     }
 
+    // TODO: If we find points where a new HostedRepository is added, we should be using its comprehensive index to minimize the index damage to the group.
     private void removeAllSupercededMemberContent( ArtifactStore store, Map<ArtifactStore, ArtifactStore> changeMap )
     {
         Logger logger = LoggerFactory.getLogger( getClass() );

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
@@ -17,8 +17,10 @@ package org.commonjava.indy.content.index;
 
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -28,24 +30,24 @@ import java.io.ObjectOutput;
 /**
  * Created by jdcasey on 3/15/16.
  */
-@Indexed
+@Indexed(index = "indexedStorePath")
 public class IndexedStorePath
         implements Externalizable
 {
 
-    @Field
+    @Field( name = "storeType", store = Store.YES, analyze = Analyze.NO )
     private StoreType storeType;
 
-    @Field
+    @Field( name = "storeName", store = Store.YES, analyze = Analyze.NO )
     private String storeName;
 
-    @Field
+    @Field( name = "originStoreType", store = Store.YES, analyze = Analyze.NO )
     private StoreType originStoreType;
 
-    @Field
+    @Field( name = "originStoreName", store = Store.YES, analyze = Analyze.NO )
     private String originStoreName;
 
-    @Field
+    @Field( name = "path", store = Store.YES, analyze = Analyze.NO )
     private String path;
 
     public IndexedStorePath( StoreKey storeKey, StoreKey origin, String path )

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
@@ -50,6 +50,14 @@ public class IndexedStorePath
     @Field( name = "path", store = Store.YES, analyze = Analyze.NO )
     private String path;
 
+    public IndexedStorePath( StoreKey storeKey, String path )
+    {
+        this.storeType = storeKey.getType();
+        this.storeName = storeKey.getName();
+
+        this.path = path;
+    }
+
     public IndexedStorePath( StoreKey storeKey, StoreKey origin, String path )
     {
         this.storeType = storeKey.getType();
@@ -119,14 +127,7 @@ public class IndexedStorePath
         {
             return false;
         }
-        if ( originStoreType != that.originStoreType )
-        {
-            return false;
-        }
-        if ( !originStoreName.equals( that.originStoreName ) )
-        {
-            return false;
-        }
+
         return getPath().equals( that.getPath() );
 
     }
@@ -136,8 +137,6 @@ public class IndexedStorePath
     {
         int result = getStoreType().hashCode();
         result = 31 * result + getStoreName().hashCode();
-        result = 31 * result + originStoreType.hashCode();
-        result = 31 * result + originStoreName.hashCode();
         result = 31 * result + getPath().hashCode();
         return result;
     }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
@@ -64,7 +64,7 @@ public abstract class IndexingDirectContentAccessDecorator
         {
             logger.debug( "Got transfer from delegate: {} (will index)", transfer );
 
-            indexManager.indexTransferIn( transfer, store.getKey(), LocationUtils.getKey( transfer ) );
+            indexManager.indexTransferIn( transfer, store.getKey() );
         }
 
         logger.debug( "Returning transfer: {}", transfer );

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.content.index;
 
 import org.commonjava.indy.IndyWorkflowException;

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
@@ -259,10 +259,11 @@ public class FoloAdminController
                     entry.setOriginUrl( remoteUrl );
 
                     final Map<ContentDigest, String> digests =
-                            contentManager.digest( key, path, ContentDigest.MD5, ContentDigest.SHA_256 );
+                            contentManager.digest( key, path, ContentDigest.MD5, ContentDigest.SHA_1, ContentDigest.SHA_256 );
 
                     entry.setMd5( digests.get( ContentDigest.MD5 ) );
                     entry.setSha256( digests.get( ContentDigest.SHA_256 ) );
+                    entry.setSha1( digests.get( ContentDigest.SHA_1 ) );
 
                     entries.add( entry );
                 }

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
@@ -33,6 +33,8 @@ public class TrackedContentEntryDTO
 
     private String sha256;
 
+    private String sha1;
+
     public TrackedContentEntryDTO()
     {
     }
@@ -83,6 +85,15 @@ public class TrackedContentEntryDTO
         this.sha256 = sha256;
     }
 
+    public void setSha1( String sha1 )
+    {
+        this.sha1 = sha1;
+    }
+
+    public String getSha1()
+    {
+        return sha1;
+    }
     public StoreKey getStoreKey()
     {
         return storeKey;

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentDTOTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.folo.dto;
 
 import org.commonjava.indy.folo.model.TrackingKey;

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTOTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.folo.dto;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -38,10 +53,12 @@ public class TrackedContentEntryDTOTest
         String content = "This is a test string";
         in.setMd5( DigestUtils.md5Hex( content ) );
         in.setSha256( DigestUtils.sha256Hex( content ) );
+        in.setSha1( DigestUtils.shaHex( content ) );
 
         assertRoundTrip( in, (out)->{
             assertThat( out.getMd5(), equalTo( in.getMd5() ) );
             assertThat( out.getSha256(), equalTo( in.getSha256() ) );
+            assertThat( out.getSha1(), equalTo( in.getSha1() ) );
         } );
     }
 

--- a/addons/promote/common/src/main/data/promote/rules/artifact-refs-via.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/artifact-refs-via.groovy
@@ -54,11 +54,11 @@ class ArtifactRefAvailability implements ValidationRule {
                             def target = rel.getTarget()
                             def path = tools.toArtifactPath(target)
                             def txfr = tools.getTransfer(verifyStoreKey, path)
-                            logger.info("{} in {}: {}. Exists? {}", target, verifyStoreKey, txfr, txfr.exists())
-                            if (!txfr.exists()) {
+                            logger.info("{} in {}: {}. Exists? {}", target, verifyStoreKey, txfr, txfr == null ? false : txfr.exists())
+                            if (txfr == null || !txfr.exists()) {
                                 txfr = tools.getTransfer(request.getSource(), path)
-                                logger.info("{} in {}: {}. Exists? {}", target, request.getSource(), txfr, txfr.exists())
-                                if (!txfr.exists()) {
+                                logger.info("{} in {}: {}. Exists? {}", target, request.getSource(), txfr, txfr == null ? false : txfr.exists())
+                                if (txfr == null || !txfr.exists()) {
                                     if (builder.length() > 0) {
                                         builder.append("\n")
                                     }
@@ -69,11 +69,11 @@ class ArtifactRefAvailability implements ValidationRule {
                             if ((target instanceof ArtifactRef) && !pomTC.equals(((ArtifactRef) target).getTypeAndClassifier())) {
                                 path = tools.toArtifactPath(target.asPomArtifact())
                                 txfr = tools.getTransfer(verifyStoreKey, path)
-                                logger.info("POM {} in {}: {}. Exists? {}", target.asPomArtifact(), verifyStoreKey, txfr, txfr.exists())
-                                if (!txfr.exists()) {
+                                logger.info("POM {} in {}: {}. Exists? {}", target.asPomArtifact(), verifyStoreKey, txfr, txfr == null ? false : txfr.exists())
+                                if (txfr == null || !txfr.exists()) {
                                     txfr = tools.getTransfer(request.getSource(), path)
-                                    logger.info("{} in {}: {}. Exists? {}", target, request.getSource(), txfr, txfr.exists())
-                                    if (!txfr.exists()) {
+                                    logger.info("{} in {}: {}. Exists? {}", target, request.getSource(), txfr, txfr == null ? false : txfr.exists())
+                                    if (txfr == null || !txfr.exists()) {
                                         if (builder.length() > 0) {
                                             builder.append("\n")
                                         }

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -332,7 +332,7 @@ public class PromotionManager
             {
                 for ( final Transfer transfer : contents )
                 {
-                    if ( transfer.exists() )
+                    if ( transfer != null && transfer.exists() )
                     {
                         InputStream stream = null;
                         try
@@ -415,7 +415,7 @@ public class PromotionManager
 //                        synchronized ( target )
 //                        {
                             // TODO: Should the request object have an overwrite attribute? Is that something the user is qualified to decide?
-                            if ( target.exists() )
+                            if ( target != null && target.exists() )
                             {
                                 logger.warn( "NOT promoting: {} from: {} to: {}. Target file already exists.", path,
                                              request.getSource(), request.getTarget() );
@@ -479,7 +479,7 @@ public class PromotionManager
         for ( final String path : paths )
         {
             final Transfer txfr = downloadManager.getStorageReference( source, path );
-            if ( !txfr.exists() )
+            if ( txfr == null || !txfr.exists() )
             {
                 logger.warn( "Cannot promote path: '{}' from source: '{}'. It does not exist!", path, source );
                 // TODO: Fail??

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationCatalogDTOTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationCatalogDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.promote.model;
 
 import org.apache.commons.io.IOUtils;

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationResultTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationResultTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.promote.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationRuleDTOTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationRuleDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.promote.model;
 
 import org.apache.commons.io.IOUtils;

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreEnablementEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreEnablementEvent.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.change.event;
 
 import org.commonjava.indy.model.core.ArtifactStore;

--- a/api/src/main/java/org/commonjava/indy/content/ContentDigest.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentDigest.java
@@ -22,7 +22,8 @@ package org.commonjava.indy.content;
 public enum ContentDigest
 {
 
-    MD5, SHA_256( "SHA-256" );
+    MD5, SHA_256( "SHA-256" ),
+    SHA_1 ( "SHA-1" );
 
     private String digestName;
 

--- a/api/src/main/java/org/commonjava/indy/content/ContentManager.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentManager.java
@@ -146,18 +146,18 @@ public interface ContentManager
     Transfer store( final ArtifactStore store , final String path , final InputStream stream , TransferOperation op , EventMetadata eventMetadata  )
         throws IndyWorkflowException;
 
-    /**
-     * Store the content contained in the {@link InputStream} under the given path within the storage directory for first appropriate instance among 
-     * the given {@link ArtifactStore}'s. Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions. 
-     * Return the {@link Transfer} that references the stored content.
-     * <br/>
-     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository}, 
-     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment 
-     * (releases-only for snapshot content, or vice versa), then fail.
-     */
-    Transfer store( final List<? extends ArtifactStore> stores, final String path, final InputStream stream,
-                    TransferOperation op )
-        throws IndyWorkflowException;
+//    /**
+//     * Store the content contained in the {@link InputStream} under the given path within the storage directory for first appropriate instance among
+//     * the given {@link ArtifactStore}'s. Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions.
+//     * Return the {@link Transfer} that references the stored content.
+//     * <br/>
+//     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository},
+//     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment
+//     * (releases-only for snapshot content, or vice versa), then fail.
+//     */
+//    Transfer store( final List<? extends ArtifactStore> stores, final String path, final InputStream stream,
+//                    TransferOperation op )
+//        throws IndyWorkflowException;
 
     /**
      * Store the content contained in the {@link InputStream} under the given path within the storage directory for first appropriate instance among 
@@ -167,10 +167,11 @@ public interface ContentManager
      * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository}, 
      * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment 
      * (releases-only for snapshot content, or vice versa), then fail.
+     * @param topKey
      * @param eventMetadata TODO
      */
-    Transfer store( final List<? extends ArtifactStore> stores , final String path , final InputStream stream ,
-                    TransferOperation op , EventMetadata eventMetadata  )
+    Transfer store( final List<? extends ArtifactStore> stores, StoreKey topKey, final String path, final InputStream stream,
+                    TransferOperation op, EventMetadata eventMetadata )
         throws IndyWorkflowException;
 
     boolean delete( final ArtifactStore store, String path )

--- a/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
+++ b/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.content;
 
 import org.commonjava.indy.IndyWorkflowException;

--- a/api/src/main/java/org/commonjava/indy/util/LocationUtils.java
+++ b/api/src/main/java/org/commonjava/indy/util/LocationUtils.java
@@ -68,6 +68,9 @@ public final class LocationUtils
                 AttributePasswordManager.bind( location, PasswordEntry.PROXY_PASSWORD, repository.getProxyPassword() );
                 AttributePasswordManager.bind( location, PasswordEntry.USER_PASSWORD, repository.getPassword() );
 
+                // for testing purposes only...
+                location.setAttribute( Location.MAX_CONNECTIONS, 30 );
+
                 return location;
             }
         }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -32,7 +32,6 @@ import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.model.galley.KeyedLocation;
 import org.commonjava.indy.util.ApplicationStatus;
-import org.commonjava.maven.galley.TransferLocationException;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
@@ -310,7 +309,7 @@ public class DefaultContentManager
             {
                 final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
 
-                final Transfer txfr = store( allMembers, path, stream, op, eventMetadata );
+                final Transfer txfr = store( allMembers, store.getKey(), path, stream, op, eventMetadata );
                 logger.info( "Stored: {} for group: {} in: {}", path, store.getKey(), txfr );
                 return txfr;
             }
@@ -354,16 +353,16 @@ public class DefaultContentManager
         return txfr;
     }
 
-    @Override
-    public Transfer store( final List<? extends ArtifactStore> stores, final String path, final InputStream stream,
-                           final TransferOperation op )
-            throws IndyWorkflowException
-    {
-        return store( stores, path, stream, op, new EventMetadata() );
-    }
+//    @Override
+//    public Transfer store( final List<? extends ArtifactStore> stores, final String path, final InputStream stream,
+//                           final TransferOperation op )
+//            throws IndyWorkflowException
+//    {
+//        return store( stores, path, stream, op, new EventMetadata() );
+//    }
 
     @Override
-    public Transfer store( final List<? extends ArtifactStore> stores, final String path, final InputStream stream,
+    public Transfer store( final List<? extends ArtifactStore> stores, StoreKey topKey, final String path, final InputStream stream,
                            final TransferOperation op, final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.core.content;
 
 import org.commonjava.indy.IndyWorkflowException;

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -223,8 +223,11 @@ public class MemoryStoreDataManager
     public Set<Group> getGroupsContaining( final StoreKey repo )
             throws IndyDataException
     {
-        Set<Group> groups = reverseGroupMemberships.get( repo );
-        return groups == null ? Collections.emptySet() : Collections.unmodifiableSet( groups );
+        synchronized ( StoreKey.dedupe( repo ) )
+        {
+            Set<Group> groups = reverseGroupMemberships.get( repo );
+            return groups == null ? Collections.emptySet() : Collections.unmodifiableSet( new HashSet<>( groups ) );
+        }
     }
 
     private boolean groupContains( final Group g, final StoreKey key )

--- a/embedders/savant/pom.xml
+++ b/embedders/savant/pom.xml
@@ -200,11 +200,6 @@
     <profile>
       <id>run-its</id>
 
-<!--       <properties>
-        <skipTests>false</skipTests>
-        <test>org.commonjava.indy.promote.ftest.GroupPromoteAndRollbackTest</test>
-      </properties>
- -->      
       <build>
         <pluginManagement>
           <plugins>
@@ -217,6 +212,10 @@
                   <forkCount>${test-forkCount}</forkCount>
                   <reuseForks>false</reuseForks>
                   <redirectTestOutputToFile>${test-redirectOutput}</redirectTestOutputToFile>
+
+                  <!-- <test>org.commonjava.indy.ftest.core.content.StoreAndVerifyJarViaDirectDownloadTest</test> -->
+
+
                   <dependenciesToScan>
                     <dependency>org.commonjava.indy:indy-ftests-core</dependency>
                     <dependency>org.commonjava.indy:indy-ftests-autoprox</dependency>

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -29,6 +29,7 @@ import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProviderConfig;
 import org.commonjava.maven.galley.io.ChecksummingTransferDecorator;
 import org.commonjava.maven.galley.io.checksum.Md5GeneratorFactory;
 import org.commonjava.maven.galley.io.checksum.Sha1GeneratorFactory;
+import org.commonjava.maven.galley.io.checksum.Sha256GeneratorFactory;
 import org.commonjava.maven.galley.model.FilePatternMatcher;
 import org.commonjava.maven.galley.model.SpecialPathInfo;
 import org.commonjava.maven.galley.model.TransferOperation;
@@ -85,7 +86,8 @@ public class DefaultGalleyStorageProvider
         transferDecorator =
             new ChecksummingTransferDecorator( Collections.singleton( TransferOperation.GENERATE ), specialPathManager,
                                                new Md5GeneratorFactory(),
-                                               new Sha1GeneratorFactory() );
+                                               new Sha1GeneratorFactory(),
+                                               new Sha256GeneratorFactory() );
         transferDecorator = new ContentsFilteringTransferDecorator( transferDecorator );
 
         final PartyLineCacheProviderConfig cacheProviderConfig =

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/fixture/IDETestProvider.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/fixture/IDETestProvider.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.ftest.core.fixture;
 
 import org.commonjava.indy.conf.IndyConfiguration;

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataPassthroughTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataPassthroughTimeoutWorkingTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.ftest.core.content;
 
 import org.commonjava.indy.model.core.RemoteRepository;

--- a/ftests/core/src/test/java/org/commonjava/indy/ftest/core/fixture/TestProvider.java
+++ b/ftests/core/src/test/java/org/commonjava/indy/ftest/core/fixture/TestProvider.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.ftest.core.fixture;
 
 import org.commonjava.indy.conf.IndyConfiguration;

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/DirectoryListingDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/DirectoryListingDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.model.core.dto;
 
 import org.commonjava.indy.model.core.StoreKey;

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/DirectoryListingEntryDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/DirectoryListingEntryDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.model.core.dto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/EndpointViewListingTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/EndpointViewListingTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.model.core.dto;
 
 import org.commonjava.indy.model.core.RemoteRepository;

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/NotFoundCacheDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/NotFoundCacheDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.model.core.dto;
 
 import org.commonjava.indy.model.core.StoreKey;

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/NotFoundCacheSectionDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/NotFoundCacheSectionDTOTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.model.core.dto;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <infinispan
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="urn:infinispan:config:8.1 http://www.infinispan.org/schemas/infinispan-config-8.1.xsd"
-    xmlns="urn:infinispan:config:8.1">
+    xsi:schemaLocation="urn:infinispan:config:8.2 http://www.infinispan.org/schemas/infinispan-config-8.2.xsd"
+    xmlns="urn:infinispan:config:8.2">
 
   <cache-container default-cache="dont-use" name="IndyCacheManager" shutdown-hook="DEFAULT">
-    <local-cache name="folo-in-progress">
+    <local-cache name="folo-in-progress" >
       <eviction size="100000" type="COUNT"/>
       <persistence passivation="false">
         <file-store purge="false" read-only="false" fetch-state="true" path="${indy.work}/folo-in-progress">
           <write-behind/>
         </file-store>
       </persistence>
-      <indexing index="ALL"/>
     </local-cache>
 
     <local-cache name="folo-sealed">
@@ -20,7 +19,11 @@
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/folo"/>
       </persistence>
-      <indexing auto-config="true"/>
+      <indexing index="ALL">
+        <indexed-entities>
+          <indexed-entity>org.commonjava.indy.folo.data.idxmodel.AffectedStoreRecordKey</indexed-entity>
+        </indexed-entities>
+      </indexing>
     </local-cache>
     
     <local-cache name="content-index">
@@ -30,9 +33,42 @@
           <write-behind/>
         </file-store>
       </persistence>
-      <indexing index="ALL"/>
+      <indexing index="LOCAL">
+        <property name="default.directory_provider">infinispan</property>
+        <property name="default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
+        <property name="default.metadata_cachename">content-idx-lucene-metadata</property>
+        <property name="default.data_cachename">content-idx-lucene-data</property>
+        <property name="default.locking_cachename">content-idx-lucene-locks</property>
+        <indexed-entities>
+          <indexed-entity>org.commonjava.indy.content.index.IndexedStorePath</indexed-entity>
+        </indexed-entities>
+      </indexing>
     </local-cache>
-    
+
+    <local-cache name="content-index-lucene-metadata">
+      <eviction size="1000000" type="COUNT"/>
+      <persistence passivation="true">
+        <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/metadata">
+          <write-behind/>
+        </file-store>
+      </persistence>
+    </local-cache>
+    <local-cache name="content-index-lucene-data">
+      <eviction size="1000000" type="COUNT"/>
+      <persistence passivation="true">
+        <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/data">
+          <write-behind/>
+        </file-store>
+      </persistence>
+    </local-cache>
+    <local-cache name="content-index-lucene-locks">
+      <eviction size="1000000" type="COUNT"/>
+      <persistence passivation="true">
+        <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/locks">
+          <write-behind/>
+        </file-store>
+      </persistence>
+    </local-cache>
     <!-- <local-cache name="fs-storage-metadata">
       <locking isolation="READ_COMMITTED"/>
       <eviction max-entries="100000" type="COUNT"/>


### PR DESCRIPTION
* fixed StackOverflowException in list() (had to do with content index maintenance)
* fixed a couple of ConcurrentModificationExceptions, in ContentIndexManager and MemoryStoreDataManager
* fixed Infinispan complaints about no indexable entities (blah, blah, blah...it's such a whiner)
* MAJOR revamp to content indexing to optimize downloads and group-content searches when lots of hosted repos are present (treating hosted repos as fully indexed, because store() maintains the index)...we need to revisit this for hosted repos with pre-existing content (defining the repo around the content)