### PR TITLE
Fix 404 page with status 200

### DIFF
--- a/api/src/main/java/org/commonjava/indy/content/ContentGenerator.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentGenerator.java
@@ -24,14 +24,14 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 
 /**
- * Interface to support dynamic content generation. This was originally intended for generating metadata files when they aren't present on 
+ * Interface to support dynamic content generation. This was originally intended for generating metadata files when they aren't present on
  * remote repositories. However, it's designed to accommodate all sorts of dynamic content.
  */
 public interface ContentGenerator
 {
 
     /**
-     * Generate dynamic content in the event it's not found in the ArtifactStore. This is secondary to the main content retrieval logic, as a 
+     * Generate dynamic content in the event it's not found in the ArtifactStore. This is secondary to the main content retrieval logic, as a
      * last effort to avoid returning a missing result.
      */
     Transfer generateFileContent( ArtifactStore store, String path, EventMetadata eventMetadata )
@@ -71,5 +71,10 @@ public interface ContentGenerator
      */
     void handleContentDeletion( ArtifactStore store, String path, EventMetadata eventMetadata )
         throws IndyWorkflowException;
+
+    /**
+     * Checks if this content generator processes the provided path.
+     */
+    boolean canProcess( String path );
 
 }

--- a/core/src/main/java/org/commonjava/indy/core/content/ArchetypeCatalogGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/ArchetypeCatalogGenerator.java
@@ -32,7 +32,6 @@ import javax.inject.Inject;
 
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.DirectContentAccess;
-import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.content.group.ArchetypeCatalogMerger;
 import org.commonjava.indy.core.content.group.GroupMergeHelper;
@@ -77,7 +76,8 @@ public class ArchetypeCatalogGenerator
         this.helper = mergeHelper;
     }
 
-    private boolean canProcess( final String path )
+    @Override
+    public boolean canProcess( final String path )
     {
         for ( final String filename : HANDLED_FILENAMES )
         {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -234,16 +234,18 @@ public class DefaultContentManager
             }
 
             item = null;
+            boolean generated = false;
             for ( final ContentGenerator generator : contentGenerators )
             {
-                item = generator.generateGroupFileContent( (Group) store, members, path, eventMetadata );
-                if ( item != null )
+                if ( generator.canProcess( path ) )
                 {
+                    item = generator.generateGroupFileContent( (Group) store, members, path, eventMetadata );
+                    generated = true;
                     break;
                 }
             }
 
-            if ( item == null )
+            if ( !generated )
             {
                 for ( final ArtifactStore member : members )
                 {

--- a/core/src/main/java/org/commonjava/indy/core/content/HttpMetadataCleanupGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/HttpMetadataCleanupGenerator.java
@@ -109,4 +109,10 @@ public class HttpMetadataCleanupGenerator
         }
     }
 
+    @Override
+    public boolean canProcess( final String path )
+    {
+        return false;
+    }
+
 }

--- a/core/src/main/java/org/commonjava/indy/core/content/MavenMetadataGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/MavenMetadataGenerator.java
@@ -332,7 +332,8 @@ public class MavenMetadataGenerator
         return null;
     }
 
-    private boolean canProcess( final String path )
+    @Override
+    public boolean canProcess( final String path )
     {
         for ( final String filename : HANDLED_FILENAMES )
         {


### PR DESCRIPTION
There is a strange repository at http://deadlock.netbeans.org/maven2/
which sometimes for non-existing content returns status 200 with 404
error page. It happens for some maven-metadata.xml files. So when Indy
tries to create the merged content, it parses the 404 page, but it is
not a valid XML so it results in parse error and the generator returns
null, because no other store in the group provides the requested path.

In the end no other generator produces the requested resource so it
tries to cycle through the stores in the group if one of them provides
content with matching path and there it hits the error page and returns
it as regular content.

I think the best solution is to strictly say "if a path is handled by
a content generator, nothing else will be tried to provide the content".
I reused the method canProcess in some of the generators and made it
part of the generator interface.