### PR TITLE
Fix error response for urlmap and content

### DIFF
--- a/addons/depgraph/jaxrs/src/main/java/org/commonjava/indy/depgraph/jaxrs/render/RepositoryResource.java
+++ b/addons/depgraph/jaxrs/src/main/java/org/commonjava/indy/depgraph/jaxrs/render/RepositoryResource.java
@@ -57,7 +57,6 @@ public class RepositoryResource
     @POST
     public RepoContentResult getRepoContent( final RepositoryContentRequest request, final @Context UriInfo uriInfo )
     {
-        Response response = null;
         try
         {
             final String baseUri = uriInfo.getAbsolutePathBuilder().path( "api" ).build().toString();
@@ -67,7 +66,7 @@ public class RepositoryResource
         catch ( final IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e );
+            throwError( e );
         }
 
         return null;
@@ -78,7 +77,6 @@ public class RepositoryResource
     @POST
     public UrlMapResult getUrlMap( final RepositoryContentRequest request, final @Context UriInfo uriInfo )
     {
-        Response response = null;
         try
         {
             final String baseUri = uriInfo.getAbsolutePathBuilder().path( "api" ).build().toString();
@@ -88,7 +86,7 @@ public class RepositoryResource
         catch ( final IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e );
+            throwError( e );
         }
 
         return null;
@@ -99,7 +97,6 @@ public class RepositoryResource
     @Produces( text_plain )
     public DownlogResult getDownloadLog( final DownlogRequest request, final @Context UriInfo uriInfo )
     {
-        Response response = null;
         try
         {
             final String baseUri = uriInfo.getAbsolutePathBuilder().path( "api" ).build().toString();
@@ -118,7 +115,7 @@ public class RepositoryResource
     @Path( "/zip" )
     @POST
     @Produces( application_zip )
-    public StreamingOutput getZipRepository( RepositoryContentRequest request )
+    public StreamingOutput getZipRepository( final RepositoryContentRequest request )
     {
         return ( output ) -> {
             try

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
@@ -326,10 +326,10 @@ public final class ResponseUtils
     public static CharSequence formatEntity( final String id, final Throwable error, final String message )
     {
         final StringWriter sw = new StringWriter();
-        sw.append( "Id: " ).append( id );
+        sw.append( "Id: " ).append( id ).append( '\n' );
         if ( message != null )
         {
-            sw.append( "\nMessage: " ).append( message );
+            sw.append( "Message: " ).append( message ).append( '\n' );
         }
 
         sw.append( error.getMessage() );


### PR DESCRIPTION
The error response was formated but not thrown, only returned and then not used anymore. Instead there was null returned which led to "204 No Content" response.

Also once fixed the error message was not separated from error ID by a new line.