### PR TITLE
(master) Fix broken imports, and add reproducer test for NOS-881

### DIFF
--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreThenGetUnSuffixedDirAndDownloadTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreThenGetUnSuffixedDirAndDownloadTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.StoreKey;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies that nothing happens to stored content when an implied directory listing is requested.
+ * <br/>
+ * Given:
+ * <ul>
+ *     <li>Content is stored in a hosted repository</li>
+ * </ul>
+ * <br/>
+ * When:
+ * <ul>
+ *     <li>A directory on the stored content's path is requested via GET.
+ *        <br/>
+ *        <ul>
+ *          <li>directly from the hosted repository</li>
+ *          <li>without a trailing '/' or a '/index.html' in the requested path</li>
+ *          <li>without using Accept: application/json</li>
+ *        </ul>
+ *      </li>
+ * </ul>
+ * <br/>
+ * Then:
+ * <ul>
+ *     <li>The directory listing should be rendered to HTML</li>
+ *     <li>The stored content should be unaffected</li>
+ * </ul>
+ */
+public class StoreThenGetUnSuffixedDirAndDownloadTest
+        extends AbstractContentManagementTest
+{
+
+    @Test
+    public void run()
+        throws Exception
+    {
+        final String content = "This is a test: " + System.nanoTime();
+        final InputStream stream = new ByteArrayInputStream( content.getBytes() );
+
+        final String dirPath = "/org/foo/bar/1";
+        final String path = dirPath + "/bar-1.pom";
+
+        assertThat( client.content()
+                          .exists( hosted, STORE, path ), equalTo( false ) );
+
+        client.content()
+              .store( hosted, STORE, path, stream );
+
+        try(InputStream htmlIn = client.content().get( new StoreKey( hosted, STORE ), dirPath ))
+        {
+            assertThat( htmlIn, notNullValue() );
+            String html = IOUtils.toString( htmlIn );
+            assertThat( html.contains( "<html>" ), equalTo( true ) );
+            assertThat( html.contains( "bar-1.pom" ), equalTo( true ) );
+        }
+
+        assertThat( client.content()
+                          .exists( hosted, STORE, path ), equalTo( true ) );
+
+        assertThat( client.content()
+                          .exists( hosted, STORE, path ), equalTo( true ) );
+
+        final URL url = new URL( client.content()
+                                       .contentUrl( hosted, STORE, path ) );
+
+        final InputStream is = url.openStream();
+
+        final String result = IOUtils.toString( is );
+        is.close();
+
+        assertThat( result, equalTo( content ) );
+
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreThenGetUnSuffixedDirAndDownloadViaGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreThenGetUnSuffixedDirAndDownloadViaGroupTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.StoreKey;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.commonjava.indy.model.core.StoreType.group;
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies that nothing happens to stored content when an implied directory listing is requested.
+ * <br/>
+ * Given:
+ * <ul>
+ *     <li>Content is stored in a hosted repository</li>
+ *     <li>Hosted repository is a member of a group</li>
+ * </ul>
+ * <br/>
+ * When:
+ * <ul>
+ *     <li>A directory on the stored content's path is requested via GET.
+ *        <br/>
+ *        <ul>
+ *          <li>from the group</li>
+ *          <li>without a trailing '/' or a '/index.html' in the requested path</li>
+ *          <li>without using Accept: application/json</li>
+ *        </ul>
+ *      </li>
+ * </ul>
+ * <br/>
+ * Then:
+ * <ul>
+ *     <li>The directory listing should be rendered to HTML</li>
+ *     <li>The stored content should be unaffected</li>
+ * </ul>
+ */
+public class StoreThenGetUnSuffixedDirAndDownloadViaGroupTest
+        extends AbstractContentManagementTest
+{
+
+    @Test
+    public void run()
+        throws Exception
+    {
+        final String content = "This is a test: " + System.nanoTime();
+        final InputStream stream = new ByteArrayInputStream( content.getBytes() );
+
+        final String dirPath = "/org/foo/bar/1";
+        final String path = dirPath + "/bar-1.pom";
+
+        assertThat( client.content()
+                          .exists( hosted, STORE, path ), equalTo( false ) );
+
+        client.content()
+              .store( hosted, STORE, path, stream );
+
+        try(InputStream htmlIn = client.content().get( new StoreKey( group, PUBLIC ), dirPath ))
+        {
+            assertThat( htmlIn, notNullValue() );
+            String html = IOUtils.toString( htmlIn );
+            assertThat( html.contains( "<html>" ), equalTo( true ) );
+            assertThat( html.contains( "bar-1.pom" ), equalTo( true ) );
+        }
+
+        assertThat( client.content()
+                          .exists( group, PUBLIC, path ), equalTo( true ) );
+
+        assertThat( client.content()
+                          .exists( hosted, STORE, path ), equalTo( true ) );
+
+        final URL url = new URL( client.content()
+                                       .contentUrl( hosted, STORE, path ) );
+
+        final InputStream is = url.openStream();
+
+        final String result = IOUtils.toString( is );
+        is.close();
+
+        assertThat( result, equalTo( content ) );
+
+    }
+}

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/GenericPackageTypeDescriptor.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/GenericPackageTypeDescriptor.java
@@ -1,7 +1,5 @@
 package org.commonjava.indy.model.core;
 
-import org.commonjava.atservice.annotation.Service;
-
 import static org.commonjava.maven.galley.io.SpecialPathConstants.PKG_TYPE_GENERIC_HTTP;
 
 /**

--- a/models/core-java/src/main/java/org/commonjava/indy/pkg/maven/model/MavenPackageTypeDescriptor.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/pkg/maven/model/MavenPackageTypeDescriptor.java
@@ -1,6 +1,5 @@
 package org.commonjava.indy.pkg.maven.model;
 
-import org.commonjava.atservice.annotation.Service;
 import org.commonjava.indy.model.core.PackageTypeDescriptor;
 
 import static org.commonjava.maven.galley.io.SpecialPathConstants.PKG_TYPE_MAVEN;


### PR DESCRIPTION
A PR has already been submitted which indicates the conditions under which
NOS-881 can occur. When the user uploads content to a hosted repository, then
retrieves a directory listing without using either a trailing slash '/' or
'/index.html' on that same directory path, Indy for some reason deletes the
entire directory. I assume this was something aimed at remote repositories,
to prompt a refresh of the directory listing. But even for that, it seems to
cut too deep.

And of course, for hosted repositories deleting a directory is a disaster.

This change adds a test that reproduces the simple case, where content
is stored, then the directory referenced in a GET request (prompting deletion
in the old code), and finally the originally stored artifact is re-requested
via simple GET.

[NOS-881] Adding second ftest to verify content after index.html GET via group