### PR TITLE
Bump partyline to work on size/checksum mismatch coming from folo tracking records

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.httprox.handler;
 
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestFactory;
@@ -93,6 +94,12 @@ public final class ProxyRequestReader
 
                     writer.setHttpRequest( request );
                     sendResponse = true;
+                }
+                catch ( ConnectionClosedException e )
+                {
+                    logger.warn("Client closed connection. Aborting proxy request.");
+                    sendResponse = false;
+                    channel.resumeReads();
                 }
                 catch ( HttpException e )
                 {

--- a/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
@@ -35,7 +35,7 @@ public class DefaultIndyConfiguration
 
     public static final int DEFAULT_NOT_FOUND_CACHE_TIMEOUT_SECONDS = 300;
 
-    public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 5;
+    public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 30; // 5 seconds (previous) is crazy on most normal networks
 
     public static final int DEFAULT_STORE_DISABLE_TIMEOUT_SECONDS = 1800; // 30 minutes
 

--- a/embedders/savant/src/main/resources/META-INF/beans.xml
+++ b/embedders/savant/src/main/resources/META-INF/beans.xml
@@ -32,7 +32,7 @@
     <!-- StoreDataManager decorators -->
     <class>org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator</class>
     <class>org.commonjava.indy.implrepo.data.ImpliedReposStoreDataManagerDecorator</class>
-    <class>org.commonjava.indy.implrepo.data.ValidRemoteStoreDataManagerDecorator</class>
+    <!--<class>org.commonjava.indy.implrepo.data.ValidRemoteStoreDataManagerDecorator</class>-->
   </decorators>
       
 </beans>

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoInValidUrlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoInValidUrlTest.java
@@ -17,11 +17,13 @@ package org.commonjava.indy.ftest.core.store;
 
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class RemoteRepoInValidUrlTest
         extends AbstractStoreManagementTest
 {
+    @Ignore( "Disabling validating decorator around StoreDataManager until we can be more certain it's correct and stable for all use cases" )
     @Test( expected = IndyClientException.class )
     public void run()
             throws Exception

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <galleyVersion>0.13.6</galleyVersion>
     <bomVersion>21</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
-    <partylineVersion>1.9.2</partylineVersion>
+    <partylineVersion>1.9.3-SNAPSHOT</partylineVersion>
     <jhttpcVersion>1.4</jhttpcVersion>
     <kojijiVersion>1.6</kojijiVersion>
     <rwxVersion>1.1</rwxVersion>


### PR DESCRIPTION
* update to latest partyline snapshot
* update default remote repo request timeout to 30 seconds (can be configured back to 5s where needed via `request.timeout` in main.conf)
* disable validation of urls when remote repos are stored, since it's too aggressive