### PR TITLE
Fix NPE when someone attempts to delete content from a disabled group

### DIFF
--- a/api/src/main/java/org/commonjava/indy/content/DownloadManager.java
+++ b/api/src/main/java/org/commonjava/indy/content/DownloadManager.java
@@ -48,14 +48,14 @@ public interface DownloadManager
     String ROOT_PATH = "/";
 
     /**
-     * Retrieve the content at the given path from the first store possible, then return then return the transfer that references the content without 
+     * Retrieve the content at the given path from the first store possible, then return then return the transfer that references the content without
      * iterating any farther.
      */
     Transfer retrieveFirst( final List<? extends ArtifactStore> stores, final String path )
         throws IndyWorkflowException;
 
     /**
-     * Retrieve the content at the given path from the first store possible, then return then return the transfer that references the content without 
+     * Retrieve the content at the given path from the first store possible, then return then return the transfer that references the content without
      * iterating any farther.
      * @param eventMetadata TODO
      */
@@ -90,11 +90,11 @@ public interface DownloadManager
 
     /**
      * Store the content contained in the {@link InputStream} under the given path within the storage directory for the given {@link ArtifactStore}.
-     * Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions. Return the {@link Transfer} that 
+     * Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions. Return the {@link Transfer} that
      * references the stored content.
      * <br/>
-     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository}, 
-     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment 
+     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository},
+     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment
      * (releases-only for snapshot content, or vice versa), then fail.
      */
     Transfer store( final ArtifactStore store, final String path, final InputStream stream, TransferOperation op )
@@ -102,11 +102,11 @@ public interface DownloadManager
 
     /**
      * Store the content contained in the {@link InputStream} under the given path within the storage directory for the given {@link ArtifactStore}.
-     * Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions. Return the {@link Transfer} that 
+     * Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions. Return the {@link Transfer} that
      * references the stored content.
      * <br/>
-     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository}, 
-     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment 
+     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository},
+     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment
      * (releases-only for snapshot content, or vice versa), then fail.
      * @param eventMetadata TODO
      */
@@ -114,12 +114,12 @@ public interface DownloadManager
         throws IndyWorkflowException;
 
     /**
-     * Store the content contained in the {@link InputStream} under the given path within the storage directory for first appropriate instance among 
-     * the given {@link ArtifactStore}'s. Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions. 
+     * Store the content contained in the {@link InputStream} under the given path within the storage directory for first appropriate instance among
+     * the given {@link ArtifactStore}'s. Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions.
      * Return the {@link Transfer} that references the stored content.
      * <br/>
-     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository}, 
-     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment 
+     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository},
+     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment
      * (releases-only for snapshot content, or vice versa), then fail.
      */
     Transfer store( final List<? extends ArtifactStore> stores, final String path, final InputStream stream,
@@ -127,12 +127,12 @@ public interface DownloadManager
         throws IndyWorkflowException;
 
     /**
-     * Store the content contained in the {@link InputStream} under the given path within the storage directory for first appropriate instance among 
-     * the given {@link ArtifactStore}'s. Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions. 
+     * Store the content contained in the {@link InputStream} under the given path within the storage directory for first appropriate instance among
+     * the given {@link ArtifactStore}'s. Use the given {@link TransferOperation} to trigger the appropriate tangential maintenance, etc. actions.
      * Return the {@link Transfer} that references the stored content.
      * <br/>
-     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository}, 
-     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment 
+     * If the given {@link ArtifactStore} isn't a {@link HostedRepository}, or is a {@link Group} that doesn't contain a {@link HostedRepository},
+     * fail. If the {@link HostedRepository} instances involved don't allow deployment/storage, or don't allow <b>appropriate</b> deployment
      * (releases-only for snapshot content, or vice versa), then fail.
      * @param eventMetadata TODO
      */
@@ -177,13 +177,15 @@ public interface DownloadManager
 
     Transfer getStorageReference( final ArtifactStore store, final String... path );
 
+    Transfer getStorageReference( final ArtifactStore store, final boolean allowDisabled, final String... path );
+
     List<Transfer> listRecursively( StoreKey src, String startPath )
         throws IndyWorkflowException;
 
     /**
-     * Retrieve a {@link Transfer} object suitable for use in the specified operation. This method handles the selection logic, and doesn't fire any 
+     * Retrieve a {@link Transfer} object suitable for use in the specified operation. This method handles the selection logic, and doesn't fire any
      * events (the returned {@link Transfer} object handles that in this case). The first suitable store is used to hold the Transfer.
-     * 
+     *
      * @param stores The stores in which the Transfer should reside
      * @param path The path of the Transfer inside the store
      * @param op The operation we want to execute on the returned Transfer
@@ -194,9 +196,9 @@ public interface DownloadManager
         throws IndyWorkflowException;
 
     /**
-     * Retrieve a {@link Transfer} object suitable for use in the specified operation. This method handles the selection logic in the event the store 
+     * Retrieve a {@link Transfer} object suitable for use in the specified operation. This method handles the selection logic in the event the store
      * is a {@link Group}, and doesn't fire any events (the returned {@link Transfer} object handles that in this case).
-     * 
+     *
      * @param store The store in which the Transfer should reside
      * @param path The path of the Transfer inside the store
      * @param op The operation we want to execute on the returned Transfer

--- a/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
@@ -118,7 +118,7 @@ public abstract class AbstractMergedContentGenerator
         throws IndyWorkflowException
     {
         // delete so it'll be recomputed.
-        final Transfer target = fileManager.getStorageReference( group, path );
+        final Transfer target = fileManager.getStorageReference( group, true, path );
         try
         {
             logger.debug( "Deleting merged file: {}", target );

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -402,7 +402,7 @@ public class DefaultDownloadManager
         }
     }
 
-    private List<ArtifactStore> findEnabled( List<? extends ArtifactStore> stores )
+    private List<ArtifactStore> findEnabled( final List<? extends ArtifactStore> stores )
     {
         List<ArtifactStore> enabled = new ArrayList<>( stores.size() );
         for ( ArtifactStore store: stores )
@@ -803,7 +803,14 @@ public class DefaultDownloadManager
     @Override
     public Transfer getStorageReference( final ArtifactStore store, final String... path )
     {
-        if ( store.isDisabled() )
+        return getStorageReference( store, false, path );
+    }
+
+    @Override
+    public Transfer getStorageReference( final ArtifactStore store, final boolean allowDisabled,
+                                         final String... path )
+    {
+        if ( store.isDisabled() && !allowDisabled )
         {
             return null;
         }


### PR DESCRIPTION
I created an overloaded method allowing us to get the Transfer no matter if the store is disabled or not.

This issue affects only 0.99.1.x branch, because in master it is already refactored to use DirectContentAccess.

The error in the log was:
```
    2016-05-31 11:28:22.166 [DELETE /group/public/com/sun/istack/istack-commons-runtime/maven-metadata.xml] DEBUG o.c.i.c.c.MavenMetadataGenerator - Deleting merged file: null
    2016-05-31 11:28:22.166 [XNIO-2 task-42] ERROR io.undertow.request - UT005023: Exception handling request to /api/group/public/com/sun/istack/istack-commons-runtime/maven-metadata.xml
    org.jboss.resteasy.spi.UnhandledException: java.lang.NullPointerException
            at org.jboss.resteasy.core.ExceptionHandler.handleApplicationException(ExceptionHandler.java:76) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
            at org.jboss.resteasy.core.ExceptionHandler.handleException(ExceptionHandler.java:212) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
            at org.jboss.resteasy.core.SynchronousDispatcher.writeException(SynchronousDispatcher.java:149) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
            at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:372) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
            at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:179) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
            at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:220) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
            at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
            at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
            at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[jboss-servlet-api_3.1_spec-1.0.0.Final.jar:1.0.0.Final]
            at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:130) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at org.commonjava.indy.bind.jaxrs.ResourceManagementFilter.doFilter(ResourceManagementFilter.java:60) ~[indy-embedder-savant-0.99.1.3.jar:na]
            at org.commonjava.indy.bind.jaxrs.ResourceManagementFilter$Proxy$_$$_WeldClientProxy.doFilter(Unknown Source) ~[indy-embedder-savant-0.99.1.3.jar:na]
            at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:60) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:132) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:85) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:61) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:56) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:45) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:63) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:58) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:70) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.security.handlers.SecurityInitialHandler.handleRequest(SecurityInitialHandler.java:76) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
            at org.commonjava.indy.bind.jaxrs.HeaderDebugger.handleRequest(HeaderDebugger.java:93) ~[indy-embedder-savant-0.99.1.3.jar:na]
            at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:261) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:247) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:76) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:166) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.server.Connectors.executeRootHandler(Connectors.java:197) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
            at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:764) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_51]
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_51]
            at java.lang.Thread.run(Thread.java:745) [na:1.8.0_51]
    java.lang.NullPointerException: null
    2016-05-31 11:28:22.168 [galley-transfers-6] DEBUG o.c.m.g.t.h.internal.HttpDownload - HEAD HTTP/1.1 404 Not Found : https://repository.jboss.org/nexus/content/repositories/snapshots/org/ops4j/pax/url/2.2.0/url-2.2.0.pom
    2016-05-31 11:28:22.168 [galley-transfers-6] DEBUG o.c.m.g.t.h.internal.HttpDownload - Detected failure response: 404
```