### PR TITLE
Fix wrong latest/release versions for MavenMetadataMerger

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMerger.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMerger.java
@@ -235,6 +235,13 @@ public class MavenMetadataMerger
 
             versioning.setVersions(
                     versionObjects.stream().map( SingleVersion::renderStandard ).collect( Collectors.toList() ) );
+
+            if ( versionObjects.size() > 0 )
+            {
+                String latest = versionObjects.get( versionObjects.size() - 1 ).renderStandard();
+                versioning.setLatest( latest );
+                versioning.setRelease( latest );
+            }
         }
 
         if ( merged )

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataTest.java
@@ -70,6 +70,8 @@ public class RepositoryPathMaskMetadataTest
             "  <groupId>org.bar</groupId>\n" +
             "  <artifactId>bar-project</artifactId>\n" +
             "  <versioning>\n" +
+            "    <latest>2.0</latest>\n" +
+            "    <release>2.0</release>\n" +
             "    <versions>\n" +
             "      <version>1.0</version>\n" +
             "      <version>2.0</version>\n" +


### PR DESCRIPTION
By using the last item in versions array. I do not change the way lastUpdated is merged, since current test cases all use it in assert. And the original way (most recent in versions array) is safe too.  