### PR TITLE
(1.1.x) Add drop-down menu item for Diagnostic Bundle download

### DIFF
--- a/addons/diagnostics/jaxrs/src/main/java/org/commonjava/indy/diag/bind/jaxrs/DiagnosticsResource.java
+++ b/addons/diagnostics/jaxrs/src/main/java/org/commonjava/indy/diag/bind/jaxrs/DiagnosticsResource.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.diag.data.DiagnosticsManager;
+import org.commonjava.indy.util.ApplicationHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +31,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 
@@ -57,7 +59,7 @@ public class DiagnosticsResource
     @GET
     @Path( "/bundle" )
     @Produces(application_zip)
-    public File getBundle()
+    public Response getBundle()
     {
         try
         {
@@ -65,7 +67,10 @@ public class DiagnosticsResource
             Logger logger = LoggerFactory.getLogger( getClass() );
             logger.info( "Returning diagnostic bundle: {}", bundle );
 
-            return bundle;
+            return Response.ok( bundle )
+                           .header( ApplicationHeader.content_disposition.key(),
+                                    "attachment; filename=indy-diagnostic-bundle-" + System.currentTimeMillis()
+                                            + ".zip" ).build();
         }
         catch ( IOException e )
         {

--- a/api/src/main/java/org/commonjava/indy/util/ApplicationHeader.java
+++ b/api/src/main/java/org/commonjava/indy/util/ApplicationHeader.java
@@ -29,7 +29,8 @@ public enum ApplicationHeader
     authorization( "Authorization" ),
     proxy_authenticate( "Proxy-Authenticate" ),
     proxy_authorization( "Proxy-Authorization" ),
-    cache_control( "Cache-Control" );
+    cache_control( "Cache-Control" ),
+    content_disposition( "Content-Disposition" );
 
     private final String key;
 

--- a/uis/layover/app/index.html
+++ b/uis/layover/app/index.html
@@ -66,6 +66,7 @@
 			    <li class="dropdown">
 			      <a href="#" class="dropdown-toggle" data-toggle="dropdown">More <span class="caret"></span></a>
 			      <ul class="dropdown-menu" role="menu">
+                      <li><a class="fa" target="_new" href="/api/diag/bundle">Diagnostic Bundle</a></li>
 			        <li><a class="fa" href="#/nfc">Not-Found Cache</a></li>
 			        <li class="divider"></li>
               <li ng-repeat="addon in addon_navs"><a class="fa" href="#{{addon.route}}">{{addon.name}}</a></li>


### PR DESCRIPTION
This patch changes the diagnostic bundle REST endpoint to suggest
a filename and prompt the browser to download the file instead of
just displaying it to the screen. It also adds a UI menu item to
help the user access the bundle.