### PR TITLE
Change rescheduling approach for metadata and .listing.txt files

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
@@ -41,8 +41,10 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.event.FileAccessEvent;
 import org.commonjava.maven.galley.event.FileDeletionEvent;
 import org.commonjava.maven.galley.event.FileStorageEvent;
+import org.commonjava.maven.galley.model.SpecialPathInfo;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,6 +64,9 @@ public class TimeoutEventListener
 
     @Inject
     private IndyObjectMapper objectMapper;
+
+    @Inject
+    private SpecialPathManager specialPathManager;
 
     //    @Inject
     //    @ExecutorConfig( daemon = true, priority = 7, named = "indy-events" )
@@ -187,13 +192,17 @@ public class TimeoutEventListener
             }
             else if ( type == StoreType.remote )
             {
-                try
+                SpecialPathInfo info = specialPathManager.getSpecialPathInfo( transfer );
+                if ( info == null || !info.isMetadata() )
                 {
-                    scheduleManager.setProxyTimeouts( key, transfer.getPath() );
-                }
-                catch ( final IndySchedulerException e )
-                {
-                    logger.error( "Failed to set proxy-cache timeouts related to: " + transfer, e );
+                    try
+                    {
+                        scheduleManager.setProxyTimeouts( key, transfer.getPath() );
+                    }
+                    catch ( final IndySchedulerException e )
+                    {
+                        logger.error( "Failed to set proxy-cache timeouts related to: " + transfer, e );
+                    }
                 }
             }
         }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentRescheduleTimeoutTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.helper.PathInfo;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Date;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test if normal content re-schedule mechanism is working. When content is re-requested during the timeout interval,
+ * the timeout for this content should be re-scheduled.
+ */
+public class ContentRescheduleTimeoutTest
+        extends AbstractContentManagementTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "repos" );
+
+    @Test
+    public void timeout()
+            throws Exception
+    {
+        final String repoId = "test-repo";
+        final String pomPath = "org/foo/bar/1.0/bar-1.0.pom";
+        final String pomUrl = server.formatUrl( repoId, pomPath );
+        final int CACHE_TIMEOUT_SECONDS = 6;
+        final int CACHE_TIMEOUT_WAITING_MILLISECONDS = 3000;
+
+        // mocking up a http server that expects access to a .pom
+        final String datetime = ( new Date() ).toString();
+        server.expect( pomUrl, 200, String.format( "pom %s", datetime ) );
+
+        // set up remote repository pointing to the test http server, and timeout little later
+        final String changelog = "Timeout Testing: " + name.getMethodName();
+        final RemoteRepository repository = new RemoteRepository( repoId, server.formatUrl( repoId ) );
+        repository.setCacheTimeoutSeconds( CACHE_TIMEOUT_SECONDS );
+        client.stores().create( repository, changelog, RemoteRepository.class );
+
+        // first time trigger normal content storage with timeout, should be 6s
+        PathInfo pomResult = client.content().getInfo( remote, repoId, pomPath );
+        assertThat( "no pom result", pomResult, notNullValue() );
+        assertThat( "pom doesn't exist", pomResult.exists(), equalTo( true ) );
+        String pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
+                                            remote.name(), repoId, pomPath );
+        File pomFile = new File( pomFilePath );
+        assertThat( "pom doesn't exist", pomFile.exists(), equalTo( true ) );
+
+        // wait for first 3s
+        Thread.sleep( CACHE_TIMEOUT_WAITING_MILLISECONDS );
+
+        // as the normal content re-request, the timeout interval should be re-scheduled
+        client.content().get( remote, repoId, pomPath );
+
+        // will wait another 3.5s
+        Thread.sleep( CACHE_TIMEOUT_WAITING_MILLISECONDS + 500 );
+        // as rescheduled in 3s, the new timeout should be 3+6=9s, so the artifact should not be deleted
+        assertThat( "artifact should not be removed as it is rescheduled with new request", pomFile.exists(),
+                    equalTo( true ) );
+
+        // another round wait for 3.5s
+        Thread.sleep( CACHE_TIMEOUT_WAITING_MILLISECONDS + 500 );
+        assertThat( "artifact should be removed when new scheduled cache timeout", pomFile.exists(), equalTo( false ) );
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRescheduleTimeoutTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.helper.PathInfo;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Date;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test if metadata content re-schedule mechanism is working. When metadata is re-requested during the timeout interval,
+ * the timeout for this content should NOT be re-scheduled.
+ */
+public class MetadataRescheduleTimeoutTest
+        extends AbstractContentManagementTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "repos" );
+
+    @Test
+    public void timeout()
+            throws Exception
+    {
+        final int METADATA_TIMEOUT_SECONDS = 4;
+        final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 2500;
+
+        final String repoId = "test-repo";
+        final String metadataPath = "org/foo/bar/maven-metadata.xml";
+
+        final String metadataUrl = server.formatUrl( repoId, metadataPath );
+
+        // mocking up a http server that expects access to metadata
+        final String datetime = ( new Date() ).toString();
+        server.expect( metadataUrl, 200, String.format( "metadata %s", datetime ) );
+
+        // set up remote repository pointing to the test http server, and timeout little later
+        final String changelog = "Timeout Testing: " + name.getMethodName();
+        final RemoteRepository repository = new RemoteRepository( repoId, server.formatUrl( repoId ) );
+        repository.setMetadataTimeoutSeconds( METADATA_TIMEOUT_SECONDS );
+        client.stores().create( repository, changelog, RemoteRepository.class );
+
+        // first time trigger normal content storage with timeout, should be 4s
+        PathInfo pomResult = client.content().getInfo( remote, repoId, metadataPath );
+        assertThat( "no metadata result", pomResult, notNullValue() );
+        assertThat( "metadata doesn't exist", pomResult.exists(), equalTo( true ) );
+        String metadataFilePath =
+                String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
+                               remote.name(), repoId, metadataPath );
+        File metadataFile = new File( metadataFilePath );
+        assertThat( "metadata doesn't exist", metadataFile.exists(), equalTo( true ) );
+
+        // wait for first 2.5s
+        Thread.sleep( METADATA_TIMEOUT_WAITING_MILLISECONDS );
+
+        // as the metadata content re-request, the metadata timeout interval should NOT be re-scheduled
+        client.content().get( remote, repoId, metadataPath );
+
+        // will wait another 2.5s
+        Thread.sleep( METADATA_TIMEOUT_WAITING_MILLISECONDS );
+        // as rescheduled, the artifact should not be deleted
+        assertThat( "artifact should be removed as the rescheduled of metadata should not succeed",
+                    metadataFile.exists(), equalTo( false ) );
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.helper.PathInfo;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Date;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Test if normal content timeout will be influenced by metadata re-request. When metadata is re-requested during the
+ * normal content timeout interval, the timeout for this content should NOT be re-scheduled.
+ */
+public class MixContentRescheduleTimeoutTest
+        extends AbstractContentManagementTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "repos" );
+
+    @Test
+    public void timeout()
+            throws Exception
+    {
+        final String repoId = "test-repo";
+        final String pomPath = "org/foo/bar/1.0/bar-1.0.pom";
+        final String metadataPath = "org/foo/bar/maven-metadata.xml";
+        final String pomUrl = server.formatUrl( repoId, pomPath );
+        final String metadataUrl = server.formatUrl( repoId, metadataPath );
+        final int CACHE_TIMEOUT_SECONDS = 8;
+        final int CACHE_TIMEOUT_WAITING_MILLISECONDS = 4000;
+        final int METADATA_TIMEOUT_SECONDS = 4;
+
+        // mocking up a http server that expects access to a .pom
+        final String datetime = ( new Date() ).toString();
+        server.expect( pomUrl, 200, String.format( "pom %s", datetime ) );
+        server.expect( metadataUrl, 200, String.format( "metadata %s", datetime ) );
+
+        // set up remote repository pointing to the test http server, and timeout little later
+        final String changelog = "Timeout Testing: " + name.getMethodName();
+        final RemoteRepository repository = new RemoteRepository( repoId, server.formatUrl( repoId ) );
+        repository.setCacheTimeoutSeconds( CACHE_TIMEOUT_SECONDS );
+        repository.setMetadataTimeoutSeconds( METADATA_TIMEOUT_SECONDS );
+        client.stores().create( repository, changelog, RemoteRepository.class );
+
+        // first time trigger normal content storage with timeout, should be 8s
+        PathInfo pomResult = client.content().getInfo( remote, repoId, pomPath );
+        assertThat( "no pom result", pomResult, notNullValue() );
+        assertThat( "pom doesn't exist", pomResult.exists(), equalTo( true ) );
+        String pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
+                                            remote.name(), repoId, pomPath );
+        File pomFile = new File( pomFilePath );
+        assertThat( "pom doesn't exist", pomFile.exists(), equalTo( true ) );
+
+        // first time trigger metadata storage with timeout, should be 4s
+        PathInfo metadataResult = client.content().getInfo( remote, repoId, metadataPath );
+        assertThat( "no metadata result", metadataResult, notNullValue() );
+        assertThat( "metadata doesn't exist", metadataResult.exists(), equalTo( true ) );
+        String metadataFilePath =
+                String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
+                               remote.name(), repoId, metadataPath );
+        File metadataFile = new File( metadataFilePath );
+        assertThat( "metadata doesn't exist", metadataFile.exists(), equalTo( true ) );
+
+        // wait for first 4s
+        Thread.sleep( CACHE_TIMEOUT_WAITING_MILLISECONDS );
+
+        // as the metadata re-request, the timeout interval should NOT be re-scheduled
+        client.content().get( remote, repoId, metadataPath );
+
+        // will wait another 4.5s
+        Thread.sleep( CACHE_TIMEOUT_WAITING_MILLISECONDS + 500 );
+        // even meta file re-request @ 4s, normal content timeout should not be rescheduled, so the artifact should be deleted
+        assertThat( "artifact should be removed even metadata rescheduled with new request", pomFile.exists(),
+                    equalTo( false ) );
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
I've split the .listing.txt metadata ftest to a single commit as it still has problem.

BTW, @jdcasey I've seen that you have concern about if the metadata will never be set timeout if we did this change to TimeoutEventListner, when I did the MetadataRescheduleTimoutTest, seems the metadata is successfully be deleted when timeout arrived. And I think the initial timeout is set in onFileStorageEvent but not onFileAccessEvent. What's your opinions about this?