### PR TITLE
Fixing project-artifacts promotion rule to ignore POM artifacts that …

### DIFF
--- a/addons/promote/common/src/main/data/promote/rules/project-artifacts.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/project-artifacts.groovy
@@ -29,6 +29,7 @@ class ProjectArtifacts implements ValidationRule {
             def projectTCs = [:]
             request.getSourcePaths().each {
                 def ref = tools.getArtifact(it)
+//                if (ref != null && ref.getType() != "pom") {
                 if (ref != null) {
                     def gav = ref.asProjectVersionRef()
                     def found = projectTCs[gav]
@@ -41,12 +42,14 @@ class ProjectArtifacts implements ValidationRule {
             }
 
             projectTCs.each { entry ->
-                tcs.each { tc ->
-                    if (!entry.value.contains(tc)) {
-                        if (builder.length() > 0) {
-                            builder.append("\n")
+                if ( entry.value.size > 1 || !entry.value.contains(new SimpleTypeAndClassifier("pom"))) {
+                    tcs.each { tc ->
+                        if (!entry.value.contains(tc)) {
+                            if (builder.length() > 0) {
+                                builder.append("\n")
+                            }
+                            builder.append(entry.key).append(": missing artifact with type/classifier: ").append(tc)
                         }
-                        builder.append(entry.key).append(": missing artifact with type/classifier: ").append(tc)
                     }
                 }
             }

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRule_PomDeploymentTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRule_PomDeploymentTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest.rule;
+
+import org.apache.commons.lang3.StringUtils;
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.promote.model.GroupPromoteRequest;
+import org.commonjava.indy.promote.model.GroupPromoteResult;
+import org.commonjava.indy.promote.model.ValidationResult;
+import org.commonjava.indy.promote.model.ValidationRuleSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by jdcasey on 9/23/15.
+ */
+public class ProjectArtifactsRule_PomDeploymentTest
+        extends AbstractValidationRuleTest<Group>
+{
+
+    private static final String RULE = "project-artifacts.groovy";
+
+    private static final String CONTENT = "this is some content";
+
+    @Test
+    @Category( EventDependent.class )
+    public void run()
+            throws Exception
+    {
+        String validGav = "org.foo:valid:1.1";
+
+        String validPom = "org/foo/valid/1.1/valid-1.1.pom";
+
+        deploy( validPom, CONTENT );
+
+        waitForEventPropagation();
+
+        GroupPromoteRequest request = new GroupPromoteRequest( source.getKey(), target.getName() );
+        GroupPromoteResult result = module.promoteToGroup( request );
+        assertThat( result, notNullValue() );
+
+        ValidationResult validations = result.getValidations();
+        assertThat( validations, notNullValue() );
+
+        Map<String, String> validatorErrors = validations.getValidatorErrors();
+        assertThat( validatorErrors, notNullValue() );
+
+        System.out.println(validatorErrors);
+
+        String errors = validatorErrors.get( RULE );
+
+        System.out.println(validatorErrors);
+        assertThat( errors, nullValue() );
+    }
+
+    public ProjectArtifactsRule_PomDeploymentTest()
+    {
+        super( Group.class );
+    }
+
+    @Override
+    protected String getRuleScriptFile()
+    {
+        return RULE;
+    }
+
+    @Override
+    protected String getRuleScriptContent()
+            throws IOException
+    {
+        String path = "promote/rules/" + RULE;
+        return readTestResource( path );
+    }
+
+    protected ValidationRuleSet getRuleSet()
+    {
+        ValidationRuleSet ruleSet = new ValidationRuleSet();
+        ruleSet.setName( "test" );
+        ruleSet.setStoreKeyPattern( "group:target" );
+        ruleSet.setRuleNames( Collections.singletonList( getRuleScriptFile() ) );
+        ruleSet.setValidationParameters( Collections.singletonMap( "classifierAndTypeSet", "sources:jar,javadoc:jar" ) );
+
+        return ruleSet;
+    }
+
+}


### PR DESCRIPTION
…don't have requisite attachments like javadoc, etc.