### PR TITLE
Fixing test regression introduced by PR#306, and fixing httprox regression

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
@@ -133,24 +133,30 @@ public class FoloRecordCache
     {
         TrackedContentRecord record = sealedRecordCache.get( key );
 
+        Logger logger = LoggerFactory.getLogger( getClass() );
         if ( record != null )
         {
+            logger.debug( "Tracking record: {} already sealed! Returning sealed record.", key );
             return record;
         }
 
         TrackedContentRecord created = new TrackedContentRecord( key );
 
+        logger.debug( "Listing unsealed tracking record entries for: {}...", key );
         Query query = inProgressByTrackingKey( key ).build();
         List<AffectedStoreRecordKey> results = query.list();
         if ( results != null )
         {
+            logger.debug( "Adding {} entries to record: {}", results.size(), key );
             results.forEach( (result)->{
                 AffectedStoreRecord store = created.getAffectedStore( result.getStoreKey(), true );
                 store.add( result.getPath(), result.getEffect() );
+                logger.debug( "Removing in-progress entry: {}", result );
                 inProgressRecordCache.remove( result );
             });
         }
 
+        logger.debug( "Sealing record for: {}", key );
         sealedRecordCache.put( key, created );
         return created;
     }

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/conf/HttproxConfig.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/conf/HttproxConfig.java
@@ -18,6 +18,8 @@ package org.commonjava.indy.httprox.conf;
 import org.commonjava.indy.conf.IndyConfigInfo;
 import org.commonjava.web.config.annotation.ConfigName;
 import org.commonjava.web.config.annotation.SectionName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
@@ -51,6 +53,8 @@ public class HttproxConfig
 
     public TrackingType getTrackingType()
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.debug( "Using configured tracking type: '{}'", trackingType );
         return TrackingType.valueOf( trackingType == null ? DEFAULT_TRACKING_TYPE : trackingType.toUpperCase() );
     }
 

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyAcceptHandler.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyAcceptHandler.java
@@ -19,6 +19,7 @@ import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.httprox.conf.HttproxConfig;
 import org.commonjava.indy.httprox.keycloak.KeycloakProxyAuthenticator;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.ChannelListener;
@@ -47,15 +48,19 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
     @Inject
     private KeycloakProxyAuthenticator proxyAuthenticator;
 
+    @Inject
+    private CacheProvider cacheProvider;
+
     protected ProxyAcceptHandler(){}
 
     public ProxyAcceptHandler( HttproxConfig config, StoreDataManager storeManager,
-                               ContentController contentController, KeycloakProxyAuthenticator proxyAuthenticator )
+                               ContentController contentController, KeycloakProxyAuthenticator proxyAuthenticator, CacheProvider cacheProvider )
     {
         this.config = config;
         this.storeManager = storeManager;
         this.contentController = contentController;
         this.proxyAuthenticator = proxyAuthenticator;
+        this.cacheProvider = cacheProvider;
     }
 
     @Override
@@ -85,7 +90,7 @@ public class ProxyAcceptHandler implements ChannelListener<AcceptingChannel<Stre
         final ConduitStreamSinkChannel sink = accepted.getSinkChannel();
 
         final ProxyResponseWriter writer =
-                        new ProxyResponseWriter( config, storeManager, contentController, proxyAuthenticator );
+                        new ProxyResponseWriter( config, storeManager, contentController, proxyAuthenticator, cacheProvider );
 
         logger.debug( "Setting writer: {}", writer );
         sink.getWriteSetter()

--- a/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
@@ -148,7 +148,7 @@ public class HttpProxyTest
         final KeycloakProxyAuthenticator auth = new KeycloakProxyAuthenticator( kcConfig, config );
 
         proxy = new HttpProxy( config, bootOpts,
-                               new ProxyAcceptHandler( config, storeManager, contentController, auth ) );
+                               new ProxyAcceptHandler( config, storeManager, contentController, auth, core.getCache() ) );
         proxy.start();
     }
 

--- a/addons/httprox/ftests/pom.xml
+++ b/addons/httprox/ftests/pom.xml
@@ -35,6 +35,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-infinispan</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-client-core-java</artifactId>
     </dependency>
     <dependency>

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AbstractHttproxFunctionalTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AbstractHttproxFunctionalTest.java
@@ -46,7 +46,9 @@ public class AbstractHttproxFunctionalTest
     extends AbstractIndyFunctionalTest
 {
 
-    private static final String HOST = "127.0.0.1";
+    protected static final String HOST = "127.0.0.1";
+
+    protected static final String DEFAULT_BASE_HTTPROX_CONFIG = "[httprox]\nenabled=true\nport=${proxyPort}" ;
 
     protected final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -80,18 +82,31 @@ public class AbstractHttproxFunctionalTest
     {
         proxyPort = PortFinder.findOpenPort( 16 );
 
+        String baseHttproxConfig = getBaseHttproxConfig();
+        if ( isEmpty( baseHttproxConfig ) )
+        {
+            baseHttproxConfig = DEFAULT_BASE_HTTPROX_CONFIG;
+        }
+
+        baseHttproxConfig = baseHttproxConfig.replaceAll( "\\$\\{proxyPort\\}", Integer.toString( proxyPort ) );
+
         String additionalConfig = getAdditionalHttproxConfig();
         if ( additionalConfig == null )
         {
             additionalConfig = "";
         }
 
-        writeConfigFile( "conf.d/httprox.conf", "[httprox]\nenabled=true\nport=" + proxyPort + "\n" + additionalConfig );
+        writeConfigFile( "conf.d/httprox.conf", baseHttproxConfig + "\n" + additionalConfig );
+    }
+
+    protected String getBaseHttproxConfig()
+    {
+        return "";
     }
 
     protected String getAdditionalHttproxConfig()
     {
-        return null;
+        return "";
     }
 
     protected PomRef loadPom( final String name, final Map<String, String> substitutions )

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AbstractHttproxTrackingFunctionalTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AbstractHttproxTrackingFunctionalTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.httprox;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.routing.HttpRoutePlanner;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.commonjava.indy.boot.PortFinder;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.galley.maven.parse.PomPeek;
+import org.commonjava.test.http.TestHttpServer;
+import org.junit.Rule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import static org.junit.Assert.fail;
+
+public class AbstractHttproxTrackingFunctionalTest
+    extends AbstractHttproxFunctionalTest
+{
+
+    @Override
+    protected String getBaseHttproxConfig()
+    {
+        return DEFAULT_BASE_HTTPROX_CONFIG + "\nsecured=true";
+    }
+}

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/ProxyReleasesFileLockOnCompletionTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/ProxyReleasesFileLockOnCompletionTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.httprox;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.commonjava.indy.client.core.helper.HttpResources;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ProxyReleasesFileLockOnCompletionTest
+    extends AbstractHttproxFunctionalTest
+{
+
+    private static final String USER = "user";
+
+    private static final String PASS = "password";
+
+    @Test
+    public void run()
+        throws Exception
+    {
+        final String testRepo = "test";
+        final PomRef pom = loadPom( "simple.pom", Collections.<String, String> emptyMap() );
+        final String url = server.formatUrl( testRepo, pom.path );
+        server.expect( url, 200, pom.pom );
+
+        Stream.of( 1, 2).forEach( (currentTry)->{
+            CloseableHttpResponse response = null;
+            InputStream stream = null;
+            final HttpGet get = new HttpGet( url );
+            CloseableHttpClient client = null;
+            try
+            {
+                client = proxiedHttp();
+
+                response = client.execute( get, proxyContext( USER, PASS ) );
+                stream = response.getEntity()
+                                 .getContent();
+                final String resultingPom = IOUtils.toString( stream );
+
+                assertThat( currentTry + ": retrieved POM was null!", resultingPom, notNullValue() );
+                assertThat( currentTry + ": retrieved POM contains wrong content!", resultingPom, equalTo( pom.pom ) );
+            }
+            catch ( Exception e )
+            {
+                e.printStackTrace();
+                Assert.fail( currentTry + ": Failed to retrieve file: " + url );
+            }
+            finally
+            {
+                IOUtils.closeQuietly( stream );
+                HttpResources.cleanupResources( get, response, client );
+            }
+        } );
+
+        final RemoteRepository remoteRepo = this.client.stores()
+                       .load( StoreType.remote, "httprox_127-0-0-1", RemoteRepository.class );
+
+        assertThat( remoteRepo, notNullValue() );
+        assertThat( remoteRepo.getUrl(), equalTo( server.getBaseUri() ) );
+    }
+
+}

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomInAlwaysOnTrackingReportTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomInAlwaysOnTrackingReportTest.java
@@ -39,7 +39,7 @@ import org.commonjava.indy.model.core.StoreType;
 import org.junit.Test;
 
 public class RetrievedPomInAlwaysOnTrackingReportTest
-    extends AbstractHttproxFunctionalTest
+    extends AbstractHttproxTrackingFunctionalTest
 {
 
     private static final String USER = "user";
@@ -110,7 +110,7 @@ public class RetrievedPomInAlwaysOnTrackingReportTest
     @Override
     protected String getAdditionalHttproxConfig()
     {
-        return "tracking.type=always";
+        return super.getAdditionalHttproxConfig() + "\ntracking.type=always";
     }
 
 }

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomInSuffixTrackingReportTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomInSuffixTrackingReportTest.java
@@ -39,7 +39,7 @@ import org.commonjava.indy.model.core.StoreType;
 import org.junit.Test;
 
 public class RetrievedPomInSuffixTrackingReportTest
-    extends AbstractHttproxFunctionalTest
+    extends AbstractHttproxTrackingFunctionalTest
 {
 
     private static final String USER = "user+tracking";
@@ -110,7 +110,7 @@ public class RetrievedPomInSuffixTrackingReportTest
     @Override
     protected String getAdditionalHttproxConfig()
     {
-        return "tracking.type=suffix";
+        return super.getAdditionalHttproxConfig() + "\ntracking.type=suffix";
     }
 
 }

--- a/addons/httprox/ftests/src/main/resources/META-INF/beans.xml
+++ b/addons/httprox/ftests/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2014 Red Hat, Inc..
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the GNU Public License v3.0
+  which accompanies this distribution, and is available at
+  http://www.gnu.org/licenses/gpl.html
+  
+  Contributors:
+      Red Hat, Inc. - initial API and implementation
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>

--- a/addons/httprox/ftests/src/main/resources/logback.xml
+++ b/addons/httprox/ftests/src/main/resources/logback.xml
@@ -1,0 +1,34 @@
+<!--
+
+    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  
+  <logger name="org.commonjava.util.partyline" level="TRACE" />
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+  
+</configuration>

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -278,9 +278,6 @@ public class ContentAccessHandler
                 }
                 else
                 {
-                    // TODO: Do we need this if the TransferStreamingOutput is triggering an access event??
-                    item.touch( eventMetadata );
-
                     final ResponseBuilder builder = Response.ok( new TransferStreamingOutput( item, eventMetadata ) );
                     setInfoHeaders( builder, item, sk, path, false, contentController.getContentType( path ),
                                     contentController.getHttpMetadata( sk, path ) );

--- a/embedders/savant/pom.xml
+++ b/embedders/savant/pom.xml
@@ -30,6 +30,10 @@
   <name>Indy :: Embedders :: Savant</name>
   <description>REST + Cartographer + DotMaven + Autoprox + Folo + Revisions + SetBack + Infinispan infrastructure</description>
 
+  <properties>
+    <oneTest></oneTest>
+  </properties>
+
 <!--   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -213,7 +217,7 @@
                   <reuseForks>false</reuseForks>
                   <redirectTestOutputToFile>${test-redirectOutput}</redirectTestOutputToFile>
 
-                  <!-- <test>org.commonjava.indy.ftest.core.content.StoreAndVerifyJarViaDirectDownloadTest</test> -->
+                  <test>${oneTest}</test>
 
 
                   <dependenciesToScan>

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -252,4 +252,9 @@ public abstract class AbstractIndyFunctionalTest
         return fixture.getTempFolder();
     }
 
+    protected boolean isEmpty( String val )
+    {
+        return val == null || val.length() < 1;
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <resteasyVersion>3.0.9.Final</resteasyVersion>
     <undertowVersion>1.1.2.Final</undertowVersion>
     <xnioVersion>3.3.0.Final</xnioVersion>
-    <partylineVersion>1.6</partylineVersion>
+    <partylineVersion>1.7-SNAPSHOT</partylineVersion>
     <keycloakVersion>1.2.0.Final</keycloakVersion>
     <jhttpcVersion>1.1</jhttpcVersion>
     

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/CacheProducer.java
@@ -134,7 +134,7 @@ public class CacheProducer
 
     @Produces
     @ApplicationScoped
-    @Production
+//    @Production
     @Default
     public EmbeddedCacheManager getCacheManager()
     {


### PR DESCRIPTION
HTTProx regression was caused by Transfer.touch() waiting for write lock.

This requires rebuild of galley and partyline snapshots.