### PR TITLE
Fix resource tracking and cleanup using new Weft ThreadContext

### DIFF
--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.Date;
 
 import static org.commonjava.indy.model.core.StoreType.remote;
@@ -95,7 +96,7 @@ public class MixContentRescheduleTimeoutTest
         Thread.sleep( CACHE_TIMEOUT_WAITING_MILLISECONDS );
 
         // as the metadata re-request, the timeout interval should NOT be re-scheduled
-        client.content().get( remote, repoId, metadataPath ).close();
+        try(InputStream is = client.content().get( remote, repoId, metadataPath )){}
 
         // will wait another 4.5s
         Thread.sleep( CACHE_TIMEOUT_WAITING_MILLISECONDS + 500 );

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <jhttpcVersion>1.4</jhttpcVersion>
     <kojijiVersion>1.3</kojijiVersion>
     <rwxVersion>1.1</rwxVersion>
-    <weftVersion>1.2</weftVersion>
+    <weftVersion>1.3-SNAPSHOT</weftVersion>
     <httpTestserverVersion>1.3</httpTestserverVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
@@ -223,7 +223,7 @@ public class IndyDeployment
         classes.addAll( providerClasses );
         classes.addAll( resourceClasses );
         classes.addAll( Arrays.asList( ApiListingResource.class, SwaggerSerializers.class ) );
-        classes.addAll( Arrays.asList( JacksonJsonProvider.class ) );
+        classes.addAll( Arrays.asList( JacksonJsonProvider.class, UnhandledIOExceptionHandler.class ) );
         return classes;
     }
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/UnhandledIOExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/UnhandledIOExceptionHandler.java
@@ -1,0 +1,31 @@
+package org.commonjava.indy.bind.jaxrs;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+/**
+ * Created by jdcasey on 1/3/17.
+ * Based on: http://stackoverflow.com/questions/13857638/global-custom-exception-handler-in-resteasy
+ */
+@Provider
+public class UnhandledIOExceptionHandler
+        implements ExceptionMapper<IOException>//, RestProvider
+{
+    public Response toResponse( IOException exception )
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.error( "Unhandled exception: " + exception.getMessage(), exception );
+
+        return Response.status( Response.Status.INTERNAL_SERVER_ERROR )
+                       .entity( ExceptionUtils.getFullStackTrace( exception ) )
+                       .type( MediaType.TEXT_PLAIN )
+                       .build();
+    }
+}


### PR DESCRIPTION
Add unhandled IOException handler to ensure they get logged.