### PR TITLE
reinstate INFO logging for CacheProducer, IndyLifecycleManager, plus minor tweaks

### DIFF
--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleManager.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleManager.java
@@ -230,19 +230,15 @@ public class IndyLifecycleManager
      */
     public Runnable createShutdownRunnable()
     {
-        return new Runnable()
+        return ()->
         {
-            @Override
-            public void run()
+            try
             {
-                try
-                {
-                    stop();
-                }
-                catch ( final IndyLifecycleException e )
-                {
-                    throw new RuntimeException( "\n\nFailed to stop Indy: " + e.getMessage(), e );
-                }
+                stop();
+            }
+            catch ( final IndyLifecycleException e )
+            {
+                throw new RuntimeException( "\n\nFailed to stop Indy: " + e.getMessage(), e );
             }
         };
     }

--- a/deployments/launchers/savant/src/main/etc/indy/logging/logback.xml
+++ b/deployments/launchers/savant/src/main/etc/indy/logging/logback.xml
@@ -50,6 +50,8 @@
   -->
   
   <logger name="org.commonjava" level="WARN" />
+  <logger name="org.commonjava.indy.action.IndyLifecycleManager" level="INFO" />
+  <logger name="org.commonjava.indy.subsys.infinispan.inject.CacheProducer" level="INFO" />
 
   <!-- <logger name="org.commonjava.maven.galley.transport" level="DEBUG" /> -->
 

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -9,7 +9,7 @@
       <eviction size="100000" type="COUNT"/>
       <persistence passivation="false">
         <file-store purge="false" read-only="false" fetch-state="true" path="${indy.work}/folo-in-progress">
-          <write-behind/>
+          <!--<write-behind/>-->
         </file-store>
       </persistence>
     </local-cache>
@@ -27,10 +27,10 @@
     </local-cache>
     
     <local-cache name="content-index">
-      <eviction size="1000000" type="COUNT"/>
+      <eviction size="10000" type="COUNT"/>
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index">
-          <write-behind/>
+          <!--<write-behind/>-->
         </file-store>
       </persistence>
       <indexing index="LOCAL">
@@ -46,26 +46,26 @@
     </local-cache>
 
     <local-cache name="content-index-lucene-metadata">
-      <eviction size="1000000" type="COUNT"/>
+      <eviction size="10000" type="COUNT"/>
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/metadata">
-          <write-behind/>
+          <!--<write-behind/>-->
         </file-store>
       </persistence>
     </local-cache>
     <local-cache name="content-index-lucene-data">
-      <eviction size="1000000" type="COUNT"/>
+      <eviction size="10000" type="COUNT"/>
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/data">
-          <write-behind/>
+          <!--<write-behind/>-->
         </file-store>
       </persistence>
     </local-cache>
     <local-cache name="content-index-lucene-locks">
-      <eviction size="1000000" type="COUNT"/>
+      <eviction size="10000" type="COUNT"/>
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/locks">
-          <write-behind/>
+          <!--<write-behind/>-->
         </file-store>
       </persistence>
     </local-cache>


### PR DESCRIPTION
also:

* Make CacheProducer implement ShutdownAction so it gets stopped in an orderly fashion during Indy shutdown
* Try to force infinispan cache to persist to disk for content indexing (doesn't do it yet).