### PR TITLE
working on reproducing error where group metadata sometimes not re-merged

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -295,6 +295,8 @@ public class MavenMetadataGenerator
 
         final Transfer target = fileManager.getTransfer( group, path );
 
+        logger.debug( "Working on metadata file: {} (already exists? {})", target, target != null && target.exists() );
+
         if ( !target.exists() )
         {
             String toMergePath = path;

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnNewMemberTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnNewMemberTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.content;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.helper.PathInfo;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+
+import static org.commonjava.indy.model.core.StoreType.group;
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check that merged metadata in a group full of hosted repositories is updated when a new hosted repository is added to
+ * the membership.
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>HostedRepositories A, B, and C</li>
+ *     <li>Group G with HostedRepository members A and B</li>
+ *     <li>HostedRepositories A, B, and C all contain metadata path P</li>
+ *     <li>Each metadata file contains different versions of the same project</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>HostedRepository C is appended to the end of Group G's membership</li>
+ *     <li>Metadata path P is requested from Group G <b>after events of membership change have settled</b></li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>Group G's metadata path P should reflect values in HostedRepository C's metadata path P</li>
+ * </ul>
+ */
+public class GroupHostedMetadataRemergedOnNewMemberTest
+        extends AbstractContentManagementTest
+{
+    private static final String GROUP_G_NAME= "G";
+    private static final String HOSTED_A_NAME= "A";
+    private static final String HOSTED_B_NAME= "B";
+    private static final String HOSTED_C_NAME= "C";
+
+    private static final String A_VERSION = "1.0";
+    private static final String B_VERSION = "1.1";
+    private static final String C_VERSION = "1.2";
+
+    private static final String PATH = "/org/foo/bar/maven-metadata.xml";
+
+    /* @formatter:off */
+    private static final String REPO_CONTENT_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>%version%</latest>\n" +
+        "    <release>%version%</release>\n" +
+        "    <versions>\n" +
+        "      <version>%version%</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20150722164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    /* @formatter:off */
+    private static final String BEFORE_GROUP_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>1.1</latest>\n" +
+        "    <release>1.1</release>\n" +
+        "    <versions>\n" +
+        "      <version>1.0</version>\n" +
+        "      <version>1.1</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20150722164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    /* @formatter:off */
+    private static final String AFTER_GROUP_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>1.2</latest>\n" +
+        "    <release>1.2</release>\n" +
+        "    <versions>\n" +
+        "      <version>1.0</version>\n" +
+        "      <version>1.1</version>\n" +
+        "      <version>1.2</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20150722164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    private Group g;
+
+    private HostedRepository a;
+    private HostedRepository b;
+    private HostedRepository c;
+
+    @Before
+    public void setupRepos()
+            throws IndyClientException
+    {
+        String message = "test setup";
+
+        a = client.stores().create( new HostedRepository( HOSTED_A_NAME ), message, HostedRepository.class );
+        b = client.stores().create( new HostedRepository( HOSTED_B_NAME ), message, HostedRepository.class );
+        c = client.stores().create( new HostedRepository( HOSTED_C_NAME ), message, HostedRepository.class );
+
+        g = client.stores().create( new Group( GROUP_G_NAME, a.getKey(), b.getKey() ), message, Group.class );
+
+        client.content()
+              .store( a.getKey(), PATH, new ByteArrayInputStream(
+                      REPO_CONTENT_TEMPLATE.replaceAll( "%version%", A_VERSION ).getBytes() ) );
+
+        client.content()
+              .store( b.getKey(), PATH, new ByteArrayInputStream(
+                      REPO_CONTENT_TEMPLATE.replaceAll( "%version%", B_VERSION ).getBytes() ) );
+
+        client.content()
+              .store( c.getKey(), PATH, new ByteArrayInputStream(
+                      REPO_CONTENT_TEMPLATE.replaceAll( "%version%", C_VERSION ).getBytes() ) );
+    }
+
+    @Test
+    @Category( EventDependent.class )
+    public void run()
+            throws Exception
+    {
+        assertContent( g, PATH, BEFORE_GROUP_CONTENT );
+
+        g.addConstituent( c );
+        client.stores().update( g, "Adding hosted c to membership" );
+
+        waitForEventPropagation();
+
+        assertContent( g, PATH, AFTER_GROUP_CONTENT );
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnMemberAddTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnMemberAddTest.java
@@ -174,17 +174,17 @@ public class RecursiveGroupMetadataClearOnMemberAddTest
     public void run()
             throws Exception
     {
-        assertContent( hostedX, HOSTED_X_CONTENT );
-        assertContent( groupA, HOSTED_X_CONTENT );
-        assertContent( groupB, HOSTED_X_CONTENT );
-        assertContent( groupC, HOSTED_X_CONTENT );
+        assertContent( hostedX, PATH, HOSTED_X_CONTENT );
+        assertContent( groupA, PATH, HOSTED_X_CONTENT );
+        assertContent( groupB, PATH, HOSTED_X_CONTENT );
+        assertContent( groupC, PATH, HOSTED_X_CONTENT );
 
         client.content()
               .store( hostedY.getKey(), PATH, new ByteArrayInputStream( HOSTED_Y_CONTENT.getBytes( "UTF-8" ) ) );
 
         waitForEventPropagation();
 
-        assertContent( hostedY, HOSTED_Y_CONTENT );
+        assertContent( hostedY, PATH, HOSTED_Y_CONTENT );
 
         groupA.addConstituent( hostedY );
         boolean updated = client.stores().update( groupA, "Add hosted Y" );
@@ -196,37 +196,9 @@ public class RecursiveGroupMetadataClearOnMemberAddTest
         // Order is important here...we want to try the most ambitious one first and move down to the simpler cases.
         // This will prevent us from inadvertently triggering metadata aggregation in a lower group that might not
         // happen otherwise.
-        assertContent( groupC, COMBINED_CONTENT );
-        assertContent( groupB, COMBINED_CONTENT );
-        assertContent( groupA, COMBINED_CONTENT );
-    }
-
-    private void assertContent( ArtifactStore store, String expectedXml )
-            throws IndyClientException, IOException
-    {
-        InputStream stream = client.content().get( store.getKey(), PATH );
-
-        assertThat( stream, notNullValue() );
-
-        String downloaded = IOUtils.toString( stream );
-
-        logger.debug( "Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", downloaded, expectedXml );
-
-        try
-        {
-            XMLUnit.setIgnoreWhitespace( true );
-            XMLUnit.setIgnoreDiffBetweenTextAndCDATA( true );
-            XMLUnit.setIgnoreAttributeOrder( true );
-            XMLUnit.setIgnoreComments( true );
-
-            assertXMLEqual( "Downloaded XML not equal to expected XML from: " + PATH + " in: " + store.getKey(),
-                            downloaded, expectedXml );
-        }
-        catch ( SAXException e )
-        {
-            e.printStackTrace();
-            fail( "Downloaded XML not equal to expected XML from: " + PATH + " in: " + store.getKey() );
-        }
+        assertContent( groupC, PATH, COMBINED_CONTENT );
+        assertContent( groupB, PATH, COMBINED_CONTENT );
+        assertContent( groupA, PATH, COMBINED_CONTENT );
     }
 
     @Override

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnUploadTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnUploadTest.java
@@ -135,9 +135,9 @@ public class RecursiveGroupMetadataClearOnUploadTest
     public void run()
             throws Exception
     {
-        assertContent( hostedRepo, firstPassContent );
-        assertContent( groupA, firstPassContent );
-        assertContent( groupB, firstPassContent );
+        assertContent( hostedRepo, path, firstPassContent );
+        assertContent( groupA, path, firstPassContent );
+        assertContent( groupB, path, firstPassContent );
 
         client.content()
               .store( hostedRepo.getKey(), path, new ByteArrayInputStream( secondPassContent.getBytes( "UTF-8" ) ) );
@@ -146,37 +146,9 @@ public class RecursiveGroupMetadataClearOnUploadTest
 
         //        assertContent( hostedRepo, secondPassContent );
         //        assertContent( groupA, secondPassContent );
-        assertContent( groupB, secondPassContent );
+        assertContent( groupB, path, secondPassContent );
 
         Thread.currentThread().sleep( 4000 );
-    }
-
-    private void assertContent( ArtifactStore store, String expectedXml )
-            throws IndyClientException, IOException
-    {
-        InputStream stream = client.content().get( store.getKey(), path );
-
-        assertThat( stream, notNullValue() );
-
-        String downloaded = IOUtils.toString( stream );
-
-        logger.debug( "Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", downloaded, expectedXml );
-
-        try
-        {
-            XMLUnit.setIgnoreWhitespace( true );
-            XMLUnit.setIgnoreDiffBetweenTextAndCDATA( true );
-            XMLUnit.setIgnoreAttributeOrder( true );
-            XMLUnit.setIgnoreComments( true );
-
-            assertXMLEqual( "Downloaded XML not equal to expected XML from: " + path + " in: " + store.getKey(),
-                            downloaded, expectedXml );
-        }
-        catch ( SAXException e )
-        {
-            e.printStackTrace();
-            fail( "Downloaded XML not equal to expected XML from: " + path + " in: " + store.getKey() );
-        }
     }
 
     @Override

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataFoundAfterMemberAddTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataFoundAfterMemberAddTest.java
@@ -156,41 +156,6 @@ public class RecursiveGroupMetadataFoundAfterMemberAddTest
         assertContent( groupA, PATH, HOSTED_X_CONTENT );
     }
 
-    private void assertContent( ArtifactStore store, String path, String expectedXml )
-            throws IndyClientException, IOException
-    {
-        try(InputStream stream = client.content().get( store.getKey(), path ))
-        {
-            assertThat( "Stream for " + store.getKey() + ":" + path + " was missing!", stream, notNullValue() );
-
-            String downloaded = IOUtils.toString( stream );
-
-            logger.debug( "{}:{}: Comparing downloaded XML:\n\n{}\n\nTo expected XML:\n\n{}\n\n", store.getKey(), path, downloaded, expectedXml );
-
-            XMLUnit.setIgnoreWhitespace( true );
-            XMLUnit.setIgnoreDiffBetweenTextAndCDATA( true );
-            XMLUnit.setIgnoreAttributeOrder( true );
-            XMLUnit.setIgnoreComments( true );
-
-            assertXMLEqual( "Downloaded XML not equal to expected XML from: " + path + " in: " + store.getKey(),
-                            downloaded, expectedXml );
-        }
-        catch ( SAXException e )
-        {
-            e.printStackTrace();
-            fail( "Downloaded XML not equal to expected XML from: " + path + " in: " + store.getKey() );
-        }
-    }
-
-    private void assertNullContent( ArtifactStore store, String path )
-            throws IndyClientException, IOException
-    {
-        try(InputStream stream = client.content().get( store.getKey(), path ))
-        {
-            assertThat( "Stream for " + store.getKey() + ":" + path + " was NOT missing!", stream, nullValue() );
-        }
-    }
-
     @Override
     protected boolean createStandardTestStructures()
     {

--- a/addons/pkg-maven/ftests/src/test/resources/META-INF/beans.xml
+++ b/addons/pkg-maven/ftests/src/test/resources/META-INF/beans.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2014 Red Hat, Inc..
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the GNU Public License v3.0
+  which accompanies this distribution, and is available at
+  http://www.gnu.org/licenses/gpl.html
+  
+  Contributors:
+      Red Hat, Inc. - initial API and implementation
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+      
+  <alternatives>
+    <stereotype>org.commonjava.indy.inject.Production</stereotype>
+
+    <class>org.commonjava.indy.flat.data.DataFileStoreDataManager</class>
+  </alternatives>
+
+  <!-- NOTE: In the decorators below, the FIRST listed will be invoked FIRST (outer-most in the stack) -->
+  <decorators>
+    <!-- ContentManager decorators -->
+    <class>org.commonjava.indy.content.index.IndexingContentManagerDecorator</class>
+
+    <!-- ContentManagerDirectAccess decorators -->
+    <class>org.commonjava.indy.content.index.IndexingDirectContentAccessDecorator</class>
+
+  </decorators>
+      
+</beans>

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -250,6 +250,8 @@ public class DefaultContentManager
                 if ( generator.canProcess( path ) )
                 {
                     item = generator.generateGroupFileContent( (Group) store, members, path, eventMetadata );
+                    logger.debug( "From content {}.generateGroupFileContent: {} (exists? {})",
+                                  generator.getClass().getSimpleName(), item, item != null && item.exists() );
                     generated = true;
                     break;
                 }

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -17,10 +17,19 @@ package org.commonjava.indy.ftest.core;
 
 import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
@@ -99,5 +108,27 @@ public class AbstractContentManagementTest
     {
         return true;
     }
+
+    protected void assertContent( ArtifactStore store, String path, String expected )
+            throws IndyClientException, IOException
+    {
+        try(InputStream in = client.content().get( store.getKey(), path))
+        {
+            assertThat( "Content not found: " + path + " in store: " + store.getKey(), in, notNullValue() );
+
+            assertThat( "Content is wrong: " + path + " in store: " + store.getKey(), IOUtils.toString( in ),
+                        equalTo( expected ) );
+        }
+    }
+
+    protected void assertNullContent( ArtifactStore store, String path )
+            throws IndyClientException, IOException
+    {
+        try(InputStream in = client.content().get( store.getKey(), path))
+        {
+            assertThat( "Content found: " + path + " in store: " + store.getKey(), in, nullValue() );
+        }
+    }
+
 
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupContentCopiedEarlierInMembershipIsReturnedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupContentCopiedEarlierInMembershipIsReturnedTest.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.ftest.core.content;
 
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
@@ -57,7 +58,7 @@ import static org.junit.Assert.assertThat;
  * </ul>
  */
 public class GroupContentCopiedEarlierInMembershipIsReturnedTest
-        extends AbstractIndyFunctionalTest
+        extends AbstractContentManagementTest
 {
 
     private static final String REPO_X = "X";
@@ -104,29 +105,18 @@ public class GroupContentCopiedEarlierInMembershipIsReturnedTest
     public void run()
             throws IndyClientException, IOException
     {
-        assertContent( repoX, CONTENT_1 );
-        assertContent( groupA, CONTENT_1 );
-        assertContent( groupB, CONTENT_1 );
+        assertContent( repoX, PATH, CONTENT_1 );
+        assertContent( groupA, PATH, CONTENT_1 );
+        assertContent( groupB, PATH, CONTENT_1 );
 
         // now, copy the content into hosted repo Y.
         client.content().store( repoY.getKey(), PATH, new ByteArrayInputStream( content2 ) );
 
         // the content should be available in repoY.
-        assertContent( repoY, CONTENT_2 );
+        assertContent( repoY, PATH, CONTENT_2 );
 
         // the content should also be available in groupB.
-        assertContent( groupB, CONTENT_2 );
+        assertContent( groupB, PATH, CONTENT_2 );
     }
 
-    private void assertContent( ArtifactStore store, String expected )
-            throws IndyClientException, IOException
-    {
-        try(InputStream in = client.content().get( store.getKey(), PATH))
-        {
-            assertThat( "Content not found: " + PATH + " in store: " + store.getKey(), in, notNullValue() );
-
-            assertThat( "Content is wrong: " + PATH + " in store: " + store.getKey(), IOUtils.toString( in ),
-                        equalTo( expected ) );
-        }
-    }
 }


### PR DESCRIPTION
This seems to be happening at times when by-group promotion completes. My initial attempt has been to reproduce the effect of the promotion in a simpler context, by manually adding a new member and re-checking the metadata content. It does not reproduce the problem yet.

It's not clear whether this is a race condition, or under what conditions we can verify this as an actual bug.