### PR TITLE
Add infinispan eviction for folo-in-progress cache to avoid memory leak

### DIFF
--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -10,6 +10,7 @@
     </local-cache>
 
     <local-cache name="folo-in-progress" >
+      <eviction size="1000" type="COUNT" strategy="LRU"/>
     </local-cache>
 
     <local-cache name="folo-sealed">


### PR DESCRIPTION
Add eviction for folo-in-progress. Testing shows the memory footprint keeps increasing if this is ignored. 