### PR TITLE
Fix MissingPropertyException in brew pull

### DIFF
--- a/addons/koji/common/src/main/data/scripts/stores/koji-repo-creator.groovy
+++ b/addons/koji/common/src/main/data/scripts/stores/koji-repo-creator.groovy
@@ -24,7 +24,7 @@ class RepoCreator implements KojiRepositoryCreator
         hosted.setMetadata( KojiContentManagerDecorator.CREATION_TRIGGER_GAV, artifactRef.toString() );
         hosted.setMetadata( KojiContentManagerDecorator.NVR, nvr );
         hosted.setDescription(
-                String.format( "Koji build: %s (triggered by: %s via: %s)", build.getNvr(), originatingPath,
+                String.format( "Koji build: %s (triggered by: %s via: %s)", nvr, originatingPath,
                         eventMetadata.get( ENTRY_POINT_STORE ) ) );
     }
 }


### PR DESCRIPTION
There is no build class property nor a method parameter or local
variable with such name, but nvr is passed as a method param. The
exception was:
```
2016-09-07 10:26:17.720 [HEAD /group/builds-untested/org/jbpm/jbpm-case-mgmt/6.4.0.Final-redhat-3/jbpm-case-mgmt-6.4.0.Final-redhat-3.pom (1473258369888.4687940368073419)] ERROR o.c.i.c.b.jaxrs.ContentAccessHandler - Failed to download artifact: org/jbpm/jbpm-case-mgmt/6.4.0.Final-redhat-3/jbpm-case-mgmt-6.4.0.Final-redhat-3.pom from: builds-untested. Reason: Cannot retrieve builds for: org.jbpm:jbpm-case-mgmt:pom:6.4.0.Final-redhat-3. Error: Koji withSession lambda command failed: No such property: build for class: org.commonjava.indy.koji.RepoCreator
org.commonjava.indy.IndyWorkflowException: Cannot retrieve builds for: org.jbpm:jbpm-case-mgmt:pom:6.4.0.Final-redhat-3. Error: Koji withSession lambda command failed: No such property: build for class: org.commonjava.indy.koji.RepoCreator
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.proxyKojiBuild(KojiContentManagerDecorator.java:261) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.retrieve(KojiContentManagerDecorator.java:192) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at sun.reflect.GeneratedMethodAccessor137.invoke(Unknown Source) ~[na:na]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_101]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_101]
    at org.jboss.weld.annotated.runtime.InvokableAnnotatedMethod.invokeOnInstance(InvokableAnnotatedMethod.java:97) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:80) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:69) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.interceptor.util.proxy.TargetInstanceProxyMethodHandler.invoke(TargetInstanceProxyMethodHandler.java:33) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.TargetBeanInstance.invoke(TargetBeanInstance.java:88) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_Weld$Proxy$.retrieve(Unknown Source) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.content.index.IndexingContentManagerDecorator.retrieve(IndexingContentManagerDecorator.java:207) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at sun.reflect.GeneratedMethodAccessor137.invoke(Unknown Source) ~[na:na]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_101]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_101]
    at org.jboss.weld.annotated.runtime.InvokableAnnotatedMethod.invokeOnInstance(InvokableAnnotatedMethod.java:97) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:80) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:69) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.interceptor.util.proxy.TargetInstanceProxyMethodHandler.invoke(TargetInstanceProxyMethodHandler.java:33) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.TargetBeanInstance.invoke(TargetBeanInstance.java:88) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_Weld$Proxy$.retrieve(Unknown Source) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at sun.reflect.GeneratedMethodAccessor146.invoke(Unknown Source) ~[na:na]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_101]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_101]
    at org.jboss.weld.util.reflection.Reflections.invokeAndUnwrap(Reflections.java:401) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.jboss.weld.bean.proxy.CombinedInterceptorAndDecoratorStackMethodHandler.invoke(CombinedInterceptorAndDecoratorStackMethodHandler.java:62) ~[weld-se-2.1.2.Final.jar:2014-01-09 09:23]
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_WeldSubclass.retrieve(Unknown Source) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.core.ctl.ContentController.get(ContentController.java:147) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.core.ctl.ContentController$Proxy$_$$_WeldClientProxy.get(Unknown Source) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler.doHead(ContentAccessHandler.java:187) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.core.bind.jaxrs.ContentAccessResource.doHead(ContentAccessResource.java:110) [indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.core.bind.jaxrs.ContentAccessResource$Proxy$_$$_WeldClientProxy.doHead(Unknown Source) [indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_101]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_101]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_101]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_101]
    at org.jboss.resteasy.core.MethodInjectorImpl.invoke(MethodInjectorImpl.java:137) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.ResourceMethodInvoker.invokeOnTarget(ResourceMethodInvoker.java:296) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:250) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:237) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:356) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.core.SynchronousDispatcher.invoke(SynchronousDispatcher.java:179) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.plugins.server.servlet.ServletContainerDispatcher.service(ServletContainerDispatcher.java:220) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:56) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher.service(HttpServletDispatcher.java:51) [resteasy-jaxrs-3.0.9.Final.jar:na]
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:847) [jboss-servlet-api_3.0_spec-1.0.1.Final.jar:1.0.1.Final]
    at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:130) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at org.commonjava.indy.bind.jaxrs.ResourceManagementFilter.doFilter(ResourceManagementFilter.java:67) [indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.bind.jaxrs.ResourceManagementFilter$Proxy$_$$_WeldClientProxy.doFilter(Unknown Source) [indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:60) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:132) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:85) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:61) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:56) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:45) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:63) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:58) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:70) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.security.handlers.SecurityInitialHandler.handleRequest(SecurityInitialHandler.java:76) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at org.commonjava.indy.bind.jaxrs.HeaderDebugger.handleRequest(HeaderDebugger.java:93) [indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:261) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:247) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:76) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:166) [undertow-servlet-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.server.Connectors.executeRootHandler(Connectors.java:197) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:764) [undertow-core-1.1.2.Final.jar:1.1.2.Final]
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_101]
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_101]
    at java.lang.Thread.run(Thread.java:745) [na:1.8.0_101]
Caused by: com.redhat.red.build.koji.KojiClientException: Koji withSession lambda command failed: No such property: build for class: org.commonjava.indy.koji.RepoCreator
    at com.redhat.red.build.koji.KojiClient.withKojiSession(KojiClient.java:348) ~[kojiji-1.1.jar:1.1]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.proxyKojiBuild(KojiContentManagerDecorator.java:215) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    ... 76 common frames omitted
Caused by: groovy.lang.MissingPropertyException: No such property: build for class: org.commonjava.indy.koji.RepoCreator
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:50) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.callsite.GetEffectivePogoPropertySite.getProperty(GetEffectivePogoPropertySite.java:86) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGroovyObjectGetProperty(AbstractCallSite.java:231) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.commonjava.indy.koji.RepoCreator.createHostedRepository(script14731509010711096910796.groovy:27) ~[na:na]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.transferBuild(KojiContentManagerDecorator.java:286) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at org.commonjava.indy.koji.content.KojiContentManagerDecorator.lambda$proxyKojiBuild$1(KojiContentManagerDecorator.java:242) ~[indy-embedder-savant-1.0.1-SNAPSHOT.jar:na]
    at com.redhat.red.build.koji.KojiClient.withKojiSession(KojiClient.java:332) ~[kojiji-1.1.jar:1.1]
    ... 77 common frames omitted
```