### PR TITLE
Fix ConcurrentModificationException

### DIFF
--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecorator.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecorator.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.autoprox.data;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.decorator.Decorator;
@@ -118,7 +119,7 @@ public abstract class AutoProxDataManagerDecorator
             if ( g != null )
             {
                 logger.info( "Validating group: {}", g );
-                for ( final StoreKey key : g.getConstituents() )
+                for ( final StoreKey key : new ArrayList<>( g.getConstituents() ) )
                 {
                     final ArtifactStore store = getArtifactStore( key, impliedBy == null ? g.getKey() : impliedBy );
                     if ( store == null )


### PR DESCRIPTION
when requesting a non-existing group containing a non existing store like "group:central+bla" when no store bla is available.

The exception (in 0.99.1.x) was:
```
11:18:14.763 [XNIO-1 task-2] ERROR io.undertow.request - UT005023: Exception handling request to /api/depgraph/repo/urlmap
org.jboss.resteasy.spi.UnhandledException: java.util.ConcurrentModificationException
        at org.jboss.resteasy.core.ExceptionHandler.handleApplicationException(ExceptionHandler.java:76) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.core.ExceptionHandler.handleException(ExceptionHandler.java:212) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.core.SynchronousDispatcher.writeException(SynchronousDispatcher.java:149) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:372) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:179) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:220) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790) ~[jboss-servlet-api_3.1_spec-1.0.0.Final.jar:1.0.0.Final]
        at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:130) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at org.commonjava.indy.bind.jaxrs.ResourceManagementFilter.doFilter(ResourceManagementFilter.java:60) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.bind.jaxrs.ResourceManagementFilter$Proxy$_$$_WeldClientProxy.doFilter(Unknown Source) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:60) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:132) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:85) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:61) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:56) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:45) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:63) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:58) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:70) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.security.handlers.SecurityInitialHandler.handleRequest(SecurityInitialHandler.java:76) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
        at org.commonjava.indy.bind.jaxrs.HeaderDebugger.handleRequest(HeaderDebugger.java:93) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) ~[undertow-core-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:261) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:247) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:76) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:166) ~[undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.server.Connectors.executeRootHandler(Connectors.java:197) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
        at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:764) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_65]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_65]
        at java.lang.Thread.run(Thread.java:745) [na:1.8.0_65]
Caused by: java.util.ConcurrentModificationException: null
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901) ~[na:1.8.0_65]
        at java.util.ArrayList$Itr.next(ArrayList.java:851) ~[na:1.8.0_65]
        at java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1042) ~[na:1.8.0_65]
        at org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator.getGroup(AutoProxDataManagerDecorator.java:121) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator.getArtifactStore(AutoProxDataManagerDecorator.java:339) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator.getArtifactStore(AutoProxDataManagerDecorator.java:326) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_65]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_65]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_65]
        at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_65]
        at org.jboss.weld.annotated.runtime.InvokableAnnotatedMethod.invokeOnInstance(InvokableAnnotatedMethod.java:97) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
        at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:80) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
        at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:69) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
        at org.jboss.weld.interceptor.util.proxy.TargetInstanceProxyMethodHandler.invoke(TargetInstanceProxyMethodHandler.java:33) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
        at org.jboss.weld.bean.proxy.TargetBeanInstance.invoke(TargetBeanInstance.java:88) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
        at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
        at org.commonjava.indy.flat.data.DataFileStoreDataManager$Proxy$_$$_Weld$Proxy$.getArtifactStore(Unknown Source) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_65]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_65]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_65]
        at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_65]
        at org.jboss.weld.util.reflection.Reflections.invokeAndUnwrap(Reflections.java:401) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
        at org.jboss.weld.bean.proxy.CombinedInterceptorAndDecoratorStackMethodHandler.invoke(CombinedInterceptorAndDecoratorStackMethodHandler.java:62) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
        at org.commonjava.indy.flat.data.DataFileStoreDataManager$Proxy$_$$_WeldSubclass.getArtifactStore(Unknown Source) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.flat.data.DataFileStoreDataManager$Proxy$_$$_WeldClientProxy.getArtifactStore(Unknown Source) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.model.galley.IndyLocationResolver.resolve(IndyLocationResolver.java:63) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.cartographer.graph.RecipeResolver.resolveSourceLocations(RecipeResolver.java:291) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.cartographer.graph.RecipeResolver.resolve(RecipeResolver.java:92) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.cartographer.INTERNAL.ops.ResolveOpsImpl.resolveRepositoryContents(ResolveOpsImpl.java:105) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.depgraph.rest.RepositoryController.resolveContents(RepositoryController.java:257) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.depgraph.rest.RepositoryController.getUrlMap(RepositoryController.java:95) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.depgraph.rest.RepositoryController$Proxy$_$$_WeldClientProxy.getUrlMap(Unknown Source) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.depgraph.jaxrs.render.RepositoryResource.getUrlMap(RepositoryResource.java:84) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at org.commonjava.indy.depgraph.jaxrs.render.RepositoryResource$Proxy$_$$_WeldClientProxy.getUrlMap(Unknown Source) ~[indy-embedder-savant-0.99.1.8-SNAPSHOT.jar:na]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_65]
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_65]
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_65]
        at java.lang.reflect.Method.invoke(Method.java:497) ~[na:1.8.0_65]
        at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:137) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:296) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:250) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:237) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:356) ~[resteasy-jaxrs-3.0.9.Final.jar:na]
        ... 34 common frames omitted

```