### PR TITLE
use ReentrantLock for by-path promotions and fix sync in getGroupsContaining

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/conf/PromoteConfig.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/conf/PromoteConfig.java
@@ -35,9 +35,15 @@ public class PromoteConfig
 
     public static final String ENABLED_PARAM = "enabled";
 
+    private static final String LOCK_TIMEOUT_SECONDS_PARAM = "lock.timeout.seconds";
+
+    public static final long DEFAULT_LOCK_TIMEOUT_SECONDS = 30;
+
     private String basedir;
 
     private boolean enabled = true;
+
+    private Long lockTimeoutSeconds;
 
     public PromoteConfig()
     {
@@ -69,6 +75,17 @@ public class PromoteConfig
     public void setEnabled( final boolean enabled )
     {
         this.enabled = enabled;
+    }
+
+    public Long getLockTimeoutSeconds()
+    {
+        return lockTimeoutSeconds == null ? DEFAULT_LOCK_TIMEOUT_SECONDS : lockTimeoutSeconds;
+    }
+
+    @ConfigName( PromoteConfig.LOCK_TIMEOUT_SECONDS_PARAM )
+    public void setLockTimeoutSeconds( Long lockTimeoutSeconds )
+    {
+        this.lockTimeoutSeconds = lockTimeoutSeconds;
     }
 
     @Override

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -119,7 +119,10 @@ public class PromotionManagerTest
                                                                           galleyParts.getMavenMetadataReader(),
                                                                           modelProcessor, galleyParts.getTypeMapper(),
                                                                           galleyParts.getTransferManager() ) );
-        manager = new PromotionManager( validator, contentManager, downloadManager, storeManager );
+
+        PromoteConfig config = new PromoteConfig();
+
+        manager = new PromotionManager( validator, contentManager, downloadManager, storeManager, config );
 
         executor = Executors.newCachedThreadPool();
     }

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -225,14 +225,11 @@ public class MemoryStoreDataManager
     }
 
     @Override
-    public Set<Group> getGroupsContaining( final StoreKey repo )
+    public synchronized Set<Group> getGroupsContaining( final StoreKey repo )
             throws IndyDataException
     {
-        synchronized ( StoreKey.dedupe( repo ) )
-        {
-            Set<Group> groups = reverseGroupMemberships.get( repo );
-            return groups == null ? Collections.emptySet() : Collections.unmodifiableSet( groups );
-        }
+        Set<Group> groups = reverseGroupMemberships.get( repo );
+        return groups == null ? Collections.emptySet() : Collections.unmodifiableSet( groups );
     }
 
     private boolean groupContains( final Group g, final StoreKey key )
@@ -342,14 +339,10 @@ public class MemoryStoreDataManager
                     if ( memberIn == null )
                     {
                         memberIn = new HashSet<>();
-                    }
-                    else
-                    {
-                        memberIn = new HashSet<>( memberIn );
+                        reverseGroupMemberships.put( memberKey, memberIn );
                     }
 
                     memberIn.add( g );
-                    reverseGroupMemberships.put( memberKey, memberIn );
                 } );
             }
             else if ( store instanceof RemoteRepository )


### PR DESCRIPTION
* ReentrantLock is mapped to target StoreKey to lock the target and allow only one promotion on that target at a time
* MemoryStoreDataManager synchronization was using StoreKey in one case and `this` in other cases when dealing with group-member reverse mapping. Fixed to always synchronize on MemoryStoreDataManager instance in order to keep monitor effects localized