### PR TITLE
NFC not cleared when metadata file added to multilayer group structure via leaf repository upload.

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -335,7 +335,11 @@ public class ContentIndexManager
             return;
         }
 
+        Logger logger = LoggerFactory.getLogger( getClass() );
+//        logger.debug( "Clearing path: '{}' from content index and storage of: {}", path, groups );
+
         groups.forEach( (group)->{
+            logger.debug( "Clearing path: '{}' from content index and storage of: {}", path, group.getName() );
             removeIndexedStorePath( path, group.getKey(), pathConsumer );
         } );
     }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -25,8 +25,10 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
+import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.infinispan.cdi.ConfigureCache;
 import org.infinispan.query.Search;
 import org.infinispan.query.dsl.Query;
@@ -66,6 +68,22 @@ public class ContentIndexManager
     @WeftManaged
     @Inject
     private Executor executor;
+
+    @Inject
+    private NotFoundCache nfc;
+
+    protected ContentIndexManager(){}
+
+    public ContentIndexManager( StoreDataManager storeDataManager, SpecialPathManager specialPathManager,
+                                CacheHandle<IndexedStorePath, IndexedStorePath> contentIndex, Executor executor,
+                                NotFoundCache nfc )
+    {
+        this.storeDataManager = storeDataManager;
+        this.specialPathManager = specialPathManager;
+        this.contentIndex = contentIndex;
+        this.executor = executor;
+        this.nfc = nfc;
+    }
 
     public void removeAllOriginIndexedPathsForStore( StoreKey memberKey, Consumer<IndexedStorePath> pathConsumer )
     {
@@ -161,15 +179,21 @@ public class ContentIndexManager
         } );
     }
 
-    public void removeIndexedStorePath( String path, StoreKey key, Consumer<IndexedStorePath> pathConsumer )
+    public boolean removeIndexedStorePath( String path, StoreKey key, Consumer<IndexedStorePath> pathConsumer )
     {
 //        Logger logger = LoggerFactory.getLogger( getClass() );
         IndexedStorePath topPath = new IndexedStorePath( key, path );
 //        logger.trace( "Attempting to remove indexed path: {}", topPath );
-        if ( contentIndex.remove( topPath ) != null && pathConsumer != null )
+        if ( contentIndex.remove( topPath ) != null )
         {
-            pathConsumer.accept( topPath );
+            if ( pathConsumer != null )
+            {
+                pathConsumer.accept( topPath );
+            }
+            return true;
         }
+
+        return false;
 //
 //        QueryFactory queryFactory = Search.getQueryFactory( contentIndex );
 //
@@ -340,7 +364,13 @@ public class ContentIndexManager
 
         groups.forEach( (group)->{
             logger.debug( "Clearing path: '{}' from content index and storage of: {}", path, group.getName() );
-            removeIndexedStorePath( path, group.getKey(), pathConsumer );
+
+            // if we remove an indexed path, it SHOULD mean there was content. If not, we should delete the NFC entry.
+            if ( !removeIndexedStorePath( path, group.getKey(), pathConsumer ) )
+            {
+                ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( group ), path );
+                nfc.clearMissing( resource );
+            }
         } );
     }
 

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexObserver.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexObserver.java
@@ -316,11 +316,13 @@ public class ContentIndexObserver
                 }
             }
 
+            logger.debug( "Got members affected by membership divergence: {}", affectedMembers );
             if ( !affectedMembers.isEmpty() )
             {
                 Set<Group> groups = storeDataManager.getGroupsAffectedBy( group.getKey() );
                 groups.add( group );
 
+                logger.debug( "Got affected groups: {}", groups );
                 Set<String> paths = new HashSet<>();
                 affectedMembers.forEach( ( memberKey ) -> paths.addAll(
                         indexManager.getAllIndexedPathsForStore( memberKey )

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexObserver.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexObserver.java
@@ -15,12 +15,9 @@
  */
 package org.commonjava.indy.content.index;
 
-import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.ThreadContext;
-import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.change.event.ArtifactStoreDeletePostEvent;
-import org.commonjava.indy.change.event.ArtifactStoreDeletePreEvent;
 import org.commonjava.indy.change.event.ArtifactStoreEnablementEvent;
 import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
@@ -29,7 +26,6 @@ import org.commonjava.indy.core.expire.ContentExpiration;
 import org.commonjava.indy.core.expire.ScheduleManager;
 import org.commonjava.indy.core.expire.SchedulerEvent;
 import org.commonjava.indy.core.expire.SchedulerEventType;
-import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
@@ -50,16 +46,11 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -100,7 +91,7 @@ public class ContentIndexObserver
 
     public ContentIndexObserver( final StoreDataManager storeDataManager, final ContentIndexManager indexManager,
                                  final SpecialPathManager specialPathManager,
-                                 final DirectContentAccess directContentAccess, final IndyObjectMapper objectMapper)
+                                 final DirectContentAccess directContentAccess, final IndyObjectMapper objectMapper )
     {
         this.storeDataManager = storeDataManager;
         this.indexManager = indexManager;
@@ -339,114 +330,114 @@ public class ContentIndexObserver
 
     private void propagatePathlessStoreEvent( final Iterable<ArtifactStore> stores )
     {
-        StreamSupport.stream( stores.spliterator(), true).forEach( ( store ) -> {
-                final StoreKey key = store.getKey();
+        StreamSupport.stream( stores.spliterator(), true ).forEach( ( store ) -> {
+            final StoreKey key = store.getKey();
 
-                Set<String> paths = new HashSet<>();
-                indexManager.removeAllIndexedPathsForStore( key, indexedStorePath -> {
-                    paths.add( indexedStorePath.getPath() );
-                } );
-                indexManager.removeAllOriginIndexedPathsForStore( key, indexedStorePath -> {
-                    paths.add( indexedStorePath.getPath() );
-                } );
-
-                if ( !paths.isEmpty() )
-                {
-                    Set<Group> groups = storeDataManager.getGroupsAffectedBy( key );
-
-                    paths.stream()
-                         .filter( mergablePathStrings() )
-                         .forEach( ( path ) -> indexManager.clearIndexedPathFrom( path, groups, deleteTransfers() ) );
-                }
+            Set<String> paths = new HashSet<>();
+            indexManager.removeAllIndexedPathsForStore( key, indexedStorePath -> {
+                paths.add( indexedStorePath.getPath() );
             } );
+            indexManager.removeAllOriginIndexedPathsForStore( key, indexedStorePath -> {
+                paths.add( indexedStorePath.getPath() );
+            } );
+
+            if ( !paths.isEmpty() )
+            {
+                Set<Group> groups = storeDataManager.getGroupsAffectedBy( key );
+
+                paths.stream()
+                     .filter( mergablePathStrings() )
+                     .forEach( ( path ) -> indexManager.clearIndexedPathFrom( path, groups, deleteTransfers() ) );
+            }
+        } );
     }
 
     private void propagateStoreEnablementEvent( final Iterable<ArtifactStore> stores )
     {
-        StreamSupport.stream( stores.spliterator(), true).forEach( ( store ) -> {
-                final StoreKey key = store.getKey();
-                if ( key.getType() == StoreType.hosted )
+        StreamSupport.stream( stores.spliterator(), true ).forEach( ( store ) -> {
+            final StoreKey key = store.getKey();
+            if ( key.getType() == StoreType.hosted )
+            {
+                // for hosted repos we need to delete from containing groups all mergable content present in the
+                // hosted repo's index, because it is always complete and up-to-date (if initial indexing is
+                // finished)
+
+                List<IndexedStorePath> indexedStorePaths = indexManager.getAllIndexedPathsForStore( key );
+
+                if ( indexedStorePaths != null && !indexedStorePaths.isEmpty() )
                 {
-                    // for hosted repos we need to delete from containing groups all mergable content present in the
-                    // hosted repo's index, because it is always complete and up-to-date (if initial indexing is
-                    // finished)
+                    Set<Group> groups = storeDataManager.getGroupsAffectedBy( key );
 
-                    List<IndexedStorePath> indexedStorePaths = indexManager.getAllIndexedPathsForStore( key );
-
-                    if ( indexedStorePaths != null && !indexedStorePaths.isEmpty() )
+                    indexedStorePaths.stream().filter( mergableStorePaths() ).forEach( ( indexedStorePath ) -> {
+                        String path = indexedStorePath.getPath();
+                        indexManager.clearIndexedPathFrom( path, groups, deleteTransfers() );
+                    } );
+                }
+            }
+            else
+            {
+                // for remote repos and groups we need to delete from containing groups ALL mergable content,
+                // because we don't have a complete index for it and building it is too expensive, so we cannot
+                // be sure if the resulting mergable content would be influenced by the newly added/enabled repo
+                // or not
+                try
+                {
+                    Set<Group> groups = storeDataManager.getGroupsAffectedBy( key );
+                    if ( !groups.isEmpty() )
                     {
-                        Set<Group> groups = storeDataManager.getGroupsAffectedBy( key );
-
-                        indexedStorePaths.stream().filter( mergableStorePaths() ).forEach( ( indexedStorePath ) -> {
-                            String path = indexedStorePath.getPath();
-                            indexManager.clearIndexedPathFrom( path, groups, deleteTransfers() );
+                        groups.parallelStream().forEach( ( group ) -> {
+                            List<IndexedStorePath> paths = indexManager.getAllIndexedPathsForStore( group.getKey() );
+                            if ( paths != null )
+                            {
+                                paths.stream()
+                                     .filter( mergableStorePaths() )
+                                     .forEach( path -> indexManager.clearIndexedPathFrom( path.getPath(), groups,
+                                                                                          deleteTransfers() ) );
+                            }
                         } );
                     }
                 }
-                else
+                catch ( Exception e )
                 {
-                    // for remote repos and groups we need to delete from containing groups ALL mergable content,
-                    // because we don't have a complete index for it and building it is too expensive, so we cannot
-                    // be sure if the resulting mergable content would be influenced by the newly added/enabled repo
-                    // or not
-                    try
-                    {
-                        Set<Group> groups = storeDataManager.getGroupsAffectedBy( key );
-                        if ( !groups.isEmpty() )
-                        {
-                            groups.parallelStream().forEach( ( group ) -> {
-                                List<IndexedStorePath> paths =
-                                        indexManager.getAllIndexedPathsForStore( group.getKey() );
-                                if ( paths != null )
-                                {
-                                    paths.stream()
-                                         .filter( mergableStorePaths() )
-                                         .forEach( path -> indexManager.clearIndexedPathFrom( path.getPath(), groups,
-                                                                                              deleteTransfers() ) );
-                                }
-                            } );
-                        }
-                    }
-                    catch ( Exception e )
-                    {
-                        Logger logger = LoggerFactory.getLogger( getClass() );
-                        logger.error( String.format( "Failed to lookup groups containing: %s. Reason: %s", key,
-                                                     e.getMessage() ), e );
-                    }
+                    Logger logger = LoggerFactory.getLogger( getClass() );
+                    logger.error(
+                            String.format( "Failed to lookup groups containing: %s. Reason: %s", key, e.getMessage() ),
+                            e );
                 }
-            } );
+            }
+        } );
     }
 
-//    private void propagatePathRemovals( final Set<IndexedStorePath> removals )
-//    {
-//        Map<StoreKey, Set<Group>> containersForKey = new HashMap<>();
-//        removals.stream().filter( mergableStorePaths() ).forEach( indexedStorePath -> {
-//            StoreKey storeKey = indexedStorePath.getStoreKey();
-//            try
-//            {
-//                ArtifactStore store = storeDataManager.getArtifactStore( storeKey );
-//
-//                Set<Group> groups = containersForKey.get( storeKey );
-//                if ( groups == null )
-//                {
-//                    groups = storeDataManager.getGroupsAffectedBy( storeKey );
-//                    containersForKey.put( storeKey, groups );
-//                }
-//
-//                String path = indexedStorePath.getPath();
-//
-//                // If the file is stored local to the group, it's merged and must die.
-//                indexManager.clearIndexedPathFrom( path, groups, deleteTransfers() );
-//            }
-//            catch ( IndyDataException e )
-//            {
-//                Logger logger = LoggerFactory.getLogger( getClass() );
-//                logger.error(
-//                        String.format( "Failed to lookup store, or groups containing store: %s. Reason: %s", storeKey,
-//                                       e.getMessage() ), e );
-//            }
-//        } );
-//    }
+    //    private void propagatePathRemovals( final Set<IndexedStorePath> removals )
+    //    {
+    //        Map<StoreKey, Set<Group>> containersForKey = new HashMap<>();
+    //        removals.stream().filter( mergableStorePaths() ).forEach( indexedStorePath -> {
+    //            StoreKey storeKey = indexedStorePath.getStoreKey();
+    //            try
+    //            {
+    //                ArtifactStore store = storeDataManager.getArtifactStore( storeKey );
+    //
+    //                Set<Group> groups = containersForKey.get( storeKey );
+    //                if ( groups == null )
+    //                {
+    //                    groups = storeDataManager.getGroupsAffectedBy( storeKey );
+    //                    containersForKey.put( storeKey, groups );
+    //                }
+    //
+    //                String path = indexedStorePath.getPath();
+    //
+    //                // If the file is stored local to the group, it's merged and must die.
+    //                indexManager.clearIndexedPathFrom( path, groups, deleteTransfers() );
+    //            }
+    //            catch ( IndyDataException e )
+    //            {
+    //                Logger logger = LoggerFactory.getLogger( getClass() );
+    //                logger.error(
+    //                        String.format( "Failed to lookup store, or groups containing store: %s. Reason: %s", storeKey,
+    //                                       e.getMessage() ), e );
+    //            }
+    //        } );
+    //    }
 
     private void propagateClear( final StoreKey key, final String path )
     {

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataFoundAfterMemberAddTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataFoundAfterMemberAddTest.java
@@ -1,0 +1,184 @@
+package org.commonjava.indy.pkg.maven.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestRule;
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.util.concurrent.TimeUnit;
+
+import static org.commonjava.indy.ftest.core.fixture.ThreadDumper.timeoutRule;
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by jdcasey on 1/19/17.
+ *
+ * This test assures that a particular maven-metadata.xml file should be missing in a group structure, but after it's
+ * uploaded to a repository all groups affected by that repository should be able to return the metadata file.
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Group A with no members.</li>
+ *     <li>Group B containing only Group A as a member.</li>
+ *     <li>Retrieval of metadata path P from Group A returns null/404 result</li>
+ *     <li>Retrieval of metadata path P from Group B returns null/404 result</li>
+ *     <li>HostedRepository X is created for a build</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>metadata path P is uploaded to HostedRepository X as part of a build</li>
+ *     <li>HostedRepository X is added to the membership of Group A</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ol>
+ *     <li>Subsequent requests for metadata path P from Group B return the uploaded metadata</li>
+ *     <li>Subsequent requests for metadata path P from Group A return the uploaded metadata</li>
+ * </ol>
+ * <br/>
+ * (<b>NOTE:</b> Order of operations is important for verification steps, just in case checking Group A's metadata could
+ * trigger the availability of the metadata in Group B.)
+ */
+public class RecursiveGroupMetadataFoundAfterMemberAddTest
+        extends AbstractContentManagementTest
+{
+//    @ClassRule
+//    public static TestRule TIMEOUT = timeoutRule( 10, TimeUnit.SECONDS );
+
+    private static final String HOSTED_X = "hostedX";
+
+    private static final String GROUP_A = "groupA";
+
+    private static final String GROUP_B = "groupB";
+
+    private static final String GROUP_C = "groupC";
+
+    private static final String PATH = "org/foo/bar/maven-metadata.xml";
+
+    /* @formatter:off */
+    private static final String HOSTED_X_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<metadata>\n" +
+            "  <groupId>org.foo</groupId>\n" +
+            "  <artifactId>bar</artifactId>\n" +
+            "  <versioning>\n" +
+            "    <latest>1.0</latest>\n" +
+            "    <release>1.0</release>\n" +
+            "    <versions>\n" +
+            "      <version>1.0</version>\n" +
+            "    </versions>\n" +
+            "    <lastUpdated>20150722164334</lastUpdated>\n" +
+            "  </versioning>\n" +
+            "</metadata>\n";
+    /* @formatter:on */
+
+    private HostedRepository hostedX;
+
+    private Group groupA;
+
+    private Group groupB;
+
+    private Group groupC;
+
+    @Before
+    public void setupRepos()
+            throws IndyClientException, UnsupportedEncodingException
+    {
+        String change = "Setup test";
+        hostedX = client.stores().create( new HostedRepository( HOSTED_X ), change, HostedRepository.class );
+        groupA = client.stores().create( new Group( GROUP_A ), change, Group.class );
+        groupB = client.stores().create( new Group( GROUP_B, groupA.getKey() ), change, Group.class );
+        groupC = client.stores().create( new Group( GROUP_C, groupB.getKey() ), change, Group.class );
+    }
+
+    @Test
+    @Category( EventDependent.class )
+    public void run()
+            throws Exception
+    {
+        assertNullContent( hostedX, PATH );
+        assertNullContent( groupA, PATH );
+        assertNullContent( groupB, PATH );
+
+        client.content()
+              .store( hostedX.getKey(), PATH, new ByteArrayInputStream( HOSTED_X_CONTENT.getBytes( "UTF-8" ) ) );
+
+        waitForEventPropagation();
+
+        assertContent( hostedX, PATH,HOSTED_X_CONTENT );
+
+        groupA.addConstituent( hostedX );
+        boolean updated = client.stores().update( groupA, "Add hosted X" );
+
+        assertThat( "Group A was NOT updated with HostedRepository X membership!", updated, equalTo( true ) );
+
+        waitForEventPropagation();
+
+        // Order is important here...we want to try the most ambitious one first and move down to the simpler cases.
+        // This will prevent us from inadvertently triggering metadata aggregation in a lower group that might not
+        // happen otherwise.
+        assertContent( groupC, PATH, HOSTED_X_CONTENT );
+        assertContent( groupB, PATH, HOSTED_X_CONTENT );
+        assertContent( groupA, PATH, HOSTED_X_CONTENT );
+    }
+
+    private void assertContent( ArtifactStore store, String path, String expectedXml )
+            throws IndyClientException, IOException
+    {
+        try(InputStream stream = client.content().get( store.getKey(), path ))
+        {
+            assertThat( stream, notNullValue() );
+
+            String downloaded = IOUtils.toString( stream );
+
+            logger.debug( "Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", downloaded, expectedXml );
+
+            XMLUnit.setIgnoreWhitespace( true );
+            XMLUnit.setIgnoreDiffBetweenTextAndCDATA( true );
+            XMLUnit.setIgnoreAttributeOrder( true );
+            XMLUnit.setIgnoreComments( true );
+
+            assertXMLEqual( "Downloaded XML not equal to expected XML from: " + path + " in: " + store.getKey(),
+                            downloaded, expectedXml );
+        }
+        catch ( SAXException e )
+        {
+            e.printStackTrace();
+            fail( "Downloaded XML not equal to expected XML from: " + path + " in: " + store.getKey() );
+        }
+    }
+
+    private void assertNullContent( ArtifactStore store, String path )
+            throws IndyClientException, IOException
+    {
+        try(InputStream stream = client.content().get( store.getKey(), path ))
+        {
+            assertThat( stream, nullValue() );
+        }
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataFoundAfterMemberAddTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataFoundAfterMemberAddTest.java
@@ -146,11 +146,11 @@ public class RecursiveGroupMetadataFoundAfterMemberAddTest
     {
         try(InputStream stream = client.content().get( store.getKey(), path ))
         {
-            assertThat( stream, notNullValue() );
+            assertThat( "Stream for " + store.getKey() + ":" + path + " was missing!", stream, notNullValue() );
 
             String downloaded = IOUtils.toString( stream );
 
-            logger.debug( "Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", downloaded, expectedXml );
+            logger.debug( "{}:{}: Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", store.getKey(), path, downloaded, expectedXml );
 
             XMLUnit.setIgnoreWhitespace( true );
             XMLUnit.setIgnoreDiffBetweenTextAndCDATA( true );
@@ -172,7 +172,7 @@ public class RecursiveGroupMetadataFoundAfterMemberAddTest
     {
         try(InputStream stream = client.content().get( store.getKey(), path ))
         {
-            assertThat( stream, nullValue() );
+            assertThat( "Stream for " + store.getKey() + ":" + path + " was NOT missing!", stream, nullValue() );
         }
     }
 

--- a/addons/pkg-maven/ftests/src/main/resources/logback-test.xml
+++ b/addons/pkg-maven/ftests/src/main/resources/logback-test.xml
@@ -22,6 +22,7 @@
   <logger name="com.redhat.red.build.koji.model.xmlrpc.KojiXmlRpcBindery" level="WARN"/>
 
   <logger name="org.commonjava.indy" level="DEBUG"/>
+  <logger name="org.apache.http" level="DEBUG"/>
 
   <!-- Strictly speaking, the level attribute is not necessary since -->
   <!-- the level of the root level is set to DEBUG by default.       -->

--- a/addons/promote/ftests/pom.xml
+++ b/addons/promote/ftests/pom.xml
@@ -81,5 +81,10 @@
       <artifactId>xmlunit</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-index</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/AbstractPromotionManagerTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/AbstractPromotionManagerTest.java
@@ -38,6 +38,8 @@ public class AbstractPromotionManagerTest
 
     protected ArtifactStore target;
 
+    protected final IndyPromoteClientModule promotions = new IndyPromoteClientModule();
+
     @Before
     public void setupRepos()
         throws Exception
@@ -75,6 +77,6 @@ public class AbstractPromotionManagerTest
     @Override
     protected Collection<IndyClientModule> getAdditionalClientModules()
     {
-        return Collections.singletonList( new IndyPromoteClientModule() );
+        return Collections.singletonList( promotions );
     }
 }

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RecursiveGroupMetadataFoundAfterMemberPromotedTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RecursiveGroupMetadataFoundAfterMemberPromotedTest.java
@@ -144,11 +144,11 @@ public class RecursiveGroupMetadataFoundAfterMemberPromotedTest
     {
         try(InputStream stream = client.content().get( store.getKey(), path ))
         {
-            assertThat( stream, notNullValue() );
+            assertThat( "Stream for " + store.getKey() + ":" + path + " was missing!", stream, notNullValue() );
 
             String downloaded = IOUtils.toString( stream );
 
-            logger.debug( "Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", downloaded, expectedXml );
+            logger.debug( "{}:{}: Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", store.getKey(), path, downloaded, expectedXml );
 
             XMLUnit.setIgnoreWhitespace( true );
             XMLUnit.setIgnoreDiffBetweenTextAndCDATA( true );
@@ -170,7 +170,7 @@ public class RecursiveGroupMetadataFoundAfterMemberPromotedTest
     {
         try(InputStream stream = client.content().get( store.getKey(), path ))
         {
-            assertThat( stream, nullValue() );
+            assertThat( "Stream for " + store.getKey() + ":" + path + " was NOT missing!", stream, nullValue() );
         }
     }
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RecursiveGroupMetadataFoundAfterMemberPromotedTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RecursiveGroupMetadataFoundAfterMemberPromotedTest.java
@@ -1,0 +1,177 @@
+package org.commonjava.indy.promote.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.promote.model.GroupPromoteRequest;
+import org.commonjava.indy.promote.model.GroupPromoteResult;
+import org.custommonkey.xmlunit.XMLUnit;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+
+import static org.custommonkey.xmlunit.XMLAssert.assertXMLEqual;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by jdcasey on 1/19/17.
+ *
+ * This test assures that a particular maven-metadata.xml file should be missing in a group structure, but after it's
+ * uploaded to a repository all groups affected by that repository should be able to return the metadata file.
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Group A with no members.</li>
+ *     <li>Group B containing only Group A as a member.</li>
+ *     <li>Retrieval of metadata path P from Group A returns null/404 result</li>
+ *     <li>Retrieval of metadata path P from Group B returns null/404 result</li>
+ *     <li>HostedRepository X is created for a build</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>metadata path P is uploaded to HostedRepository X as part of a build</li>
+ *     <li>HostedRepository X is promoted via {@link org.commonjava.indy.promote.model.GroupPromoteRequest} into Group A</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ol>
+ *     <li>Subsequent requests for metadata path P from Group B return the uploaded metadata</li>
+ *     <li>Subsequent requests for metadata path P from Group A return the uploaded metadata</li>
+ * </ol>
+ * <br/>
+ * (<b>NOTE:</b> Order of operations is important for verification steps, just in case checking Group A's metadata could
+ * trigger the availability of the metadata in Group B.)
+ */
+public class RecursiveGroupMetadataFoundAfterMemberPromotedTest
+        extends AbstractPromotionManagerTest
+{
+//    @ClassRule
+//    public static TestRule TIMEOUT = timeoutRule( 10, TimeUnit.SECONDS );
+
+    private static final String HOSTED_X = "hostedX";
+
+    private static final String GROUP_A = "groupA";
+
+    private static final String GROUP_B = "groupB";
+
+    private static final String GROUP_C = "groupC";
+
+    private static final String PATH = "org/foo/bar/maven-metadata.xml";
+
+    /* @formatter:off */
+    private static final String HOSTED_X_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<metadata>\n" +
+            "  <groupId>org.foo</groupId>\n" +
+            "  <artifactId>bar</artifactId>\n" +
+            "  <versioning>\n" +
+            "    <latest>1.0</latest>\n" +
+            "    <release>1.0</release>\n" +
+            "    <versions>\n" +
+            "      <version>1.0</version>\n" +
+            "    </versions>\n" +
+            "    <lastUpdated>20150722164334</lastUpdated>\n" +
+            "  </versioning>\n" +
+            "</metadata>\n";
+    /* @formatter:on */
+
+    private HostedRepository hostedX;
+
+    private Group groupA;
+
+    private Group groupB;
+
+    private Group groupC;
+
+    @Before
+    public void setupRepos()
+            throws IndyClientException, UnsupportedEncodingException
+    {
+        String change = "Setup test";
+        hostedX = client.stores().create( new HostedRepository( HOSTED_X ), change, HostedRepository.class );
+        groupA = client.stores().create( new Group( GROUP_A ), change, Group.class );
+        groupB = client.stores().create( new Group( GROUP_B, groupA.getKey() ), change, Group.class );
+        groupC = client.stores().create( new Group( GROUP_C, groupB.getKey() ), change, Group.class );
+    }
+
+    @Test
+    @Category( EventDependent.class )
+    public void run()
+            throws Exception
+    {
+        assertNullContent( hostedX, PATH );
+        assertNullContent( groupA, PATH );
+        assertNullContent( groupB, PATH );
+
+        client.content()
+              .store( hostedX.getKey(), PATH, new ByteArrayInputStream( HOSTED_X_CONTENT.getBytes( "UTF-8" ) ) );
+
+        waitForEventPropagation();
+
+        assertContent( hostedX, PATH,HOSTED_X_CONTENT );
+
+        GroupPromoteRequest request = new GroupPromoteRequest( hostedX.getKey(), groupA.getName() );
+        GroupPromoteResult result = promotions.promoteToGroup( request );
+
+        assertThat( result.succeeded(), equalTo( true ) );
+
+        waitForEventPropagation();
+
+        // Order is important here...we want to try the most ambitious one first and move down to the simpler cases.
+        // This will prevent us from inadvertently triggering metadata aggregation in a lower group that might not
+        // happen otherwise.
+        assertContent( groupC, PATH, HOSTED_X_CONTENT );
+        assertContent( groupB, PATH, HOSTED_X_CONTENT );
+        assertContent( groupA, PATH, HOSTED_X_CONTENT );
+    }
+
+    private void assertContent( ArtifactStore store, String path, String expectedXml )
+            throws IndyClientException, IOException
+    {
+        try(InputStream stream = client.content().get( store.getKey(), path ))
+        {
+            assertThat( stream, notNullValue() );
+
+            String downloaded = IOUtils.toString( stream );
+
+            logger.debug( "Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", downloaded, expectedXml );
+
+            XMLUnit.setIgnoreWhitespace( true );
+            XMLUnit.setIgnoreDiffBetweenTextAndCDATA( true );
+            XMLUnit.setIgnoreAttributeOrder( true );
+            XMLUnit.setIgnoreComments( true );
+
+            assertXMLEqual( "Downloaded XML not equal to expected XML from: " + path + " in: " + store.getKey(),
+                            downloaded, expectedXml );
+        }
+        catch ( SAXException e )
+        {
+            e.printStackTrace();
+            fail( "Downloaded XML not equal to expected XML from: " + path + " in: " + store.getKey() );
+        }
+    }
+
+    private void assertNullContent( ArtifactStore store, String path )
+            throws IndyClientException, IOException
+    {
+        try(InputStream stream = client.content().get( store.getKey(), path ))
+        {
+            assertThat( stream, nullValue() );
+        }
+    }
+
+}

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/helper/HttpResources.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/helper/HttpResources.java
@@ -149,8 +149,11 @@ public class HttpResources
     public void close()
         throws IOException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.debug( "Closing resources for: {}", request == null ? "UNKNOWN" : request.getRequestLine().getUri() );
         if ( responseEntityStream != null )
         {
+            logger.debug( "Closing response entity stream" );
             // do this quietly, since it's probable that the wrapper HttpResourcesManagingInputStream will have closed it implicitly before this is called.
             IOUtils.closeQuietly( responseEntityStream );
         }

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyContentClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyContentClientModule.java
@@ -169,12 +169,12 @@ public class IndyContentClientModule
 
         if ( resources.getStatusCode() != 200 )
         {
+            IOUtils.closeQuietly( resources );
             if ( resources.getStatusCode() == 404 )
             {
                 return null;
             }
 
-            IOUtils.closeQuietly( resources );
             throw new IndyClientException( resources.getStatusCode(), "Response returned status: %s.",
                                             resources.getStatusLine() );
         }
@@ -187,6 +187,7 @@ public class IndyContentClientModule
         }
         catch ( final IOException e )
         {
+            IOUtils.closeQuietly( resources );
             throw new IndyClientException( "Failed to open response content stream: %s", e,
                                             e.getMessage() );
         }

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/fixture/ThreadDumper.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/fixture/ThreadDumper.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.fixture;
+
+import org.junit.rules.TestRule;
+import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestTimedOutException;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.apache.commons.lang.StringUtils.join;
+
+/**
+ * Created by jdcasey on 11/28/16.
+ */
+public final class ThreadDumper
+{
+    private ThreadDumper()
+    {
+    }
+
+    public static void dumpThreads()
+    {
+        StringBuilder sb = new StringBuilder();
+        ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        ThreadInfo[] threadInfos = threadMXBean.getThreadInfo( threadMXBean.getAllThreadIds(), 100 );
+        Stream.of( threadInfos ).forEachOrdered( ( ti ) -> {
+            if ( sb.length() > 0 )
+            {
+                sb.append( "\n\n" );
+            }
+
+            sb.append( ti.getThreadName() )
+              .append( "\n  State: " )
+              .append( ti.getThreadState() )
+              .append( "\n  Lock Info: " )
+              .append( ti.getLockInfo() )
+              .append( "\n  Monitors:" );
+
+            MonitorInfo[] monitors = ti.getLockedMonitors();
+            if ( monitors == null || monitors.length < 1 )
+            {
+                sb.append( "  -NONE-" );
+            }
+            else
+            {
+                sb.append( "\n  - " ).append( join( monitors, "\n  - " ) );
+            }
+
+            sb.append( "\n  Trace:\n    " ).append( join( ti.getStackTrace(), "\n    " ) );
+
+        } );
+
+        System.out.println( sb );
+    }
+
+    public static TestRule timeoutRule( int timeout, TimeUnit units )
+    {
+        return ( base, description ) -> new Statement()
+        {
+            public void evaluate()
+                    throws Throwable
+            {
+                System.out.printf( "Setting up timeout: %d %s to wrap: %s\n", timeout, units, base );
+                AtomicReference<Throwable> error = new AtomicReference<>();
+                CountDownLatch latch = new CountDownLatch( 1 );
+                FutureTask<Void> task = new FutureTask<>( () -> {
+                    try
+                    {
+                        latch.countDown();
+                        base.evaluate();
+                    }
+                    catch ( Throwable t )
+                    {
+                        error.set( t );
+                    }
+
+                    return null;
+                } );
+
+                ThreadGroup tg = new ThreadGroup( "Test Timeout Group" );
+                Thread t = new Thread( tg, task, "Test Timeout Thread" );
+                t.setDaemon( true );
+                t.start();
+
+                try
+                {
+                    System.out.println("Waiting for test to start.");
+                    latch.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    error.set( e );
+                }
+
+                if ( error.get() == null )
+                {
+                    try
+                    {
+                        System.out.println( "Waiting for test to complete (or timeout)" );
+                        task.get( timeout, units );
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        error.set( e );
+                    }
+                    catch ( ExecutionException e )
+                    {
+                        error.set( e.getCause() );
+                    }
+                    catch ( TimeoutException e )
+                    {
+                        System.out.printf( "Test timeout %d %s expired!\n", timeout, units.name() );
+                        dumpThreads();
+                        StackTraceElement[] stackTrace = t.getStackTrace();
+                        Exception currThreadException = new TestTimedOutException(timeout, units);
+                        if (stackTrace != null) {
+                            currThreadException.setStackTrace(stackTrace);
+                            t.interrupt();
+                        }
+
+                        throw currThreadException;
+                    }
+                }
+
+                Throwable throwable = error.get();
+                if ( throwable != null )
+                {
+                    throw throwable;
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
The problem seems to be somewhere in a multilayer group configuration. The requested maven-metadata.xml doesn't exist at first
but should become available when a hosted repo containing it is promoted (by-group) into the lowest layer of the multilayer group config.
This does not seem to make the metadata file available via the topmost group in the PNC environment.

I cannot reproduce this scenario so far.