### PR TITLE
Koji metadata generation speedup

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -194,6 +194,12 @@ public class KojiMavenMetadataProvider
                                 logger.debug( "Skipping non-POM: {}", archive.getFilename() );
                                 continue;
                             }
+                            SingleVersion singleVersion = VersionUtils.createSingleVersion( archive.getVersion() );
+                            if ( versions.contains( singleVersion ) )
+                            {
+                                logger.debug( "Skipping already collected version: {}", archive.getVersion() );
+                                continue;
+                            }
 
                             KojiBuildInfo build;
                             if ( seenBuilds.contains( archive.getBuildId() ) )
@@ -262,7 +268,7 @@ public class KojiMavenMetadataProvider
                                 try
                                 {
                                     logger.debug( "Adding version: {} for: {}", archive.getVersion(), path );
-                                    versions.add( VersionUtils.createSingleVersion( archive.getVersion() ) );
+                                    versions.add( singleVersion );
                                 }
                                 catch ( InvalidVersionSpecificationException e )
                                 {


### PR DESCRIPTION
Do not check the same version multiple times if a different build of the
same version is already added to the list.