### PR TITLE
FIX: NOS-602, By-Group Promotion should cancel hosted repository expiration

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -24,6 +24,7 @@ import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.promote.conf.PromoteConfig;
 import org.commonjava.indy.promote.model.GroupPromoteRequest;
@@ -142,6 +143,15 @@ public class PromotionManager
                 target.addConstituent( request.getSource() );
                 try
                 {
+                    ArtifactStore store = storeManager.getArtifactStore( request.getSource() );
+
+                    if ( store instanceof HostedRepository )
+                    {
+                        ( (HostedRepository) store ).setRepoTimeoutSeconds( null );
+                        storeManager.storeArtifactStore( store, new ChangeSummary( user, "update host repo: "
+                                + store.getKey() ) );
+                    }
+
                     storeManager.storeArtifactStore( target, new ChangeSummary( user, "Promoting " + request.getSource()
                             + " into membership of group: " + target.getKey() ), false, new EventMetadata() );
                 }

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteThenHostedRepoTimeoutTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteThenHostedRepoTimeoutTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest;
+
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.promote.client.IndyPromoteClientModule;
+import org.commonjava.indy.promote.model.GroupPromoteRequest;
+import org.commonjava.indy.promote.model.GroupPromoteResult;
+import org.junit.Test;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+public class GroupPromoteThenHostedRepoTimeoutTest
+        extends AbstractPromotionManagerTest
+{
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final int REPO_TIMEOUT_SECONDS = 6;
+        final int TIMEOUT_WAITING_MILLISECONDS = 8000;
+        final String hostedRepo = "hostedRepo";
+
+        final HostedRepository repo = new HostedRepository( hostedRepo );
+        repo.setRepoTimeoutSeconds( REPO_TIMEOUT_SECONDS );
+
+        client.stores().create( repo, "adding hosted", HostedRepository.class );
+        HostedRepository loaded = client.stores().load( hosted, hostedRepo, HostedRepository.class );
+
+        assertThat( loaded.getRepoTimeoutSeconds(), equalTo( REPO_TIMEOUT_SECONDS ) );
+
+        final GroupPromoteResult result = client.module( IndyPromoteClientModule.class )
+                                                .promoteToGroup(
+                                                        new GroupPromoteRequest( repo.getKey(), target.getName() ) );
+
+        HostedRepository reloaded = client.stores().load( hosted, hostedRepo, HostedRepository.class );
+
+        assertThat( result.getRequest().getSource(), equalTo( repo.getKey() ) );
+        assertNull( reloaded.getRepoTimeoutSeconds() );
+        assertThat( result.getError(), nullValue() );
+
+        // wait for timeout which is beyond the original timeout seconds, verify the original expiration schedule jobs are cancelled if no repo is deleted.
+        Thread.sleep( TIMEOUT_WAITING_MILLISECONDS );
+        assertThat( client.stores().exists( hosted, hostedRepo ), equalTo( true ) );
+    }
+
+    @Override
+    protected ArtifactStore createTarget( String changelog )
+            throws Exception
+    {
+        Group group = new Group( "test" );
+        return client.stores().create( group, changelog, Group.class );
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
@@ -194,7 +194,7 @@ public class TimeoutEventListener
                 try
                 {
                     scheduleManager.setSnapshotTimeouts( key, transfer.getPath() );
-                    scheduleManager.setRepoTimeouts( key, transfer.getPath() );
+                    scheduleManager.setRepoTimeouts( key );
                 }
                 catch ( final IndySchedulerException e )
                 {
@@ -243,7 +243,7 @@ public class TimeoutEventListener
                     try
                     {
                         scheduleManager.setSnapshotTimeouts( key, transfer.getPath() );
-                        scheduleManager.setRepoTimeouts( key, transfer.getPath() );
+                        scheduleManager.setRepoTimeouts( key );
                     }
                     catch ( final IndySchedulerException e )
                     {

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/HostedRepositoryNullTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/HostedRepositoryNullTimeoutTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.store;
+
+import org.commonjava.indy.model.core.HostedRepository;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class HostedRepositoryNullTimeoutTest
+        extends AbstractStoreManagementTest
+{
+    @Test
+    public void run()
+            throws Exception
+    {
+        final int REPO_TIMEOUT_SECONDS = 6;
+        final int TIMEOUT_WAITING_MILLISECONDS = 8000;
+
+        final String content = "This is a test: " + System.nanoTime();
+        final InputStream stream = new ByteArrayInputStream( content.getBytes() );
+
+        final String path = "/path/to/foo.class";
+        final String hostedRepo = "hostedRepo";
+
+        HostedRepository repo = new HostedRepository( hostedRepo );
+        repo.setRepoTimeoutSeconds( REPO_TIMEOUT_SECONDS );
+
+        client.stores().create( repo, "adding hosted", HostedRepository.class );
+        client.content().store( hosted, hostedRepo, path, stream );
+
+        // wait for 8s
+        Thread.sleep( TIMEOUT_WAITING_MILLISECONDS );
+        assertThat( client.content().exists( hosted, hostedRepo, path ), equalTo( false ) );
+        assertThat( client.stores().exists( hosted, hostedRepo ), equalTo( false ) );
+
+        repo.setRepoTimeoutSeconds( null );
+        client.stores().create( repo, "re-adding hosted", HostedRepository.class );
+        client.content().store( hosted, hostedRepo, path, stream );
+
+        // wait for 8s, null timeout means no expiration scheduler job will be triggered.
+        Thread.sleep( TIMEOUT_WAITING_MILLISECONDS );
+        assertThat( client.content().exists( hosted, hostedRepo, path ), equalTo( true ) );
+        assertThat( client.stores().exists( hosted, hostedRepo ), equalTo( true ) );
+    }
+}

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
@@ -15,8 +15,8 @@
  */
 package org.commonjava.indy.model.core;
 
-import io.swagger.annotations.ApiModel;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
 
 @ApiModel( description = "Hosts artifact content on the local system", parent = ArtifactStore.class )
 public class HostedRepository
@@ -30,7 +30,7 @@ public class HostedRepository
     private int snapshotTimeoutSeconds;
 
     @JsonProperty( "repo_timeout" )
-    private int repoTimeoutSeconds;
+    private Integer repoTimeoutSeconds;
 
     HostedRepository()
     {
@@ -59,12 +59,12 @@ public class HostedRepository
         this.snapshotTimeoutSeconds = snapshotTimeoutSeconds;
     }
 
-    public int getRepoTimeoutSeconds()
+    public Integer getRepoTimeoutSeconds()
     {
         return repoTimeoutSeconds;
     }
 
-    public void setRepoTimeoutSeconds( final int repoTimeoutSeconds )
+    public void setRepoTimeoutSeconds( final Integer repoTimeoutSeconds )
     {
         this.repoTimeoutSeconds = repoTimeoutSeconds;
     }


### PR DESCRIPTION
@jdcasey

this PR, add some null timeout deal logic and hosted timeout nullify in group promotion manager, also add the ftest (GroupPromoteThenHostedRepoTimeoutTest) for this, also add another extra ftest in indy-ftest-core for null timeout check (HostedRepositoryNullTimeoutTest), pls check, all the ftests run passed in my local's integration test.