### PR TITLE
NOS-567 - Use remote existence check instead of get for HEAD requests…

### DIFF
--- a/api/src/main/java/org/commonjava/indy/content/ContentManager.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentManager.java
@@ -217,4 +217,6 @@ public interface ContentManager
     HttpExchangeMetadata getHttpMetadata( StoreKey storeKey, String path )
         throws IndyWorkflowException;
 
+    boolean exists(ArtifactStore store, String path)
+        throws IndyWorkflowException;
 }

--- a/api/src/main/java/org/commonjava/indy/content/DownloadManager.java
+++ b/api/src/main/java/org/commonjava/indy/content/DownloadManager.java
@@ -206,4 +206,13 @@ public interface DownloadManager
     Transfer getStorageReference( ArtifactStore store, String path, TransferOperation op )
         throws IndyWorkflowException;
 
+    /**
+     * Artifact existence check for given store and path. This method doesn't fire any events.
+     *
+     * @param store The store in which the check is performed
+     * @param path The path of the Transfer inside the store
+     * @throws IndyWorkflowException in case no suitable storage location can be found
+     */
+    boolean exists( ArtifactStore store, String path )
+        throws IndyWorkflowException;
 }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -174,18 +174,18 @@ public class ContentAccessHandler
         {
             try
             {
-                Transfer item;
-                if ( Boolean.TRUE.equals( cacheOnly ) )
-                {
-                    logger.info( "[CACHE-ONLY] Checking existence of: {}:{}", sk, path );
+                Transfer item = null;
+                logger.info( "Checking existence of: {}:{}", sk, path );
+
+                if (StoreType.remote == st && !Boolean.TRUE.equals(cacheOnly)) {
+                    // Use exists for remote repo to avoid downloading file. Use getTransfer for everything else (hosted, cache-only).
+                    // Response will be composed of metadata by getHttpMetadata which get metadata from .http-metadata.json (because HTTP transport always writes a .http-metadata.json
+                    // file when it makes a request). This file stores the HTTP response status code and headers regardless exist returning true or false.
+                    boolean exists = contentController.exists(sk, path);
+                    logger.debug("Got exists: {}", exists);
+                } else {
                     item = contentController.getTransfer( sk, path, TransferOperation.DOWNLOAD );
-                    logger.debug( "Got cache-only transfer reference: {}", item );
-                }
-                else
-                {
-                    logger.info( "Retrieving: {}:{} for existence test", sk, path );
-                    item = contentController.get( sk, path, eventMetadata );
-                    logger.debug( "Got retrieved transfer reference: {}", item );
+                    logger.debug( "Got transfer reference: {}", item );
                 }
 
                 if ( item == null || !item.exists() )

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -742,6 +742,14 @@ public class DefaultContentManager
         return readExchangeMetadata( meta );
     }
 
+    @Override
+    public boolean exists(ArtifactStore store, String path)
+        throws IndyWorkflowException
+    {
+        // TODO: to add content generation handling here, for things like merged metadata, checksum files, etc.
+        return downloadManager.exists(store, path);
+    }
+
     private HttpExchangeMetadata readExchangeMetadata( final Transfer meta )
             throws IndyWorkflowException
     {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -473,6 +473,31 @@ public class DefaultDownloadManager
         return target;
     }
 
+    @Override
+    public boolean exists(final ArtifactStore store, String path)
+            throws IndyWorkflowException
+    {
+        final ConcreteResource res = new ConcreteResource( LocationUtils.toLocation( store ), path );
+        if ( store instanceof RemoteRepository )
+        {
+            try {
+                return transfers.exists( res );
+            } catch (TransferException e) {
+                logger.warn( "Existence check: " + e.getMessage(), e );
+                return false;
+            }
+        }
+        else
+        {
+            Transfer target = transfers.getCacheReference(res);
+            if ( target != null )
+            {
+                return target.exists();
+            }
+        }
+        return false;
+    }
+
     /*
      * (non-Javadoc)
      * @see org.commonjava.indy.core.rest.util.FileManager#upload(org.commonjava.indy.core.model.DeployPoint,

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -478,4 +478,7 @@ public class ContentController
         return contentManager.getHttpMetadata( txfr );
     }
 
+    public boolean exists(StoreKey sk, String path) throws IndyWorkflowException {
+        return contentManager.exists( getStore( sk ), path );
+    }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractContentTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractContentTimeoutWorkingTest.java
@@ -75,6 +75,7 @@ public abstract class AbstractContentTimeoutWorkingTest
         assertThat( "no result", result, notNullValue() );
         assertThat( "doesn't exist", result.exists(), equalTo( true ) );
 
+        client.content().get(remote, repoId, pomPath); // force storage
         String pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
                                      remote.name(), repoId, pomPath );
 

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractMetadataTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractMetadataTimeoutWorkingTest.java
@@ -84,6 +84,7 @@ public abstract class AbstractMetadataTimeoutWorkingTest
 
         // ensure the pom exist before the timeout checking
         final PathInfo pomResult = client.content().getInfo( remote, repoId, pomPath );
+        client.content().get( remote, repoId, pomPath ); // force storage
         assertThat( "no pom result", pomResult, notNullValue() );
         assertThat( "pom doesn't exist", pomResult.exists(), equalTo( true ) );
         String pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
@@ -93,6 +94,7 @@ public abstract class AbstractMetadataTimeoutWorkingTest
 
         // ensure the metadata exist before the timeout checking
         final PathInfo metadataResult = client.content().getInfo( remote, repoId, metadataPath );
+        client.content().get( remote, repoId, metadataPath ); // force storage
         assertThat( "no metadata result", metadataResult, notNullValue() );
         assertThat( "metadata doesn't exist", metadataResult.exists(), equalTo( true ) );
         String metadataFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
@@ -102,6 +104,7 @@ public abstract class AbstractMetadataTimeoutWorkingTest
 
         // ensure the archetype exist before the timeout checking
         final PathInfo archetypeResult = client.content().getInfo( remote, repoId, archetypePath );
+        client.content().get( remote, repoId, archetypePath ); // force storage
         assertThat( "no archetype result", archetypeResult, notNullValue() );
         assertThat( "archetype doesn't exist", archetypeResult.exists(), equalTo( true ) );
         String archetypeFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentRescheduleTimeoutTest.java
@@ -22,6 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.Date;
 
 import static org.commonjava.indy.model.core.StoreType.remote;
@@ -62,6 +63,7 @@ public class ContentRescheduleTimeoutTest
 
         // first time trigger normal content storage with timeout, should be 6s
         PathInfo pomResult = client.content().getInfo( remote, repoId, pomPath );
+        client.content().get(remote, repoId, pomPath); // force storage
         assertThat( "no pom result", pomResult, notNullValue() );
         assertThat( "pom doesn't exist", pomResult.exists(), equalTo( true ) );
         String pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRescheduleTimeoutTest.java
@@ -68,6 +68,8 @@ public class MetadataRescheduleTimeoutTest
 
         // first time trigger normal content storage with timeout, should be 4s
         PathInfo pomResult = client.content().getInfo( remote, repoId, metadataPath );
+        client.content().get( remote, repoId, metadataPath ); // force storage
+
         assertThat( "no metadata result", pomResult, notNullValue() );
         assertThat( "metadata doesn't exist", pomResult.exists(), equalTo( true ) );
         String metadataFilePath =

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
@@ -70,6 +70,7 @@ public class MixContentRescheduleTimeoutTest
 
         // first time trigger normal content storage with timeout, should be 8s
         PathInfo pomResult = client.content().getInfo( remote, repoId, pomPath );
+        client.content().get( remote, repoId, pomPath ); // force storage
         assertThat( "no pom result", pomResult, notNullValue() );
         assertThat( "pom doesn't exist", pomResult.exists(), equalTo( true ) );
         String pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),
@@ -79,6 +80,7 @@ public class MixContentRescheduleTimeoutTest
 
         // first time trigger metadata storage with timeout, should be 4s
         PathInfo metadataResult = client.content().getInfo( remote, repoId, metadataPath );
+        client.content().get( remote, repoId, metadataPath ); // force storage
         assertThat( "no metadata result", metadataResult, notNullValue() );
         assertThat( "metadata doesn't exist", metadataResult.exists(), equalTo( true ) );
         String metadataFilePath =

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoHeadExistenceCheckTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoHeadExistenceCheckTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.http.HttpStatus;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.helper.PathInfo;
+import org.commonjava.indy.client.core.module.IndyContentClientModule;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.core.dto.DirectoryListingDTO;
+import org.commonjava.indy.model.core.dto.DirectoryListingEntryDTO;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.List;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class RemoteRepoHeadExistenceCheckTest
+    extends AbstractContentManagementTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    @Test
+    public void run()
+        throws Exception
+    {
+        final InputStream stream = new ByteArrayInputStream( ( "{\"content\": \"This is a test: " + System.nanoTime() + "\"}" ).getBytes() );
+        final String path = "org/foo/foo-project/1/foo-1.txt";
+        final String nonExistPath = "org/foo/foo-project/1/foo-2.txt";
+
+        server.expect( server.formatUrl( STORE, path ), 200, stream );
+        server.expect( server.formatUrl( STORE, nonExistPath ), 404, "not exist" );
+
+        client.stores()
+                .create( new RemoteRepository( STORE, server.formatUrl( STORE ) ), "adding test proxy",
+                        RemoteRepository.class );
+
+        final PathInfo result = client.content()
+                .getInfo( remote, STORE, path );
+
+        try
+        {
+            boolean exists = client.content().exists( remote, STORE, path );
+            assertTrue(exists);
+            File f = new File(new File(fixture.getBootOptions().getIndyHome()), "var/lib/indy/storage/remote-test/" + path);
+            assertTrue(!f.exists());
+
+            exists = client.content().exists( remote, STORE, nonExistPath );
+            assertFalse(exists);
+        }
+        catch ( final IndyClientException e )
+        {
+            fail("IndyClientException: " + e);
+        }
+
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Not get (download) a remote resource when the request is HEAD type. Am I on right track? Do not merge this, I will add some ftest later. 