### PR TITLE
Fix groovy.lang.MissingMethodException in template rule script

### DIFF
--- a/addons/promote/common/src/main/data/promote/rules/project-artifacts.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/project-artifacts.groovy
@@ -18,7 +18,7 @@ class ProjectArtifacts implements ValidationRule {
                 def parts = ctString.split(":")
                 if (parts.length > 0) {
                     if (parts.length < 2) {
-                        parts << ""
+                        parts += ""
                     }
 
                     tcs << new SimpleTypeAndClassifier(parts[1], parts[0])


### PR DESCRIPTION
Promotion validation failed in project-artifacts.groovy, line 21.
It seems the leftShift (<<) operator does not work well with empty string in groovy 2.2.1.
The error was:
```
groovy.lang.MissingMethodException: No signature of method: [Ljava.lang.String;.leftShift() is applicable for argument types: (java.lang.String) values: []
    at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:55) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.callsite.PojoMetaClassSite.call(PojoMetaClassSite.java:46) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.commonjava.indy.promote.rules.ProjectArtifacts$_validate_closure1.doCall(script14798676412292044149799.groovy:21) ~[na:na]
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:1.8.0_111]
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:1.8.0_111]
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:1.8.0_111]
    at java.lang.reflect.Method.invoke(Method.java:498) ~[na:1.8.0_111]
    at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90) ~[groovy-all-2.2.1.jar:2.2.1]
    at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:272) ~[groovy-all-2.2.1.jar:2.2.1]
    at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:909) ~[groovy-all-2.2.1.jar:2.2.1]
    at groovy.lang.Closure.call(Closure.java:423) ~[groovy-all-2.2.1.jar:2.2.1]
    at groovy.lang.Closure.call(Closure.java:439) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:1324) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:1296) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.dgm$147.invoke(Unknown Source) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:271) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:53) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116) ~[groovy-all-2.2.1.jar:2.2.1]
    at org.commonjava.indy.promote.rules.ProjectArtifacts.validate(script14798676412292044149799.groovy:17) ~[na:na]
    at org.commonjava.indy.promote.validate.PromotionValidator.validate(PromotionValidator.java:94) ~[indy-embedder-savant-1.1.1-SNAPSHOT.jar:na]
    ... 47 common frames omitted```