### PR TITLE
Change httprox.secured default value to false

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/conf/HttproxConfig.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/conf/HttproxConfig.java
@@ -35,7 +35,7 @@ public class HttproxConfig
 
     private static final String DEFAULT_PROXY_REALM = "httprox";
 
-    private static final boolean DEFAULT_SECURED = true;
+    private static final boolean DEFAULT_SECURED = false;
 
     private static final String DEFAULT_TRACKING_TYPE = TrackingType.SUFFIX.name();
 


### PR DESCRIPTION
...to provide the same default experience for both maven repositories
and general proxy.

This was requested as NCL-1901.