### PR TITLE
[master] Fix NOS-881: Random content deletion

### DIFF
--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -392,11 +392,14 @@ public class ContentAccessHandler
                     {
                         return handleMissingContentQuery( sk, path, builderModifier );
                     }
-                    else if ( item.isDirectory() || ( path.endsWith( "index.html" ) ) )
+                    else if ( item.isDirectory() || ( path.endsWith( LISTING_HTML_FILE ) ) )
                     {
                         try
                         {
-                            item.delete( false );
+                            if ( item.isFile() && item.getLocation().allowsDownloading() )
+                            {
+                                item.delete( false );
+                            }
 
                             logger.info( "Getting listing at: {}", path + "/" );
                             final String content =


### PR DESCRIPTION
The whole directory tree from a hosted repo was deleted when somebody
requested a directory listing from a group where this hosted repo was a
constituent without an ending slash in URL.

The deletion only makes sense if the content is file and the source repo
allows downloading, i.e. we can refresh the contents from the remote
location. Otherwise we risk losing data from a hosted repo.