### PR TITLE
Add a new category for Byteman tests

### DIFF
--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RecalculateMissingChecksumForTrackingRecordTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RecalculateMissingChecksumForTrackingRecordTest.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.folo.client.IndyFoloAdminClientModule;
 import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
 import org.commonjava.indy.folo.dto.TrackedContentDTO;
 import org.commonjava.indy.folo.dto.TrackedContentEntryDTO;
+import org.commonjava.indy.ftest.core.category.BytemanTest;
 import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
@@ -47,7 +48,7 @@ import static org.junit.Assert.assertThat;
 
 @RunWith( BMUnitRunner.class )
 @BMUnitConfig( debug = true )
-@Category( TimingDependent.class )
+@Category( BytemanTest.class )
 public class RecalculateMissingChecksumForTrackingRecordTest
         extends AbstractTrackingReportTest
 {

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/UseChecksumFromTransferDecoratorForTrackingRecordTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/UseChecksumFromTransferDecoratorForTrackingRecordTest.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.folo.client.IndyFoloAdminClientModule;
 import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
 import org.commonjava.indy.folo.dto.TrackedContentDTO;
 import org.commonjava.indy.folo.dto.TrackedContentEntryDTO;
+import org.commonjava.indy.ftest.core.category.BytemanTest;
 import org.commonjava.indy.ftest.core.category.EventDependent;
 import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.model.core.RemoteRepository;
@@ -48,7 +49,7 @@ import static org.junit.Assert.assertThat;
 
 @RunWith( BMUnitRunner.class )
 @BMUnitConfig( debug = true )
-@Category( TimingDependent.class )
+@Category( BytemanTest.class )
 public class UseChecksumFromTransferDecoratorForTrackingRecordTest
         extends AbstractTrackingReportTest
 {

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnUploadTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnUploadTest.java
@@ -18,7 +18,9 @@ package org.commonjava.indy.pkg.maven.content;
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.category.BytemanTest;
 import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -61,6 +63,7 @@ import static org.junit.Assert.fail;
  */
 @RunWith( BMUnitRunner.class )
 @BMUnitConfig( debug = true )
+@Category( BytemanTest.class )
 public class RecursiveGroupMetadataClearOnUploadTest
         extends AbstractContentManagementTest
 {

--- a/embedders/pom.xml
+++ b/embedders/pom.xml
@@ -273,7 +273,7 @@
               </goals>
               <configuration>
                 <skip>${skipMainFTests}</skip>
-                <excludedGroups>org.commonjava.indy.ftest.core.category.TimingDependent</excludedGroups>
+                <excludedGroups>org.commonjava.indy.ftest.core.category.TimingDependent, org.commonjava.indy.ftest.core.category.BytemanTest</excludedGroups>
               </configuration>
             </execution>
             <execution>
@@ -285,7 +285,7 @@
               <configuration>
                 <skip>${skipTimingFTests}</skip>
                 <forkCount>1</forkCount>
-                <groups>org.commonjava.indy.ftest.core.category.TimingDependent</groups>
+                <groups>org.commonjava.indy.ftest.core.category.TimingDependent, org.commonjava.indy.ftest.core.category.BytemanTest</groups>
               </configuration>
             </execution>
           </executions>

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/category/BytemanTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/category/BytemanTest.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.category;
+
+/**
+ * These tests use Byteman, and may collide if run in parallel. This is because byteman uses a static (not dynammically
+ * assigned) port on the system for injecting rules.
+ */
+public class BytemanTest
+{
+}


### PR DESCRIPTION
Byteman uses a predictable port on the system for injecting its rules.
This means if more than one process/thread starts Byteman separately,
they may compete for the port. It may be possible to assign different
ports to different tests, but this would be hard to maintain
appropriately.

Instead, we can just run these tests in non-forking mode. It's not
perfect (multiple concurrent builds in CI could still collide), but
it should be okay as a workaround until we can develop dynamic port
allocation for Byteman and get it contributed.