### PR TITLE
Fix Koji add-on to lookup archive GAVs instead of build GAVS, etc...

### DIFF
--- a/addons/koji/common/src/main/conf/conf.d/koji.conf
+++ b/addons/koji/common/src/main/conf/conf.d/koji.conf
@@ -4,9 +4,28 @@
 ## Minimum configuration for using the Koji add-on.
 ####################################################
 
-## Disabled by default.
+## Global enabled flag. It is disabled by default.
 #
 # enabled=false
+
+##
+## ***********************************************************************
+## ***********************************************************************
+## ** YOUR GROUP WILL NOT BE ENABLED UNTIL YOU SPECIFY A TARGET FOR IT. **
+## ***********************************************************************
+## ***********************************************************************
+##
+## Target group mappings
+## These map entry-point group to a sub-group that should contain the Koji build repositories.
+##
+## NOTE: The keys of these mappings are regular expressions (after the 'target.' prefix)
+#
+# target.entry-group-pattern=capture-group-name
+# target.other-entry-pattern=other-capture
+#
+## Or, to just enable a group without changing the target
+#
+# target.public=public
 
 ## URL to Koji hub
 #
@@ -50,10 +69,5 @@
 #
 # max.connections=4
 # request.timeout.seconds=10
-
-## Target group mappings
-## If you have an entry-point group with a sub-group that should contain the Koji build proxies, map them here.
-#
-# target.entry-group-pattern=capture-group-name
-# target.other-entry-pattern=other-capture
+# download.timeout.seconds=600
 

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.koji.conf;
 
 import com.redhat.red.build.koji.config.KojiConfig;
 import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.util.jhttpc.model.SiteConfig;
 import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
 import org.commonjava.util.jhttpc.model.SiteTrustType;
@@ -61,6 +62,8 @@ public class IndyKojiConfig
 
     private static final boolean DEFAULT_ENABLED = false;
 
+    private static final Integer DEFAULT_DOWNLOAD_TIMEOUT_SECONDS = 600;
+
     private Boolean enabled;
 
     private String url;
@@ -90,6 +93,8 @@ public class IndyKojiConfig
     private List<String> tagPatterns;
 
     private Map<String, String> targetGroups;
+
+    private Integer downloadTimeoutSeconds;
 
     @Override
     public SiteConfig getKojiSiteConfig()
@@ -195,6 +200,11 @@ public class IndyKojiConfig
     public Integer getRequestTimeoutSeconds()
     {
         return requestTimeoutSeconds == null ? DEFAULT_REQUEST_TIMEOUT_SECONDS : requestTimeoutSeconds;
+    }
+
+    public Integer getDownloadTimeoutSeconds()
+    {
+        return downloadTimeoutSeconds == null ? DEFAULT_DOWNLOAD_TIMEOUT_SECONDS : downloadTimeoutSeconds;
     }
 
     public String getSiteTrustType()
@@ -459,4 +469,21 @@ public class IndyKojiConfig
         return null;
     }
 
+    public boolean isEnabledFor( String name )
+    {
+        if ( targetGroups == null )
+        {
+            return false;
+        }
+
+        for ( String key : targetGroups.keySet() )
+        {
+            if ( name.matches( key ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
@@ -426,7 +426,8 @@ public class IndyKojiConfig
                         targetGroups = new LinkedHashMap<>();
                     }
 
-                    String source = name.substring( "target.".length(), name.length() - 1 );
+                    String source = name.substring( "target.".length(), name.length() );
+                    logger.debug( "KOJI: Group {} targets group {}", source, value );
                     targetGroups.put( source, value );
                 }
                 else
@@ -471,19 +472,24 @@ public class IndyKojiConfig
 
     public boolean isEnabledFor( String name )
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
         if ( targetGroups == null )
         {
+            logger.warn( "No target groups defined for Koji access!" );
             return false;
         }
 
         for ( String key : targetGroups.keySet() )
         {
-            if ( name.matches( key ) )
+            logger.debug( "Checking target pattern '{}' against group name: '{}'", key, name );
+            if ( name.equals(key) || name.matches( key ) )
             {
+                logger.info( "Target group for {} is {}", name, key );
                 return true;
             }
         }
 
+        logger.warn( "No target group found for: {}", name );
         return false;
     }
 }

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -151,7 +151,7 @@ public abstract class KojiContentManagerDecorator
         try
         {
             return kojiClient.withKojiSession( ( session ) -> {
-                List<KojiBuildInfo> builds = kojiClient.listBuilds( gav, session );
+                List<KojiBuildInfo> builds = kojiClient.listBuildsContaining( gav, session );
 
                 Collections.sort( builds, ( build1, build2 ) -> build1.getCreationTime().compareTo( build2.getCreationTime() ) );
 

--- a/addons/koji/common/src/main/resources/default-koji.conf
+++ b/addons/koji/common/src/main/resources/default-koji.conf
@@ -4,9 +4,28 @@
 ## Minimum configuration for using the Koji add-on.
 ####################################################
 
-## Disabled by default.
+## Global enabled flag. It is disabled by default.
 #
 # enabled=false
+
+##
+## ***********************************************************************
+## ***********************************************************************
+## ** YOUR GROUP WILL NOT BE ENABLED UNTIL YOU SPECIFY A TARGET FOR IT. **
+## ***********************************************************************
+## ***********************************************************************
+##
+## Target group mappings
+## These map entry-point group to a sub-group that should contain the Koji build repositories.
+##
+## NOTE: The keys of these mappings are regular expressions (after the 'target.' prefix)
+#
+# target.entry-group-pattern=capture-group-name
+# target.other-entry-pattern=other-capture
+#
+## Or, to just enable a group without changing the target
+#
+# target.public=public
 
 ## URL to Koji hub
 #
@@ -50,11 +69,5 @@
 #
 # max.connections=4
 # request.timeout.seconds=10
-
-## Target group mappings
-## If you have an entry-point group with a sub-group that should contain the Koji build proxies, map them here.
-## NOTE: The keys of these mappings are regular expressions (after the 'target.' prefix)
-#
-# target.entry-group-pattern=capture-group-name
-# target.other-entry-pattern=other-capture
+# download.timeout.seconds=600
 

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -265,6 +265,7 @@ public class ScheduleManager
         {
             if ( (info != null && info.isMetadata()) && repo.getMetadataTimeoutSeconds() > 0 )
             {
+                logger.debug( "Using metadata timeout for: {}", resource );
                 timeout = repo.getMetadataTimeoutSeconds();
             }
             else

--- a/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
@@ -195,6 +195,7 @@ public class TimeoutEventListener
                 SpecialPathInfo info = specialPathManager.getSpecialPathInfo( transfer );
                 if ( info == null || !info.isMetadata() )
                 {
+                    logger.debug( "Accessed resource {} timeout will be reset.", transfer );
                     try
                     {
                         scheduleManager.setProxyTimeouts( key, transfer.getPath() );
@@ -203,6 +204,10 @@ public class TimeoutEventListener
                     {
                         logger.error( "Failed to set proxy-cache timeouts related to: " + transfer, e );
                     }
+                }
+                else
+                {
+                    logger.debug( "Accessed resource {} is metadata. NOT rescheduling timeout!", transfer );
                 }
             }
         }

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -121,7 +121,7 @@ public abstract class AbstractIndyFunctionalTest
         // give events time to propagate
         try
         {
-            Thread.sleep( 3000 );
+            Thread.sleep( 200 * getTestTimeoutMultiplier() );
         }
         catch ( InterruptedException e )
         {

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadWhileProxyingInProgressTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadWhileProxyingInProgressTest.java
@@ -46,8 +46,11 @@ public class DownloadWhileProxyingInProgressTest
     public void downloadWhileSlowProxyCompletes()
         throws Exception
     {
+        RemoteRepository rmt = new RemoteRepository( STORE, server.formatUrl( STORE ) );
+        rmt.setTimeoutSeconds( 30 );
+
         client.stores()
-              .create( new RemoteRepository( STORE, server.formatUrl( STORE ) ), "adding test proxy",
+              .create( rmt, "adding test proxy",
                        RemoteRepository.class );
 
         final String path = "org/foo/foo-project/1/foo-1.txt";
@@ -67,17 +70,20 @@ public class DownloadWhileProxyingInProgressTest
         System.out.println( "Waiting for content transfers to complete." );
         latch.await();
 
-        final PathInfo result = client.content()
-                                      .getInfo( remote, STORE, path );
-
-        assertThat( "no result", result, notNullValue() );
-        assertThat( "doesn't exist", result.exists(), equalTo( true ) );
+        waitForEventPropagation();
 
         System.out.printf( "Timing results:\n  Input started: {}\n  Input ended: {}\n  Download started: {}\n  Download ended: {}",
                            input.getStartTime(), input.getEndTime(), download.getStartTime(), download.getEndTime() );
 
         assertThat( download.getContent().toByteArray(), equalTo( data ) );
         assertThat( input.getEndTime() > download.getStartTime(), equalTo( true ) );
+
+        final PathInfo result = client.content()
+                                      .getInfo( remote, STORE, path );
+
+        assertThat( "no result", result, notNullValue() );
+        assertThat( "doesn't exist", result.exists(), equalTo( true ) );
+
     }
 
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetaOverlapWithNestedGroupOfHostRepoMetaTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetaOverlapWithNestedGroupOfHostRepoMetaTest.java
@@ -180,6 +180,8 @@ public class GroupMetaOverlapWithNestedGroupOfHostRepoMetaTest
         System.out.printf( "\n\nUpdated bottom group constituents are:\n  %s\n\n",
                            StringUtils.join( bottomGroup.getConstituents(), "\n  " ) );
 
+        waitForEventPropagation();
+
         // the top group should reflect the meta file deprecation and re-indexing
         final String gpLevelMetaFilePath =
                 String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(), group.name(),

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetaOverlapWithNestedGroupOfHostRepoNoMetaTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetaOverlapWithNestedGroupOfHostRepoNoMetaTest.java
@@ -167,6 +167,8 @@ public class GroupMetaOverlapWithNestedGroupOfHostRepoNoMetaTest
         System.out.printf( "\n\nUpdated group constituents are:\n  %s\n\n",
                            StringUtils.join( bottomGroup.getConstituents(), "\n  " ) );
 
+        waitForEventPropagation();
+
         // the top group should not reflect the meta file deprecation and expiration
         final String gpLevelMetaFilePath =
                 String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(), group.name(),

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataOverlappingWithMetadataOfHostedReposTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataOverlappingWithMetadataOfHostedReposTest.java
@@ -171,6 +171,8 @@ public class GroupMetadataOverlappingWithMetadataOfHostedReposTest
         System.out.printf( "\n\nUpdated group constituents are:\n  %s\n\n",
                            StringUtils.join( g.getConstituents(), "\n  " ) );
 
+        waitForEventPropagation();
+
         final String gpLevelMetaFilePath =
                 String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(), group.name(),
                                g.getName(), path );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataOverlappingWithoutMetadataOfHostedReposTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataOverlappingWithoutMetadataOfHostedReposTest.java
@@ -155,6 +155,8 @@ public class GroupMetadataOverlappingWithoutMetadataOfHostedReposTest
         System.out.printf( "\n\nUpdated group constituents are:\n  %s\n\n",
                            StringUtils.join( g.getConstituents(), "\n  " ) );
 
+        waitForEventPropagation();
+
         final String gpLevelMetaFilePath =
                 String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(), group.name(),
                                g.getName(), path );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/LateJoinDownloadWhileProxyingInProgressTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/LateJoinDownloadWhileProxyingInProgressTest.java
@@ -50,8 +50,11 @@ public class LateJoinDownloadWhileProxyingInProgressTest
     public void downloadTwiceWhileSlowProxyCompletes()
         throws Exception
     {
+        RemoteRepository rmt = new RemoteRepository( STORE, server.formatUrl( STORE ) );
+        rmt.setTimeoutSeconds( 30 );
+
         client.stores()
-              .create( new RemoteRepository( STORE, server.formatUrl( STORE ) ), "adding test proxy",
+              .create( rmt, "adding test proxy",
                        RemoteRepository.class );
 
         final String path = "org/foo/foo-project/1/foo-1.txt";
@@ -75,18 +78,14 @@ public class LateJoinDownloadWhileProxyingInProgressTest
         System.out.println( "Waiting for content transfers to complete." );
         latch.await();
 
-        final PathInfo result = client.content()
-                                      .getInfo( remote, STORE, path );
-
-        assertThat( "no result", result, notNullValue() );
-        assertThat( "doesn't exist", result.exists(), equalTo( true ) );
+        waitForEventPropagation();
 
         System.out.printf( "Timing results:\n  Input started: {}\n  Input ended: {}\n  Download1 started: {}\n  Download1 ended: {}\\n  Download2 started: {}\\n  Download2 ended: {}",
                            input.getStartTime(), input.getEndTime(), download.getStartTime(), download.getEndTime(),
                            download2.getStartTime(), download2.getEndTime() );
 
         assertThat( "First download retrieved wrong content", Arrays.equals( download.getContent()
-                                           .toByteArray(), data ), equalTo( true ) );
+                                                                                     .toByteArray(), data ), equalTo( true ) );
 
         assertThat( "Second download retrieved wrong content", Arrays.equals( download2.getContent()
                                                                                        .toByteArray(), data ),
@@ -97,6 +96,12 @@ public class LateJoinDownloadWhileProxyingInProgressTest
 
         assertThat( "Second download started after input ended.", input.getEndTime() > download2.getStartTime(),
                     equalTo( true ) );
+
+        final PathInfo result = client.content()
+                                      .getInfo( remote, STORE, path );
+
+        assertThat( "no result", result, notNullValue() );
+        assertThat( "doesn't exist", result.exists(), equalTo( true ) );
     }
 
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetaListingRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetaListingRescheduleTimeoutTest.java
@@ -53,7 +53,7 @@ public class MetaListingRescheduleTimeoutTest
             throws Exception
     {
         final int METADATA_TIMEOUT_SECONDS = 4;
-        final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 2500;
+        final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 3000;
 
         final String repoId = "test-repo";
         // path without trailing slash for ExpectationServer...
@@ -109,6 +109,8 @@ public class MetaListingRescheduleTimeoutTest
 
         // will wait another 2.5s
         Thread.sleep( METADATA_TIMEOUT_WAITING_MILLISECONDS );
+
+//        logger.info( "Checking whether metadata file {} has been deleted...", listingMetaFile );
         // as rescheduled, the artifact should not be deleted
         assertThat( "artifact should be removed as the rescheduled of metadata should not succeed",
                     listingMetaFile.exists(), equalTo( false ) );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataFirstTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataFirstTimeoutWorkingTest.java
@@ -29,13 +29,13 @@ import static org.junit.Assert.assertThat;
 public class MetadataFirstTimeoutWorkingTest
         extends AbstractMetadataTimeoutWorkingTest
 {
-    private static final int METADATA_TIMEOUT_SECONDS = 2;
+    private final int METADATA_TIMEOUT_SECONDS = 2;
 
-    private static final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 3000;
+    private final int METADATA_TIMEOUT_WAITING_MILLISECONDS = getTestTimeoutMultiplier() * 3000;
 
-    private static final int CACHE_TIMEOUT_SECONDS = 7;
+    private final int CACHE_TIMEOUT_SECONDS = 7;
 
-    private static final int CACHE_TIMEOUT_WAITING_MILLISECONDS = 5000;
+    private final int CACHE_TIMEOUT_WAITING_MILLISECONDS = getTestTimeoutMultiplier() * 5000;
 
     @Test
     public void timeout()

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataPassthroughTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataPassthroughTimeoutWorkingTest.java
@@ -33,17 +33,17 @@ import static org.junit.Assert.assertThat;
 public class MetadataPassthroughTimeoutWorkingTest
         extends AbstractMetadataTimeoutWorkingTest
 {
-    private static final int CACHE_TIMEOUT_SECONDS = 2;
+    private final int CACHE_TIMEOUT_SECONDS = 2;
 
-    private static final int CACHE_TIMEOUT_WAITING_MILLISECONDS = 3000;
+    private final int CACHE_TIMEOUT_WAITING_MILLISECONDS = getTestTimeoutMultiplier() * 3000;
 
-    private static final int METADATA_TIMEOUT_SECONDS = 7;
+    private final int METADATA_TIMEOUT_SECONDS = 7;
 
-    private static final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 5000;
+    private final int METADATA_TIMEOUT_WAITING_MILLISECONDS = getTestTimeoutMultiplier() * 5000;
 
-    private static final int PASSTHROUGH_TIMEOUT_SECONDS = 9;
+    private final int PASSTHROUGH_TIMEOUT_SECONDS = 9;
 
-    private static final int PASSTHROUGH_TIMEOUT_WAITING_MILLISECONDS = 2000;
+    private final int PASSTHROUGH_TIMEOUT_WAITING_MILLISECONDS = getTestTimeoutMultiplier() * 2000;
 
     @Override
     protected void initTestConfig( CoreServerFixture fixture )

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRescheduleTimeoutTest.java
@@ -46,7 +46,7 @@ public class MetadataRescheduleTimeoutTest
             throws Exception
     {
         final int METADATA_TIMEOUT_SECONDS = 4;
-        final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 2500;
+        final int METADATA_TIMEOUT_WAITING_MILLISECONDS = getTestTimeoutMultiplier() * 2500;
 
         final String repoId = "test-repo";
         final String metadataPath = "org/foo/bar/maven-metadata.xml";

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
@@ -50,7 +50,7 @@ public class MixContentRescheduleTimeoutTest
         final String pomUrl = server.formatUrl( repoId, pomPath );
         final String metadataUrl = server.formatUrl( repoId, metadataPath );
         final int CACHE_TIMEOUT_SECONDS = 8;
-        final int CACHE_TIMEOUT_WAITING_MILLISECONDS = 4000;
+        final int CACHE_TIMEOUT_WAITING_MILLISECONDS = getTestTimeoutMultiplier() * 4000;
         final int METADATA_TIMEOUT_SECONDS = 4;
 
         // mocking up a http server that expects access to a .pom

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,8 @@
     <partylineVersion>1.7</partylineVersion>
     <keycloakVersion>1.9.8.Final</keycloakVersion>
     <jhttpcVersion>1.3-SNAPSHOT</jhttpcVersion>
-    <kojijiVersion>1.0</kojijiVersion>
+    <kojijiVersion>1.1-SNAPSHOT</kojijiVersion>
     <rwxVersion>1.0</rwxVersion>
-    <kojijiVersion>1.0</kojijiVersion>
     <bouncycastleVersion>1.53</bouncycastleVersion>
     
     <test-forkCount>4</test-forkCount>

--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,14 @@
     <resteasyVersion>3.0.9.Final</resteasyVersion>
     <undertowVersion>1.1.2.Final</undertowVersion>
     <xnioVersion>3.3.0.Final</xnioVersion>
-    <partylineVersion>1.7</partylineVersion>
+    <partylineVersion>1.8-SNAPSHOT</partylineVersion>
     <keycloakVersion>1.9.8.Final</keycloakVersion>
     <jhttpcVersion>1.3-SNAPSHOT</jhttpcVersion>
     <kojijiVersion>1.1-SNAPSHOT</kojijiVersion>
     <rwxVersion>1.0</rwxVersion>
     <bouncycastleVersion>1.53</bouncycastleVersion>
     
-    <test-forkCount>4</test-forkCount>
+    <test-forkCount>3</test-forkCount>
     <test-redirectOutput>true</test-redirectOutput>
     <skipITs>true</skipITs>
     <quickITs>true</quickITs>
@@ -1226,7 +1226,7 @@
       <id>ci</id>
       <properties>
         <skipTests>false</skipTests>
-        <test-forkCount>2</test-forkCount>
+        <test-forkCount>1</test-forkCount>
         <testEnvTimeoutMultiplier>6</testEnvTimeoutMultiplier>
 
         <dockerNetworkMode>custom</dockerNetworkMode>

--- a/test/docker/gogs-test-appliance/pom.xml
+++ b/test/docker/gogs-test-appliance/pom.xml
@@ -88,9 +88,9 @@
                 <cmd><![CDATA[git clone http://gogs-test-appliance:3000/commonjava/indy-config.git && (cd indy-config && pwd)]]></cmd>
               </build>
               <run>
-<!--                 <links>
+                <links>
                   <link>gogs-test-appliance:gogs-test-appliance</link>
-                </links> -->
+                </links>
                 <log>
                   <file>${project.build.directory}/git-test.log</file>
                 </log>


### PR DESCRIPTION
* Pre-emptively download all content for a Koji build to a hosted repo (backgrounded, triggered by user request for the first file)
* Make download timeout seconds configurable for Koji content retrieval
* Limit group participation to those with target groups (even if the target is the group itself)