### PR TITLE
[master] Cleanups

### DIFF
--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -392,15 +392,10 @@ public class ContentAccessHandler
                     {
                         return handleMissingContentQuery( sk, path, builderModifier );
                     }
-                    else if ( item.isDirectory() || ( path.endsWith( LISTING_HTML_FILE ) ) )
+                    else if ( item.isDirectory() )
                     {
                         try
                         {
-                            if ( item.isFile() && item.getLocation().allowsDownloading() )
-                            {
-                                item.delete( false );
-                            }
-
                             logger.info( "Getting listing at: {}", path + "/" );
                             final String content =
                                     contentController.renderListing( standardAccept, st, name, path + "/", baseUri,
@@ -408,7 +403,7 @@ public class ContentAccessHandler
 
                             response = formatOkResponseWithEntity( content, acceptInfo.getRawAccept(), builderModifier );
                         }
-                        catch ( final IndyWorkflowException | IOException e )
+                        catch ( final IndyWorkflowException e )
                         {
                             logger.error(
                                     String.format( "Failed to render content listing: %s from: %s. Reason: %s", path,

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -104,7 +104,7 @@ public class ContentAccessHandler
         try
         {
             transfer =
-                    contentController.store( new StoreKey( st, name ), path, request.getInputStream(), eventMetadata );
+                    contentController.store( sk, path, request.getInputStream(), eventMetadata );
 
             final StoreKey storageKey = LocationUtils.getKey( transfer );
             logger.info( "Key for storage location: {}", storageKey );


### PR DESCRIPTION
* remove the deletion causing the previous issues completely - the code was not reachable at all in current state. There was another possible solution to reduce the condition to "location.allowsDowenloading()" only, but IMO it doesn't make sense anyway, because it would delete the directory and then recreate it to refresh the listing, but the refresh can happen also without the deletion of everything cached in it. Another thing would be if it tried to cache a file with the same name instead of directory, but that's not what is happening there.
* use correct package type in ContentAccessHandler.doCreate()