### PR TITLE
Catch up to indy-1.1.x changes resulting from checksum mismatch bug hunt

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.httprox.handler;
 
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestFactory;
@@ -93,6 +94,12 @@ public final class ProxyRequestReader
 
                     writer.setHttpRequest( request );
                     sendResponse = true;
+                }
+                catch ( ConnectionClosedException e )
+                {
+                    logger.warn("Client closed connection. Aborting proxy request.");
+                    sendResponse = false;
+                    channel.resumeReads();
                 }
                 catch ( HttpException e )
                 {

--- a/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
@@ -35,7 +35,7 @@ public class DefaultIndyConfiguration
 
     public static final int DEFAULT_NOT_FOUND_CACHE_TIMEOUT_SECONDS = 300;
 
-    public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 5;
+    public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 30; // 5 seconds (previous) is crazy on most normal networks
 
     public static final int DEFAULT_STORE_DISABLE_TIMEOUT_SECONDS = 1800; // 30 minutes
 

--- a/embedders/savant/src/main/resources/META-INF/beans.xml
+++ b/embedders/savant/src/main/resources/META-INF/beans.xml
@@ -32,7 +32,7 @@
     <!-- StoreDataManager decorators -->
     <class>org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator</class>
     <class>org.commonjava.indy.implrepo.data.ImpliedReposStoreDataManagerDecorator</class>
-    <class>org.commonjava.indy.implrepo.data.ValidRemoteStoreDataManagerDecorator</class>
+    <!--<class>org.commonjava.indy.implrepo.data.ValidRemoteStoreDataManagerDecorator</class>-->
   </decorators>
       
 </beans>

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoInValidUrlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoInValidUrlTest.java
@@ -17,11 +17,13 @@ package org.commonjava.indy.ftest.core.store;
 
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class RemoteRepoInValidUrlTest
         extends AbstractStoreManagementTest
 {
+    @Ignore( "Disabling validating decorator around StoreDataManager until we can be more certain it's correct and stable for all use cases" )
     @Test( expected = IndyClientException.class )
     public void run()
             throws Exception

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/UnhandledRuntimeExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/UnhandledRuntimeExceptionHandler.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.bind.jaxrs;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+/**
+ * Created by jdcasey on 1/3/17.
+ * Based on: http://stackoverflow.com/questions/13857638/global-custom-exception-handler-in-resteasy
+ */
+@Provider
+public class UnhandledRuntimeExceptionHandler
+        implements ExceptionMapper<RuntimeException>//, RestProvider
+{
+    public Response toResponse( RuntimeException exception )
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.error( "Unhandled exception: " + exception.getMessage(), exception );
+
+        return Response.status( Response.Status.INTERNAL_SERVER_ERROR )
+                       .entity( ExceptionUtils.getFullStackTrace( exception ) )
+                       .type( MediaType.TEXT_PLAIN )
+                       .build();
+    }
+}


### PR DESCRIPTION
* update request timeout default value to 30 seconds (it's still globally configurable)
* clean up ConnectionClosedException in httprox
* disable URL validations on remote repositories as current impl is too aggressive
* add handler for unhandled RuntimeException for Resteasy to use
* use blocking locks in GitManager to prevent slow filesystems from messing up git storage