### PR TITLE
Perform requests in parallel for metadata generator

### DIFF
--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
@@ -327,7 +327,8 @@ public class KojiMavenMetadataProviderTest
         DownloadManager downloadManager = new DefaultDownloadManager( storeDataManager, galley.getTransferManager(),
                                                                       new IndyLocationExpander( storeDataManager ) );
 
-        DirectContentAccess directContentAccess = new DefaultDirectContentAccess( downloadManager );
+        DirectContentAccess directContentAccess = new DefaultDirectContentAccess( downloadManager,
+                                                                                  Executors.newCachedThreadPool() );
 
         KojiBuildAuthority buildAuthority =
                 new KojiBuildAuthority( kojiConfig, new StandardTypeMapper(), kojiClient, storeDataManager,

--- a/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGeneratorTest.java
+++ b/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGeneratorTest.java
@@ -55,6 +55,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Executors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -90,7 +91,8 @@ public class MavenMetadataGeneratorTest
         final MavenMetadataMerger merger = new MavenMetadataMerger( Collections.emptyList() );
         final GroupMergeHelper helper = new GroupMergeHelper( downloads );
 
-        DefaultDirectContentAccess contentAccess = new DefaultDirectContentAccess( downloads );
+        DefaultDirectContentAccess contentAccess = new DefaultDirectContentAccess( downloads,
+                                                                                   Executors.newCachedThreadPool() );
 
         generator = new MavenMetadataGenerator( contentAccess, stores, xml, types, merger, helper, new MemoryNotFoundCache() );
 
@@ -107,7 +109,7 @@ public class MavenMetadataGeneratorTest
 
         final Transfer transfer =
             generator.generateFileContent( stores.getArtifactStore( resource.getStoreKey() ),
-                                           ( (ConcreteResource) resource.getChild( "maven-metadata.xml" ) ).getPath(),
+                                           resource.getChild( "maven-metadata.xml" ).getPath(),
                                            emd );
 
         assertThat( transfer, notNullValue() );
@@ -179,7 +181,7 @@ public class MavenMetadataGeneratorTest
         throws Exception
     {
         final StoreResource resource = setupVersionsStructureWith2Versions();
-        final ConcreteResource metadataFile = (ConcreteResource) resource.getChild( "maven-metadata.xml" );
+        final ConcreteResource metadataFile = resource.getChild( "maven-metadata.xml" );
 
         final Transfer transfer =
             generator.generateFileContent( stores.getArtifactStore( resource.getStoreKey() ), metadataFile.getPath(),
@@ -251,13 +253,13 @@ public class MavenMetadataGeneratorTest
                .registerListing( resource,
                                  new TestListing( new ListingResult( resource, new String[] { "1.0/", "1.1/" } ) ) );
 
-        ConcreteResource versionDir = ( (ConcreteResource) resource.getChild( "1.0/" ) );
+        ConcreteResource versionDir = ( resource.getChild( "1.0/" ) );
         fixture.getTransport()
                .registerListing( versionDir,
                                  new TestListing( new ListingResult( versionDir, new String[] { "artifact-1.0.jar",
                                      "artifact-1.0.pom" } ) ) );
 
-        versionDir = ( (ConcreteResource) resource.getChild( "1.1/" ) );
+        versionDir = ( resource.getChild( "1.1/" ) );
         fixture.getTransport()
                .registerListing( versionDir,
                                  new TestListing( new ListingResult( versionDir, new String[] { "artifact-1.1.jar",

--- a/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
+++ b/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
@@ -21,9 +21,8 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
-import org.commonjava.maven.galley.model.TransferOperation;
-
 import java.util.List;
+import java.util.Map;
 
 /**
  * This component is useful for content generators, that need access to raw files used as inputs for generating other
@@ -79,6 +78,9 @@ public interface DirectContentAccess
             throws IndyWorkflowException;
 
     List<StoreResource> listRaw( ArtifactStore store, String parentPath )
+            throws IndyWorkflowException;
+
+    Map<String, List<StoreResource>> listRaw( ArtifactStore store, List<String> parentPathList )
             throws IndyWorkflowException;
 
 }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
@@ -57,9 +57,10 @@ public class DefaultDirectContentAccess
 
     public DefaultDirectContentAccess(){}
 
-    public DefaultDirectContentAccess( final DownloadManager downloadManager )
+    public DefaultDirectContentAccess( final DownloadManager downloadManager, ExecutorService executorService )
     {
         this.downloadManager = downloadManager;
+        this.executorService = executorService;
     }
 
 


### PR DESCRIPTION
When directory listing for a group is generated MavenMetadataGenerator
needs to list all subdirectories to decide if maven-metadata.xml should
be part of the list. (The decision is based on if a pom is found in one
of the subdirectories.) So to speed up the listings we can perform them
in parallel for all subdirectories.

When generating the maven metadata themselves there is a similar
situation - we need to merge metadata from all constituents of the group
so collecting those can run in parallel.

The executor services in these cases are intentionally not limited to a
maximum thread count, because the limitation happens in galley on the
http level so it is limited anyway and IMO the limitation here does not
make much sense.