### PR TITLE
NCL-2266: artifact size exposed in TrackedContentEntryDTO

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.folo.change;
 
 import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.content.ArtifactData;
 import org.commonjava.indy.content.ContentDigest;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.DownloadManager;
@@ -187,14 +188,15 @@ public class FoloTrackingListener
                 }
 
 
-                Map<ContentDigest, String> digests =
+                ArtifactData artifactData =
                         contentManager.digest( affectedStore, path, ContentDigest.MD5, ContentDigest.SHA_1,
                                                ContentDigest.SHA_256 );
+                Map<ContentDigest, String> digests = artifactData.getDigests();
                 //TODO: As localUrl needs a apiBaseUrl which is from REST service context, to avoid deep propagate
                 //      of it, this step will be done in REST layer. Will think better way in the future.
                 entry = new TrackedContentEntry( trackingKey, affectedStore, accessChannel, remoteUrl, path, effect,
-                                                 digests.get( ContentDigest.MD5 ), digests.get( ContentDigest.SHA_1 ),
-                                                 digests.get( ContentDigest.SHA_256 ) );
+                                                 artifactData.getSize(), digests.get( ContentDigest.MD5 ),
+                                                 digests.get( ContentDigest.SHA_1 ), digests.get( ContentDigest.SHA_256 ) );
             }
             catch ( final IndyDataException e )
             {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
@@ -252,6 +252,7 @@ public class FoloAdminController
         entryDTO.setMd5( entry.getMd5() );
         entryDTO.setSha1( entry.getSha1() );
         entryDTO.setSha256( entry.getSha256() );
+        entryDTO.setSize( entry.getSize() );
         return entryDTO;
     }
 

--- a/addons/folo/common/src/test/java/org/commonjava/indy/folo/data/FoloRecordCacheTest.java
+++ b/addons/folo/common/src/test/java/org/commonjava/indy/folo/data/FoloRecordCacheTest.java
@@ -31,6 +31,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Set;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -79,11 +81,12 @@ public class FoloRecordCacheTest
             throws Exception
     {
         final TrackingKey key = newKey();
+        final long size = 123L;
         assertThat( cache.hasRecord( key ), equalTo( false ) );
 
         cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ),
-                                                       AccessChannel.MAVEN_REPO, "", "/path", StoreEffect.DOWNLOAD, "", "",
-                                                       "" ) );
+                                                       AccessChannel.MAVEN_REPO, "", "/path",
+                                                       StoreEffect.DOWNLOAD, size, "", "", "" ) );
 
         assertThat( cache.hasRecord( key ), equalTo( true ) );
         assertThat( cache.hasInProgressRecord( key ), equalTo( true ) );
@@ -94,6 +97,11 @@ public class FoloRecordCacheTest
         assertThat( cache.hasRecord( key ), equalTo( true ) );
         assertThat( cache.hasInProgressRecord( key ), equalTo( false ) );
         assertThat( cache.hasSealedRecord( key ), equalTo( true ) );
+        Set<TrackedContentEntry> downloads = cache.get(key).getDownloads();
+        assertThat( downloads, notNullValue() );
+        assertThat( downloads.size(), equalTo( 1 ) );
+        TrackedContentEntry entry = downloads.iterator().next();
+        assertThat( entry.getSize(), equalTo( size ) );
     }
 
     @Test
@@ -104,8 +112,8 @@ public class FoloRecordCacheTest
         assertThat( cache.hasRecord( key ), equalTo( false ) );
 
         cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ),
-                                                       AccessChannel.MAVEN_REPO, "", "/path", StoreEffect.DOWNLOAD, "",
-                                                       "", "" ) );
+                                                       AccessChannel.MAVEN_REPO, "", "/path",
+                                                       StoreEffect.DOWNLOAD, 124L, "", "", "" ) );
 
         assertThat( cache.hasRecord( key ), equalTo( true ) );
         assertThat( cache.hasInProgressRecord( key ), equalTo( true ) );
@@ -126,8 +134,8 @@ public class FoloRecordCacheTest
         assertThat( cache.hasRecord( key ), equalTo( false ) );
 
         cache.recordArtifact( new TrackedContentEntry( key, new StoreKey( StoreType.remote, "foo" ),
-                                                       AccessChannel.MAVEN_REPO, "", "/path", StoreEffect.DOWNLOAD, "",
-                                                       "", "" ) );
+                                                       AccessChannel.MAVEN_REPO, "", "/path",
+                                                       StoreEffect.DOWNLOAD, 127L, "", "", "" ) );
 
         TrackedContent record = cache.seal( key );
 

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
@@ -38,6 +38,8 @@ public class TrackedContentEntryDTO
 
     private String sha1;
 
+    private Long size;
+
     public TrackedContentEntryDTO()
     {
     }
@@ -128,6 +130,16 @@ public class TrackedContentEntryDTO
         this.path = path.startsWith( "/" ) ? path : "/" + path;
     }
 
+    public Long getSize()
+    {
+        return size;
+    }
+
+    public void setSize( final Long size )
+    {
+        this.size = size;
+    }
+
     @Override
     public int compareTo( final TrackedContentEntryDTO other )
     {
@@ -210,8 +222,8 @@ public class TrackedContentEntryDTO
     @Override
     public String toString()
     {
-        return String.format( "TrackedContentEntryDTO [\n  storeKey=%s\n  accessChannel=%s\n  path=%s\n  originUrl=%s\n  localUrl=%s\n  md5=%s\n  sha256=%s\n]",
-                              storeKey, accessChannel, path, originUrl, localUrl, md5, sha256 );
+        return String.format( "TrackedContentEntryDTO [\n  storeKey=%s\n  accessChannel=%s\n  path=%s\n  originUrl=%s\n  localUrl=%s\n  size=%d\n md5=%s\n  sha256=%s\n]",
+                              storeKey, accessChannel, path, originUrl, localUrl, size, md5, sha256 );
     }
 
 }

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
@@ -63,6 +63,9 @@ public class TrackedContentEntry
     private String sha1;
 
     @Field
+    private Long size;
+
+    @Field
     private long index = System.currentTimeMillis();
 
     public TrackedContentEntry()
@@ -71,7 +74,8 @@ public class TrackedContentEntry
 
     public TrackedContentEntry( final TrackingKey trackingKey, final StoreKey storeKey,
                                 final AccessChannel accessChannel, final String originUrl, final String path,
-                                final StoreEffect effect, final String md5, final String sha1, final String sha256 )
+                                final StoreEffect effect, final Long size,
+                                final String md5, final String sha1, final String sha256 )
     {
         this.trackingKey = trackingKey;
         this.storeKey = storeKey;
@@ -82,6 +86,7 @@ public class TrackedContentEntry
         this.md5=md5;
         this.sha1=sha1;
         this.sha256=sha256;
+        this.size = size;
     }
 
     public String getOriginUrl()
@@ -127,6 +132,11 @@ public class TrackedContentEntry
     public StoreEffect getEffect()
     {
         return effect;
+    }
+
+    public Long getSize()
+    {
+        return size;
     }
 
     public long getIndex()
@@ -235,6 +245,7 @@ public class TrackedContentEntry
         out.writeObject( md5 == null ? "" : md5 );
         out.writeObject( sha1 == null ? "" : sha1 );
         out.writeObject( sha256 == null ? "" : sha256 );
+        out.writeObject( size );
         out.writeLong( index );
     }
 
@@ -268,6 +279,8 @@ public class TrackedContentEntry
 
         final String sha256Str = (String) in.readObject();
         sha256 = "".equals( sha256Str ) ? null : sha256Str;
+
+        size = (Long) in.readObject();
 
         index = in.readLong();
     }

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTOTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTOTest.java
@@ -64,6 +64,17 @@ public class TrackedContentEntryDTOTest
             assertThat( out.getSha1(), equalTo( in.getSha1() ) );
         } );
     }
+    @Test
+    public void jsonRoundTrip_size()
+            throws IOException
+    {
+        TrackedContentEntryDTO in =
+                new TrackedContentEntryDTO( new StoreKey( StoreType.remote, "foo" ), AccessChannel.MAVEN_REPO, "/path/to/my.pom" );
+
+        in.setSize(1234123L);
+
+        assertRoundTrip( in, (out)-> assertThat( out.getSize(), equalTo( in.getSize() ) ) );
+    }
 
     @Test
     public void jsonRoundTrip_Urls()

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -382,7 +382,7 @@ public class PromotionValidationTools
     public Map<ContentDigest, String> digest( StoreKey key, String path, ContentDigest... types )
             throws IndyWorkflowException
     {
-        return contentManager.digest( key, path, types );
+        return contentManager.digest( key, path, types ).getDigests();
     }
 
     public HttpExchangeMetadata getHttpMetadata( Transfer txfr )

--- a/api/src/main/java/org/commonjava/indy/content/ArtifactData.java
+++ b/api/src/main/java/org/commonjava/indy/content/ArtifactData.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.content;
+
+import java.util.Map;
+
+/**
+ * Author: Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * Date: 8/19/16
+ * Time: 1:15 PM
+ */
+public class ArtifactData {
+    private final Map<ContentDigest, String> digests;
+    private final Long size;
+
+    public ArtifactData( Map<ContentDigest, String> digests, Long size )
+    {
+        this.digests = digests;
+        this.size = size;
+    }
+
+    public Map<ContentDigest, String> getDigests()
+    {
+        return digests;
+    }
+
+    public Long getSize()
+    {
+        return size;
+    }
+}

--- a/api/src/main/java/org/commonjava/indy/content/ContentManager.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentManager.java
@@ -15,10 +15,6 @@
  */
 package org.commonjava.indy.content;
 
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
@@ -28,6 +24,9 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
+
+import java.io.InputStream;
+import java.util.List;
 
 /**
  * High-level interface for retrieving, storing, etc. content which includes both produced (i.e. generated) content as well as downloaded and stored
@@ -209,7 +208,7 @@ public interface ContentManager
     List<StoreResource> list( List<? extends ArtifactStore> stores, String path )
         throws IndyWorkflowException;
 
-    Map<ContentDigest, String> digest( StoreKey key, String path, ContentDigest... types )
+    ArtifactData digest( StoreKey key, String path, ContentDigest... types )
         throws IndyWorkflowException;
 
     HttpExchangeMetadata getHttpMetadata( Transfer txfr )


### PR DESCRIPTION
Added `size` to `TrackedContentEntry` and `TrackedContentEntryDTO`.

In order not to download the artifact twice, the size is calculated together with hashes of the artifact.
The `ContentManager#digest` method has been changed to return newly created `ArtifactData`, that contains hashes and size.