### PR TITLE
Fix folo-sealed infinispan cache size not work by adding right strategy

### DIFF
--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -13,7 +13,7 @@
     </local-cache>
 
     <local-cache name="folo-sealed">
-      <eviction size="1000" type="COUNT"/>
+      <eviction size="1000" type="COUNT" strategy="LRU"/>
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/folo"/>
       </persistence>


### PR DESCRIPTION
If eviction strategy is missing, the default is NONE (Never evict entries). This should fix the problem. 