### PR TITLE
(1.1.x) Fix SIGTERM propagation in Docker images

### DIFF
--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleManager.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleManager.java
@@ -183,6 +183,8 @@ public class IndyLifecycleManager
     public void stop()
         throws IndyLifecycleException
     {
+        System.out.println( "Shutting down Indy" );
+
         logger.info( "\n\n\n\n\n SHUTTING DOWN Indy\n    Version: {}\n    Built-By: {}\n    Commit-ID: {}\n    Built-On: {}\n\n\n\n\n",
                      versioning.getVersion(), versioning.getBuilder(), versioning.getCommitId(),
                      versioning.getTimestamp() );
@@ -251,8 +253,9 @@ public class IndyLifecycleManager
 
     /**
      * Create a Runnable that can be used in {@link Runtime#addShutdownHook(Thread)}.
+     * @param server
      */
-    public Runnable createShutdownRunnable()
+    public Runnable createShutdownRunnable( final Object server )
     {
         return ()->
         {
@@ -263,6 +266,13 @@ public class IndyLifecycleManager
             catch ( final IndyLifecycleException e )
             {
                 throw new RuntimeException( "\n\nFailed to stop Indy: " + e.getMessage(), e );
+            }
+            finally
+            {
+                synchronized ( server )
+                {
+                    server.notifyAll();
+                }
             }
         };
     }

--- a/boot/jaxrs/src/main/java/org/commonjava/indy/boot/jaxrs/JaxRsBooter.java
+++ b/boot/jaxrs/src/main/java/org/commonjava/indy/boot/jaxrs/JaxRsBooter.java
@@ -364,12 +364,12 @@ public class JaxRsBooter
     {
         start( bootOptions );
 
-        logger.info( "Setting up shutdown hook..." );
-        Runtime.getRuntime()
-               .addShutdownHook( new Thread( lifecycleManager.createShutdownRunnable() ) );
-
         if ( server != null )
         {
+            logger.info( "Setting up shutdown hook..." );
+            Runtime.getRuntime()
+                   .addShutdownHook( new Thread( lifecycleManager.createShutdownRunnable( server ) ) );
+
             synchronized ( server )
             {
                 try

--- a/deployments/docker/base/src/main/docker/Dockerfile
+++ b/deployments/docker/base/src/main/docker/Dockerfile
@@ -36,7 +36,9 @@ RUN chmod +x /usr/local/bin/* && \
 	yum -y install wget git tar which curl tree java-1.8.0-openjdk-devel && \
 	yum clean all
 
-ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/start-indy.py"]
+#ENTRYPOINT ["/usr/local/bin/dumb-init", "/usr/local/bin/start-indy.py"]
+ENTRYPOINT ["/usr/local/bin/start-indy.py"]
+#ENTRYPOINT ["/bin/bash"]
 
 # Unpack the distro that was created elsewhere in this Indy build.
 

--- a/deployments/docker/pom.xml
+++ b/deployments/docker/pom.xml
@@ -137,7 +137,12 @@
                     <port>indy-vanilla.port:8080</port>
                   </ports>
                   <wait>
-                    <log>${indy-waitFor}</log>
+                    <tcp>
+                      <ports>
+                        <port>8080</port>
+                      </ports>
+                    </tcp>
+                    <!-- <log>${indy-waitFor}</log> -->
                     <time>${dockerStartTimeout}</time>
                   </wait>
                   <log>
@@ -163,7 +168,12 @@
                     <link>gogs-test-appliance:gogs</link>
                   </links>
                   <wait>
-                    <log>${indy-waitFor}</log>
+                    <tcp>
+                      <ports>
+                        <port>8080</port>
+                      </ports>
+                    </tcp>
+                    <!-- <log>${indy-waitFor}</log> -->
                     <time>${dockerStartTimeout}</time>
                   </wait>
                   <log>
@@ -190,7 +200,12 @@
                     <link>gogs-test-appliance:gogs</link>
                   </links>
                   <wait>
-                    <log>${indy-waitFor}</log>
+                    <tcp>
+                      <ports>
+                        <port>8080</port>
+                      </ports>
+                    </tcp>
+                    <!-- <log>${indy-waitFor}</log> -->
                     <time>${dockerStartTimeout}</time>
                   </wait>
                   <log>
@@ -217,7 +232,12 @@
                     <link>gogs-test-appliance:gogs</link>
                   </links>
                   <wait>
-                    <log>${indy-waitFor}</log>
+                    <tcp>
+                      <ports>
+                        <port>8080</port>
+                      </ports>
+                    </tcp>
+                    <!-- <log>${indy-waitFor}</log> -->
                     <time>${dockerStartTimeout}</time>
                   </wait>
                   <log>

--- a/deployments/launchers/base/src/main/bin/indy.sh
+++ b/deployments/launchers/base/src/main/bin/indy.sh
@@ -59,10 +59,4 @@ JAVA_OPTS="$JAVA_OPTS $JAVA_DEBUG_OPTS"
 
 MAIN_CLASS=org.commonjava.indy.boot.jaxrs.JaxRsBooter
 
-"$JAVA" ${JAVA_OPTS} -cp "${CP}" -Dindy.home="${BASEDIR}" -Dindy.boot.defaults=${BASEDIR}/bin/boot.properties ${MAIN_CLASS} "$@"
-ret=$?
-if [ $ret == 0 -o $ret == 130 ]; then
-  exit 0
-else
-  exit $ret
-fi
+exec "$JAVA" ${JAVA_OPTS} -cp "${CP}" -Dindy.home="${BASEDIR}" -Dindy.boot.defaults=${BASEDIR}/bin/boot.properties ${MAIN_CLASS} "$@"


### PR DESCRIPTION
Previously, somewhere in the start-indy.py or indy.sh scripts, SIGTERM
was being discarded. This meant that Indy's shutdown hook was never
executing, and the shutdown for Infinispan and the scheduler DB were
never running. This is why we've been seeing corrupted scheduler data
periodically...but it's also potentially why things in the Infinispan
cache go missing. Infinispan caches are supposed to write through by
default IIRC when persistence is setup, but it seems possible with a
misconfiguration we might end up with a tracking record or something
sitting in memory without being pushed to disk. If this happens and
Indy is killed (SIGKILL) or doesn't run its shutdown hook, it could
result in that data being discarded.

This change uses exec in the indy.sh script, and sets up a signal
handler in start-indy.py, to ensure SIGTERM is propagated all the
way to Indy.