### PR TITLE
add no param construtor for LegacyQuartzDBMigrationAction

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/LegacyQuartzDBMigrationAction.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/LegacyQuartzDBMigrationAction.java
@@ -26,6 +26,12 @@ public class LegacyQuartzDBMigrationAction
 
     private static final String SCHEDULE_DB_NAME = "scheduler";
 
+    public LegacyQuartzDBMigrationAction()
+    {
+
+    }
+
+    // Used for unit test only
     LegacyQuartzDBMigrationAction( DataFileConfiguration fileConfig )
     {
         this.fileConfig = fileConfig;


### PR DESCRIPTION
  lack of this constructor may break CDI bean constructor injection.