### PR TITLE
Fix #361: Add some content along with 404 status

### DIFF
--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -74,7 +74,7 @@ public class ContentAccessHandler
     }
 
     public ContentAccessHandler( final ContentController controller, final UriFormatter uriFormatter,
-                                 JaxRsRequestHelper jaxRsRequestHelper )
+                                 final JaxRsRequestHelper jaxRsRequestHelper )
     {
         this.contentController = controller;
         this.uriFormatter = uriFormatter;
@@ -82,7 +82,7 @@ public class ContentAccessHandler
     }
 
     public Response doCreate( final String type, final String name, final String path, final HttpServletRequest request,
-                              EventMetadata eventMetadata, Supplier<URI> uriBuilder )
+                              EventMetadata eventMetadata, final Supplier<URI> uriBuilder )
     {
         final StoreType st = StoreType.get( type );
         StoreKey sk = new StoreKey( st, name );
@@ -113,7 +113,7 @@ public class ContentAccessHandler
         return response;
     }
 
-    public Response doDelete( String type, String name, String path, EventMetadata eventMetadata )
+    public Response doDelete( final String type, final String name, final String path, EventMetadata eventMetadata )
     {
         final StoreType st = StoreType.get( type );
         StoreKey sk = new StoreKey( st, name );
@@ -136,8 +136,8 @@ public class ContentAccessHandler
         return response;
     }
 
-    public Response doHead( String type, String name, String path, Boolean cacheOnly, String baseUri,
-                            HttpServletRequest request, EventMetadata eventMetadata )
+    public Response doHead( final String type, final String name, final String path, final Boolean cacheOnly, final String baseUri,
+                            final HttpServletRequest request, EventMetadata eventMetadata )
     {
         final StoreType st = StoreType.get( type );
         final StoreKey sk = new StoreKey( st, name );
@@ -243,7 +243,7 @@ public class ContentAccessHandler
         return response;
     }
 
-    public Response doGet( String type, String name, String path, String baseUri, HttpServletRequest request,
+    public Response doGet( final String type, final String name, final String path, final String baseUri, final HttpServletRequest request,
                            EventMetadata eventMetadata )
     {
         final StoreType st = StoreType.get( type );
@@ -357,7 +357,7 @@ public class ContentAccessHandler
         return response;
     }
 
-    private Response handleMissingContentQuery( StoreKey sk, String path )
+    private Response handleMissingContentQuery( final StoreKey sk, final String path )
     {
         Response response = null;
 
@@ -388,7 +388,8 @@ public class ContentAccessHandler
 
         if ( response == null )
         {
-            response = Response.status( Status.NOT_FOUND ).build();
+            response = formatResponse( ApplicationStatus.NOT_FOUND, null,
+                                       "Path " + path + " is not available in store " + sk + "." );
         }
 
         return response;

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
@@ -293,7 +293,7 @@ public final class ResponseUtils
         LOGGER.error( "Sending error response: {} {}\n{}", code.getStatusCode(), code.getReasonPhrase(), msg );
 
         Response response = Response.status( code )
-                       .header( ApplicationHeader.content_type.key(), ApplicationContent.text_plain )
+                       .type( MediaType.TEXT_PLAIN )
                        .entity( msg )
                        .build();
 
@@ -330,22 +330,25 @@ public final class ResponseUtils
     public static CharSequence formatEntity( final String id, final Throwable error, final String message )
     {
         final StringWriter sw = new StringWriter();
-        sw.append( "Id: " ).append( id );
+        sw.append( "Id: " ).append( id ).append( "\n" );
         if ( message != null )
         {
-            sw.append( "\nMessage: " ).append( message );
+            sw.append( "Message: " ).append( message ).append( "\n" );
         }
 
-        sw.append( error.getMessage() );
-
-        final Throwable cause = error.getCause();
-        if ( cause != null )
+        if ( error != null )
         {
-            sw.append( "\nError:\n\n" );
-            cause.printStackTrace( new PrintWriter( sw ) );
-        }
+            sw.append( error.getMessage() );
 
-        sw.write( '\n' );
+            final Throwable cause = error.getCause();
+            if ( cause != null )
+            {
+                sw.append( "Error:\n\n" );
+                cause.printStackTrace( new PrintWriter( sw ) );
+            }
+
+            sw.write( '\n' );
+        }
 
         return sw.toString();
     }


### PR DESCRIPTION
Without it user in a browser can't tell what the response was and even
if any response was received at all or the browser just gave up, because
previous page is still shown, at least in Firefox.

This also adds a newline character after error ID in error message which
was missing before.