### PR TITLE
Fix scheduler timeouts

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/EventTypeMatcher.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/EventTypeMatcher.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.expire;
+
+import org.quartz.TriggerKey;
+import org.quartz.impl.matchers.GroupMatcher;
+
+public class EventTypeMatcher
+    extends GroupMatcher<TriggerKey>
+{
+
+    private static final long serialVersionUID = 1L;
+
+    public EventTypeMatcher( final String eventType )
+    {
+        super( ScheduleManager.groupNameSuffix( eventType ), StringOperatorName.ENDS_WITH );
+    }
+
+}


### PR DESCRIPTION
- remove trigger unscheduling, because even when a trigger is
  unscheduled job is still present in the DB and when a new trigger got
  scheduled it failed with ObjectAlreadyExistsException. It is better
  to use scheduleJob method with replace=true. It performs all needed
  cleanup if necessary, creates the job when missing and schedules the
  new trigger set.
```
04:29:33.160 [indy-event-dispatch-0] ERROR o.c.i.c.expire.TimeoutEventListener - Failed to set proxy-cache timeouts related to: RepositoryLocation [remote:test-repo]:junit/junit/maven-metadata.xml
org.commonjava.indy.core.expire.IndySchedulerException: Failed to schedule content-expiration job.
	at org.commonjava.indy.core.expire.ScheduleManager.scheduleForStore(ScheduleManager.java:351) ~[indy-embedder-savant-0.99.3-SNAPSHOT.jar:na]
	at org.commonjava.indy.core.expire.ScheduleManager.scheduleContentExpiration(ScheduleManager.java:365) ~[indy-embedder-savant-0.99.3-SNAPSHOT.jar:na]
	at org.commonjava.indy.core.expire.ScheduleManager.setProxyTimeouts(ScheduleManager.java:284) ~[indy-embedder-savant-0.99.3-SNAPSHOT.jar:na]
	at org.commonjava.indy.core.expire.ScheduleManager$Proxy$_$$_WeldClientProxy.setProxyTimeouts(Unknown Source) ~[indy-embedder-savant-0.99.3-SNAPSHOT.jar:na]
	at org.commonjava.indy.core.expire.TimeoutEventListener.onFileAccessEvent(TimeoutEventListener.java:192) ~[indy-embedder-savant-0.99.3-SNAPSHOT.jar:na]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_91]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_91]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_91]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_91]
	at org.jboss.weld.injection.MethodInjectionPoint.invokeOnInstanceWithSpecialValue(MethodInjectionPoint.java:93) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:266) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.jboss.weld.event.ObserverMethodImpl.sendEvent(ObserverMethodImpl.java:253) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.jboss.weld.event.ObserverMethodImpl.notify(ObserverMethodImpl.java:232) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.jboss.weld.event.ObserverNotifier.notifyObserver(ObserverNotifier.java:169) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.jboss.weld.event.ObserverNotifier.notifyObserver(ObserverNotifier.java:165) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.jboss.weld.event.ObserverNotifier.notifyObservers(ObserverNotifier.java:119) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.jboss.weld.event.ObserverNotifier.fireEvent(ObserverNotifier.java:112) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.jboss.weld.event.EventImpl.fire(EventImpl.java:83) [weld-se-2.1.2.Final.jar:2014-01-09 09:23]
	at org.commonjava.indy.core.change.event.IndyFileEventManager.lambda$doFire$0(IndyFileEventManager.java:110) [indy-embedder-savant-0.99.3-SNAPSHOT.jar:na]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_91]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_91]
	at java.lang.Thread.run(Thread.java:745) ~[na:1.8.0_91]
Caused by: org.quartz.ObjectAlreadyExistsException: Unable to store Job : 'remote:test-repo:CONTENT.junit/junit/maven-metadata.xml', because one already exists with this identification.
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeJob(JobStoreSupport.java:1108) ~[quartz-2.2.1.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$2.executeVoid(JobStoreSupport.java:1062) ~[quartz-2.2.1.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$VoidTransactionCallback.execute(JobStoreSupport.java:3703) ~[quartz-2.2.1.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$VoidTransactionCallback.execute(JobStoreSupport.java:3701) ~[quartz-2.2.1.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.executeInNonManagedTXLock(JobStoreSupport.java:3787) ~[quartz-2.2.1.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreTX.executeInLock(JobStoreTX.java:93) ~[quartz-2.2.1.jar:na]
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.storeJobAndTrigger(JobStoreSupport.java:1058) ~[quartz-2.2.1.jar:na]
	at org.quartz.core.QuartzScheduler.scheduleJob(QuartzScheduler.java:886) ~[quartz-2.2.1.jar:na]
	at org.quartz.impl.StdScheduler.scheduleJob(StdScheduler.java:249) ~[quartz-2.2.1.jar:na]
	at org.commonjava.indy.core.expire.ScheduleManager.scheduleForStore(ScheduleManager.java:347) ~[indy-embedder-savant-0.99.3-SNAPSHOT.jar:na]
	... 21 common frames omitted
```
- in cancel() rearrange the code to use deleteJob directly, because
  once jobs get uscheduled the trigger cannot be retrieved to get jobKey
  from it. But deleteJob also removes all triggers, so there is no need
  to do this manually before job deletion.
- add EventTypeMatcher to easily identify CONTENT jobs
- use triggerKey to construct jobKey for CONTENT jobs in
  IndySchedulerListener.jobUnscheduled, because trigger does not exist
  anymore at his point, so it cannot be retrieved and used to get
  jobKey from it. This caused errors in the log when a job got triggered like
```
04:29:33.148 [indy-event-dispatch-0] ERROR o.c.i.c.expire.IndyScheduleListener - Cannot find scheduler trigger for key: remote:test-repo:CONTENT.junit/junit/maven-metadata.xml
```