### PR TITLE
Infinispan caches in Indy don't seem to write to disk

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -20,10 +20,9 @@ import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
-import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.subsys.infinispan.inject.qualifer.ContentIndexCache;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
@@ -58,6 +57,7 @@ public class ContentIndexManager
     private SpecialPathManager specialPathManager;
 
     @ConfigureCache( "content-index" )
+    @ContentIndexCache
     @Inject
     private Cache<IndexedStorePath, IndexedStorePath> contentIndex;
 
@@ -99,7 +99,7 @@ public class ContentIndexManager
         List<IndexedStorePath> paths = getAllIndexedPathsForStore( key );
         paths.forEach( ( indexedStorePath ) -> {
             logger.debug( "Removing: {}", indexedStorePath );
-            contentIndex.remove( indexedStorePath );
+            contentIndex.remove( indexedStorePath.toString() );
             if ( pathConsumer != null )
             {
                 pathConsumer.accept( indexedStorePath );

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
@@ -15,12 +15,14 @@
  */
 package org.commonjava.indy.content.index;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.Store;
+import org.infinispan.query.Transformable;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -30,7 +32,8 @@ import java.io.ObjectOutput;
 /**
  * Created by jdcasey on 3/15/16.
  */
-@Indexed(index = "indexedStorePath")
+@Indexed( index = "indexedStorePath" )
+@Transformable( transformer = IndexedStorePathTransformer.class )
 public class IndexedStorePath
         implements Externalizable
 {
@@ -50,6 +53,8 @@ public class IndexedStorePath
     @Field( name = "path", store = Store.YES, analyze = Analyze.NO )
     private String path;
 
+    private IndexedStorePath(){}
+
     public IndexedStorePath( StoreKey storeKey, String path )
     {
         this.storeType = storeKey.getType();
@@ -68,11 +73,13 @@ public class IndexedStorePath
         this.path = path;
     }
 
+    @JsonIgnore
     public StoreKey getStoreKey()
     {
         return new StoreKey( storeType, storeName );
     }
 
+    @JsonIgnore
     public StoreKey getOriginStoreKey()
     {
         return new StoreKey( originStoreType, originStoreName );
@@ -147,8 +154,14 @@ public class IndexedStorePath
     {
         out.writeObject( storeType.name() );
         out.writeObject( storeName );
-        out.writeObject( originStoreType.name() );
-        out.writeObject( originStoreName );
+        if ( originStoreType != null )
+        {
+            out.writeObject( originStoreType.name() );
+        }
+        if ( originStoreName != null )
+        {
+            out.writeObject( originStoreName );
+        }
         out.writeObject( path );
     }
 

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePathTransformer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePathTransformer.java
@@ -1,0 +1,55 @@
+package org.commonjava.indy.content.index;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.infinispan.query.Transformer;
+
+import java.io.IOException;
+
+/**
+ * A customized infinispan {@link org.infinispan.query.Transformer} used for {@link org.commonjava.indy.content.index.IndexedStorePath}
+ * to support it to be used as infinispan cache key in indexing.
+ */
+public class IndexedStorePathTransformer
+        implements Transformer
+{
+    //FIXME: not sure why the IndyObjectMapper cannot be successfully injected here, so use default objmapper instead
+    //    @Inject
+    //    private IndyObjectMapper objectMapper;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Object fromString( String s )
+    {
+        try
+        {
+            return objectMapper.readValue( s, IndexedStorePath.class );
+        }
+        catch ( IOException e )
+        {
+            throw new IllegalStateException( e );
+        }
+    }
+
+    @Override
+    public String toString( Object customType )
+    {
+
+        if ( customType instanceof IndexedStorePath )
+        {
+            try
+            {
+                return objectMapper.writeValueAsString( customType );
+            }
+            catch ( JsonProcessingException e )
+            {
+                throw new IllegalStateException( e );
+            }
+        }
+        else
+        {
+            throw new IllegalArgumentException( "Expected customType to be a " + IndexedStorePath.class.getName() );
+        }
+    }
+}

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/CacheProducer.java
@@ -25,8 +25,10 @@ import org.commonjava.indy.action.ShutdownAction;
 import org.commonjava.indy.conf.IndyConfiguration;
 import org.commonjava.indy.inject.Production;
 import org.commonjava.indy.subsys.infinispan.conf.InfinispanSubsystemConfig;
+import org.commonjava.indy.subsys.infinispan.inject.qualifer.ContentIndexCache;
 import org.infinispan.Cache;
 import org.infinispan.cdi.ConfigureCache;
+import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.io.GridFile;
 import org.infinispan.io.GridFilesystem;
 import org.infinispan.manager.DefaultCacheManager;
@@ -139,6 +141,15 @@ public class CacheProducer
     public EmbeddedCacheManager getCacheManager()
     {
         return cacheManager;
+    }
+
+    @ConfigureCache( "content-index" )
+    @ContentIndexCache
+    @Produces
+    @ApplicationScoped
+    public Configuration contentIndexCacheCfg()
+    {
+        return cacheManager.getCacheConfiguration( "content-index" );
     }
 
     @Produces

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/qualifer/ContentIndexCache.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/qualifer/ContentIndexCache.java
@@ -1,0 +1,19 @@
+package org.commonjava.indy.subsys.infinispan.inject.qualifer;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply "content-index" cache in infinispan.xml.
+ */
+@Qualifier
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface ContentIndexCache
+{
+}


### PR DESCRIPTION
Here are two notes:

1. In IndexedStorePath, the writeExternal will cause Infinispan Persistence error because of nullable of originStoreType and originStoreName, so I added it. Not sure if it needs to write an empty string when they are null, or may cause readExternal error.

2. In IndexedStorePathTransformer class, I don't know why the IndyObjectMapper cannot be injected by container, so I newed a ObjectMapper to prove it can work. So @jdcasey , can you help if needs some additional settings for this injection?