### PR TITLE
Disable ORDER BY clause in Folo's in-progress cache, since it causes …

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
@@ -27,6 +27,7 @@ import org.infinispan.query.Search;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryBuilder;
 import org.infinispan.query.dsl.QueryFactory;
+import org.infinispan.query.dsl.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -164,8 +165,10 @@ public class FoloRecordCache
             QueryBuilder qb = queryFactory.from( TrackedContentEntry.class )
                                              .having( "trackingKey.id" )
                                              .eq( key.getId() )
-                                             .toBuilder()
-                                             .orderBy( "index" );
+                                             .toBuilder();
+            // FIXME: Ordering breaks the query parser (it expects a LPAREN for some reason, and adding it to the string below doesn't work)
+//                                             .orderBy( "index", SortOrder.ASC );
+
             return operation.apply( qb, inProgressRecordCache );
         } );
     }

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContent.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContent.java
@@ -15,9 +15,15 @@
  */
 package org.commonjava.indy.folo.model;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.HashSet;
 import java.util.Set;
 
 public class TrackedContent
+        implements Externalizable
 {
 
     private TrackingKey key;
@@ -71,5 +77,26 @@ public class TrackedContent
     public int hashCode()
     {
         return getKey() != null ? getKey().hashCode() : 0;
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput objectOutput )
+            throws IOException
+    {
+        objectOutput.writeObject( key );
+        objectOutput.writeObject( uploads );
+        objectOutput.writeObject( downloads );
+    }
+
+    @Override
+    public void readExternal( ObjectInput objectInput )
+            throws IOException, ClassNotFoundException
+    {
+        key = (TrackingKey) objectInput.readObject();
+        Set<TrackedContentEntry> ups = (Set<TrackedContentEntry>) objectInput.readObject();
+        uploads = ups == null ? new HashSet<>() : new HashSet<>( ups );
+
+        Set<TrackedContentEntry> downs = (Set<TrackedContentEntry>) objectInput.readObject();
+        downloads = downs == null ? new HashSet<>() : new HashSet<>( downs );
     }
 }

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.folo.model;
 import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Indexed;
@@ -65,7 +66,7 @@ public class TrackedContentEntry
     @Field
     private Long size;
 
-    @Field
+    @Field( analyze = Analyze.NO )
     private long index = System.currentTimeMillis();
 
     public TrackedContentEntry()

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackingKey.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackingKey.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.folo.model;
 
+import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 
@@ -27,7 +28,7 @@ import java.io.ObjectOutput;
 public class TrackingKey implements Externalizable
 {
 
-    @Field
+    @Field( analyze = Analyze.NO )
     private String id;
 
     public TrackingKey()


### PR DESCRIPTION
…some sort of query parsing exception. Don't analyze Folo fields we use for querying