### PR TITLE
Fix ConcurrentModificationException

### DIFF
--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecorator.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecorator.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.autoprox.data;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.decorator.Decorator;
@@ -118,7 +119,7 @@ public abstract class AutoProxDataManagerDecorator
             if ( g != null )
             {
                 logger.info( "Validating group: {}", g );
-                for ( final StoreKey key : g.getConstituents() )
+                for ( final StoreKey key : new ArrayList<>( g.getConstituents() ) )
                 {
                     final ArtifactStore store = getArtifactStore( key, impliedBy == null ? g.getKey() : impliedBy );
                     if ( store == null )


### PR DESCRIPTION
when requesting a non-existing group containing a non existing store
like "group:central+bla" when no store bla is available.

Backport of #354 into 0.99.1.x.