### PR TITLE
Add IndyChecksumAdvisor to allow add-ons to determine when content checksums are calculated

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/content/FoloChecksumAdvisor.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/content/FoloChecksumAdvisor.java
@@ -1,0 +1,48 @@
+package org.commonjava.indy.folo.content;
+
+import org.commonjava.indy.content.IndyChecksumAdvisor;
+import org.commonjava.indy.folo.ctl.FoloConstants;
+import org.commonjava.indy.folo.model.TrackingKey;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.Optional;
+
+import static org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor.ChecksumAdvice.CALCULATE_NO_WRITE;
+
+/**
+ * Created by jdcasey on 5/5/17.
+ */
+@ApplicationScoped
+public class FoloChecksumAdvisor
+        implements IndyChecksumAdvisor
+{
+    @Override
+    public Optional<ChecksummingDecoratorAdvisor.ChecksumAdvice> getChecksumReadAdvice( final Transfer transfer,
+                                                                                        final TransferOperation operation,
+                                                                                        final EventMetadata eventMetadata )
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ChecksummingDecoratorAdvisor.ChecksumAdvice> getChecksumWriteAdvice( final Transfer transfer,
+                                                                                         final TransferOperation operation,
+                                                                                         final EventMetadata eventMetadata )
+    {
+        final TrackingKey trackingKey = (TrackingKey) eventMetadata.get( FoloConstants.TRACKING_KEY );
+        if ( trackingKey == null )
+        {
+            return Optional.empty();
+        }
+
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.debug( "Enabling checksumming for {} of: {} with tracking key: {}", operation, transfer, trackingKey );
+        return Optional.of( CALCULATE_NO_WRITE );
+    }
+}

--- a/api/src/main/java/org/commonjava/indy/content/IndyChecksumAdvisor.java
+++ b/api/src/main/java/org/commonjava/indy/content/IndyChecksumAdvisor.java
@@ -1,0 +1,22 @@
+package org.commonjava.indy.content;
+
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+
+import java.util.Optional;
+
+/**
+ * Created by jdcasey on 5/5/17.
+ */
+public interface IndyChecksumAdvisor
+{
+    Optional<ChecksummingDecoratorAdvisor.ChecksumAdvice> getChecksumReadAdvice( Transfer transfer,
+                                                                             TransferOperation operation,
+                                                                             EventMetadata eventMetadata );
+
+    Optional<ChecksummingDecoratorAdvisor.ChecksumAdvice> getChecksumWriteAdvice( Transfer transfer,
+                                                                                 TransferOperation operation,
+                                                                                 EventMetadata eventMetadata );
+}

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
@@ -89,7 +89,7 @@ public class DefaultContentDigester
     public synchronized boolean needsMetadataFor( final Transfer transfer )
     {
         String cacheKey = generateCacheKey( transfer );
-        return metadataCache.containsKey( cacheKey );
+        return !metadataCache.containsKey( cacheKey );
     }
 
     private String generateCacheKey( final Transfer transfer )

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>0.17.1</atlasVersion>
-    <galleyVersion>0.14.0</galleyVersion>
+    <galleyVersion>0.14.1-SNAPSHOT</galleyVersion>
     <bomVersion>21</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.9.3</partylineVersion>


### PR DESCRIPTION
The old ChecksummingTransferDecorator implementation from galley didn't provide much flexibility
in terms of turning checksumming on/off, and its configuration was a mass of confusion. We don't
need to calculate checksums, except in two cases:

* when we generate a file, such as maven-metadata.xml
* when we store or download a file via Folo tracking

This change takes advantage of a refactored ChecksummingTransferDecorator, which introduces a
ChecksummingDecoratorAdvisor interface. Two of these are passed into the decorator's constructor,
one for reads and another for writes. Indy extends this concept with IndyChecksumAdvisor. Where
ChecksummingDecoratorAdvisor returns a ChecksumAdvice value, IndyChecksumAdvisor returns one of
these values wrapped in Optional. This allows the Indy advisor to abstain on making a decision
for content it doesn't care about, while asserting certain advice for other content. Additionally,
the Indy interface it intended to be injectable and additive. The most onerous advice available
for any piece of content is selected (where most onerous is calculating and writing the checksum
file).

Indy collects these advisors into two lambda implementations of ChecksummingDecoratorAdvisor,
which implement the selection of the most onerous advice. If no advisors are available or contribute
to the decision-making for a file, then checksums are only written when a generated file is written.

Folo provides the first implementation of IndyChecksumAdvisor, in order to furnish the checksums
for the tracking records it maintains.