### PR TITLE
FIX: NOS-682, adding url validation for RemoteRepository in #359

### DIFF
--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ValidRemoteStoreDataManagerDecorator.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ValidRemoteStoreDataManagerDecorator.java
@@ -1,0 +1,165 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.implrepo.data;
+
+import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.maven.galley.TransferException;
+import org.commonjava.maven.galley.TransferManager;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.util.PathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.inject.Inject;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Wrap methods that are storeXXX(..), make sure all the {@link RemoteRepository} returned are checked the validity.
+ */
+@Decorator
+public abstract class ValidRemoteStoreDataManagerDecorator
+        implements StoreDataManager
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Delegate
+    @Inject
+    private StoreDataManager delegate;
+
+    @Inject
+    private TransferManager transferManager;
+
+    protected ValidRemoteStoreDataManagerDecorator()
+    {
+    }
+
+    public ValidRemoteStoreDataManagerDecorator( final StoreDataManager delegate,
+                                                 final TransferManager transferManager )
+    {
+        this.delegate = delegate;
+        this.transferManager = transferManager;
+    }
+
+    protected final StoreDataManager getDelegate()
+    {
+        return delegate;
+    }
+
+    @Override
+    public boolean storeArtifactStore( ArtifactStore key, ChangeSummary summary )
+            throws IndyDataException
+    {
+        if ( key instanceof RemoteRepository && !checkValidity( key ) )
+        {
+            return false;
+        }
+        return delegate.storeArtifactStore( key, summary );
+    }
+
+    @Override
+    public boolean storeArtifactStore( ArtifactStore key, ChangeSummary summary, EventMetadata eventMetadata )
+            throws IndyDataException
+    {
+        if ( key instanceof RemoteRepository && !checkValidity( key ) )
+        {
+            return false;
+        }
+        return delegate.storeArtifactStore( key, summary, eventMetadata );
+    }
+
+    @Override
+    public boolean storeArtifactStore( ArtifactStore key, ChangeSummary summary, boolean skipIfExists )
+            throws IndyDataException
+    {
+        if ( key instanceof RemoteRepository && !checkValidity( key ) )
+        {
+            return false;
+        }
+        return delegate.storeArtifactStore( key, summary, skipIfExists );
+    }
+
+    @Override
+    public boolean storeArtifactStore( ArtifactStore key, ChangeSummary summary, boolean skipIfExists,
+                                       EventMetadata eventMetadata )
+            throws IndyDataException
+    {
+        if ( key instanceof RemoteRepository && !checkValidity( key ) )
+        {
+            return false;
+        }
+        return delegate.storeArtifactStore( key, summary, skipIfExists, eventMetadata );
+    }
+
+    @Override
+    public boolean storeArtifactStore( ArtifactStore key, ChangeSummary summary, boolean skipIfExists,
+                                       boolean fireEvents )
+            throws IndyDataException
+    {
+        if ( key instanceof RemoteRepository && !checkValidity( key ) )
+        {
+            return false;
+        }
+        return delegate.storeArtifactStore( key, summary, skipIfExists, fireEvents );
+    }
+
+    @Override
+    public boolean storeArtifactStore( ArtifactStore key, ChangeSummary summary, boolean skipIfExists,
+                                       boolean fireEvents, EventMetadata eventMetadata )
+            throws IndyDataException
+    {
+        if ( key instanceof RemoteRepository && !checkValidity( key ) )
+        {
+            return false;
+        }
+        return delegate.storeArtifactStore( key, summary, skipIfExists, fireEvents, eventMetadata );
+    }
+
+    private boolean checkValidity( ArtifactStore key )
+    {
+        RemoteRepository remoteRepository = (RemoteRepository) key;
+        URL url = null;
+        try
+        {
+            url = new URL( remoteRepository.getUrl() );
+            ConcreteResource concreteResource =
+                    new ConcreteResource( LocationUtils.toLocation( remoteRepository ), PathUtils.ROOT );
+
+            return transferManager.exists( concreteResource );
+        }
+        catch ( final MalformedURLException e )
+        {
+            logger.error( "[RemoteValidation] Failed to parse repository URL: '{}'. Reason: {}", e, url,
+                          e.getMessage() );
+        }
+        catch ( final TransferException e )
+        {
+            logger.warn( "[RemoteValidation] Cannot connect to target repository: '{}'. Reason: {}", this,
+                         e.getMessage() );
+            logger.debug( "[RemoteValidation] exception from validation attempt for: {}", this, e );
+        }
+
+        return false;
+    }
+}

--- a/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/data/ValidRemoteStoreDataManagerTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/data/ValidRemoteStoreDataManagerTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.implrepo.data;
+
+import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.implrepo.fixture.TestValidRemoteStoreDataManager;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.maven.galley.auth.MemoryPasswordManager;
+import org.commonjava.maven.galley.cache.FileCacheProvider;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.event.NoOpFileEventManager;
+import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
+import org.commonjava.maven.galley.io.NoOpTransferDecorator;
+import org.commonjava.maven.galley.maven.GalleyMaven;
+import org.commonjava.maven.galley.maven.GalleyMavenBuilder;
+import org.commonjava.maven.galley.transport.htcli.HttpClientTransport;
+import org.commonjava.maven.galley.transport.htcli.HttpImpl;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ValidRemoteStoreDataManagerTest
+{
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    private StoreDataManager storeManager;
+
+    private FileCacheProvider cache;
+
+    private GalleyMaven galley;
+
+    private File cacheDir;
+
+    private ChangeSummary summary;
+
+    @Before
+    public void setup()
+            throws Exception
+    {
+        cacheDir = temp.newFolder();
+        cache = new FileCacheProvider( cacheDir, new HashedLocationPathGenerator(), new NoOpFileEventManager(),
+                                       new NoOpTransferDecorator() );
+
+        galley = new GalleyMavenBuilder( cache ).withEnabledTransports(
+                new HttpClientTransport( new HttpImpl( new MemoryPasswordManager() ) ) ).build();
+
+        storeManager = new TestValidRemoteStoreDataManager( galley.getTransferManager() );
+
+        summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" );
+    }
+
+    @Test
+    public void testRepoValidation()
+            throws Exception
+    {
+        RemoteRepository validRepo = new RemoteRepository( "test", "http://www.foo.com" );
+        assertTrue( storeManager.storeArtifactStore( validRepo, summary, new EventMetadata() ) );
+
+        RemoteRepository inValidRepo = new RemoteRepository( "test", "this.is.not.valid.repo" );
+        assertFalse( storeManager.storeArtifactStore( inValidRepo, summary, new EventMetadata() ) );
+
+        Group group = new Group( "group" );
+        assertTrue( storeManager.storeArtifactStore( group, summary, new EventMetadata() ) );
+
+        HostedRepository hostedRepository = new HostedRepository( "hosted" );
+        assertTrue( storeManager.storeArtifactStore( hostedRepository, summary, new EventMetadata() ) );
+    }
+}

--- a/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/fixture/TestValidRemoteStoreDataManager.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/fixture/TestValidRemoteStoreDataManager.java
@@ -1,0 +1,209 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.implrepo.fixture;
+
+import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.implrepo.data.ValidRemoteStoreDataManagerDecorator;
+import org.commonjava.indy.mem.data.MemoryStoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.maven.galley.TransferManager;
+import org.commonjava.maven.galley.event.EventMetadata;
+
+import java.util.List;
+import java.util.Set;
+
+public class TestValidRemoteStoreDataManager
+        extends ValidRemoteStoreDataManagerDecorator
+        implements StoreDataManager
+{
+
+    private final StoreDataManager delegate;
+
+    public TestValidRemoteStoreDataManager( final TransferManager transferManager )
+    {
+        super( new MemoryStoreDataManager( true ), transferManager );
+        delegate = getDelegate();
+    }
+
+    @Override
+    public HostedRepository getHostedRepository( String name )
+            throws IndyDataException
+    {
+        return delegate.getHostedRepository( name );
+    }
+
+    @Override
+    public RemoteRepository getRemoteRepository( String name )
+            throws IndyDataException
+    {
+        return delegate.getRemoteRepository( name );
+    }
+
+    @Override
+    public Group getGroup( String name )
+            throws IndyDataException
+    {
+        return delegate.getGroup( name );
+    }
+
+    @Override
+    public ArtifactStore getArtifactStore( StoreKey key )
+            throws IndyDataException
+    {
+        return delegate.getArtifactStore( key );
+    }
+
+    @Override
+    public List<ArtifactStore> getAllArtifactStores()
+            throws IndyDataException
+    {
+        return delegate.getAllArtifactStores();
+    }
+
+    @Override
+    public List<? extends ArtifactStore> getAllArtifactStores( StoreType type )
+            throws IndyDataException
+    {
+        return delegate.getAllArtifactStores( type );
+    }
+
+    @Override
+    public List<Group> getAllGroups()
+            throws IndyDataException
+    {
+        return delegate.getAllGroups();
+    }
+
+    @Override
+    public List<RemoteRepository> getAllRemoteRepositories()
+            throws IndyDataException
+    {
+        return delegate.getAllRemoteRepositories();
+    }
+
+    @Override
+    public List<HostedRepository> getAllHostedRepositories()
+            throws IndyDataException
+    {
+        return delegate.getAllHostedRepositories();
+    }
+
+    @Override
+    public List<ArtifactStore> getAllConcreteArtifactStores()
+            throws IndyDataException
+    {
+        return delegate.getAllConcreteArtifactStores();
+    }
+
+    @Override
+    public List<ArtifactStore> getOrderedConcreteStoresInGroup( String groupName, boolean enabledOnly )
+            throws IndyDataException
+    {
+        return delegate.getOrderedConcreteStoresInGroup( groupName, enabledOnly );
+    }
+
+    @Override
+    public List<ArtifactStore> getOrderedStoresInGroup( String groupName, boolean enabledOnly )
+            throws IndyDataException
+    {
+        return delegate.getOrderedStoresInGroup( groupName, enabledOnly );
+    }
+
+    @Override
+    public Set<Group> getGroupsContaining( StoreKey repo )
+            throws IndyDataException
+    {
+        return delegate.getGroupsContaining( repo );
+    }
+
+    @Override
+    public void deleteArtifactStore( StoreKey key, ChangeSummary summary )
+            throws IndyDataException
+    {
+        deleteArtifactStore( key, summary, new EventMetadata() );
+    }
+
+    @Override
+    public void deleteArtifactStore( StoreKey key, ChangeSummary summary, EventMetadata eventMetadata )
+            throws IndyDataException
+    {
+        delegate.deleteArtifactStore( key, summary, new EventMetadata() );
+    }
+
+    @Override
+    public void clear( ChangeSummary summary )
+            throws IndyDataException
+    {
+        delegate.clear( summary );
+    }
+
+    @Override
+    public void install()
+            throws IndyDataException
+    {
+        delegate.install();
+    }
+
+    @Override
+    public void reload()
+            throws IndyDataException
+    {
+        delegate.reload();
+    }
+
+    @Override
+    public boolean hasRemoteRepository( String name )
+    {
+        return delegate.hasRemoteRepository( name );
+    }
+
+    @Override
+    public boolean hasGroup( String name )
+    {
+        return delegate.hasGroup( name );
+    }
+
+    @Override
+    public boolean hasHostedRepository( String name )
+    {
+        return delegate.hasHostedRepository( name );
+    }
+
+    @Override
+    public boolean hasArtifactStore( StoreKey key )
+    {
+        return delegate.hasArtifactStore( key );
+    }
+
+    @Override
+    public RemoteRepository findRemoteRepository( String url )
+    {
+        return delegate.findRemoteRepository( url );
+    }
+
+    @Override
+    public boolean isStarted()
+    {
+        return delegate.isStarted();
+    }
+}

--- a/embedders/savant/src/main/resources/META-INF/beans.xml
+++ b/embedders/savant/src/main/resources/META-INF/beans.xml
@@ -26,6 +26,7 @@
     <class>org.commonjava.indy.content.index.IndexingDirectContentAccessDecorator</class>
     <class>org.commonjava.indy.koji.content.KojiContentManagerDecorator</class>
     <class>org.commonjava.indy.implrepo.data.ImpliedReposStoreDataManagerDecorator</class>
+    <class>org.commonjava.indy.implrepo.data.ValidRemoteStoreDataManagerDecorator</class>
   </decorators>
       
 </beans>

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoInValidUrlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoInValidUrlTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.store;
+
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Test;
+
+public class RemoteRepoInValidUrlTest
+        extends AbstractStoreManagementTest
+{
+    @Test( expected = IndyClientException.class )
+    public void run()
+            throws Exception
+    {
+        final String INVALID_REPO = "invalid-repo";
+        final String INVALID_URL = "this.is.not.valid.url";
+
+        client.stores()
+              .create( new RemoteRepository( INVALID_REPO, INVALID_URL ), "adding invalid test",
+                       RemoteRepository.class );
+    }
+
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoValidUrlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoValidUrlTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.store;
+
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Test;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.junit.Assert.assertTrue;
+
+public class RemoteRepoValidUrlTest
+        extends AbstractStoreManagementTest
+{
+    @Test
+    public void run()
+            throws Exception
+    {
+        final String VALID_REPO = "valid";
+        final String VALID_URL = "http://www.foo.com";
+
+        client.stores().create( new RemoteRepository( VALID_REPO, VALID_URL ),
+                                "adding valid test", RemoteRepository.class );
+
+        assertTrue( client.stores().exists( remote, VALID_REPO ) );
+    }
+
+}


### PR DESCRIPTION
@jdcasey

The commit has resolved the validation function, two ftest and one unit test included, TestValidRemoteStoreDataManager is provided for the unit test (ValidRemoteStoreDataManagerTest), all the tests are passed in my local.