### PR TITLE
Add ftests for addons/relate

### DIFF
--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadDepFromParentTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadDepFromParentTest.java
@@ -1,0 +1,130 @@
+package org.commonjava.indy.relate.ftest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.maven.atlas.graph.jackson.ProjectRelationshipSerializerModule;
+import org.commonjava.maven.atlas.graph.model.EProjectDirectRelationships;
+import org.commonjava.maven.atlas.ident.jackson.ProjectVersionRefSerializerModule;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by ruhan on 2/17/17.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>{@link RemoteRepository} A proxy an upstream server</li>
+ *     <li>Path P points to a parent POM file in {@link RemoteRepository} A</li>
+ *     <li>Path C points to a consumer POM file in {@link RemoteRepository} A</li>
+ *     <li>Path CR points to the Rel file of the consumer POM</li>
+ *     <li>Path PR points to the Rel file of the parent POM</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Path C is requested from {@link RemoteRepository} A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>{@link RemoteRepository} A returns notNull (exists) for Path C</li>
+ *     <li>{@link RemoteRepository} A returns notNull (exists) for Path CR</li>
+ *     <li>{@link RemoteRepository} A returns notNull (exists) for Path P</li>
+ *     <li>{@link RemoteRepository} A returns notNull (exists) for Path PR</li>
+ *     <li>Rel file from Path CR is identical to expected output file</li>
+ * </ul>
+ */
+public class PomDownloadDepFromParentTest
+                extends AbstractIndyFunctionalTest
+{
+    private static final String resource = "dep-from-parent";
+
+    private static final String repo = resource + "/repo";
+
+    private static final String pathDep = "org/bar/dep/1.1/dep-1.1.pom";
+
+    private static final String pathConsumer = "org/foo/consumer/1/consumer-1.pom";
+
+    private static final String pathConsumerParent = "org/foo/parent/1/parent-1.pom";
+
+    private static final String pathConsumerRel = pathConsumer + ".rel";
+
+    private static final String pathConsumerParentRel = pathConsumerParent + ".rel";
+
+    private static final String repo1 = "repo1";
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    ObjectMapper mapper;
+
+    @Before
+    public void init()
+    {
+        mapper = new ObjectMapper();
+        mapper.registerModules( new ProjectVersionRefSerializerModule(), new ProjectRelationshipSerializerModule() );
+    }
+
+    @Test
+    public void run() throws Exception
+    {
+        String depPom = readTestResource( repo + "/" + pathDep );
+        server.expect( server.formatUrl( repo1, pathDep ), 200, depPom );
+
+        String consumerPom = readTestResource( repo + "/" + pathConsumer );
+        server.expect( server.formatUrl( repo1, pathConsumer ), 200, consumerPom );
+
+        String consumerParentPom = readTestResource( repo + "/" + pathConsumerParent );
+        server.expect( server.formatUrl( repo1, pathConsumerParent ), 200, consumerParentPom );
+
+        // Create remote repositories
+        RemoteRepository remote1 = new RemoteRepository( repo1, server.formatUrl( repo1 ) );
+        client.stores().create( remote1, "adding remote1", RemoteRepository.class );
+
+        // Get consumer pom
+        InputStream is = client.content().get( remote, repo1, pathConsumer );
+        assertThat( is, notNullValue() );
+        String s = IOUtils.toString( is );
+        logger.debug( ">>> " + s );
+        assertThat( s, equalTo( consumerPom ) );
+
+        waitForEventPropagation();
+
+        boolean exists = false;
+
+        // Check consumer rel exists
+        exists = client.content().exists( remote, repo1, pathConsumerRel, true );
+        assertThat( exists, equalTo( true ) );
+
+        // Check consumer's parent pom exists
+        exists = client.content().exists( remote, repo1, pathConsumerParent, true );
+        assertThat( exists, equalTo( true ) );
+
+        // Check consumer's parent rel exists
+        exists = client.content().exists( remote, repo1, pathConsumerParentRel, true );
+        assertThat( exists, equalTo( true ) );
+
+        // Check consumer rel content
+        InputStream ris = client.content().get( remote, repo1, pathConsumerRel );
+        assertThat( ris, notNullValue() );
+        String rel = IOUtils.toString( ris );
+        logger.debug( ">>> " + rel );
+        String output = readTestResource( resource + "/output/rel.json" );
+        EProjectDirectRelationships eRel = mapper.readValue( rel, EProjectDirectRelationships.class );
+        EProjectDirectRelationships eRelOutput = mapper.readValue( output, EProjectDirectRelationships.class );
+        assertThat( eRel.getParent(), equalTo( eRelOutput.getParent() ) );
+    }
+}

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadListenerTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadListenerTest.java
@@ -18,6 +18,25 @@ import static org.junit.Assert.assertThat;
 
 /**
  * Created by ruhan on 2/17/17.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>{@link RemoteRepository} A proxy an upstream server</li>
+ *     <li>Path P points to a POM file in {@link RemoteRepository} A</li>
+ *     <li>Path R points to the Rel file of the target POM</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Path R is requested from {@link RemoteRepository} A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>{@link RemoteRepository} A returns notNull (exists) for Path R</li>
+ * </ul>
  */
 public class PomDownloadListenerTest
                 extends AbstractIndyFunctionalTest

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadSimpleDepTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadSimpleDepTest.java
@@ -1,0 +1,128 @@
+package org.commonjava.indy.relate.ftest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.maven.atlas.graph.jackson.ProjectRelationshipSerializerModule;
+import org.commonjava.maven.atlas.graph.model.EProjectDirectRelationships;
+import org.commonjava.maven.atlas.ident.jackson.ProjectVersionRefSerializerModule;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.commonjava.indy.model.core.StoreType.group;
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by ruhan on 2/17/17.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>{@link Group} A contains {@link RemoteRepository} B which proxy an upstream server</li>
+ *     <li>Path PD points to a dependant POM file in {@link RemoteRepository} B</li>
+ *     <li>Path PC points to a consumer POM file in {@link RemoteRepository} B</li>
+ *     <li>Path R points to the Rel file of the consumer POM</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Path PC is requested from {@link Group} A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>{@link Group} A returns notNull (exists) for Path PC</li>
+ *     <li>{@link Group} A returns notNull (exists) for Path R</li>
+ *     <li>Rel file from Path R is identical to expected output file</li>
+ * </ul>
+ */
+public class PomDownloadSimpleDepTest
+                extends AbstractIndyFunctionalTest
+{
+    private static final String resource = "simple-dep";
+
+    private static final String repo = resource + "/repo";
+
+    private static final String pathDep = "org/bar/dep/1.1/dep-1.1.pom";
+
+    private static final String pathConsumer = "org/foo/consumer/1/consumer-1.pom";
+
+    private static final String pathConsumerRel = pathConsumer + ".rel";
+
+    private static final String repo1 = "repo1";
+
+    private static final String group1 = "group1";
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    ObjectMapper mapper;
+
+    @Before
+    public void init()
+    {
+        mapper = new ObjectMapper();
+        mapper.registerModules( new ProjectVersionRefSerializerModule(), new ProjectRelationshipSerializerModule() );
+    }
+
+    @Test
+    public void run() throws Exception
+    {
+        String depPom = readTestResource( repo + "/" + pathDep );
+        server.expect( server.formatUrl( repo1, pathDep ), 200, depPom );
+
+        String consumerPom = readTestResource( repo + "/" + pathConsumer );
+        server.expect( server.formatUrl( repo1, pathConsumer ), 200, consumerPom );
+
+        // Create remote repository
+        RemoteRepository remote1 = new RemoteRepository( repo1, server.formatUrl( repo1 ) );
+        client.stores().create( remote1, "adding remote1", RemoteRepository.class );
+
+        // Add to a group
+        client.stores().create( new Group( group1, remote1.getKey() ), "adding group", Group.class );
+
+        // Get consumer pom via group
+        InputStream is = client.content().get( group, group1, pathConsumer );
+        String s = IOUtils.toString( is );
+        logger.debug( ">>> " + s );
+        assertThat( s, equalTo( consumerPom ) );
+
+        waitForEventPropagation();
+
+        boolean exists = false;
+
+        // Check consumer pom exists on group
+        exists = client.content().exists( group, group1, pathConsumer, true );
+        assertThat( exists, equalTo( true ) );
+
+        // Check consumer rel exists on group
+        exists = client.content().exists( group, group1, pathConsumerRel );
+        assertThat( exists, equalTo( true ) );
+
+        // Check consumer rel exists on remote
+        exists = client.content().exists( remote, repo1, pathConsumerRel, true );
+        assertThat( exists, equalTo( true ) );
+
+        // Check consumer rel content is not empty via group
+        InputStream ris = client.content().get( group, group1, pathConsumerRel );
+        String rel = IOUtils.toString( ris );
+        logger.debug( ">>> " + rel );
+        assertThat( StringUtils.isNotEmpty( rel ), equalTo( true ) );
+
+        // Check consumer rel output
+        String output = readTestResource( resource + "/output/rel.json" );
+        EProjectDirectRelationships eRel = mapper.readValue( rel, EProjectDirectRelationships.class );
+        EProjectDirectRelationships eRelOutput = mapper.readValue( output, EProjectDirectRelationships.class );
+        assertThat( eRel.getDependencies(), equalTo( eRelOutput.getDependencies() ) );
+    }
+}

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadViaGroupListenerTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadViaGroupListenerTest.java
@@ -3,6 +3,7 @@ package org.commonjava.indy.relate.ftest;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Rule;
@@ -10,9 +11,9 @@ import org.junit.Test;
 
 import java.io.InputStream;
 
+import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.model.core.StoreType.remote;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -20,26 +21,26 @@ import static org.junit.Assert.assertThat;
  *
  * <b>GIVEN:</b>
  * <ul>
- *     <li>{@link RemoteRepository} A proxy an upstream server</li>
- *     <li>Path P in {@link RemoteRepository} A points to an POM file in upstream</li>
- *     <li>Path R in {@link RemoteRepository} A points to the Rel file of the target POM</li>
+ *     <li>{@link Group} A contains {@link RemoteRepository} B which proxy an upstream server</li>
+ *     <li>Path P points to a POM file in {@link RemoteRepository} B</li>
+ *     <li>Path R points to the Rel file of the target POM</li>
  * </ul>
  *
  * <br/>
  * <b>WHEN:</b>
  * <ul>
- *     <li>Path R is requested from {@link RemoteRepository} A before Path P is requested</li>
- *     <li>Path P is requested from {@link RemoteRepository} A</li>
+ *     <li>Path R is requested from {@link Group} A</li>
+ *     <li>Path P is requested from {@link Group} A</li>
  * </ul>
  *
  * <br/>
  * <b>THEN:</b>
  * <ul>
- *     <li>{@link RemoteRepository} A returns notNull (exists) for Path R</li>
- *     <li>{@link RemoteRepository} A returns notNull (exists) for Path P</li>
+ *     <li>{@link Group} A returns notNull (exists) for Path R</li>
+ *     <li>{@link Group} A returns notNull (exists) for Path P</li>
  * </ul>
  */
-public class RelDownloadBeforePomTest
+public class PomDownloadViaGroupListenerTest
                 extends AbstractIndyFunctionalTest
 {
     private static final String path = "org/foo/bar/1/bar-1.pom";
@@ -56,21 +57,33 @@ public class RelDownloadBeforePomTest
     public void run() throws Exception
     {
         final String repo1 = "repo1";
+        final String group1 = "group1";
 
         server.expect( server.formatUrl( repo1, path ), 200, content );
 
         RemoteRepository remote1 = new RemoteRepository( repo1, server.formatUrl( repo1 ) );
         client.stores().create( remote1, "adding remote", RemoteRepository.class );
 
-        // Download .rel before even touching POM
-        InputStream rel = client.content().get( remote, repo1, pathRel );
-        assertThat( rel, notNullValue() );
-        String s = IOUtils.toString( rel );
-        logger.debug( ">>> " + s );
-        assertThat( StringUtils.isNotEmpty( s ), equalTo( true ) );
+        client.stores().create( new Group( group1, remote1.getKey() ), "adding group", Group.class );
 
-        // check POM is downloaded
-        boolean exists = client.content().exists( remote, repo1, path, true );
+        InputStream is = client.content().get( group, group1, path );
+        String s = IOUtils.toString( is );
+        assertThat( s, equalTo( content ) );
+
+        waitForEventPropagation();
+
+        // Check .rel exist on group1
+        boolean exists = client.content().exists( group, group1, pathRel, true );
         assertThat( exists, equalTo( true ) );
+
+        // Check .rel exist on remote1
+        exists = client.content().exists( remote, repo1, pathRel, true );
+        assertThat( exists, equalTo( true ) );
+
+        // Check .rel content is not empty
+        InputStream ris = client.content().get( group, group1, pathRel );
+        String rel = IOUtils.toString( ris );
+        logger.debug( ">>> " + rel );
+        assertThat( StringUtils.isNotEmpty( rel ), equalTo( true ) );
     }
 }

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomUploadListenerTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomUploadListenerTest.java
@@ -14,6 +14,25 @@ import static org.junit.Assert.assertThat;
 
 /**
  * Created by ruhan on 2/17/17.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>{@link HostedRepository} A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Path P points to a POM file and the POM is uploaded to {@link HostedRepository} A</li>
+ *     <li>Path R points to the Rel file of the target POM</li>
+ *     <li>Path R is requested from {@link HostedRepository} A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>{@link HostedRepository} A returns notNull (exists) for Path R</li>
+ * </ul>
  */
 public class PomUploadListenerTest
                 extends AbstractIndyFunctionalTest

--- a/addons/relate/ftests/src/main/resources/dep-from-parent/output/rel.json
+++ b/addons/relate/ftests/src/main/resources/dep-from-parent/output/rel.json
@@ -1,0 +1,25 @@
+{
+  "source" : "http://127.0.0.1:26081/repo1.rel",
+  "projectRef" : "org.foo:consumer:1",
+  "dependencies" : [ {
+    "type" : "DEPENDENCY",
+    "pom-location-uri" : "pom:root",
+    "inherited" : true,
+    "source-uris" : [ "http://127.0.0.1:26081/repo1.rel" ],
+    "declaring" : "org.foo:consumer:1",
+    "target" : "org.bar:dep:jar:1.1",
+    "scope" : "compile",
+    "managed" : false,
+    "optional" : false,
+    "idx" : 0
+  } ],
+  "parent" : {
+    "type" : "PARENT",
+    "pom-location-uri" : "pom:root",
+    "inherited" : false,
+    "source-uris" : [ "http://127.0.0.1:26081/repo1.rel" ],
+    "declaring" : "org.foo:consumer:1",
+    "target" : "org.foo:parent:1",
+    "idx" : 0
+  }
+}

--- a/addons/relate/ftests/src/main/resources/dep-from-parent/repo/org/bar/dep/1.1/dep-1.1.pom
+++ b/addons/relate/ftests/src/main/resources/dep-from-parent/repo/org/bar/dep/1.1/dep-1.1.pom
@@ -1,0 +1,6 @@
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.bar</groupId>
+	<artifactId>dep</artifactId>
+	<version>1.1</version>
+</project>

--- a/addons/relate/ftests/src/main/resources/dep-from-parent/repo/org/foo/consumer/1/consumer-1.pom
+++ b/addons/relate/ftests/src/main/resources/dep-from-parent/repo/org/foo/consumer/1/consumer-1.pom
@@ -1,0 +1,9 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.foo</groupId>
+        <artifactId>parent</artifactId>
+        <version>1</version>
+    </parent>
+    <artifactId>consumer</artifactId>
+</project>

--- a/addons/relate/ftests/src/main/resources/dep-from-parent/repo/org/foo/parent/1/parent-1.pom
+++ b/addons/relate/ftests/src/main/resources/dep-from-parent/repo/org/foo/parent/1/parent-1.pom
@@ -1,0 +1,14 @@
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.foo</groupId>
+    <artifactId>parent</artifactId>
+    <version>1</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.bar</groupId>
+            <artifactId>dep</artifactId>
+            <version>1.1</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/addons/relate/ftests/src/main/resources/simple-dep/output/rel.json
+++ b/addons/relate/ftests/src/main/resources/simple-dep/output/rel.json
@@ -1,0 +1,25 @@
+{
+  "source" : "http://127.0.0.1:23332/repo1.rel",
+  "projectRef" : "org.foo:consumer:1",
+  "dependencies" : [ {
+    "type" : "DEPENDENCY",
+    "pom-location-uri" : "pom:root",
+    "inherited" : false,
+    "source-uris" : [ "http://127.0.0.1:23332/repo1.rel" ],
+    "declaring" : "org.foo:consumer:1",
+    "target" : "org.bar:dep:jar:1.1",
+    "scope" : "compile",
+    "managed" : false,
+    "optional" : false,
+    "idx" : 0
+  } ],
+  "parent" : {
+    "type" : "PARENT",
+    "pom-location-uri" : "pom:root",
+    "inherited" : false,
+    "source-uris" : [ "atlas:terminal-parent" ],
+    "declaring" : "org.foo:consumer:1",
+    "target" : "org.foo:consumer:1",
+    "idx" : 0
+  }
+}

--- a/addons/relate/ftests/src/main/resources/simple-dep/repo/org/bar/dep/1.1/dep-1.1.pom
+++ b/addons/relate/ftests/src/main/resources/simple-dep/repo/org/bar/dep/1.1/dep-1.1.pom
@@ -1,0 +1,6 @@
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.bar</groupId>
+	<artifactId>dep</artifactId>
+	<version>1.1</version>
+</project>

--- a/addons/relate/ftests/src/main/resources/simple-dep/repo/org/foo/consumer/1/consumer-1.pom
+++ b/addons/relate/ftests/src/main/resources/simple-dep/repo/org/foo/consumer/1/consumer-1.pom
@@ -1,0 +1,14 @@
+<project>
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>org.foo</groupId>
+	<artifactId>consumer</artifactId>
+	<version>1</version>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.bar</groupId>
+			<artifactId>dep</artifactId>
+			<version>1.1</version>
+		</dependency>
+	</dependencies>
+</project>


### PR DESCRIPTION
I add 3 tests for relate addon.
1. PomDownloadViaGroupListenerTest: gets rel via group
2. RelDownloadPomNotFound404Test: get rel but 404 to simulate upstream error; re-register expectation to 200, retry again to simulate upstream fixed. 
3. PomDownloadWithDependencyViaGroupListenerTest: two poms, one depends on another, put them in two repos, add to a group, then get .rel via this group. 

The first two are Okay. What is confusing is the last one. The dep pom is not downloaded automatically. I remember you mentioned 

MavenPomView pomView = mavenPomReader.read( ref, transfer, supplementalLocations, ALL_PROFILES );

will download dep/parent/etc poms. I need to look into the code. If you have any insights into this, please shed light on it. 