### PR TITLE
Fix handling of mergable content

### DIFF
--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecorator.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecorator.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.indy.autoprox.data;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.decorator.Decorator;
@@ -148,7 +147,7 @@ public abstract class AutoProxDataManagerDecorator
     }
 
     /**
-     * Validates the remote connection, produced from rule-set for given name, 
+     * Validates the remote connection, produced from rule-set for given name,
      * for a remote repo or group containing a remote. If:
      *
      * <ul>
@@ -350,19 +349,19 @@ public abstract class AutoProxDataManagerDecorator
     }
 
     @Override
-    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String groupName )
+    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String groupName, final boolean enabledOnly )
             throws IndyDataException
     {
         getGroup( groupName );
-        return dataManager.getOrderedConcreteStoresInGroup( groupName );
+        return dataManager.getOrderedConcreteStoresInGroup( groupName, enabledOnly );
     }
 
     @Override
-    public List<ArtifactStore> getOrderedStoresInGroup( final String groupName )
+    public List<ArtifactStore> getOrderedStoresInGroup( final String groupName, final boolean enabledOnly )
             throws IndyDataException
     {
         getGroup( groupName );
-        return dataManager.getOrderedStoresInGroup( groupName );
+        return dataManager.getOrderedStoresInGroup( groupName, enabledOnly );
     }
 
     @Override

--- a/addons/autoprox/common/src/test/java/org/commonjava/indy/autoprox/fixture/TestAutoProxyDataManager.java
+++ b/addons/autoprox/common/src/test/java/org/commonjava/indy/autoprox/fixture/TestAutoProxyDataManager.java
@@ -89,17 +89,17 @@ public class TestAutoProxyDataManager
     }
 
     @Override
-    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String groupName )
+    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String groupName, final boolean enabledOnly )
         throws IndyDataException
     {
-        return delegate.getOrderedConcreteStoresInGroup( groupName );
+        return delegate.getOrderedConcreteStoresInGroup( groupName, enabledOnly );
     }
 
     @Override
-    public List<ArtifactStore> getOrderedStoresInGroup( final String groupName )
+    public List<ArtifactStore> getOrderedStoresInGroup( final String groupName, final boolean enabledOnly )
         throws IndyDataException
     {
-        return delegate.getOrderedStoresInGroup( groupName );
+        return delegate.getOrderedStoresInGroup( groupName, enabledOnly );
     }
 
     @Override

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -96,6 +96,21 @@ public class ContentIndexManager
         Logger logger = LoggerFactory.getLogger( getClass() );
 
         // invalidate indexes for the store itself
+        List<IndexedStorePath> paths = getAllIndexedPathsForStore( key );
+        paths.forEach( ( indexedStorePath ) -> {
+            logger.debug( "Removing: {}", indexedStorePath );
+            contentIndex.remove( indexedStorePath );
+            if ( pathConsumer != null )
+            {
+                pathConsumer.accept( indexedStorePath );
+            }
+        } );
+
+        return paths;
+    }
+
+    public List<IndexedStorePath> getAllIndexedPathsForStore( StoreKey key )
+    {
         QueryFactory queryFactory = Search.getQueryFactory( contentIndex );
         QueryBuilder<Query> queryBuilder = queryFactory.from( IndexedStorePath.class )
                                                        .having( "storeType" )
@@ -106,15 +121,6 @@ public class ContentIndexManager
                                                        .toBuilder();
 
         List<IndexedStorePath> paths = queryBuilder.build().list();
-        paths.forEach( ( indexedStorePath ) -> {
-            logger.debug( "Removing: {}", indexedStorePath );
-            contentIndex.remove( indexedStorePath );
-            if ( pathConsumer != null )
-            {
-                pathConsumer.accept( indexedStorePath );
-            }
-        } );
-
         return paths;
     }
 

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/data/StorageAdvisor.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/data/StorageAdvisor.java
@@ -55,7 +55,7 @@ public class StorageAdvisor
                 List<ArtifactStore> constituents;
                 try
                 {
-                    constituents = dataManager.getOrderedConcreteStoresInGroup( store.getName() );
+                    constituents = dataManager.getOrderedConcreteStoresInGroup( store.getName(), false );
                 }
                 catch ( final IndyDataException e )
                 {

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/ArtifactStoreSubStore.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/ArtifactStoreSubStore.java
@@ -182,7 +182,7 @@ public class ArtifactStoreSubStore
         {
             if ( StoreType.group == key.getType() )
             {
-                final List<ArtifactStore> stores = indy.getOrderedStoresInGroup( key.getName() );
+                final List<ArtifactStore> stores = indy.getOrderedStoresInGroup( key.getName(), false );
                 for ( final ArtifactStore store : stores )
                 {
                     //                    logger.info( "Getting Transfer for: {} from: {}", path, store );
@@ -284,7 +284,7 @@ public class ArtifactStoreSubStore
             {
                 if ( StoreType.group == key.getType() )
                 {
-                    final List<ArtifactStore> stores = indy.getOrderedStoresInGroup( key.getName() );
+                    final List<ArtifactStore> stores = indy.getOrderedStoresInGroup( key.getName(), false );
                     final Set<String> noms = new TreeSet<String>();
                     for ( final ArtifactStore store : stores )
                     {

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -460,13 +460,13 @@ public class PromotionValidationTools
     public List<ArtifactStore> getOrderedConcreteStoresInGroup( String groupName )
             throws IndyDataException
     {
-        return storeDataManager.getOrderedConcreteStoresInGroup( groupName );
+        return storeDataManager.getOrderedConcreteStoresInGroup( groupName, false );
     }
 
     public List<ArtifactStore> getOrderedStoresInGroup( String groupName )
             throws IndyDataException
     {
-        return storeDataManager.getOrderedStoresInGroup( groupName );
+        return storeDataManager.getOrderedStoresInGroup( groupName, false );
     }
 
     public Set<Group> getGroupsContaining( StoreKey repo )

--- a/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackSettingsManager.java
+++ b/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackSettingsManager.java
@@ -228,7 +228,7 @@ public class SetBackSettingsManager
         List<ArtifactStore> concreteStores;
         try
         {
-            concreteStores = storeManager.getOrderedConcreteStoresInGroup( group.getName() );
+            concreteStores = storeManager.getOrderedConcreteStoresInGroup( group.getName(), false );
         }
         catch ( final IndyDataException e )
         {

--- a/api/src/main/java/org/commonjava/indy/content/IndyLocationExpander.java
+++ b/api/src/main/java/org/commonjava/indy/content/IndyLocationExpander.java
@@ -93,7 +93,7 @@ public class IndyLocationExpander
                 {
                     logger.debug( "Expanding group: {}", gl.getKey() );
                     final List<ArtifactStore> members = data.getOrderedConcreteStoresInGroup( gl.getKey()
-                                                                                                .getName() );
+                                                                                                .getName(), false );
                     if ( members != null )
                     {
                         for ( final ArtifactStore member : members )

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -56,7 +56,7 @@ public interface StoreDataManager
         throws IndyDataException;
 
     /**
-     * Return the {@link ArtifactStore} instance corresponding to the given key, where key is a composite of {@link StoreType} 
+     * Return the {@link ArtifactStore} instance corresponding to the given key, where key is a composite of {@link StoreType}
      * (hosted, remote, or group) and name.
      */
     ArtifactStore getArtifactStore( StoreKey key )
@@ -105,8 +105,10 @@ public interface StoreDataManager
      * <b>NOTE:</b> If any of the group's members are themselves {@link Group}'s, the method
      * recurses and substitutes that group's place in the list with the ordered, concrete stores
      * it contains.
+     *
+     * @param enabledOnly include only enabled stores
      */
-    List<ArtifactStore> getOrderedConcreteStoresInGroup( final String groupName )
+    List<ArtifactStore> getOrderedConcreteStoresInGroup( final String groupName, boolean enabledOnly )
         throws IndyDataException;
 
     /**
@@ -115,8 +117,10 @@ public interface StoreDataManager
      * <br/>
      * <b>NOTE:</b> This method does <b>not</b> perform recursion to substitute concrete stores in place
      * of any groups in the list. Groups that are members are returned along with the rest of the membership.
+     *
+     * @param enabledOnly include only enabled stores
      */
-    List<ArtifactStore> getOrderedStoresInGroup( final String groupName )
+    List<ArtifactStore> getOrderedStoresInGroup( final String groupName, boolean enabledOnly )
         throws IndyDataException;
 
     /**
@@ -126,14 +130,14 @@ public interface StoreDataManager
         throws IndyDataException;
 
     /**
-     * Store a modified or new {@link ArtifactStore} instance. This is equivalent to 
+     * Store a modified or new {@link ArtifactStore} instance. This is equivalent to
      * {@link StoreDataManager#storeArtifactStore(ArtifactStore, boolean)} with skip flag <code>false</code>
      */
     boolean storeArtifactStore( ArtifactStore key, final ChangeSummary summary )
         throws IndyDataException;
 
     /**
-     * Store a modified or new {@link ArtifactStore} instance. This is equivalent to 
+     * Store a modified or new {@link ArtifactStore} instance. This is equivalent to
      * {@link StoreDataManager#storeArtifactStore(ArtifactStore, boolean, EventMetadata)} with skip flag <code>false</code>
      * @param eventMetadata TODO
      */

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -32,9 +32,12 @@ import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.model.galley.KeyedLocation;
 import org.commonjava.indy.util.ApplicationStatus;
+import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.SpecialPathInfo;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,6 +75,9 @@ public class DefaultContentManager
 
     @Inject
     private DownloadManager downloadManager;
+
+    @Inject
+    private SpecialPathManager specialPathManager;
 
     @Inject
     private IndyObjectMapper mapper;
@@ -147,7 +153,7 @@ public class DefaultContentManager
                 List<ArtifactStore> members;
                 try
                 {
-                    members = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
+                    members = storeManager.getOrderedConcreteStoresInGroup( store.getName(), false );
                 }
                 catch ( final IndyDataException e )
                 {
@@ -214,7 +220,7 @@ public class DefaultContentManager
             List<ArtifactStore> members;
             try
             {
-                members = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
+                members = storeManager.getOrderedConcreteStoresInGroup( store.getName(), true );
             }
             catch ( final IndyDataException e )
             {
@@ -307,7 +313,7 @@ public class DefaultContentManager
         {
             try
             {
-                final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
+                final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName(), false );
 
                 final Transfer txfr = store( allMembers, store.getKey(), path, stream, op, eventMetadata );
                 logger.info( "Stored: {} for group: {} in: {}", path, store.getKey(), txfr );
@@ -362,7 +368,7 @@ public class DefaultContentManager
 //    }
 
     @Override
-    public Transfer store( final List<? extends ArtifactStore> stores, StoreKey topKey, final String path, final InputStream stream,
+    public Transfer store( final List<? extends ArtifactStore> stores, final StoreKey topKey, final String path, final InputStream stream,
                            final TransferOperation op, final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {
@@ -409,7 +415,7 @@ public class DefaultContentManager
             List<ArtifactStore> members;
             try
             {
-                members = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
+                members = storeManager.getOrderedConcreteStoresInGroup( store.getName(), false );
             }
             catch ( final IndyDataException e )
             {
@@ -518,7 +524,7 @@ public class DefaultContentManager
             List<ArtifactStore> members;
             try
             {
-                members = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
+                members = storeManager.getOrderedConcreteStoresInGroup( store.getName(), true );
             }
             catch ( final IndyDataException e )
             {
@@ -684,18 +690,23 @@ public class DefaultContentManager
     {
         if ( StoreType.group == store.getKey().getType() )
         {
-            try
+            KeyedLocation location = LocationUtils.toLocation( store );
+            SpecialPathInfo spInfo = specialPathManager.getSpecialPathInfo( location, path );
+            if ( spInfo == null || !spInfo.isMergable() )
             {
-                final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName() );
+                try
+                {
+                    final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName(), true );
 
-                logger.debug( "Trying to retrieve suitable transfer for: {} in group: {} members:\n{}", path, allMembers, store.getName() );
+                    logger.debug( "Trying to retrieve suitable transfer for: {} in group: {} members:\n{}", path, allMembers, store.getName() );
 
-                return getTransfer( allMembers, path, op );
-            }
-            catch ( final IndyDataException e )
-            {
-                throw new IndyWorkflowException( "Failed to lookup concrete members of: %s. Reason: %s", e, store,
-                                                  e.getMessage() );
+                    return getTransfer( allMembers, path, op );
+                }
+                catch ( final IndyDataException e )
+                {
+                    throw new IndyWorkflowException( "Failed to lookup concrete members of: %s. Reason: %s", e, store,
+                                                      e.getMessage() );
+                }
             }
         }
 

--- a/core/src/main/java/org/commonjava/indy/core/ctl/NfcController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/NfcController.java
@@ -87,7 +87,7 @@ public class NfcController
             List<ArtifactStore> stores;
             try
             {
-                stores = storeManager.getOrderedConcreteStoresInGroup( key.getName() );
+                stores = storeManager.getOrderedConcreteStoresInGroup( key.getName(), false );
             }
             catch ( final IndyDataException e )
             {
@@ -153,7 +153,7 @@ public class NfcController
             {
                 case group:
                 {
-                    final List<ArtifactStore> stores = storeManager.getOrderedConcreteStoresInGroup( key.getName() );
+                    final List<ArtifactStore> stores = storeManager.getOrderedConcreteStoresInGroup( key.getName(), false );
                     for ( final ArtifactStore store : stores )
                     {
                         clear( store, path );

--- a/test/db/src/main/java/org/commonjava/indy/core/data/GroupDataManagerTCK.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/GroupDataManagerTCK.java
@@ -158,7 +158,7 @@ public abstract class GroupDataManagerTCK
 
         store( grp );
 
-        final List<? extends ArtifactStore> repos = manager.getOrderedConcreteStoresInGroup( grp.getName() );
+        final List<? extends ArtifactStore> repos = manager.getOrderedConcreteStoresInGroup( grp.getName(), false );
 
         assertThat( repos, notNullValue() );
         assertThat( repos.size(), equalTo( 2 ) );
@@ -180,7 +180,7 @@ public abstract class GroupDataManagerTCK
 
         store( grp );
 
-        final List<? extends ArtifactStore> result = manager.getOrderedConcreteStoresInGroup( grp.getName() );
+        final List<? extends ArtifactStore> result = manager.getOrderedConcreteStoresInGroup( grp.getName(), false );
 
         assertThat( result, notNullValue() );
         assertThat( result.size(), equalTo( 2 ) );


### PR DESCRIPTION
I found out that the mergable content is still not handled correctly
even with the recent fix. It worked for the first download, but the
second was still incorrect.

Initially it was returning the content from the first constituent
containing the requested path. It was caused by automatic indexing of the
file based on FileStorageEvent and FileAccessEvent (and maybe more)
which I tried to avoid in the previous fix. So I fixed the
DefaultContentManager.getTransfer() method by taking mergable flag into
consideration and when it is true it returns transfer instance pointing
directly to the group instead of to one of its constituents.

With this fix it started to return merged content all the time, but it
contained also the part from disabled stores. So I added the possibility
to filter the returned list of constituents of a group to enabled only.
I used it only on 2 places where I was absolutely sure that we don't
want to have disabled in the list and left the rest with default false,
but it may need an update too at several places.