### PR TITLE
Fix what was broken a few hours ago in maven metadata generation

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -317,7 +317,6 @@ public abstract class KojiContentManagerDecorator
                     {
                         logger.debug( "Build: {} is not completed. The state is {}. Skipping.",
                                       build.getNvr(), build.getBuildState() );
-                        // This is not a real build, it's a binary import.
                         continue;
                     }
 


### PR DESCRIPTION
Switch back to listing artifacts and perform the filtering on the client side.
Also enhance the original seenBuilds concept - a build once seen does not have to be checked again even without further requests to koji, because if it was checked already, so I assume no new info making it pass in the metadata cannot be found.