### PR TITLE
Fix building of local urls in urlmap

### DIFF
--- a/addons/depgraph/jaxrs/src/main/java/org/commonjava/indy/depgraph/jaxrs/render/RepositoryResource.java
+++ b/addons/depgraph/jaxrs/src/main/java/org/commonjava/indy/depgraph/jaxrs/render/RepositoryResource.java
@@ -59,7 +59,7 @@ public class RepositoryResource
     {
         try
         {
-            final String baseUri = uriInfo.getAbsolutePathBuilder().path( "api" ).build().toString();
+            final String baseUri = uriInfo.getBaseUriBuilder().path( "api" ).build().toString();
 
             return controller.getRepoContent( request, baseUri, new JaxRsUriFormatter() );
         }
@@ -79,7 +79,7 @@ public class RepositoryResource
     {
         try
         {
-            final String baseUri = uriInfo.getAbsolutePathBuilder().path( "api" ).build().toString();
+            final String baseUri = uriInfo.getBaseUriBuilder().path( "api" ).build().toString();
 
             return controller.getUrlMap( request, baseUri, new JaxRsUriFormatter() );
         }
@@ -99,7 +99,7 @@ public class RepositoryResource
     {
         try
         {
-            final String baseUri = uriInfo.getAbsolutePathBuilder().path( "api" ).build().toString();
+            final String baseUri = uriInfo.getBaseUriBuilder().path( "api" ).build().toString();
 
             return controller.getDownloadLog( request, baseUri, new JaxRsUriFormatter() );
         }


### PR DESCRIPTION
In case a urlmap was created with usage of hosted repositories, the
resulting urls for some artifacts looked like
  http://localhost:8080/api/depgraph/repo/urlmap/api/hosted/local-repo/...
instead of just
  http://localhost:8080/api/hosted/local-repo/...

The same problem was found for downlog and content.