### PR TITLE
[promote] Allow getting validation stores without the target one

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -58,7 +58,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -120,6 +119,13 @@ public class PromotionValidationTools
     public StoreKey[] getValidationStoreKeys( final ValidationRequest request, final boolean includeSource )
             throws PromotionValidationException
     {
+        return getValidationStoreKeys( request, includeSource, true );
+    }
+
+    public StoreKey[] getValidationStoreKeys( final ValidationRequest request, final boolean includeSource,
+                                              final boolean includeTarget )
+            throws PromotionValidationException
+    {
         String verifyStores = request.getValidationParameter( PromotionValidationTools.AVAILABLE_IN_STORES );
         if ( verifyStores == null )
         {
@@ -135,7 +141,10 @@ public class PromotionValidationTools
             verifyStoreKeys.add( request.getSourceRepository().getKey() );
         }
 
-        verifyStoreKeys.add( request.getTarget() );
+        if ( includeTarget )
+        {
+            verifyStoreKeys.add( request.getTarget() );
+        }
         if ( verifyStores == null )
         {
             logger.warn(


### PR DESCRIPTION
The problem to solve here that we want to promote a build repo into builds-untested while checking for pre-existence in group:redhat-builds containing mrrc and builds-untested. Reason for using this approach is to avoid triggering BB pull for builds-untested alone, so we used different group name not matching the BB pull tag pattern.