### PR TITLE
Make the log a bit more readable

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
@@ -50,7 +50,7 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 public class KojiBuildAuthority
 {
 
-    private static final List<String> EXLUDED_FILE_ENDINGS = Collections.unmodifiableList(
+    private final static List<String> EXCLUDED_FILE_ENDINGS = Collections.unmodifiableList(
             Arrays.asList( "scm-sources.zip", "patches.zip", "sources.jar", "javadoc.jar" ) );
 
     @Inject
@@ -91,8 +91,9 @@ public class KojiBuildAuthority
     public enum TypePriority
     {
         jar,
-        pom,
-        other;
+        other,
+        xml,
+        pom;
 
         public static TypePriority get( String type )
         {
@@ -130,10 +131,10 @@ public class KojiBuildAuthority
             }
 
             // @formatter:off
-            Predicate<KojiArchiveInfo> archiveInfoFilter = ( archive ) -> EXLUDED_FILE_ENDINGS.parallelStream()
-                                                                                              .filter( ending -> archive.getFilename().endsWith( ending ) )
-                                                                                              .findAny()
-                                                                                              .isPresent();
+            Predicate<KojiArchiveInfo> archiveInfoFilter = ( archive ) -> EXCLUDED_FILE_ENDINGS.parallelStream()
+                                                                                               .filter( ending -> !archive.getFilename().endsWith( ending ) )
+                                                                                               .findAny()
+                                                                                               .isPresent();
             List<KojiArchiveInfo> sortedArchives = archiveCollection.getArchives()
                                                                     .stream()
                                                                     // filter out excluded filename endings.
@@ -216,7 +217,7 @@ public class KojiBuildAuthority
                 {
                     try (InputStream in = md5.openInputStream( true ))
                     {
-                        return IOUtils.toString( in );
+                        return IOUtils.toString( in ).trim();
                     }
                     catch ( IOException e )
                     {


### PR DESCRIPTION
...because when you call store.toString() on a Group instance, you get
a long string containing all the fields including constituents, but here
we need just a store id. And regarding the affected groups it was really
unreadable pile of letters.