### PR TITLE
use md5 digests for IndexStorePath fields to make it smaller

### DIFF
--- a/addons/content-index/pom.xml
+++ b/addons/content-index/pom.xml
@@ -55,7 +55,12 @@
       <groupId>org.commonjava.util</groupId>
       <artifactId>configuration-api</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexObserver.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexObserver.java
@@ -272,8 +272,8 @@ public class ContentIndexObserver
                 final StoreKey key = store.getKey();
 
                 Set<String> paths = new HashSet<>();
-                indexManager.removeAllIndexedPathsForStore( key, indexedStorePath ->{paths.add(indexedStorePath.getPath());} );
-                indexManager.removeAllOriginIndexedPathsForStore( key, indexedStorePath ->{paths.add(indexedStorePath.getPath());} );
+                indexManager.removeAllIndexedPathsForStore( key, indexedStorePath ->{paths.add(indexedStorePath.getPathHash());} );
+                indexManager.removeAllOriginIndexedPathsForStore( key, indexedStorePath ->{paths.add(indexedStorePath.getPathHash());} );
 
                 if ( !paths.isEmpty() )
                 {
@@ -306,7 +306,7 @@ public class ContentIndexObserver
         executor.execute( ()->{
             Map<StoreKey, Set<Group>> containersForKey = new HashMap<>();
             removals.forEach( indexedStorePath -> {
-                StoreKey storeKey = indexedStorePath.getStoreKey();
+                StoreKey storeKey = StoreKey.getByHash( indexedStorePath.getStoreHash() );
                 try
                 {
                     ArtifactStore store = storeDataManager.getArtifactStore( storeKey );
@@ -318,7 +318,7 @@ public class ContentIndexObserver
                     }
 
                     Location location = LocationUtils.toLocation( store );
-                    String path = indexedStorePath.getPath();
+                    String path = indexedStorePath.getPathHash();
 
                     // If the file is stored local to the group, it's merged and must die.
                     indexManager.clearIndexedPathFrom( path, groups, deleteTransfers() );
@@ -356,8 +356,8 @@ public class ContentIndexObserver
     private Consumer<IndexedStorePath> deleteTransfers()
     {
         return isp ->{
-            StoreKey key = isp.getStoreKey();
-            String path = isp.getPath();
+            StoreKey key = StoreKey.getByHash( isp.getStoreHash() );
+            String path = isp.getPathHash();
 
             try
             {

--- a/addons/content-index/src/test/java/org/commonjava/indy/content/index/DigestTest.java
+++ b/addons/content-index/src/test/java/org/commonjava/indy/content/index/DigestTest.java
@@ -1,0 +1,44 @@
+package org.commonjava.indy.content.index;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+/**
+ * Created by jdcasey on 5/7/16.
+ */
+public class DigestTest
+{
+    @Test
+    public void sha1VsMd5VsUtf8VsStringLengths()
+    {
+        String p1 =
+                "/org/commonjava/indy/launch/indy-launcher-savant/0.99.3/indy-launcher-savant-0.99.3-launcher.tar.gz";
+        String p2 = "/org/commonjava/commonjava/10/commonjava-10.pom";
+
+        String p3 = "remote:central";
+
+        Stream.of( p1, p2, p3 ).forEach( ( path)->
+        {
+            try
+            {
+                byte[] raw = path.getBytes( "UTF-8" );
+                byte[] sha1 = DigestUtils.sha( path );
+                byte[] md5 = DigestUtils.md5( path );
+
+                System.out.printf( "%s\n    Raw length: %s, byte length: %s, SHA1 length: %s, MD5 length: %s\n\n", path, path.length(), raw.length,
+                                   sha1.length, md5.length );
+            }
+            catch ( UnsupportedEncodingException e )
+            {
+                e.printStackTrace();
+                Assert.fail( "Failed to test digest lengths for: '" + path + "'" );
+            }
+        });
+    }
+
+}

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/SettingsTemplate.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/SettingsTemplate.java
@@ -123,7 +123,7 @@ public class SettingsTemplate
         }
         catch ( final IndyGroovyException e )
         {
-            throw new WebdavException( String.format( "Failed to render settings.xml template for: '%s'. Reason: %s",
+            throw new WebdavException( String.format( "Failed to renderString settings.xml template for: '%s'. Reason: %s",
                                                       key, e.getMessage() ), e );
         }
     }

--- a/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackSettingsManager.java
+++ b/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackSettingsManager.java
@@ -275,7 +275,7 @@ public class SetBackSettingsManager
         }
         catch ( final IndyGroovyException e )
         {
-            throw new SetBackDataException( "Failed to render template: %s for store: %s. Reason: %s", e, TEMPLATE,
+            throw new SetBackDataException( "Failed to renderString template: %s for store: %s. Reason: %s", e, TEMPLATE,
                                             key, e.getMessage() );
         }
 

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -127,14 +127,14 @@ public interface StoreDataManager
 
     /**
      * Store a modified or new {@link ArtifactStore} instance. This is equivalent to 
-     * {@link StoreDataManager#storeArtifactStore(ArtifactStore, boolean)} with skip flag <code>false</code>
+     * StoreDataManager.storeArtifactStore(ArtifactStore, boolean) with skip flag <code>false</code>
      */
     boolean storeArtifactStore( ArtifactStore key, final ChangeSummary summary )
         throws IndyDataException;
 
     /**
      * Store a modified or new {@link ArtifactStore} instance. This is equivalent to 
-     * {@link StoreDataManager#storeArtifactStore(ArtifactStore, boolean, EventMetadata)} with skip flag <code>false</code>
+     * StoreDataManager.storeArtifactStore(ArtifactStore, boolean, EventMetadata) with skip flag <code>false</code>
      * @param eventMetadata TODO
      */
     boolean storeArtifactStore( ArtifactStore key , final ChangeSummary summary , EventMetadata eventMetadata  )

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -240,7 +240,7 @@ public class ContentAccessHandler
             }
             catch ( final IndyWorkflowException e )
             {
-                logger.error( String.format( "Failed to render content listing: %s from: %s. Reason: %s", path, name,
+                logger.error( String.format( "Failed to renderString content listing: %s from: %s. Reason: %s", path, name,
                                              e.getMessage() ), e );
                 response = formatResponse( e );
             }
@@ -271,7 +271,7 @@ public class ContentAccessHandler
                     catch ( final IndyWorkflowException | IOException e )
                     {
                         logger.error(
-                                String.format( "Failed to render content listing: %s from: %s. Reason: %s", path, name,
+                                String.format( "Failed to renderString content listing: %s from: %s. Reason: %s", path, name,
                                                e.getMessage() ), e );
                         response = formatResponse( e );
                     }

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -292,7 +292,7 @@ public class ContentController
             }
             catch ( final JsonProcessingException e )
             {
-                throw new IndyWorkflowException( "Failed to render listing to JSON: %s. Reason: %s", e, dto,
+                throw new IndyWorkflowException( "Failed to renderString listing to JSON: %s. Reason: %s", e, dto,
                                                   e.getMessage() );
             }
         }
@@ -397,7 +397,7 @@ public class ContentController
         params.put( "baseUrl", serviceUrl );
         params.put( "sources", sources );
 
-        // render...
+        // renderString...
         try
         {
             return templates.render( acceptHeader, "directory-listing", params );

--- a/core/src/main/java/org/commonjava/indy/core/ctl/StatsController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/StatsController.java
@@ -213,12 +213,12 @@ public class StatsController
         }
         catch ( final IndyGroovyException e )
         {
-            throw new IndyWorkflowException( "Failed to render javascript wrapper for active addons. Reason: %s", e,
+            throw new IndyWorkflowException( "Failed to renderString javascript wrapper for active addons. Reason: %s", e,
                                               e.getMessage() );
         }
         catch ( final JsonProcessingException e )
         {
-            throw new IndyWorkflowException( "Failed to render javascript wrapper for active addons. Reason: %s", e,
+            throw new IndyWorkflowException( "Failed to renderString javascript wrapper for active addons. Reason: %s", e,
                                               e.getMessage() );
         }
     }

--- a/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/TemplatingEngine.java
+++ b/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/TemplatingEngine.java
@@ -76,7 +76,7 @@ public class TemplatingEngine
         }
         catch ( final IOException e )
         {
-            throw new IndyGroovyException( "Failed to render template: %s for accept: %s. Reason: %s", e, templateKey,
+            throw new IndyGroovyException( "Failed to renderString template: %s for accept: %s. Reason: %s", e, templateKey,
                                             acceptHeader, e.getMessage() );
         }
 


### PR DESCRIPTION
hopefully this will shrink the memory requirement for content indexing.