### PR TITLE
LegacyQuartzDBMigrationActionTest somehow fails on my local

### DIFF
--- a/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/conf/DataFileConfiguration.java
+++ b/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/conf/DataFileConfiguration.java
@@ -54,11 +54,17 @@ public class DataFileConfiguration
 
     public static final String DEFAULT_WORK_SUBDIR = "work";
 
-    public static final File DEFAULT_DATA_BASEDIR = new File( System.getProperty( "indy.home", DEFAULT_ROOT_DIR ),
-                                                              DEFAULT_DATA_SUBDIR );
+    private File getDefaultDataBasedir()
+    {
+        return new File( System.getProperty( "indy.home", DEFAULT_ROOT_DIR ),
+                DEFAULT_DATA_SUBDIR );
+    }
 
-    private static final File DEFAULT_WORK_BASEDIR = new File( System.getProperty( "indy.home", DEFAULT_ROOT_DIR ),
-                                                               DEFAULT_WORK_SUBDIR );
+    private File getDefaultWorkBasedir()
+    {
+        return new File( System.getProperty( "indy.home", DEFAULT_ROOT_DIR ),
+                DEFAULT_WORK_SUBDIR );
+    }
 
     private File dataBasedir;
 
@@ -82,7 +88,7 @@ public class DataFileConfiguration
 
     public File getDataBasedir()
     {
-        return dataBasedir == null ? DEFAULT_DATA_BASEDIR : dataBasedir;
+        return dataBasedir == null ? getDefaultDataBasedir() : dataBasedir;
     }
 
     @ConfigName( "data.dir" )
@@ -107,7 +113,7 @@ public class DataFileConfiguration
 
     public File getWorkBasedir()
     {
-        return workBasedir == null ? DEFAULT_WORK_BASEDIR : workBasedir;
+        return workBasedir == null ? getDefaultWorkBasedir() : workBasedir;
     }
 
     @ConfigName( "work.dir" )


### PR DESCRIPTION
LegacyQuartzDBMigrationActionTest somehow fails on my local due to sys indy.home loading earlier in DataFileConfiguration than being set in the test which causes invalid final constants values. Fixing it by replacing the constants with methods. 