### PR TITLE
[master] [httprox] Do not find repo by name without checking url

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -346,14 +346,13 @@ public final class ProxyResponseWriter
     private RemoteRepository getRepository( final URL url )
                     throws IndyDataException
     {
-
-        final String name = PROXY_REPO_PREFIX + url.getHost().replace( '.', '-' );
-
-        int port= url.getPort();
+        int port = url.getPort();
         if ( port < 1 )
         {
             port = url.getDefaultPort();
         }
+
+        String name = PROXY_REPO_PREFIX + url.getHost().replace( '.', '-' ) + '_' + port;
 
         final String baseUrl = String.format( "%s://%s:%s/", url.getProtocol(), url.getHost(), port );
 
@@ -362,6 +361,14 @@ public final class ProxyResponseWriter
         {
             logger.debug( "Looking for remote repo with name: {}", name );
             remote = storeManager.getRemoteRepository( name );
+            // if repo with this name already exists, it has a different url, so we need to use a different name
+            int i = 1;
+            while ( remote != null )
+            {
+                name = PROXY_REPO_PREFIX + url.getHost().replace( '.', '-' ) + "_" + i++;
+                logger.debug( "Looking for remote repo with name: {}", name );
+                remote = storeManager.getRemoteRepository( name );
+            }
         }
 
         if ( remote == null )

--- a/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
@@ -200,7 +200,7 @@ public class HttpProxyTest
         }
 
         final RemoteRepository remoteRepo = (RemoteRepository) storeManager.getArtifactStore(
-                new StoreKey( StoreType.remote, "httprox_127-0-0-1" ) );
+                new StoreKey( StoreType.remote, "httprox_127-0-0-1_" + server.getPort() ) );
 
         assertThat( remoteRepo, notNullValue() );
         assertThat( remoteRepo.getUrl(), equalTo( server.getBaseUri() ) );
@@ -231,7 +231,7 @@ public class HttpProxyTest
         }
 
         final RemoteRepository remoteRepo = (RemoteRepository) storeManager.getArtifactStore(
-                new StoreKey( StoreType.remote, "httprox_127-0-0-1" ) );
+                new StoreKey( StoreType.remote, "httprox_127-0-0-1_" + server.getPort() ) );
 
         assertThat( remoteRepo, notNullValue() );
         assertThat( remoteRepo.getUrl(), equalTo( server.getBaseUri() ) );

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AutoCreateRepoAndRetrievePomTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AutoCreateRepoAndRetrievePomTest.java
@@ -21,16 +21,12 @@ import static org.junit.Assert.assertThat;
 
 import java.io.InputStream;
 import java.util.Collections;
-import java.util.List;
-
 import org.apache.commons.io.IOUtils;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicNameValuePair;
 import org.commonjava.indy.client.core.helper.HttpResources;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreType;
@@ -75,7 +71,7 @@ public class AutoCreateRepoAndRetrievePomTest
         }
 
         final RemoteRepository remoteRepo = this.client.stores()
-                       .load( StoreType.remote, "httprox_127-0-0-1", RemoteRepository.class );
+                       .load( StoreType.remote, "httprox_127-0-0-1_" + server.getPort(), RemoteRepository.class );
 
         assertThat( remoteRepo, notNullValue() );
         assertThat( remoteRepo.getUrl(), equalTo( server.getBaseUri() ) );

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/Propagate404NotFoundTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/Propagate404NotFoundTest.java
@@ -64,7 +64,7 @@ public class Propagate404NotFoundTest
         }
 
         final RemoteRepository remoteRepo = this.client.stores()
-                       .load( StoreType.remote, "httprox_127-0-0-1", RemoteRepository.class );
+                       .load( StoreType.remote, "httprox_127-0-0-1_" + server.getPort(), RemoteRepository.class );
 
         assertThat( remoteRepo, notNullValue() );
         assertThat( remoteRepo.getUrl(), equalTo( server.getBaseUri() ) );

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/ProxyReleasesFileLockOnCompletionTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/ProxyReleasesFileLockOnCompletionTest.java
@@ -16,7 +16,6 @@
 package org.commonjava.indy.httprox;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -26,7 +25,6 @@ import org.commonjava.indy.model.core.StoreType;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.stream.Stream;
@@ -83,7 +81,7 @@ public class ProxyReleasesFileLockOnCompletionTest
         } );
 
         final RemoteRepository remoteRepo = this.client.stores()
-                       .load( StoreType.remote, "httprox_127-0-0-1", RemoteRepository.class );
+                       .load( StoreType.remote, "httprox_127-0-0-1_" + server.getPort(), RemoteRepository.class );
 
         assertThat( remoteRepo, notNullValue() );
         assertThat( remoteRepo.getUrl(), equalTo( server.getBaseUri() ) );


### PR DESCRIPTION
This way we can hit an issue when a server hosts different contents on
different ports. We've hit it recently in npm build when one build
published results to a server on port 49158 which was configured to be
used in a following build but since Indy already had a remote repo on
the same host but port 49160 it used that one instead of the requested
one.

Also once we drop the fallback lookup by name we need to add name
collision checking.