### PR TITLE
FIX: NOS-549, [github] Implied repos should not be processed from a profile, update the call method from indy

### DIFF
--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
@@ -309,7 +309,7 @@ public class ImpliedRepositoryDetector
                       new JoinString( "\n  ", job.pomView.getDocRefStack() ) );
 
         final List<List<RepositoryView>> repoLists =
-            Arrays.asList( job.pomView.getAllRepositories(), job.pomView.getAllPluginRepositories() );
+            Arrays.asList( job.pomView.getNonProfileRepositories(), job.pomView.getAllPluginRepositories() );
 
         if ( creator == null )
         {


### PR DESCRIPTION
FIX: NOS-549, [github] Implied repos should not be processed from a profile, update the call method from indy