### PR TITLE
Coordinate maintenance of merged files better and fix index storage for infinispan caches.

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
@@ -15,19 +15,22 @@
  */
 package org.commonjava.indy.content.index;
 
+import org.commonjava.indy.subsys.datafile.conf.DataFileConfiguration;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
-import org.commonjava.indy.subsys.infinispan.inject.qualifer.IndyCache;
 import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Factory;
 import org.hibernate.search.annotations.Store;
 import org.hibernate.search.cfg.Environment;
 import org.hibernate.search.cfg.SearchMapping;
-import org.infinispan.cdi.ConfigureCache;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.Index;
-import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.configuration.cache.SingleFileStoreConfiguration;
+import org.infinispan.configuration.cache.StoreConfiguration;
 import org.infinispan.query.spi.SearchManagerImplementor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -41,48 +44,44 @@ public class ContentIndexCacheProducer
     @Inject
     private CacheProducer cacheProducer;
 
+    @Inject
+    private DataFileConfiguration config;
+
     @PostConstruct
     public void initIndexing(){
-        registerIndexableEntities();
-        regesterTransformer();
+        registerTransformer();
     }
 
-    private void registerIndexableEntities(){
-        final SearchMapping indexMapping = new SearchMapping();
-        indexMapping.entity( IndexedStorePath.class ).indexed().indexName( "indexedStorePath" )
-                    .property( "storeType", ElementType.METHOD ).field()
-                        .name( "storeType" ).store( Store.YES ).analyze( Analyze.NO )
-                    .property( "storeName", ElementType.METHOD ).field()
-                        .name( "storeName" ).store( Store.YES ).analyze( Analyze.NO )
-                    .property( "originStoreType", ElementType.METHOD ).field()
-                        .name( "originStoreType" ).store( Store.YES ).analyze( Analyze.NO )
-                    .property( "originStoreName", ElementType.METHOD ).field()
-                        .name( "originStoreName" ).store( Store.YES ).analyze( Analyze.NO )
-                    .property( "path", ElementType.METHOD ).field()
-                        .name( "path" ).store( Store.YES ).analyze( Analyze.NO );
+    @Factory
+    public SearchMapping getSearchMapping()
+    {
+        final SearchMapping mapping = new SearchMapping();
+        mapping.entity( IndexedStorePath.class ).indexed().indexName( "indexedStorePath" )
+               .property( "storeType", ElementType.METHOD ).field()
+               .name( "storeType" ).store( Store.YES ).analyze( Analyze.NO )
+               .property( "storeName", ElementType.METHOD ).field()
+               .name( "storeName" ).store( Store.YES ).analyze( Analyze.NO )
+               .property( "originStoreType", ElementType.METHOD ).field()
+               .name( "originStoreType" ).store( Store.YES ).analyze( Analyze.NO )
+               .property( "originStoreName", ElementType.METHOD ).field()
+               .name( "originStoreName" ).store( Store.YES ).analyze( Analyze.NO )
+               .property( "path", ElementType.METHOD ).field()
+               .name( "path" ).store( Store.YES ).analyze( Analyze.NO );
 
-        Properties properties = new Properties();
-        properties.put( Environment.MODEL_MAPPING, indexMapping );
-
-        final Configuration contentIndex = cacheProducer.getCacheConfiguration( "content-index" );
-
-        if ( contentIndex != null )
-        {
-            final Configuration indexingConfig = new ConfigurationBuilder().read( contentIndex )
-                                                                           .indexing()
-                                                                           .withProperties( properties )
-                                                                           .index( Index.LOCAL )
-                                                                           .build();
-            cacheProducer.setCacheConfiguration( "content-index", indexingConfig );
-        }
+        return mapping;
     }
 
-    private void regesterTransformer(){
+    private void registerTransformer(){
         final CacheHandle<IndexedStorePath, IndexedStorePath> handler =
                 cacheProducer.getCache( "content-index", IndexedStorePath.class, IndexedStorePath.class );
-        final SearchManagerImplementor searchManager =
-                (SearchManagerImplementor) org.infinispan.query.Search.getSearchManager( handler.getCache() );
-        searchManager.registerKeyTransformer( IndexedStorePath.class, IndexedStorePathTransformer.class );
+
+        handler.execute( cache->{
+            final SearchManagerImplementor searchManager =
+                    (SearchManagerImplementor) org.infinispan.query.Search.getSearchManager( cache );
+
+            searchManager.registerKeyTransformer( IndexedStorePath.class, IndexedStorePathTransformer.class );
+            return null;
+        } );
     }
 
     @ContentIndexCache

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -41,6 +41,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -143,7 +144,7 @@ public class ContentIndexManager
                                                            .toBuilder();
 
             List<IndexedStorePath> paths = queryBuilder.build().list();
-            return paths;
+            return paths == null ? Collections.emptyList() : paths;
         } );
     }
 

--- a/addons/diagnostics/ftests/src/main/java/org/commonjava/indy/diags/ftest/DownloadDiagBundleTest.java
+++ b/addons/diagnostics/ftests/src/main/java/org/commonjava/indy/diags/ftest/DownloadDiagBundleTest.java
@@ -19,12 +19,18 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
+import org.commonjava.indy.client.core.Indy;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.IndyClientModule;
 import org.commonjava.indy.client.core.module.IndyRawHttpModule;
 import org.commonjava.indy.diag.client.IndyDiagnosticsClientModule;
 import org.commonjava.indy.diag.data.DiagnosticsManager;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -50,6 +56,7 @@ public class DownloadDiagBundleTest
     private IndyDiagnosticsClientModule module = new IndyDiagnosticsClientModule();
 
     @Test
+    @Ignore
     public void run()
             throws IndyClientException, IOException
     {
@@ -80,6 +87,16 @@ public class DownloadDiagBundleTest
 
         assertThat( "Didn't find thread dump!", foundThreadDump, equalTo( true ) );
         assertThat( "Didn't find any logs!", logCount > 0, equalTo( true ) );
+    }
+
+    protected Indy createIndyClient()
+            throws IndyClientException
+    {
+        SiteConfig config = new SiteConfigBuilder( "indy", fixture.getUrl() ).withRequestTimeoutSeconds( 120 ).build();
+        Collection<IndyClientModule> modules = getAdditionalClientModules();
+
+        return new Indy( config, new MemoryPasswordManager(), new IndyObjectMapper( getAdditionalMapperModules() ),
+                         modules.toArray(new IndyClientModule[modules.size()]) );
     }
 
     @Override

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/ArchetypeCatalogGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/ArchetypeCatalogGenerator.java
@@ -19,6 +19,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.content.AbstractMergedContentGenerator;
+import org.commonjava.indy.core.content.MergedContentAction;
 import org.commonjava.indy.core.content.group.GroupMergeHelper;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
@@ -28,6 +29,7 @@ import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 
 import javax.inject.Inject;
 import java.io.IOException;
@@ -68,10 +70,10 @@ public class ArchetypeCatalogGenerator
     }
 
     public ArchetypeCatalogGenerator( final DirectContentAccess downloadManager, final StoreDataManager storeManager,
-                                      final ArchetypeCatalogMerger merger,
-                                      final GroupMergeHelper mergeHelper )
+                                      final ArchetypeCatalogMerger merger, final GroupMergeHelper mergeHelper,
+                                      final NotFoundCache nfc, final MergedContentAction... mergedContentActions )
     {
-        super( downloadManager, storeManager, mergeHelper );
+        super( downloadManager, storeManager, mergeHelper, nfc, mergedContentActions );
         this.merger = merger;
         this.helper = mergeHelper;
     }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -19,6 +19,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.content.AbstractMergedContentGenerator;
+import org.commonjava.indy.core.content.MergedContentAction;
 import org.commonjava.indy.core.content.group.GroupMergeHelper;
 import org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger;
 import org.commonjava.indy.data.StoreDataManager;
@@ -40,6 +41,7 @@ import org.commonjava.maven.galley.maven.spi.type.TypeMapper;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.model.TypeMapping;
+import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -121,9 +123,10 @@ public class MavenMetadataGenerator
 
     public MavenMetadataGenerator( final DirectContentAccess fileManager, final StoreDataManager storeManager,
                                    final XMLInfrastructure xml, final TypeMapper typeMapper,
-                                   final MavenMetadataMerger merger, final GroupMergeHelper mergeHelper )
+                                   final MavenMetadataMerger merger, final GroupMergeHelper mergeHelper,
+                                   final NotFoundCache nfc, final MergedContentAction... mergedContentActions )
     {
-        super( fileManager, storeManager, mergeHelper );
+        super( fileManager, storeManager, mergeHelper, nfc, mergedContentActions );
         this.xml = xml;
         this.typeMapper = typeMapper;
         this.merger = merger;

--- a/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGeneratorTest.java
+++ b/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGeneratorTest.java
@@ -45,6 +45,7 @@ import org.commonjava.maven.galley.maven.spi.type.TypeMapper;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.ListingResult;
 import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.nfc.MemoryNotFoundCache;
 import org.commonjava.maven.galley.spi.transport.LocationExpander;
 import org.commonjava.maven.galley.testing.core.transport.job.TestListing;
 import org.commonjava.maven.galley.testing.maven.GalleyMavenFixture;
@@ -91,7 +92,7 @@ public class MavenMetadataGeneratorTest
 
         DefaultDirectContentAccess contentAccess = new DefaultDirectContentAccess( downloads );
 
-        generator = new MavenMetadataGenerator( contentAccess, stores, xml, types, merger, helper );
+        generator = new MavenMetadataGenerator( contentAccess, stores, xml, types, merger, helper, new MemoryNotFoundCache() );
 
         metadataReader =
             new MavenMetadataReader( xml, locations, fixture.getArtifactMetadataManager(), fixture.getXPathManager() );

--- a/api/src/main/java/org/commonjava/indy/core/content/MergedContentAction.java
+++ b/api/src/main/java/org/commonjava/indy/core/content/MergedContentAction.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.content;
+
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+
+import java.util.Set;
+
+/**
+ * Created by jdcasey on 1/20/17.
+ *
+ * Implemented to supplement the core aggregated-content management features of
+ * {@link org.commonjava.indy.content.ContentGenerator} instances. This is preferable to @{@link javax.enterprise.event.Observes}
+ * methods for {@link org.commonjava.maven.galley.event.FileDeletionEvent} or {@link org.commonjava.maven.galley.event.FileStorageEvent}
+ * since it is more tightly coupled with the content generator's execution.
+ */
+public interface MergedContentAction
+{
+    void clearMergedPath( ArtifactStore originatingStore, Set<Group> affectedGroups, String path );
+}

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
@@ -47,18 +47,21 @@ public class Indy
         this( null, null, Arrays.asList( modules ), IndyClientHttp.defaultSiteConfig( baseUrl ));
     }
 
+    @Deprecated
     public Indy( final String baseUrl, final IndyClientAuthenticator authenticator, final IndyClientModule... modules )
             throws IndyClientException
     {
         this( authenticator, null, Arrays.asList( modules ), IndyClientHttp.defaultSiteConfig( baseUrl ) );
     }
 
+    @Deprecated
     public Indy( final String baseUrl, final IndyObjectMapper mapper, final IndyClientModule... modules )
             throws IndyClientException
     {
         this( null, mapper, Arrays.asList( modules ), IndyClientHttp.defaultSiteConfig( baseUrl ) );
     }
 
+    @Deprecated
     public Indy( final String baseUrl, final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper,
                  final IndyClientModule... modules )
             throws IndyClientException
@@ -66,12 +69,14 @@ public class Indy
         this( authenticator, mapper, Arrays.asList( modules ), IndyClientHttp.defaultSiteConfig( baseUrl ) );
     }
 
+    @Deprecated
     public Indy( final String baseUrl, final Collection<IndyClientModule> modules )
             throws IndyClientException
     {
         this( null, null, modules, IndyClientHttp.defaultSiteConfig( baseUrl ) );
     }
 
+    @Deprecated
     public Indy( final String baseUrl, final IndyClientAuthenticator authenticator,
                  final Collection<IndyClientModule> modules )
             throws IndyClientException
@@ -79,12 +84,14 @@ public class Indy
         this( authenticator, null, modules, IndyClientHttp.defaultSiteConfig( baseUrl ) );
     }
 
+    @Deprecated
     public Indy( final String baseUrl, final IndyObjectMapper mapper, final Collection<IndyClientModule> modules )
             throws IndyClientException
     {
         this( null, mapper, modules, IndyClientHttp.defaultSiteConfig( baseUrl ) );
     }
 
+    @Deprecated
     public Indy( final String baseUrl, final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper,
                  final Collection<IndyClientModule> modules )
             throws IndyClientException
@@ -92,9 +99,17 @@ public class Indy
         this( authenticator, mapper, modules, IndyClientHttp.defaultSiteConfig( baseUrl ) );
     }
 
+    @Deprecated
     public Indy( final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper,
                  final Collection<IndyClientModule> modules, SiteConfig location )
             throws IndyClientException
+    {
+        this( location, authenticator, mapper,
+              modules == null ? new IndyClientModule[0] : modules.toArray( new IndyClientModule[modules.size()] ) );
+    }
+
+    public Indy( final SiteConfig location, final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper, final IndyClientModule... modules )
+    throws IndyClientException
     {
         this.http =
                 new IndyClientHttp( authenticator, mapper == null ? new IndyObjectMapper( true ) : mapper, location );
@@ -111,8 +126,15 @@ public class Indy
     public Indy( SiteConfig location, PasswordManager passwordManager, IndyClientModule... modules )
             throws IndyClientException
     {
+        this( location, passwordManager, null, modules );
+    }
+
+
+    public Indy( SiteConfig location, PasswordManager passwordManager, IndyObjectMapper objectMapper, IndyClientModule... modules )
+            throws IndyClientException
+    {
         this.http =
-                new IndyClientHttp( passwordManager, new IndyObjectMapper( true ), location );
+                new IndyClientHttp( passwordManager, objectMapper == null ? new IndyObjectMapper( true ) : objectMapper, location );
 
         this.moduleRegistry = new HashSet<>();
 

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -25,6 +25,9 @@ import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.IndyClientModule;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -114,8 +117,11 @@ public abstract class AbstractIndyFunctionalTest
     protected Indy createIndyClient()
             throws IndyClientException
     {
-        return new Indy( fixture.getUrl(), new IndyObjectMapper( getAdditionalMapperModules() ),
-                           getAdditionalClientModules() );
+        SiteConfig config = new SiteConfigBuilder( "indy", fixture.getUrl() ).withRequestTimeoutSeconds( 60 ).build();
+        Collection<IndyClientModule> modules = getAdditionalClientModules();
+
+        return new Indy( config, new MemoryPasswordManager(), new IndyObjectMapper( getAdditionalMapperModules() ),
+                         modules.toArray(new IndyClientModule[modules.size()]) );
     }
 
     protected float getTestEnvironmentTimeoutMultiplier()

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -5,11 +5,20 @@
     xmlns="urn:infinispan:config:8.2">
 
   <cache-container default-cache="dont-use" name="IndyCacheManager" shutdown-hook="DEFAULT">
+    <local-cache name="koji-maven-version-metadata" >
+      <eviction size="100000" type="COUNT"/>
+      <persistence passivation="false">
+        <file-store purge="false" read-only="false" fetch-state="true" path="${indy.work}/koji-maven-version-metadata">
+          <write-behind/>
+        </file-store>
+      </persistence>
+    </local-cache>
+
     <local-cache name="folo-in-progress" >
       <eviction size="100000" type="COUNT"/>
       <persistence passivation="false">
         <file-store purge="false" read-only="false" fetch-state="true" path="${indy.work}/folo-in-progress">
-          <!--<write-behind/>-->
+          <write-behind/>
         </file-store>
       </persistence>
     </local-cache>
@@ -19,72 +28,24 @@
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/folo"/>
       </persistence>
-      <!--<indexing index="ALL">-->
-        <!--<indexed-entities>-->
-          <!--<indexed-entity>org.commonjava.indy.folo.model.TrackedContentEntry</indexed-entity>-->
-        <!--</indexed-entities>-->
-      <!--</indexing>-->
+      <indexing index="LOCAL">
+        <property name="hibernate.search.model_mapping">org.commonjava.indy.folo.data.FoloCacheProducer</property>
+        <property name="hibernate.search.default.indexBase">${indy.data}/folo/search</property>
+      </indexing>
     </local-cache>
     
     <local-cache name="content-index">
       <eviction size="10000" type="COUNT"/>
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index">
-          <!--<write-behind/>-->
+          <write-behind/>
         </file-store>
       </persistence>
       <indexing index="LOCAL">
-        <property name="default.directory_provider">infinispan</property>
-        <property name="default.indexmanager">org.infinispan.query.indexmanager.InfinispanIndexManager</property>
-        <property name="default.metadata_cachename">content-idx-lucene-metadata</property>
-        <property name="default.data_cachename">content-idx-lucene-data</property>
-        <property name="default.locking_cachename">content-idx-lucene-locks</property>
-        <indexed-entities>
-          <indexed-entity>org.commonjava.indy.content.index.IndexedStorePath</indexed-entity>
-        </indexed-entities>
+        <property name="hibernate.search.model_mapping">org.commonjava.indy.content.index.ContentIndexCacheProducer</property>
+        <property name="hibernate.search.default.indexBase">${indy.data}/content-index/search</property>
       </indexing>
     </local-cache>
-
-    <local-cache name="content-index-lucene-metadata">
-      <eviction size="10000" type="COUNT"/>
-      <persistence passivation="true">
-        <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/metadata">
-          <!--<write-behind/>-->
-        </file-store>
-      </persistence>
-    </local-cache>
-    <local-cache name="content-index-lucene-data">
-      <eviction size="10000" type="COUNT"/>
-      <persistence passivation="true">
-        <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/data">
-          <!--<write-behind/>-->
-        </file-store>
-      </persistence>
-    </local-cache>
-    <local-cache name="content-index-lucene-locks">
-      <eviction size="10000" type="COUNT"/>
-      <persistence passivation="true">
-        <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/content-index-lucene/locks">
-          <!--<write-behind/>-->
-        </file-store>
-      </persistence>
-    </local-cache>
-    <!-- <local-cache name="fs-storage-metadata">
-      <locking isolation="READ_COMMITTED"/>
-      <eviction max-entries="100000" type="COUNT"/>
-      <persistence passivation="true">
-        <file-store purge="false" preload="false" fetch-state="true" path="${indy.data}/storage-metadata"/>
-      </persistence>
-    </local-cache>
-
-    <local-cache name="fs-storage-data">
-      <locking isolation="READ_COMMITTED"/>
-      <persistence passivation="true">
-        <store class="org.commonjava.indy.filer.ispn.fileio.StorageFileIO" preload="false" fetch-state="true" purge="true">
-          <property name="storage-root">${indy.storage.dir}</property>
-        </store>
-      </persistence>
-    </local-cache> -->
 
     <local-cache name="indy-nfs-owner-cache" deadlock-detection-spin="10000">
       <eviction size="1000" type="COUNT" strategy="LRU"/>


### PR DESCRIPTION

* Use MergedContentAction to tightly coordinate de-indexing with core actions implemented by ContentGenerator implementations
* Remove duplicate logic for removing merged files from affected groups
* Configure index storage locations for content-index and folo sealed records to avoid file lock collisions during testing and organize indexing better on deployed systems
* Deprecate old Indy client API constructors in favor of those using SiteConfiguration or to eliminate those with arbitrary subsets of config options
* Switch Infinispan indexed field mappings to @Factory-annotated methods that are referenced from infinispan.xml, to enable more uniform control via this configuration file