### PR TITLE
(master) Improve http-metadata retrieval and consistency of content-indexing usage

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
@@ -186,7 +186,7 @@ public class KojiBuildAuthority
                         }
                     }
                 }
-                catch ( TransferException e )
+                catch ( Exception e )
                 {
                     Logger logger = LoggerFactory.getLogger( getClass() );
                     logger.error( "SHOULD NEVER HAPPEN: Failed to transform artifact to path: " + e.getMessage(), e );

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -23,6 +23,7 @@ import org.commonjava.indy.core.bind.jaxrs.util.TransferStreamingOutput;
 import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.galley.KeyedLocation;
 import org.commonjava.indy.model.util.HttpUtils;
 import org.commonjava.indy.util.AcceptInfo;
 import org.commonjava.indy.util.ApplicationContent;
@@ -195,7 +196,9 @@ public class ContentAccessHandler
 
                 if ( exists )
                 {
-                    HttpExchangeMetadata httpMetadata = contentController.getHttpMetadata( sk, path );
+                    HttpExchangeMetadata httpMetadata = item != null ?
+                            contentController.getHttpMetadata( item ) :
+                            contentController.getHttpMetadata( sk, path );
 
                     // TODO: For hosted repo, artifacts do not have metadata generated. Fall to get(). But we need a better fix later on.
                     if ( httpMetadata == null )
@@ -332,7 +335,7 @@ public class ContentAccessHandler
                         InputStream in = item.openInputStream( true, eventMetadata );
                         final ResponseBuilder builder = Response.ok( new TransferStreamingOutput( in ) );
                         setInfoHeaders( builder, item, sk, path, true, contentController.getContentType( path ),
-                                        contentController.getHttpMetadata( sk, path ) );
+                                        contentController.getHttpMetadata( item ) );
 
                         response = builder.build();
                     }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -699,7 +699,7 @@ public class DefaultContentManager
                 {
                     final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName(), true );
 
-                    logger.debug( "Trying to retrieve suitable transfer for: {} in group: {} members:\n{}", path, allMembers, store.getName() );
+                    logger.debug( "Trying to retrieve suitable transfer for: {} in group: {} members:\n{}", path, store.getName(), allMembers );
 
                     return getTransfer( allMembers, path, op );
                 }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -731,6 +731,7 @@ public class DefaultDownloadManager
                              op );
 
                 transfer = getStorageReference( store, path );
+                logger.debug( "Checking {} (exists? {}; file: {})", transfer, transfer != null && transfer.exists(), transfer == null ? "NONE" : transfer.getFullPath() );
                 if ( transfer != null && !transfer.exists() && ( op == TransferOperation.DOWNLOAD
                         || op == TransferOperation.LISTING ) )
                 {

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -261,6 +261,11 @@ public class ContentController
             throw new IndyWorkflowException( ApplicationStatus.NOT_FOUND.code(), "Cannot find store: {}", key );
         }
 
+        if ( store.isDisabled() )
+        {
+            throw new IndyWorkflowException( ApplicationStatus.NOT_FOUND.code(), "Store is disabled: {}", key );
+        }
+
         return store;
     }
 

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -109,6 +109,13 @@ public class AbstractContentManagementTest
         return true;
     }
 
+    protected void assertExistence( ArtifactStore store, String path, boolean expected )
+            throws IndyClientException
+    {
+        assertThat( "Content should " + ( expected ? "" : "not " ) + "exist at: " + store.getKey() + ":" + path,
+                    client.content().exists( store.getKey(), path ), equalTo( expected ) );
+    }
+
     protected void assertContent( ArtifactStore store, String path, String expected )
             throws IndyClientException, IOException
     {

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoAsPomTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoAsPomTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientHttp;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.client.core.module.IndyRawHttpModule;
+import org.commonjava.indy.client.core.util.UrlUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.util.HttpUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by jdcasey on 2/6/17.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>{@link Group} A contains ordered membership of {@link RemoteRepository}s [X,Y]</li>
+ *     <li>Path P in {@link RemoteRepository} X <b>has not</b> been downloaded</li>
+ *     <li>HEAD request for Pom P in {@link RemoteRepository} X <b>has</b> been executed, resulting in creation of the associated http-metadata.json</li>
+ *     <li>Path P in {@link RemoteRepository} Y <b>has</b> been downloaded previously, also resulting in creation of associated http-metadata.json</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Pom P is requested from {@link Group} A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>{@link Group} A returns http-metadata.json associated with the Pom in {@link RemoteRepository} Y</li>
+ * </ul>
+ */
+public class GroupHttpHeadersFromSameRepoAsPomTest
+        extends AbstractContentManagementTest
+{
+
+    private static final String REPO_X = "X";
+
+    private static final String REPO_Y = "Y";
+
+    private static final String GROUP_A = "A";
+
+    private static final String CONTENT_1 = "This is content #1.";
+
+    private static final String CONTENT_2 = "This is content #2. Some more content, here.";
+
+    private static final String PATH = "/path/to/test.txt";
+
+    private RemoteRepository repoX;
+
+    private RemoteRepository repoY;
+
+    private Group groupA;
+
+    private byte[] content2;
+
+    private final IndyRawHttpModule httpModule = new IndyRawHttpModule();
+
+    @Before
+    public void setupStores()
+            throws Exception
+    {
+        String changelog = "test setup";
+        repoX = client.stores().create( new RemoteRepository( REPO_X, server.formatUrl( REPO_X ) ), changelog, RemoteRepository.class );
+        repoY = client.stores().create( new RemoteRepository( REPO_Y, server.formatUrl( REPO_Y ) ), changelog, RemoteRepository.class );
+
+        content2 = CONTENT_2.getBytes( "UTF-8" );
+
+        server.expect( server.formatUrl( REPO_X, PATH ), 200, CONTENT_1 );
+
+        server.expect( server.formatUrl( REPO_Y, PATH ), 200, new ByteArrayInputStream( content2 ) );
+
+        groupA = client.stores().create( new Group( GROUP_A, repoX.getKey(), repoY.getKey() ), changelog, Group.class );
+
+    }
+
+    @Test
+    public void run()
+            throws IndyClientException, IOException
+    {
+        assertContent( repoX, PATH, CONTENT_1 );
+        assertContent( repoY, PATH, CONTENT_2 );
+
+//        repoX.setDisabled( true );
+//        client.stores().update( repoX, "disabling" );
+
+        File remoteXFile = Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage/remote-X", PATH ).toFile();
+
+        waitForEventPropagation();
+
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.debug( "Deleting main file: {} (leaving associated http-metadata.json file in place)", remoteXFile );
+
+        assertThat( "Failed to delete: " + remoteXFile, remoteXFile.delete(), equalTo( true ) );
+
+        waitForEventPropagation();
+
+        assertContentLength( groupA, PATH, content2.length );
+        assertContentLength( repoX, PATH, CONTENT_1.getBytes().length );
+        assertContentLength( repoY, PATH, content2.length );
+    }
+
+    private void assertContentLength( ArtifactStore store, String path, int length )
+            throws IndyClientException
+    {
+        IndyClientHttp http = httpModule.getHttp();
+        Map<String, String> headers = http.head( client.content().contentPath( store.getKey(), path ) );
+
+        assertThat( headers, notNullValue() );
+
+        String clStr = headers.get( "content-length" );
+        assertThat( clStr, notNullValue() );
+
+        Long len = Long.parseLong( clStr );
+        assertThat( "Error: " + store.getKey() + ":" + path + ": had incorrect retrieved content-length (" + len
+                            + "); should have been: " + length, len, equalTo( Long.valueOf( length ) ) );
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Arrays.asList( httpModule );
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoWhenNotInPathMaskTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoWhenNotInPathMaskTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientHttp;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.client.core.helper.HttpResources;
+import org.commonjava.indy.client.core.module.IndyRawHttpModule;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by jdcasey on 2/6/17.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>{@link Group} A contains ordered membership of {@link RemoteRepository}s [X,Y]</li>
+ *     <li>Path P in {@link RemoteRepository} X <b>has not</b> been downloaded</li>
+ *     <li>HEAD request for Pom P in {@link RemoteRepository} X <b>has</b> been executed, resulting in creation of the associated http-metadata.json</li>
+ *     <li>Path P in {@link RemoteRepository} Y <b>has</b> been downloaded previously, also resulting in creation of associated http-metadata.json</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Pom P is requested from {@link Group} A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>{@link Group} A returns http-metadata.json associated with the Pom in {@link RemoteRepository} Y</li>
+ * </ul>
+ */
+public class GroupHttpHeadersFromSameRepoWhenNotInPathMaskTest
+        extends AbstractContentManagementTest
+{
+
+    private static final String REPO_X = "X";
+
+    private static final String REPO_Y = "Y";
+
+    private static final String GROUP_A = "A";
+
+    private static final String CONTENT_1 = "This is content #1.";
+
+    private static final String CONTENT_2 = "This is content #2. Some more content, here.";
+
+    private static final String PATH = "path/to/test.txt";
+
+    private RemoteRepository repoX;
+
+    private RemoteRepository repoY;
+
+    private Group groupA;
+
+    private byte[] content2;
+
+    private final IndyRawHttpModule httpModule = new IndyRawHttpModule();
+
+    @Before
+    public void setupStores()
+            throws Exception
+    {
+        String changelog = "test setup";
+        repoX = new RemoteRepository( REPO_X, server.formatUrl( REPO_X ) );
+        repoX.setPathMaskPatterns( Collections.singleton( PATH ) );
+        repoX = client.stores().create( repoX, changelog, RemoteRepository.class );
+
+        repoY = client.stores().create( new RemoteRepository( REPO_Y, server.formatUrl( REPO_Y ) ), changelog, RemoteRepository.class );
+
+        content2 = CONTENT_2.getBytes( "UTF-8" );
+
+        server.expect( server.formatUrl( REPO_X, PATH ), 200, CONTENT_1 );
+
+        server.expect( server.formatUrl( REPO_Y, PATH ), 200, new ByteArrayInputStream( content2 ) );
+
+        groupA = client.stores().create( new Group( GROUP_A, repoX.getKey(), repoY.getKey() ), changelog, Group.class );
+
+    }
+
+    @Test
+    public void run()
+            throws IndyClientException, IOException
+    {
+        assertContent( repoX, PATH, CONTENT_1 );
+        assertContent( repoY, PATH, CONTENT_2 );
+
+//        repoX.setDisabled( true );
+//        client.stores().update( repoX, "disabling" );
+
+        File remoteYFile = Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage/remote-Y", PATH ).toFile();
+
+        waitForEventPropagation();
+
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.debug( "Deleting main Y file: {} (leaving associated http-metadata.json file in place)", remoteYFile );
+
+        assertThat( "Failed to delete: " + remoteYFile, remoteYFile.delete(), equalTo( true ) );
+
+        waitForEventPropagation();
+
+        assertGetContentAndLength( groupA, PATH, CONTENT_1 );
+//        assertContentLength( repoX, PATH, CONTENT_1.getBytes().length );
+//        assertContentLength( repoY, PATH, content2.length );
+    }
+
+    private void assertGetContentAndLength( ArtifactStore store, String path, String content )
+            throws IndyClientException, IOException
+    {
+        IndyClientHttp http = httpModule.getHttp();
+        try(HttpResources resources = http.getRaw( client.content().contentPath( store.getKey(), path ) ))
+        {
+            HttpResponse response = resources.getResponse();
+            assertThat( "Request " + store.getKey() + ":" + path + " failed with status: " + response.getStatusLine(),
+                        response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+
+            Header header = response.getFirstHeader( "Content-Length" );
+            assertThat( "Content-Length header missing: " + store.getKey() + ":" + path, header, notNullValue() );
+
+            String clStr = header.getValue();
+            assertThat( clStr, notNullValue() );
+
+            long length= content.getBytes().length;
+            Long len = Long.parseLong( clStr );
+            assertThat( "Error: " + store.getKey() + ":" + path + ": had incorrect retrieved content-length (" + len
+                                + "); should have been: " + length, len, equalTo( Long.valueOf( length ) ) );
+
+            assertThat( "Unexpected response content: " + store.getKey() + ":" + path,
+                        IOUtils.toString( resources.getResponseEntityContent() ), equalTo( content ) );
+        }
+    }
+
+    private void assertContentLength( ArtifactStore store, String path, int length )
+            throws IndyClientException
+    {
+        IndyClientHttp http = httpModule.getHttp();
+        Map<String, String> headers = http.head( client.content().contentPath( store.getKey(), path ) );
+
+        assertThat( headers, notNullValue() );
+
+        String clStr = headers.get( "content-length" );
+        assertThat( clStr, notNullValue() );
+
+        Long len = Long.parseLong( clStr );
+        assertThat( "Error: " + store.getKey() + ":" + path + ": had incorrect retrieved content-length (" + len
+                            + "); should have been: " + length, len, equalTo( Long.valueOf( length ) ) );
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Arrays.asList( httpModule );
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupPreferContentFromFirstMemberTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupPreferContentFromFirstMemberTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientHttp;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.client.core.module.IndyRawHttpModule;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by jdcasey on 2/6/17.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>{@link Group} A contains ordered membership of {@link RemoteRepository}s [X,Y]</li>
+ *     <li>Path P in {@link RemoteRepository} X exists but has not yet been requested (so isn't indexed)</li>
+ *     <li>Path P in {@link RemoteRepository} Y <b>has</b> been downloaded previously, also resulting in the path being indexed</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Pom P is requested from {@link Group} A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>{@link Group} A returns content for Path P in {@link RemoteRepository} X</li>
+ * </ul>
+ */
+public class GroupPreferContentFromFirstMemberTest
+        extends AbstractContentManagementTest
+{
+
+    private static final String REPO_X = "X";
+
+    private static final String REPO_Y = "Y";
+
+    private static final String GROUP_A = "A";
+
+    private static final String CONTENT_1 = "This is content #1.";
+
+    private static final String CONTENT_2 = "This is content #2. Some more content.";
+
+    private static final String PATH = "/path/to/test.txt";
+
+    private RemoteRepository repoX;
+
+    private RemoteRepository repoY;
+
+    private Group groupA;
+
+    private byte[] content2;
+
+    @Before
+    public void setupStores()
+            throws Exception
+    {
+        String changelog = "test setup";
+        repoX = client.stores().create( new RemoteRepository( REPO_X, server.formatUrl( REPO_X ) ), changelog, RemoteRepository.class );
+        repoY = client.stores().create( new RemoteRepository( REPO_Y, server.formatUrl( REPO_Y ) ), changelog, RemoteRepository.class );
+
+        content2 = CONTENT_2.getBytes( "UTF-8" );
+
+        server.expect( server.formatUrl( REPO_X, PATH ), 200,
+                       new ByteArrayInputStream( CONTENT_1.getBytes( "UTF-8" ) ) );
+
+        server.expect( server.formatUrl( REPO_Y, PATH ), 200, new ByteArrayInputStream( content2 ) );
+
+        groupA = client.stores().create( new Group( GROUP_A, repoX.getKey(), repoY.getKey() ), changelog, Group.class );
+
+    }
+
+    @Test
+    public void run()
+            throws IndyClientException, IOException
+    {
+//        assertContent( repoX, PATH, CONTENT_1 );
+        assertContent( repoY, PATH, CONTENT_2 );
+
+        waitForEventPropagation();
+
+        assertContent( groupA, PATH, CONTENT_1 );
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NestedStoreInGroupWithErrorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NestedStoreInGroupWithErrorTest.java
@@ -71,10 +71,6 @@ public class NestedStoreInGroupWithErrorTest
         {
             assertThat( IOUtils.toString( is ), equalTo( content ) );
         }
-        catch ( final IndyClientException e )
-        {
-            fail( "should not fail" );
-        }
     }
 
     @Override

--- a/ftests/core/src/main/resources/META-INF/beans.xml
+++ b/ftests/core/src/main/resources/META-INF/beans.xml
@@ -13,4 +13,12 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
        version="1.1" bean-discovery-mode="all">
+
+  <decorators>
+    <!-- ContentManager decorators -->
+    <class>org.commonjava.indy.content.index.IndexingContentManagerDecorator</class>
+
+    <!-- ContentManagerDirectAccess decorators -->
+    <class>org.commonjava.indy.content.index.IndexingDirectContentAccessDecorator</class>
+  </decorators>
 </beans>


### PR DESCRIPTION

* Reuse existing Transfer to lookup http-metadata when possible to avoid need to re-lookup that main Transfer.
* When looking for content in a group, search the index **and try retrieve() or getTransfer()** for each member before moving on. This avoids situation where a lower member may have its content indexed but a higher member also contains the content...it's just not indexed. If we try all indexes before trying to retrieve the content from any member, the lower member's index may grant precedence to its content even though an un-indexed system would grant precedence to the higher member's content.
* Avoid recursion in the retrieve() / getTransfer() / getIndexedMemberTransfer(), using a List and while loop.
* Implement a couple of potential failure scenarios where misaligned content could be returned, or the index for a group structure could be wrong.
* Short-circuit the functions of ContentController when the store is disabled.