### PR TITLE
(master) Fix dropping of builds with old source.zip format

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
@@ -18,7 +18,6 @@ import org.commonjava.indy.koji.conf.IndyKojiConfig;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.atlas.ident.ref.ProjectRef;
-import org.commonjava.maven.galley.TransferException;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.maven.spi.type.TypeMapper;
 import org.commonjava.maven.galley.maven.util.ArtifactPathUtils;
@@ -52,7 +51,7 @@ public class KojiBuildAuthority
 {
 
     private static final List<String> EXCLUDED_FILE_ENDINGS = Collections.unmodifiableList(
-            Arrays.asList( "scm-sources.zip", "patches.zip", "sources.jar", "javadoc.jar" ) );
+            Arrays.asList( "-sources.zip", "-patches.zip", "-sources.jar", "-javadoc.jar" ) );
 
     @Inject
     private IndyKojiConfig config;


### PR DESCRIPTION
There is build org.jboss-jboss-parent-10_redhat_2-2 which contains
sources in file org.jboss-jboss-parent-10_redhat_2-sources.zip. This
file is not a valid Maven artifact, which causes the build to be thrown
away and a PNC build fails because of missing artifact.

So the excluded file endings were updated to cover this one and also to
better match only what we want to exclude - e.g. sources.jar would also
match a resources.jar etc, so the hyphen was added to avoid this. It is
still not 100% but IMO better than before.