### PR TITLE
Access channel

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
@@ -27,10 +27,12 @@ import org.commonjava.indy.folo.data.FoloRecordCache;
 import org.commonjava.indy.folo.model.StoreEffect;
 import org.commonjava.indy.folo.model.TrackedContentEntry;
 import org.commonjava.indy.folo.model.TrackingKey;
+import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.model.galley.KeyedLocation;
+import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.event.FileAccessEvent;
 import org.commonjava.maven.galley.event.FileStorageEvent;
 import org.commonjava.maven.galley.model.Location;
@@ -64,13 +66,14 @@ public class FoloTrackingListener
 
     public void onFileAccess( @Observes final FileAccessEvent event )
     {
-        final TrackingKey trackingKey = (TrackingKey) event.getEventMetadata()
-                                                           .get( FoloConstants.TRACKING_KEY );
+        EventMetadata metadata = event.getEventMetadata();
+        final TrackingKey trackingKey = (TrackingKey) metadata.get( FoloConstants.TRACKING_KEY );
         if ( trackingKey == null )
         {
             logger.info( "No tracking key for access to: {}", event.getTransfer() );
             return;
         }
+        final AccessChannel accessChannel = (AccessChannel) metadata.get( FoloConstants.ACCESS_CHANNEL );
 
         final Transfer transfer = event.getTransfer();
         if ( transfer == null )
@@ -93,7 +96,8 @@ public class FoloTrackingListener
                           keyedLocation.getKey() );
 
             recordManager.recordArtifact(
-                    createEntry( trackingKey, keyedLocation.getKey(), transfer.getPath(), StoreEffect.DOWNLOAD ));
+                    createEntry( trackingKey, keyedLocation.getKey(), accessChannel, transfer.getPath(),
+                                 StoreEffect.DOWNLOAD ));
         }
         catch ( final FoloContentException | IndyWorkflowException e )
         {
@@ -103,13 +107,14 @@ public class FoloTrackingListener
 
     public void onFileUpload( @Observes final FileStorageEvent event )
     {
-        final TrackingKey trackingKey = (TrackingKey) event.getEventMetadata()
-                                                           .get( FoloConstants.TRACKING_KEY );
+        EventMetadata metadata = event.getEventMetadata();
+        final TrackingKey trackingKey = (TrackingKey) metadata.get( FoloConstants.TRACKING_KEY );
         if ( trackingKey == null )
         {
             logger.info( "No tracking key. Not recording." );
             return;
         }
+        final AccessChannel accessChannel = (AccessChannel) metadata.get( FoloConstants.ACCESS_CHANNEL );
 
         final Transfer transfer = event.getTransfer();
         if ( transfer == null )
@@ -152,7 +157,8 @@ public class FoloTrackingListener
             logger.debug( "Tracking report: {} += {} in {} ({})", trackingKey, transfer.getPath(),
                           keyedLocation.getKey(), effect );
 
-            recordManager.recordArtifact( createEntry( trackingKey, keyedLocation.getKey(), transfer.getPath(), effect ));
+            recordManager.recordArtifact( createEntry( trackingKey, keyedLocation.getKey(), accessChannel,
+                                                       transfer.getPath(), effect ));
         }
         catch ( final FoloContentException | IndyWorkflowException e )
         {
@@ -161,7 +167,8 @@ public class FoloTrackingListener
     }
 
     private TrackedContentEntry createEntry( final TrackingKey trackingKey, final StoreKey affectedStore,
-                                                final String path, final StoreEffect effect ) throws IndyWorkflowException
+                                             final AccessChannel accessChannel, final String path,
+                                             final StoreEffect effect ) throws IndyWorkflowException
     {
         TrackedContentEntry entry = null;
         final Transfer txfr = downloadManager.getStorageReference( affectedStore, path );
@@ -185,7 +192,7 @@ public class FoloTrackingListener
                                                ContentDigest.SHA_256 );
                 //TODO: As localUrl needs a apiBaseUrl which is from REST service context, to avoid deep propagate
                 //      of it, this step will be done in REST layer. Will think better way in the future.
-                entry = new TrackedContentEntry( trackingKey, affectedStore, remoteUrl, path, effect,
+                entry = new TrackedContentEntry( trackingKey, affectedStore, accessChannel, remoteUrl, path, effect,
                                                  digests.get( ContentDigest.MD5 ), digests.get( ContentDigest.SHA_1 ),
                                                  digests.get( ContentDigest.SHA_256 ) );
             }

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
@@ -16,11 +16,7 @@
 package org.commonjava.indy.folo.ctl;
 
 import org.commonjava.indy.IndyWorkflowException;
-import org.commonjava.indy.content.ContentDigest;
 import org.commonjava.indy.content.ContentManager;
-import org.commonjava.indy.content.DownloadManager;
-import org.commonjava.indy.data.IndyDataException;
-import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.folo.data.FoloContentException;
 import org.commonjava.indy.folo.data.FoloFiler;
 import org.commonjava.indy.folo.data.FoloRecordCache;
@@ -29,9 +25,7 @@ import org.commonjava.indy.folo.dto.TrackedContentEntryDTO;
 import org.commonjava.indy.folo.model.TrackedContent;
 import org.commonjava.indy.folo.model.TrackedContentEntry;
 import org.commonjava.indy.folo.model.TrackingKey;
-import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.util.ApplicationStatus;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
@@ -50,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.zip.ZipEntry;
@@ -72,27 +65,19 @@ public class FoloAdminController
     private FoloFiler filer;
 
     @Inject
-    private DownloadManager downloadManager;
-
-    @Inject
     private ContentManager contentManager;
 
-    @Inject
-    private StoreDataManager storeManager;
 
     protected FoloAdminController()
     {
     }
 
     public FoloAdminController( final FoloRecordCache recordManager, final FoloFiler filer,
-                                final DownloadManager downloadManager, ContentManager contentManager,
-                                StoreDataManager storeManager )
+                                final ContentManager contentManager )
     {
         this.recordManager = recordManager;
         this.filer = filer;
-        this.downloadManager = downloadManager;
         this.contentManager = contentManager;
-        this.storeManager = storeManager;
     }
 
     public TrackedContentDTO seal( final String id )
@@ -162,37 +147,8 @@ public class FoloAdminController
         return file;
     }
 
-    @Deprecated
-    private void addTransfers( Set<String> paths, StoreKey sk, List<Transfer> items, String trackingId,
-                               Set<String> seenPaths )
-            throws IndyWorkflowException
-    {
-        if ( paths != null )
-        {
-            for ( String path : paths )
-            {
-                if ( path == null || seenPaths.contains( path ) )
-                {
-                    continue;
-                }
-
-                Transfer transfer = contentManager.getTransfer( sk, path, TransferOperation.DOWNLOAD );
-                if ( transfer == null )
-                {
-                    Logger logger = LoggerFactory.getLogger( getClass() );
-                    logger.warn( "While creating Folo repo zip for: {}, cannot find: {} in: {}", trackingId, path, sk );
-                }
-                else
-                {
-                    seenPaths.add( path );
-                    items.add( transfer );
-                }
-            }
-        }
-    }
-
-    private void addTransfers( Set<TrackedContentEntry> entries, List<Transfer> items, String trackingId,
-                               Set<String> seenPaths )
+    private void addTransfers( final Set<TrackedContentEntry> entries, final List<Transfer> items, final String trackingId,
+                               final Set<String> seenPaths )
             throws IndyWorkflowException
     {
         if(entries!=null && !entries.isEmpty()){
@@ -257,60 +213,6 @@ public class FoloAdminController
         return new TrackedContentDTO( tk, uploads, downloads );
     }
 
-    @Deprecated
-    private void addEntries( final Set<TrackedContentEntryDTO> entries, final StoreKey key, final Set<String> paths,
-                             final String apiBaseUrl )
-            throws IndyWorkflowException
-    {
-        for ( final String path : paths )
-        {
-            final Transfer txfr = downloadManager.getStorageReference( key, path );
-            if ( txfr != null )
-            {
-                final TrackedContentEntryDTO entry = new TrackedContentEntryDTO( key, path );
-
-                try
-                {
-                    final String localUrl =
-                            UrlUtils.buildUrl( apiBaseUrl, key.getType().singularEndpointName(), key.getName(), path );
-
-                    String remoteUrl = null;
-                    if ( StoreType.remote == key.getType() )
-                    {
-                        final RemoteRepository repo = storeManager.getRemoteRepository( key.getName() );
-                        if ( repo != null )
-                        {
-                            remoteUrl = UrlUtils.buildUrl( repo.getUrl(), path );
-                        }
-                    }
-
-                    entry.setLocalUrl( localUrl );
-                    entry.setOriginUrl( remoteUrl );
-
-                    final Map<ContentDigest, String> digests =
-                            contentManager.digest( key, path, ContentDigest.MD5, ContentDigest.SHA_1,
-                                                   ContentDigest.SHA_256 );
-
-                    entry.setMd5( digests.get( ContentDigest.MD5 ) );
-                    entry.setSha256( digests.get( ContentDigest.SHA_256 ) );
-                    entry.setSha1( digests.get( ContentDigest.SHA_1 ) );
-
-                    entries.add( entry );
-                }
-                catch ( final IndyDataException e )
-                {
-                    throw new IndyWorkflowException(
-                            "Cannot retrieve RemoteRepository: %s to calculate remote URL for: %s. Reason: %s", e, key,
-                            path, e.getMessage() );
-                }
-                catch ( final MalformedURLException e )
-                {
-                    throw new IndyWorkflowException( "Cannot format URL. Reason: %s", e, e.getMessage() );
-                }
-            }
-        }
-    }
-
     public TrackedContentDTO getRecord( final String id )
             throws IndyWorkflowException
     {
@@ -344,7 +246,8 @@ public class FoloAdminController
         {
             return null;
         }
-        TrackedContentEntryDTO entryDTO = new TrackedContentEntryDTO( entry.getStoreKey(), entry.getPath() );
+        TrackedContentEntryDTO entryDTO = new TrackedContentEntryDTO( entry.getStoreKey(), entry.getAccessChannel(),
+                                                                      entry.getPath() );
         entryDTO.setOriginUrl( entry.getOriginUrl() );
         entryDTO.setMd5( entry.getMd5() );
         entryDTO.setSha1( entry.getSha1() );

--- a/addons/folo/common/src/test/java/org/commonjava/indy/folo/data/FoloRecordCacheTest.java
+++ b/addons/folo/common/src/test/java/org/commonjava/indy/folo/data/FoloRecordCacheTest.java
@@ -19,6 +19,7 @@ import org.commonjava.indy.folo.model.StoreEffect;
 import org.commonjava.indy.folo.model.TrackedContent;
 import org.commonjava.indy.folo.model.TrackedContentEntry;
 import org.commonjava.indy.folo.model.TrackingKey;
+import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.infinispan.Cache;
@@ -80,8 +81,9 @@ public class FoloRecordCacheTest
         final TrackingKey key = newKey();
         assertThat( cache.hasRecord( key ), equalTo( false ) );
 
-        cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ), "", "/path",
-                                                       StoreEffect.DOWNLOAD, "", "", "" ) );
+        cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ),
+                                                       AccessChannel.MAVEN_REPO, "", "/path", StoreEffect.DOWNLOAD, "", "",
+                                                       "" ) );
 
         assertThat( cache.hasRecord( key ), equalTo( true ) );
         assertThat( cache.hasInProgressRecord( key ), equalTo( true ) );
@@ -101,8 +103,9 @@ public class FoloRecordCacheTest
         final TrackingKey key = newKey();
         assertThat( cache.hasRecord( key ), equalTo( false ) );
 
-        cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ), "", "/path",
-                                                       StoreEffect.DOWNLOAD, "", "", "" ) );
+        cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ),
+                                                       AccessChannel.MAVEN_REPO, "", "/path", StoreEffect.DOWNLOAD, "",
+                                                       "", "" ) );
 
         assertThat( cache.hasRecord( key ), equalTo( true ) );
         assertThat( cache.hasInProgressRecord( key ), equalTo( true ) );
@@ -122,8 +125,9 @@ public class FoloRecordCacheTest
         final TrackingKey key = newKey();
         assertThat( cache.hasRecord( key ), equalTo( false ) );
 
-        cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ), "", "/path",
-                                                       StoreEffect.DOWNLOAD, "", "", "" ) );
+        cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ),
+                                                       AccessChannel.MAVEN_REPO, "", "/path", StoreEffect.DOWNLOAD, "",
+                                                       "", "" ) );
 
         TrackedContent record = cache.seal( key );
 

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.folo.dto;
 
+import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.StoreKey;
 
 public class TrackedContentEntryDTO
@@ -22,6 +23,8 @@ public class TrackedContentEntryDTO
 {
 
     private StoreKey storeKey;
+
+    private AccessChannel accessChannel;
 
     private String path;
 
@@ -39,9 +42,10 @@ public class TrackedContentEntryDTO
     {
     }
 
-    public TrackedContentEntryDTO( final StoreKey storeKey, final String path )
+    public TrackedContentEntryDTO( final StoreKey storeKey, final AccessChannel accessChannel, final String path )
     {
         this.storeKey = storeKey;
+        this.accessChannel = accessChannel;
         this.path = path.startsWith( "/" ) ? path : "/" + path;
     }
 
@@ -85,7 +89,7 @@ public class TrackedContentEntryDTO
         this.sha256 = sha256;
     }
 
-    public void setSha1( String sha1 )
+    public void setSha1( final String sha1 )
     {
         this.sha1 = sha1;
     }
@@ -104,6 +108,16 @@ public class TrackedContentEntryDTO
         this.storeKey = storeKey;
     }
 
+    public AccessChannel getAccessChannel()
+    {
+        return accessChannel;
+    }
+
+    public void setAccessChannel( final AccessChannel accessChannel )
+    {
+        this.accessChannel = accessChannel;
+    }
+
     public String getPath()
     {
         return path;
@@ -120,6 +134,10 @@ public class TrackedContentEntryDTO
         int comp = storeKey.compareTo( other.getStoreKey() );
         if ( comp == 0 )
         {
+            comp = accessChannel.compareTo( other.getAccessChannel() );
+        }
+        if ( comp == 0 )
+        {
             comp = path.compareTo( other.getPath() );
         }
 
@@ -133,6 +151,7 @@ public class TrackedContentEntryDTO
         int result = 1;
         result = prime * result + ( ( path == null ) ? 0 : path.hashCode() );
         result = prime * result + ( ( storeKey == null ) ? 0 : storeKey.hashCode() );
+        result = prime * result + ( ( accessChannel == null ) ? 0 : accessChannel.hashCode() );
         return result;
     }
 
@@ -174,14 +193,25 @@ public class TrackedContentEntryDTO
         {
             return false;
         }
+        if ( accessChannel == null )
+        {
+            if ( other.accessChannel != null )
+            {
+                return false;
+            }
+        }
+        else if ( !accessChannel.equals( other.accessChannel ) )
+        {
+            return false;
+        }
         return true;
     }
 
     @Override
     public String toString()
     {
-        return String.format( "TrackedContentEntryDTO [\n  storeKey=%s\n  path=%s\n  originUrl=%s\n  localUrl=%s\n  md5=%s\n  sha256=%s\n]",
-                              storeKey, path, originUrl, localUrl, md5, sha256 );
+        return String.format( "TrackedContentEntryDTO [\n  storeKey=%s\n  accessChannel=%s\n  path=%s\n  originUrl=%s\n  localUrl=%s\n  md5=%s\n  sha256=%s\n]",
+                              storeKey, accessChannel, path, originUrl, localUrl, md5, sha256 );
     }
 
 }

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.folo.model;
 
+import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.hibernate.search.annotations.Field;
@@ -41,6 +42,9 @@ public class TrackedContentEntry
     private StoreKey storeKey;
 
     @Field
+    private AccessChannel accessChannel;
+
+    @Field
     private String path;
 
     @Field
@@ -65,12 +69,13 @@ public class TrackedContentEntry
     {
     }
 
-    public TrackedContentEntry( final TrackingKey trackingKey, final StoreKey storeKey, final String originUrl,
-                                final String path, final StoreEffect effect, final String md5, final String sha1,
-                                final String sha256 )
+    public TrackedContentEntry( final TrackingKey trackingKey, final StoreKey storeKey,
+                                final AccessChannel accessChannel, final String originUrl, final String path,
+                                final StoreEffect effect, final String md5, final String sha1, final String sha256 )
     {
         this.trackingKey = trackingKey;
         this.storeKey = storeKey;
+        this.accessChannel = accessChannel;
         this.path = path;
         this.originUrl = originUrl;
         this.effect = effect;
@@ -104,6 +109,11 @@ public class TrackedContentEntry
         return storeKey;
     }
 
+    public AccessChannel getAccessChannel()
+    {
+        return accessChannel;
+    }
+
     public String getPath()
     {
         return path;
@@ -130,6 +140,10 @@ public class TrackedContentEntry
         int comp = storeKey.compareTo( other.getStoreKey() );
         if ( comp == 0 )
         {
+            comp = accessChannel.compareTo( other.getAccessChannel() );
+        }
+        if ( comp == 0 )
+        {
             comp = path.compareTo( other.getPath() );
         }
 
@@ -143,6 +157,7 @@ public class TrackedContentEntry
         int result = 1;
         result = prime * result + ( ( path == null ) ? 0 : path.hashCode() );
         result = prime * result + ( ( storeKey == null ) ? 0 : storeKey.hashCode() );
+        result = prime * result + ( ( accessChannel == null ) ? 0 : accessChannel.hashCode() );
         return result;
     }
 
@@ -184,6 +199,17 @@ public class TrackedContentEntry
         {
             return false;
         }
+        if ( accessChannel == null )
+        {
+            if ( other.accessChannel != null )
+            {
+                return false;
+            }
+        }
+        else if ( !accessChannel.equals( other.accessChannel ) )
+        {
+            return false;
+        }
         return true;
     }
 
@@ -191,17 +217,18 @@ public class TrackedContentEntry
     public String toString()
     {
         return String.format(
-                "TrackedContentEntry [\n  trackingKey=%s\n  storeKey=%s\n  path=%s\n  originUrl=%s\n effect=%s\n  md5=%s\n  sha1=%s\n  sha256=%s\n]",
-                trackingKey, storeKey, path, originUrl, effect, md5, sha1, sha256 );
+                "TrackedContentEntry [\n  trackingKey=%s\n  storeKey=%s\n  accessChannel=%s\n  path=%s\n  originUrl=%s\n effect=%s\n  md5=%s\n  sha1=%s\n  sha256=%s\n]",
+                trackingKey, storeKey, accessChannel, path, originUrl, effect, md5, sha1, sha256 );
     }
 
     @Override
-    public void writeExternal( ObjectOutput out )
+    public void writeExternal( final ObjectOutput out )
             throws IOException
     {
         out.writeObject( trackingKey );
         out.writeObject( storeKey.getName() );
         out.writeObject( storeKey.getType().name() );
+        out.writeObject( accessChannel.name() );
         out.writeObject( path == null ? "" : path );
         out.writeObject( originUrl == null ? "" : originUrl );
         out.writeObject( effect == null ? "" : effect.name() );
@@ -212,7 +239,7 @@ public class TrackedContentEntry
     }
 
     @Override
-    public void readExternal( ObjectInput in )
+    public void readExternal( final ObjectInput in )
             throws IOException, ClassNotFoundException
     {
         trackingKey = (TrackingKey) in.readObject();
@@ -220,6 +247,9 @@ public class TrackedContentEntry
         final String storeKeyName = (String) in.readObject();
         final StoreType storeType = StoreType.get( (String) in.readObject() );
         storeKey = new StoreKey( storeType, storeKeyName );
+
+        final String accessChannelStr = (String) in.readObject();
+        accessChannel = "".equals( accessChannelStr ) ? null : AccessChannel.valueOf( accessChannelStr );
 
         final String pathStr = (String) in.readObject();
         path = "".equals( pathStr ) ? null : pathStr;

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackingKey.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackingKey.java
@@ -30,7 +30,7 @@ public class TrackingKey implements Externalizable
     @Field
     private String id;
 
-    protected TrackingKey()
+    public TrackingKey()
     {
     }
 
@@ -100,14 +100,14 @@ public class TrackingKey implements Externalizable
     }
 
     @Override
-    public void writeExternal( ObjectOutput out )
+    public void writeExternal( final ObjectOutput out )
             throws IOException
     {
         out.writeObject( id );
     }
 
     @Override
-    public void readExternal( ObjectInput in )
+    public void readExternal( final ObjectInput in )
             throws IOException, ClassNotFoundException
     {
         id = (String) in.readObject();

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentDTOTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentDTOTest.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.folo.dto;
 
 import org.commonjava.indy.folo.model.TrackingKey;
+import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
@@ -53,15 +54,16 @@ public class TrackedContentDTOTest
             throws IOException
     {
         Set<TrackedContentEntryDTO> downloads =
-                setOf( new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), "/path/to/my.pom" ),
+                setOf( new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), AccessChannel.MAVEN_REPO,
+                                                   "/path/to/my.pom" ),
                        new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo2" ),
-                                                   "/path/to/another/file.pom" ) );
+                                                   AccessChannel.MAVEN_REPO, "/path/to/another/file.pom" ) );
 
         Set<TrackedContentEntryDTO> uploads =
                 setOf( new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo3" ),
-                                                   "/path/to/third/artifact.pom" ),
+                                                   AccessChannel.MAVEN_REPO, "/path/to/third/artifact.pom" ),
                        new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo3" ),
-                                                   "/path/to/fourth/project.pom" ) );
+                                                   AccessChannel.MAVEN_REPO, "/path/to/fourth/project.pom" ) );
 
         TrackedContentDTO in = new TrackedContentDTO( new TrackingKey( "key" ), uploads, downloads );
 
@@ -76,9 +78,10 @@ public class TrackedContentDTOTest
             throws IOException
     {
         Set<TrackedContentEntryDTO> downloads =
-                setOf( new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), "/path/to/my.pom" ),
+                setOf( new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), AccessChannel.MAVEN_REPO,
+                                                   "/path/to/my.pom" ),
                        new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo2" ),
-                                                   "/path/to/another/file.pom" ) );
+                                                   AccessChannel.MAVEN_REPO, "/path/to/another/file.pom" ) );
 
         TrackedContentDTO in = new TrackedContentDTO( new TrackingKey( "key" ), Collections.emptySet(), downloads );
 
@@ -93,9 +96,10 @@ public class TrackedContentDTOTest
             throws IOException
     {
         Set<TrackedContentEntryDTO> uploads =
-                setOf( new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), "/path/to/my.pom" ),
+                setOf( new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), AccessChannel.MAVEN_REPO,
+                                                   "/path/to/my.pom" ),
                        new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo2" ),
-                                                   "/path/to/another/file.pom" ) );
+                                                   AccessChannel.MAVEN_REPO, "/path/to/another/file.pom" ) );
 
         TrackedContentDTO in = new TrackedContentDTO( new TrackingKey( "key" ), uploads, Collections.emptySet() );
 
@@ -105,7 +109,7 @@ public class TrackedContentDTOTest
         } );
     }
 
-    private void assertContents( Set<TrackedContentEntryDTO> result, Set<TrackedContentEntryDTO> test )
+    private void assertContents( final Set<TrackedContentEntryDTO> result, final Set<TrackedContentEntryDTO> test )
     {
         assertThat( result, notNullValue() );
         assertThat( result.size(), equalTo( test.size() ) );
@@ -115,17 +119,17 @@ public class TrackedContentDTOTest
                                          equalTo( true ) ) );
     }
 
-    private Set<TrackedContentEntryDTO> setOf( TrackedContentEntryDTO... entries )
+    private Set<TrackedContentEntryDTO> setOf( final TrackedContentEntryDTO... entries )
     {
         return Stream.of( entries ).collect( Collectors.toSet() );
     }
 
-    private void assertNullOrEmpty( Set<TrackedContentEntryDTO> values )
+    private void assertNullOrEmpty( final Set<TrackedContentEntryDTO> values )
     {
         assertThat( values == null || values.isEmpty(), equalTo( true ) );
     }
 
-    private void assertRoundTrip( TrackedContentDTO in, Consumer<TrackedContentDTO> extraAssertions )
+    private void assertRoundTrip( final TrackedContentDTO in, final Consumer<TrackedContentDTO> extraAssertions )
             throws IOException
     {
         IndyObjectMapper mapper = new IndyObjectMapper( true );

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTOTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTOTest.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.folo.dto;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
@@ -38,7 +39,8 @@ public class TrackedContentEntryDTOTest
             throws IOException
     {
         TrackedContentEntryDTO in =
-                new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), "/path/to/my.pom" );
+                new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), AccessChannel.MAVEN_REPO,
+                                            "/path/to/my.pom" );
 
         assertRoundTrip( in, (out)->{} );
     }
@@ -48,7 +50,8 @@ public class TrackedContentEntryDTOTest
             throws IOException
     {
         TrackedContentEntryDTO in =
-                new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), "/path/to/my.pom" );
+                new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), AccessChannel.MAVEN_REPO,
+                                            "/path/to/my.pom" );
 
         String content = "This is a test string";
         in.setMd5( DigestUtils.md5Hex( content ) );
@@ -67,7 +70,8 @@ public class TrackedContentEntryDTOTest
             throws IOException
     {
         TrackedContentEntryDTO in =
-                new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), "/path/to/my.pom" );
+                new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), AccessChannel.MAVEN_REPO,
+                                            "/path/to/my.pom" );
 
         in.setLocalUrl( "http://localhost:8080/api/remote/foo/path/to/my.pom" );
         in.setOriginUrl( "http://foo.com/repo/path/to/my.pom" );
@@ -78,7 +82,7 @@ public class TrackedContentEntryDTOTest
         } );
     }
 
-    private void assertRoundTrip( TrackedContentEntryDTO in, Consumer<TrackedContentEntryDTO> extraAssertions )
+    private void assertRoundTrip( final TrackedContentEntryDTO in, final Consumer<TrackedContentEntryDTO> extraAssertions )
             throws IOException
     {
         IndyObjectMapper mapper = new IndyObjectMapper( true );

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -28,6 +28,7 @@ import org.commonjava.indy.httprox.conf.HttproxConfig;
 import org.commonjava.indy.httprox.conf.TrackingType;
 import org.commonjava.indy.httprox.keycloak.KeycloakProxyAuthenticator;
 import org.commonjava.indy.httprox.util.HttpConduitWrapper;
+import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.subsys.http.HttpWrapper;
 import org.commonjava.indy.subsys.http.util.UserPass;
@@ -80,7 +81,7 @@ public final class ProxyResponseWriter
 
     public ProxyResponseWriter( final HttproxConfig config, final StoreDataManager storeManager,
                                 final ContentController contentController,
-                                KeycloakProxyAuthenticator proxyAuthenticator, CacheProvider cacheProvider )
+                                final KeycloakProxyAuthenticator proxyAuthenticator, final CacheProvider cacheProvider )
     {
         this.config = config;
         this.contentController = contentController;
@@ -203,7 +204,7 @@ public final class ProxyResponseWriter
         }
     }
 
-    private void handleError( Throwable error, HttpWrapper http )
+    private void handleError( final Throwable error, final HttpWrapper http )
     {
         logger.error( "HTTProx request failed: " + error.getMessage(), error );
         try
@@ -275,8 +276,8 @@ public final class ProxyResponseWriter
         }
     }
 
-    private EventMetadata createEventMetadata( boolean writeBody, UserPass proxyUserPass, String path,
-                                               RemoteRepository repo )
+    private EventMetadata createEventMetadata( final boolean writeBody, final UserPass proxyUserPass, final String path,
+                                               final RemoteRepository repo )
                     throws IndyWorkflowException
     {
         final EventMetadata eventMetadata = new EventMetadata();
@@ -321,6 +322,8 @@ public final class ProxyResponseWriter
             {
                 logger.debug( "TRACKING {} in {} (KEY: {})", path, repo, tk );
                 eventMetadata.set( FoloConstants.TRACKING_KEY, tk );
+
+                eventMetadata.set( FoloConstants.ACCESS_CHANNEL, AccessChannel.GENERIC_PROXY );
             }
             else
             {
@@ -381,7 +384,7 @@ public final class ProxyResponseWriter
         this.error = error;
     }
 
-    public void setHttpRequest( HttpRequest request )
+    public void setHttpRequest( final HttpRequest request )
     {
         this.httpRequest = request;
     }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AccessChannel.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AccessChannel.java
@@ -13,13 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.commonjava.indy.folo.ctl;
+package org.commonjava.indy.model.core;
 
-public class FoloConstants
+/**
+ * Enumeration to distinguish between different access channels to stores.
+ *
+ * @author pkocandr
+ */
+public enum AccessChannel
 {
 
-    public static final String TRACKING_KEY = "tracking-id";
-
-    public static final String ACCESS_CHANNEL = "access-channel";
+    /** Used when the store is accessed via httprox addon. */
+    GENERIC_PROXY,
+    /** Used when the store is accessed via regular Maven repo. */
+    MAVEN_REPO
 
 }


### PR DESCRIPTION
This is adding access channel into folo tracking report. There are currently 2 access channels - Maven repo and generic proxy. This is stored directly into the tracking report with the request, because a generic proxy repo created by httprox can also be accessed via regular Maven repo access path, so we want to distinguish between the access channels, not between addons that created the repo, although this will be probably interesting for other usages.
I'm just not sure, if "access channel" is the best name. Another option was "entry point". Or maybe there is some other even better.