### PR TITLE
Add site config for http subsys for special request

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/ctl/ReplicationController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ReplicationController.java
@@ -19,6 +19,7 @@ import static org.commonjava.maven.galley.util.UrlUtils.buildUrl;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -290,8 +291,10 @@ public class ReplicationController
         CloseableHttpClient client = null;
         try
         {
-            client = http.createClient();
-            CloseableHttpResponse response = client.execute( req, http.createContext() );
+            String siteId = new URL( remotesUrl ).getHost();
+
+            client = http.createClient( siteId );
+            CloseableHttpResponse response = client.execute( req, http.createContext( siteId ) );
 
             final StatusLine statusLine = response.getStatusLine();
             final int status = statusLine.getStatusCode();
@@ -367,9 +370,11 @@ public class ReplicationController
         CloseableHttpClient client = null;
         try
         {
-            client = http.createClient();
+            String siteId = new URL( url ).getHost();
 
-            CloseableHttpResponse response = client.execute( req, http.createContext() );
+            client = http.createClient( siteId );
+
+            CloseableHttpResponse response = client.execute( req, http.createContext( siteId ) );
 
             final StatusLine statusLine = response.getStatusLine();
             final int status = statusLine.getStatusCode();

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/lifecycle/HttpSiteConfigTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/lifecycle/HttpSiteConfigTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.lifecycle;
+
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.subsys.http.util.IndySiteConfigLookup;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.io.IOException;
+
+import static org.commonjava.indy.subsys.http.conf.IndyHttpConfig.DEFAULT_SITE;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class HttpSiteConfigTest
+        extends AbstractIndyFunctionalTest
+{
+    /**
+     * TODO: How to get the injected siteConfigLookup? It is null...
+     * We would have to change AbstractIndyFunctionalTest to use a WeldBootInterface instead of just BootInterface.
+     * Then, we would have to expose / wrap WeldBootInterface.getContainer() and allow lookup of injected components.
+     * Not impossible, but not trivial either.
+     *
+     * I use another unit test to test the config loading in http/test.
+     *
+     * The test here is only useful to verify http.conf could be loaded via normal Indy startup (by looking at the log),
+     * and not worth running it every time. I make it ignored from normal test set.
+     */
+    @Inject
+    private IndySiteConfigLookup siteConfigLookup;
+
+    @Ignore
+    @Test
+    public void run()
+        throws Exception
+    {
+        String siteId = DEFAULT_SITE;
+
+        SiteConfig conf = siteConfigLookup.lookup( siteId );
+
+        assertThat( conf.getKeyCertPem(), equalTo( PEM_CONTENT ) );
+    }
+
+    final static String PEM_CONTENT = "AAAAFFFFFSDADFADSFASDFASDFASDFASDFASDF";
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/http.conf", "[http]\n"
+                        + "enabled=true\n"
+                        + "key.cert.pem=" + PEM_CONTENT + "\n"
+                        + "max.connections=20\n"
+                        + "keycloak_yourdomain_com.key.cert.pem.path=" + fixture.getBootOptions().getIndyHome() + "/etc/indy/keycloak.pem\n"
+                        + "keycloak_yourdomain_com.request.timeout.seconds=10" );
+
+        writeConfigFile( "keycloak.pem", PEM_CONTENT );
+    }
+}

--- a/subsys/http/src/main/conf/http.conf
+++ b/subsys/http/src/main/conf/http.conf
@@ -1,0 +1,51 @@
+[http]
+##
+## Below are for default site config
+##
+
+## Site URI
+#uri=
+
+## User name
+#user=
+
+## Proxy settings
+#proxy.host=http://myproxy.com
+#proxy.port=8001
+#proxy.user=proxy-user
+
+## Trust type. Value could be either default or self-signed
+#trust.type=self-signed
+
+## Key/Server cert pem. You can specify them directly or use file path. These two ways are interchangeable.
+#key.cert.pem=AAAAFFFFFSDADFADSFASDFASDFASDFASDFASDF
+#server.cert.pem=AAAAFFFFFSDADFADSFASDFASDFASDFASDFASDF
+#key.cert.pem.path=${indy.home}/etc/indy/key.pem
+#server.cert.pem.path=${indy.home}/etc/indy/server.pem
+
+## Request timeout in seconds and max connection
+#request.timeout.seconds=10
+#max.connections=20
+
+## Password for different authentication methods
+#key.password=test
+#password=test
+#proxy.password=test
+
+##
+## Example for Keycloak site config. A site ID is added as the prefix. The site ID is similar to hostname while replacing
+## dots with underscores, e.g., "github.com" to "github_com". You can define as many sites with different site IDs.
+##
+#keycloak_yourdomain_com.uri=
+#keycloak_yourdomain_com.user=
+#keycloak_yourdomain_com.proxy.host=http://myproxy.com
+#keycloak_yourdomain_com.proxy.port=8001
+#keycloak_yourdomain_com.proxy.user=proxy-user
+#keycloak_yourdomain_com.trust.type=self-signed
+#keycloak_yourdomain_com.key.cert.pem.path=${indy.home}/etc/indy/key.pem
+#keycloak_yourdomain_com.server.cert.pem.path=${indy.home}/etc/indy/server.pem
+#keycloak_yourdomain_com.request.timeout.seconds=10
+#keycloak_yourdomain_com.max.connections=20
+#keycloak_yourdomain_com.key.password=test
+#keycloak_yourdomain_com.password=test
+#keycloak_yourdomain_com.proxy.password=test

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpProvider.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpProvider.java
@@ -19,7 +19,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.subsys.http.util.IndySiteConfigLookup;
 import org.commonjava.maven.galley.spi.auth.PasswordManager;
 import org.commonjava.maven.galley.transport.htcli.Http;
@@ -64,7 +63,7 @@ public class IndyHttpProvider
     {
         passwordManager = new org.commonjava.maven.galley.auth.AttributePasswordManager();
         http = new HttpImpl( passwordManager );
-        httpFactory = new HttpFactory( new AttributePasswordManager(siteConfigLookup) );
+        httpFactory = new HttpFactory( new AttributePasswordManager( siteConfigLookup ) );
     }
 
     @Produces
@@ -83,12 +82,17 @@ public class IndyHttpProvider
         return http;
     }
 
-    public HttpClientContext createContext()
-            throws IndyHttpException
+    /**
+     * Create http request context and apply site config.
+     * @param siteId ID to represent the site. It is generally the hostname of target site.
+     * @return
+     * @throws IndyHttpException
+     */
+    public HttpClientContext createContext( final String siteId ) throws IndyHttpException
     {
         try
         {
-            return httpFactory.createContext();
+            return httpFactory.createContext( siteConfigLookup.lookup( siteId ) );
         }
         catch ( JHttpCException e )
         {
@@ -96,42 +100,21 @@ public class IndyHttpProvider
         }
     }
 
-    public HttpClientContext createContext( final RemoteRepository repository )
-            throws IndyHttpException
+    /**
+     * Create http client and apply site config.
+     * @param siteId ID to represent the site. It is generally the hostname of target site.
+     * @return
+     * @throws IndyHttpException
+     */
+    public CloseableHttpClient createClient( final String siteId ) throws IndyHttpException
     {
         try
         {
-            return httpFactory.createContext( siteConfigLookup.toSiteConfig( repository ) );
-        }
-        catch ( JHttpCException e )
-        {
-            throw new IndyHttpException( "Failed to create http client context for remote repository: %s. Reason: %s", e, repository.getName(), e.getMessage() );
-        }
-    }
-
-    public CloseableHttpClient createClient()
-            throws IndyHttpException
-    {
-        try
-        {
-            return httpFactory.createClient();
+            return httpFactory.createClient( siteConfigLookup.lookup( siteId ) );
         }
         catch ( JHttpCException e )
         {
             throw new IndyHttpException( "Failed to create http client: %s", e, e.getMessage() );
-        }
-    }
-
-    public CloseableHttpClient createClient( final RemoteRepository repository )
-            throws IndyHttpException
-    {
-        try
-        {
-            return httpFactory.createClient( siteConfigLookup.toSiteConfig( repository ) );
-        }
-        catch ( JHttpCException e )
-        {
-            throw new IndyHttpException( "Failed to create http client for remote repository: %s. Reason: %s", e, repository.getName(), e.getMessage() );
         }
     }
 

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/conf/IndyHttpConfig.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/conf/IndyHttpConfig.java
@@ -1,0 +1,289 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.http.conf;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.util.jhttpc.auth.PasswordType;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
+import org.commonjava.util.jhttpc.model.SiteTrustType;
+import org.commonjava.web.config.ConfigurationException;
+import org.commonjava.web.config.annotation.SectionName;
+import org.commonjava.web.config.section.MapSectionListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.commonjava.util.jhttpc.auth.AttributePasswordManager.PASSWORD_PREFIX;
+
+@ApplicationScoped
+@SectionName( IndyHttpConfig.SECTION_NAME )
+public class IndyHttpConfig
+                extends MapSectionListener
+                implements IndyConfigInfo
+{
+    final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    public static final String SECTION_NAME = "http";
+
+    public static final String ENABLED = "enabled";
+
+    public static final String URI = "uri";
+
+    public static final String USER = "user";
+
+    public static final String PROXY_HOST = "proxy.host";
+
+    public static final String PROXY_PORT = "proxy.port";
+
+    public static final String PROXY_USER = "proxy.user";
+
+    public static final String TRUST_TYPE = "trust.type";
+
+    public static final String KEY_CERT_PEM = "key.cert.pem";
+
+    public static final String KEY_CERT_PEM_PATH = "key.cert.pem.path";
+
+    public static final String SERVER_CERT_PEM = "server.cert.pem";
+
+    public static final String SERVER_CERT_PEM_PATH = "server.cert.pem.path";
+
+    public static final String REQUEST_TIMEOUT_SECONDS = "request.timeout.seconds";
+
+    public static final String MAX_CONNECTIONS = "max.connections";
+
+    public static final String KEY_PASSWORD = "key.password";
+
+    public static final String PASSWORD = "password";
+
+    public static final String PROXY_PASSWORD = "proxy.password";
+
+    public IndyHttpConfig()
+    {
+    }
+
+    public static final String DEFAULT_SITE = "default";
+
+    @Override
+    public void sectionComplete( String name ) throws ConfigurationException
+    {
+        Map<String, SiteConfigBuilder> builderMap = new HashMap<>();
+        Map<String, Map<String, Object>> attributesMap = new HashMap<>(); // key: siteId, value: attributes (map)
+
+        Map<String, String> parametersMap = getConfiguration();
+        for ( Map.Entry<String, String> et : parametersMap.entrySet() )
+        {
+            String key = et.getKey();
+            String value = et.getValue();
+            switch ( key )
+            {
+                case URI:
+                case USER:
+                case PROXY_HOST:
+                case PROXY_PORT:
+                case PROXY_USER:
+                case TRUST_TYPE:
+                case KEY_CERT_PEM:
+                case KEY_CERT_PEM_PATH:
+                case SERVER_CERT_PEM:
+                case SERVER_CERT_PEM_PATH:
+                case REQUEST_TIMEOUT_SECONDS:
+                case MAX_CONNECTIONS:
+                    withEntry( getSiteConfigBuilder( builderMap, DEFAULT_SITE ), key, value );
+                    break;
+                case KEY_PASSWORD:
+                case PASSWORD:
+                case PROXY_PASSWORD:
+                    withAttribute( getAttributes( attributesMap, DEFAULT_SITE ), getAttributeName( key ), value );
+                    break;
+                default:
+                    // Not match? Never mind. These are non-default config entries, e.g., keycloak.key.cert.pem=xxx
+                    int idx = key.indexOf( "." );
+                    String siteId = key.substring( 0, idx );
+                    String realKey = key.substring( idx + 1 );
+                    if ( isAttribute( realKey ) )
+                    {
+                        withAttribute( getAttributes( attributesMap, siteId ), getAttributeName( realKey ), value );
+                    }
+                    else
+                    {
+                        withEntry( getSiteConfigBuilder( builderMap, siteId ), realKey, value );
+                    }
+                    break;
+            }
+        }
+
+        for ( Map.Entry<String, Map<String, Object>> et : attributesMap.entrySet() )
+        {
+            SiteConfigBuilder builder = builderMap.get( et.getKey() );
+            if ( builder == null )
+            {
+                throw new ConfigurationException( "[http.conf] No site " + et.getKey() + " defined for attributes" );
+            }
+            builder.withAttributes( et.getValue() );
+        }
+
+        for ( Map.Entry<String, SiteConfigBuilder> et : builderMap.entrySet() )
+        {
+            siteConfigMap.put( et.getKey(), et.getValue().build() );
+        }
+
+        logger.debug( "Section complete, name={}, siteConfigMap={}", name, siteConfigMap );
+    }
+
+    private String getAttributeName( String key )
+    {
+        switch ( key )
+        {
+            case KEY_PASSWORD:
+                return PASSWORD_PREFIX + PasswordType.KEY.name();
+            case PASSWORD:
+                return PASSWORD_PREFIX + PasswordType.USER.name();
+            case PROXY_PASSWORD:
+                return PASSWORD_PREFIX + PasswordType.PROXY.name();
+        }
+        return null;
+    }
+
+    private boolean isAttribute( String key )
+    {
+        switch ( key )
+        {
+            case KEY_PASSWORD:
+            case PASSWORD:
+            case PROXY_PASSWORD:
+                return true;
+        }
+        return false;
+    }
+
+    private void withAttribute( Map<String, Object> attributes, String key, Object value )
+    {
+        attributes.put( key, value );
+    }
+
+    private Map<String, Object> getAttributes( Map<String, Map<String, Object>> attributesMap, String siteId )
+    {
+        Map<String, Object> attributes = attributesMap.get( siteId );
+        if ( attributes == null )
+        {
+            attributes = new HashMap<>();
+            attributesMap.put( siteId, attributes );
+        }
+        return attributes;
+    }
+
+    private Map<String, SiteConfig> siteConfigMap = new HashMap<>();
+
+    public SiteConfig getSiteConfig( String siteId )
+    {
+        return siteConfigMap.get( siteId );
+    }
+
+    private void withEntry( SiteConfigBuilder siteConfigBuilder, String realKey, String value ) throws ConfigurationException
+    {
+        switch ( realKey )
+        {
+            case ENABLED:
+                break;
+            case URI:
+                siteConfigBuilder.withUri( value );
+                break;
+            case USER:
+                siteConfigBuilder.withUser( value );
+                break;
+            case PROXY_HOST:
+                siteConfigBuilder.withProxyHost( value );
+                break;
+            case PROXY_PORT:
+                siteConfigBuilder.withProxyPort( Integer.parseInt( value ) );
+                break;
+            case PROXY_USER:
+                siteConfigBuilder.withProxyUser( value );
+                break;
+            case TRUST_TYPE:
+                siteConfigBuilder.withTrustType( SiteTrustType.getType( value ) );
+                break;
+            case KEY_CERT_PEM:
+                siteConfigBuilder.withKeyCertPem( value );
+                break;
+            case KEY_CERT_PEM_PATH:
+                siteConfigBuilder.withKeyCertPem( getPemContent( value ) );
+                break;
+            case SERVER_CERT_PEM:
+                siteConfigBuilder.withServerCertPem( value );
+                break;
+            case SERVER_CERT_PEM_PATH:
+                siteConfigBuilder.withServerCertPem( getPemContent( value ) );
+                break;
+            case REQUEST_TIMEOUT_SECONDS:
+                siteConfigBuilder.withRequestTimeoutSeconds( Integer.parseInt( value ) );
+                break;
+            case MAX_CONNECTIONS:
+                siteConfigBuilder.withMaxConnections( Integer.parseInt( value ) );
+                break;
+            default:
+                throw new ConfigurationException( "[http.conf] Invalid key " + realKey );
+        }
+    }
+
+    private String getPemContent( String file ) throws ConfigurationException
+    {
+        try (InputStream stream = new FileInputStream( file ))
+        {
+            if ( stream == null )
+            {
+                throw new ConfigurationException("[http.conf] Pem file " + file + " not found");
+            }
+            return IOUtils.toString( stream );
+        }
+        catch ( final IOException e )
+        {
+            throw new ConfigurationException("[http.conf] Failed to read pem file " + file, e);
+        }
+    }
+
+    private SiteConfigBuilder getSiteConfigBuilder( Map<String, SiteConfigBuilder> siteConfigBuilderMap, String siteId )
+    {
+        SiteConfigBuilder builder = siteConfigBuilderMap.get( siteId );
+        if ( builder == null )
+        {
+            builder = new SiteConfigBuilder( siteId, null );
+            siteConfigBuilderMap.put( siteId, builder );
+        }
+        return builder;
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return "conf.d/http.conf";
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream( "default-http.conf" );
+    }
+
+}

--- a/subsys/http/src/main/resources/default-http.conf
+++ b/subsys/http/src/main/resources/default-http.conf
@@ -1,0 +1,51 @@
+[http]
+##
+## Below are for default site config
+##
+
+## Site URI
+#uri=
+
+## User name
+#user=
+
+## Proxy settings
+#proxy.host=http://myproxy.com
+#proxy.port=8001
+#proxy.user=proxy-user
+
+## Trust type. Value could be either default or self-signed
+#trust.type=self-signed
+
+## Key/Server cert pem. You can specify them directly or use file path. These two ways are interchangeable.
+#key.cert.pem=AAAAFFFFFSDADFADSFASDFASDFASDFASDFASDF
+#server.cert.pem=AAAAFFFFFSDADFADSFASDFASDFASDFASDFASDF
+#key.cert.pem.path=${indy.home}/etc/indy/key.pem
+#server.cert.pem.path=${indy.home}/etc/indy/server.pem
+
+## Request timeout in seconds and max connection
+#request.timeout.seconds=10
+#max.connections=20
+
+## Password for different authentication methods
+#key.password=test
+#password=test
+#proxy.password=test
+
+##
+## Example for Keycloak site config. A site ID is added as the prefix. The site ID is similar to hostname while replacing
+## dots with underscores, e.g., "github.com" to "github_com". You can define as many sites with different site IDs.
+##
+#keycloak_yourdomain_com.uri=
+#keycloak_yourdomain_com.user=
+#keycloak_yourdomain_com.proxy.host=http://myproxy.com
+#keycloak_yourdomain_com.proxy.port=8001
+#keycloak_yourdomain_com.proxy.user=proxy-user
+#keycloak_yourdomain_com.trust.type=self-signed
+#keycloak_yourdomain_com.key.cert.pem.path=${indy.home}/etc/indy/key.pem
+#keycloak_yourdomain_com.server.cert.pem.path=${indy.home}/etc/indy/server.pem
+#keycloak_yourdomain_com.request.timeout.seconds=10
+#keycloak_yourdomain_com.max.connections=20
+#keycloak_yourdomain_com.key.password=test
+#keycloak_yourdomain_com.password=test
+#keycloak_yourdomain_com.proxy.password=test

--- a/subsys/http/src/test/java/org/commonjava/indy/subsys/http/util/IndySiteConfigLookupTest.java
+++ b/subsys/http/src/test/java/org/commonjava/indy/subsys/http/util/IndySiteConfigLookupTest.java
@@ -15,14 +15,26 @@
  */
 package org.commonjava.indy.subsys.http.util;
 
+import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.indy.subsys.http.conf.IndyHttpConfig;
+import org.commonjava.util.jhttpc.auth.PasswordType;
 import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.commonjava.indy.subsys.http.conf.IndyHttpConfig.DEFAULT_SITE;
+import static org.commonjava.util.jhttpc.auth.AttributePasswordManager.PASSWORD_PREFIX;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -48,4 +60,56 @@ public class IndySiteConfigLookupTest
 
         assertThat( siteConfig.getServerCertPem(), equalTo( remote.getServerCertPem() ) );
     }
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void checkHttpConfigLoad() throws Exception
+    {
+        File pemFile = testFolder.newFile( "keycloak.pem");
+
+        final String _URI = "http://site.com";
+        final String _PROXY_HOST = "http://proxy.com";
+        final String _PROXY_PORT = "8001";
+        final String _PEM = "AAAAFFFFFSDADFADSFASDFASDFASDFASDFASDF";
+        final String _KEY_PASSWORD = "testme";
+        final String _KEYCLOAK_URI = "http://keycloak.com";
+        final String _KEYCLOAK_PEM_PATH = pemFile.getAbsolutePath();
+
+        IOUtils.write( _PEM, new FileOutputStream( pemFile ) );
+
+        final class TestIndyHttpConfig extends IndyHttpConfig
+        {
+            @Override
+            public Map<String, String> getConfiguration() {
+                Map<String, String> parameters = new HashMap<>();
+                parameters.put( "uri", _URI );
+                parameters.put( "proxy.host", _PROXY_HOST );
+                parameters.put( "proxy.port", _PROXY_PORT );
+                parameters.put( "key.cert.pem", _PEM );
+                parameters.put( "key.password", _KEY_PASSWORD );
+                parameters.put( "keycloak_yourdomain_com.uri", _KEYCLOAK_URI );
+                parameters.put( "keycloak_yourdomain_com.key.cert.pem.path", _KEYCLOAK_PEM_PATH );
+                return parameters;
+            }
+        }
+
+        IndyHttpConfig config = new TestIndyHttpConfig();
+        config.sectionComplete( "http" );
+
+        IndySiteConfigLookup lookup = new IndySiteConfigLookup( null, config);
+
+        SiteConfig siteConfig = lookup.lookup( DEFAULT_SITE );
+        assertThat( siteConfig.getUri(), equalTo( _URI ) );
+        assertThat( siteConfig.getProxyHost(), equalTo( _PROXY_HOST ) );
+        assertThat( siteConfig.getProxyPort(), equalTo( Integer.parseInt( _PROXY_PORT ) ) );
+        assertThat( siteConfig.getKeyCertPem(), equalTo( _PEM ) );
+        assertThat( siteConfig.getAttribute( PASSWORD_PREFIX + PasswordType.KEY.name() ), equalTo( _KEY_PASSWORD ) );
+
+        SiteConfig keycloakConfig = lookup.lookup( "keycloak.yourdomain.com" );
+        assertThat( keycloakConfig.getUri(), equalTo( _KEYCLOAK_URI ) );
+        assertThat( keycloakConfig.getKeyCertPem(), equalTo( _PEM ) );
+    }
+
 }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/BasicAuthenticationOAuthTranslator.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/BasicAuthenticationOAuthTranslator.java
@@ -65,7 +65,6 @@ import org.slf4j.LoggerFactory;
 public class BasicAuthenticationOAuthTranslator
     implements AuthenticationMechanism
 {
-
     private static final String USERNAME = "username";
 
     private static final String PASSWORD = "password";
@@ -207,7 +206,7 @@ public class BasicAuthenticationOAuthTranslator
         AccessTokenResponse tokenResponse = null;
         try
         {
-            client = http.createClient();
+            client = http.createClient( uri.getHost() );
 
             final UrlEncodedFormEntity form = new UrlEncodedFormEntity( params, "UTF-8" );
             request.setEntity( form );

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/IndyZabbixSender.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/IndyZabbixSender.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -438,7 +439,7 @@ public class IndyZabbixSender
             throw new IndyMetricsException( "can not find Zabbix's Host" );
         }
 
-        zabbixApi = new IndyZabbixApi( this.zabbixHostUrl, indyHttpProvider.createClient() );
+        zabbixApi = new IndyZabbixApi( this.zabbixHostUrl, indyHttpProvider.createClient( new URL( zabbixHostUrl ).getHost() ) );
 
         zabbixApi.init();
 

--- a/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/HttpTestFixture.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/HttpTestFixture.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.test.fixture.core;
 
+import static org.commonjava.indy.subsys.http.conf.IndyHttpConfig.DEFAULT_SITE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -171,8 +172,8 @@ public class HttpTestFixture
         CloseableHttpResponse response = null;
         try
         {
-            client = http.createClient();
-            response = client.execute( get, http.createContext() );
+            client = http.createClient( DEFAULT_SITE );
+            response = client.execute( get, http.createContext( DEFAULT_SITE ) );
 
             final StatusLine sl = response.getStatusLine();
 


### PR DESCRIPTION
I simplified the way we define site Ids. Basically, all site Ids are hostnames after replacing '.' with underscores (because '.' is used to separate site id with a key name). When the getClient/Context method is called, Indy tries to find the corresponding site config and use it if found. If not found, fall back to default. 
There is a TODO in the ftest. The problem is I can see the config is loaded from log. But I can not inject a siteConfigLookup in ftest code and test it. Any idea?