### PR TITLE
Fix NCL-2108 - NPM download is not always successful via Indy proxy

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
@@ -53,7 +53,8 @@ public class IndexedStorePath
     @Field( name = "path", store = Store.YES, analyze = Analyze.NO )
     private String path;
 
-    private IndexedStorePath(){}
+    // this needs to be public for Infinispan to not throw InvalidClassException with the first httprox request
+    public IndexedStorePath(){}
 
     public IndexedStorePath( StoreKey storeKey, String path )
     {


### PR DESCRIPTION
The error this fixes was:
```
org.infinispan.commons.CacheException: Unable to invoke method public void org.infinispan.persistence.manager.PersistenceManagerImpl.start() on object of type PersistenceManagerImpl
    at org.infinispan.commons.util.ReflectionUtil.invokeAccessibly(ReflectionUtil.java:172)
    at org.infinispan.factories.AbstractComponentRegistry$PrioritizedMethod.invoke(AbstractComponentRegistry.java:859)
    at org.infinispan.factories.AbstractComponentRegistry.invokeStartMethods(AbstractComponentRegistry.java:628)
    at org.infinispan.factories.AbstractComponentRegistry.internalStart(AbstractComponentRegistry.java:617)
    at org.infinispan.factories.AbstractComponentRegistry.start(AbstractComponentRegistry.java:542)
    at org.infinispan.factories.ComponentRegistry.start(ComponentRegistry.java:238)
    at org.infinispan.cache.impl.CacheImpl.start(CacheImpl.java:849)
    at org.infinispan.manager.DefaultCacheManager.wireAndStartCache(DefaultCacheManager.java:635)
    at org.infinispan.manager.DefaultCacheManager.createCache(DefaultCacheManager.java:585)
    at org.infinispan.manager.DefaultCacheManager.getCache(DefaultCacheManager.java:451)
    at org.infinispan.manager.DefaultCacheManager.getCache(DefaultCacheManager.java:437)
    at org.commonjava.indy.subsys.infinispan.CacheProducer.getCache(CacheProducer.java:143)
    at org.commonjava.indy.subsys.infinispan.CacheProducer$Proxy$_$$_WeldClientProxy.getCache(Unknown Source)
    at org.commonjava.indy.content.index.ContentIndexCacheProducer.contentIndexCacheCfg(ContentIndexCacheProducer.java:39)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.injection.MethodInjectionPoint.invokeOnInstanceWithSpecialValue(MethodInjectionPoint.java:93)
    at org.jboss.weld.injection.MethodInjectionPoint.invokeOnInstance(MethodInjectionPoint.java:86)
    at org.jboss.weld.injection.producer.ProducerMethodProducer.produce(ProducerMethodProducer.java:96)
    at org.jboss.weld.injection.producer.AbstractMemberProducer.produce(AbstractMemberProducer.java:151)
    at org.jboss.weld.bean.AbstractProducerBean.create(AbstractProducerBean.java:183)
    at org.jboss.weld.context.AbstractContext.get(AbstractContext.java:96)
    at org.jboss.weld.bean.proxy.ContextBeanInstance.getInstance(ContextBeanInstance.java:98)
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:78)
    at org.commonjava.indy.subsys.infinispan.CacheHandle$Proxy$_$$_WeldClientProxy.get(Unknown Source)
    at org.commonjava.indy.content.index.ContentIndexManager.getIndexedStorePath(ContentIndexManager.java:289)
    at org.commonjava.indy.content.index.ContentIndexManager$Proxy$_$$_WeldClientProxy.getIndexedStorePath(Unknown Source)
    at org.commonjava.indy.content.index.IndexingContentManagerDecorator.getIndexedTransfer(IndexingContentManagerDecorator.java:223)
    at org.commonjava.indy.content.index.IndexingContentManagerDecorator.retrieve(IndexingContentManagerDecorator.java:163)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.annotated.runtime.InvokableAnnotatedMethod.invokeOnInstance(InvokableAnnotatedMethod.java:97)
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:80)
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:69)
    at org.jboss.weld.interceptor.util.proxy.TargetInstanceProxyMethodHandler.invoke(TargetInstanceProxyMethodHandler.java:33)
    at org.jboss.weld.bean.proxy.TargetBeanInstance.invoke(TargetBeanInstance.java:88)
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100)
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_Weld$Proxy$.retrieve(Unknown Source)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.util.reflection.Reflections.invokeAndUnwrap(Reflections.java:401)
    at org.jboss.weld.bean.proxy.CombinedInterceptorAndDecoratorStackMethodHandler.invoke(CombinedInterceptorAndDecoratorStackMethodHandler.java:62)
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_WeldSubclass.retrieve(Unknown Source)
    at org.commonjava.indy.core.ctl.ContentController.get(ContentController.java:147)
    at org.commonjava.indy.core.ctl.ContentController$Proxy$_$$_WeldClientProxy.get(Unknown Source)
    at org.commonjava.indy.httprox.handler.ProxyResponseWriter.transfer(ProxyResponseWriter.java:260)
    at org.commonjava.indy.httprox.handler.ProxyResponseWriter.handleEvent(ProxyResponseWriter.java:171)
    at org.commonjava.indy.httprox.handler.ProxyResponseWriter.handleEvent(ProxyResponseWriter.java:58)
    at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
    at org.xnio.conduits.WriteReadyHandler$ChannelListenerHandler.writeReady(WriteReadyHandler.java:65)
    at org.xnio.nio.NioSocketConduit.handleReady(NioSocketConduit.java:93)
    at org.xnio.nio.WorkerThread.run(WorkerThread.java:539)
Caused by: org.infinispan.commons.CacheException: Unable to start cache loaders
    at org.infinispan.persistence.manager.PersistenceManagerImpl.start(PersistenceManagerImpl.java:174)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.infinispan.commons.util.ReflectionUtil.invokeAccessibly(ReflectionUtil.java:168)
    ... 57 more
Caused by: org.infinispan.persistence.spi.PersistenceException: java.io.InvalidClassException: org.commonjava.indy.content.index.IndexedStorePath; Class is non-public or has no public no-arg constructor
    at org.infinispan.persistence.file.SingleFileStore.start(SingleFileStore.java:135)
    at org.infinispan.persistence.manager.PersistenceManagerImpl.start(PersistenceManagerImpl.java:141)
    ... 62 more
Caused by: java.io.InvalidClassException: org.commonjava.indy.content.index.IndexedStorePath; Class is non-public or has no public no-arg constructor
    at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject(RiverUnmarshaller.java:1304)
    at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:276)
    at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:209)
    at org.jboss.marshalling.AbstractObjectInput.readObject(AbstractObjectInput.java:41)
    at org.infinispan.commons.marshall.jboss.AbstractJBossMarshaller.objectFromObjectStream(AbstractJBossMarshaller.java:134)
    at org.infinispan.marshall.core.VersionAwareMarshaller.objectFromByteBuffer(VersionAwareMarshaller.java:101)
    at org.infinispan.commons.marshall.AbstractDelegatingMarshaller.objectFromByteBuffer(AbstractDelegatingMarshaller.java:80)
    at org.infinispan.persistence.file.SingleFileStore.rebuildIndex(SingleFileStore.java:212)
    at org.infinispan.persistence.file.SingleFileStore.start(SingleFileStore.java:126)
    ... 63 more
Caused by: an exception which occurred:
    in object of type org.commonjava.indy.content.index.IndexedStorePath
org.infinispan.commons.CacheException: Unable to invoke method public void org.infinispan.persistence.manager.PersistenceManagerImpl.start() on object of type PersistenceManagerImpl
    at org.infinispan.commons.util.ReflectionUtil.invokeAccessibly(ReflectionUtil.java:172)
    at org.infinispan.factories.AbstractComponentRegistry$PrioritizedMethod.invoke(AbstractComponentRegistry.java:859)
    at org.infinispan.factories.AbstractComponentRegistry.invokeStartMethods(AbstractComponentRegistry.java:628)
    at org.infinispan.factories.AbstractComponentRegistry.internalStart(AbstractComponentRegistry.java:617)
    at org.infinispan.factories.AbstractComponentRegistry.start(AbstractComponentRegistry.java:542)
    at org.infinispan.factories.ComponentRegistry.start(ComponentRegistry.java:238)
    at org.infinispan.cache.impl.CacheImpl.start(CacheImpl.java:849)
    at org.infinispan.manager.DefaultCacheManager.wireAndStartCache(DefaultCacheManager.java:635)
    at org.infinispan.manager.DefaultCacheManager.createCache(DefaultCacheManager.java:585)
    at org.infinispan.manager.DefaultCacheManager.getCache(DefaultCacheManager.java:451)
    at org.infinispan.manager.DefaultCacheManager.getCache(DefaultCacheManager.java:437)
    at org.commonjava.indy.subsys.infinispan.CacheProducer.getCache(CacheProducer.java:143)
    at org.commonjava.indy.subsys.infinispan.CacheProducer$Proxy$_$$_WeldClientProxy.getCache(Unknown Source)
    at org.commonjava.indy.content.index.ContentIndexCacheProducer.contentIndexCacheCfg(ContentIndexCacheProducer.java:39)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.injection.MethodInjectionPoint.invokeOnInstanceWithSpecialValue(MethodInjectionPoint.java:93)
    at org.jboss.weld.injection.MethodInjectionPoint.invokeOnInstance(MethodInjectionPoint.java:86)
    at org.jboss.weld.injection.producer.ProducerMethodProducer.produce(ProducerMethodProducer.java:96)
    at org.jboss.weld.injection.producer.AbstractMemberProducer.produce(AbstractMemberProducer.java:151)
    at org.jboss.weld.bean.AbstractProducerBean.create(AbstractProducerBean.java:183)
    at org.jboss.weld.context.AbstractContext.get(AbstractContext.java:96)
    at org.jboss.weld.bean.proxy.ContextBeanInstance.getInstance(ContextBeanInstance.java:98)
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:78)
    at org.commonjava.indy.subsys.infinispan.CacheHandle$Proxy$_$$_WeldClientProxy.get(Unknown Source)
    at org.commonjava.indy.content.index.ContentIndexManager.getIndexedStorePath(ContentIndexManager.java:289)
    at org.commonjava.indy.content.index.ContentIndexManager$Proxy$_$$_WeldClientProxy.getIndexedStorePath(Unknown Source)
    at org.commonjava.indy.content.index.IndexingContentManagerDecorator.getIndexedTransfer(IndexingContentManagerDecorator.java:223)
    at org.commonjava.indy.content.index.IndexingContentManagerDecorator.retrieve(IndexingContentManagerDecorator.java:163)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.annotated.runtime.InvokableAnnotatedMethod.invokeOnInstance(InvokableAnnotatedMethod.java:97)
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:80)
    at org.jboss.weld.bean.proxy.DecoratorProxyMethodHandler.doInvoke(DecoratorProxyMethodHandler.java:69)
    at org.jboss.weld.interceptor.util.proxy.TargetInstanceProxyMethodHandler.invoke(TargetInstanceProxyMethodHandler.java:33)
    at org.jboss.weld.bean.proxy.TargetBeanInstance.invoke(TargetBeanInstance.java:88)
    at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100)
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_Weld$Proxy$.retrieve(Unknown Source)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.jboss.weld.util.reflection.Reflections.invokeAndUnwrap(Reflections.java:401)
    at org.jboss.weld.bean.proxy.CombinedInterceptorAndDecoratorStackMethodHandler.invoke(CombinedInterceptorAndDecoratorStackMethodHandler.java:62)
    at org.commonjava.indy.core.content.DefaultContentManager$Proxy$_$$_WeldSubclass.retrieve(Unknown Source)
    at org.commonjava.indy.core.ctl.ContentController.get(ContentController.java:147)
    at org.commonjava.indy.core.ctl.ContentController$Proxy$_$$_WeldClientProxy.get(Unknown Source)
    at org.commonjava.indy.httprox.handler.ProxyResponseWriter.transfer(ProxyResponseWriter.java:260)
    at org.commonjava.indy.httprox.handler.ProxyResponseWriter.handleEvent(ProxyResponseWriter.java:171)
    at org.commonjava.indy.httprox.handler.ProxyResponseWriter.handleEvent(ProxyResponseWriter.java:58)
    at org.xnio.ChannelListeners.invokeChannelListener(ChannelListeners.java:92)
    at org.xnio.conduits.WriteReadyHandler$ChannelListenerHandler.writeReady(WriteReadyHandler.java:65)
    at org.xnio.nio.NioSocketConduit.handleReady(NioSocketConduit.java:93)
    at org.xnio.nio.WorkerThread.run(WorkerThread.java:539)
Caused by: org.infinispan.commons.CacheException: Unable to start cache loaders
    at org.infinispan.persistence.manager.PersistenceManagerImpl.start(PersistenceManagerImpl.java:174)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.infinispan.commons.util.ReflectionUtil.invokeAccessibly(ReflectionUtil.java:168)
    ... 57 more
Caused by: org.infinispan.persistence.spi.PersistenceException: java.io.InvalidClassException: org.commonjava.indy.content.index.IndexedStorePath; Class is non-public or has no public no-arg constructor
    at org.infinispan.persistence.file.SingleFileStore.start(SingleFileStore.java:135)
    at org.infinispan.persistence.manager.PersistenceManagerImpl.start(PersistenceManagerImpl.java:141)
    ... 62 more
Caused by: java.io.InvalidClassException: org.commonjava.indy.content.index.IndexedStorePath; Class is non-public or has no public no-arg constructor
    at org.jboss.marshalling.river.RiverUnmarshaller.doReadNewObject(RiverUnmarshaller.java:1304)
    at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:276)
    at org.jboss.marshalling.river.RiverUnmarshaller.doReadObject(RiverUnmarshaller.java:209)
    at org.jboss.marshalling.AbstractObjectInput.readObject(AbstractObjectInput.java:41)
    at org.infinispan.commons.marshall.jboss.AbstractJBossMarshaller.objectFromObjectStream(AbstractJBossMarshaller.java:134)
    at org.infinispan.marshall.core.VersionAwareMarshaller.objectFromByteBuffer(VersionAwareMarshaller.java:101)
    at org.infinispan.commons.marshall.AbstractDelegatingMarshaller.objectFromByteBuffer(AbstractDelegatingMarshaller.java:80)
    at org.infinispan.persistence.file.SingleFileStore.rebuildIndex(SingleFileStore.java:212)
    at org.infinispan.persistence.file.SingleFileStore.start(SingleFileStore.java:126)
    ... 63 more
Caused by: an exception which occurred:
    in object of type org.commonjava.indy.content.index.IndexedStorePath
```