### PR TITLE
Fix some folo-repair script issues and make it runnable

### DIFF
--- a/scripts/folo-repair/folofix/command.py
+++ b/scripts/folo-repair/folofix/command.py
@@ -19,7 +19,7 @@ def check(indy_url, threads):
         os.makedirs(content_cache)
 
     tracking_record_queue = Queue()
-    download_file_queue = Queue()
+    download_queue = Queue()
     report_queue = Queue()
 
     try:
@@ -47,18 +47,21 @@ def check(indy_url, threads):
 
         # wait for all tracking records to be processed for content to be cached
         tracking_record_queue.join()
+        print "tracking_record_queue processed"
 
         # wait for content to be cached
-        download_file_queue.join()
+        download_queue.join()
+        print "download_queue processed"
 
         # threads for verifying content checksums / sizes
         for t in range(threads):
-            thread = reporter.Reporter(report_queue, content_cache)
+            thread = reporter.Reporter(report_queue, reports_dir)
             thread.daemon = True
             thread.start()
 
         # wait for all reports to be verified
         report_queue.join()
+        print "report_queue processed"
     except (KeyboardInterrupt, SystemExit) as e:
         print e
         print "Quitting."

--- a/scripts/folo-repair/folofix/downloader.py
+++ b/scripts/folo-repair/folofix/downloader.py
@@ -1,16 +1,17 @@
 import requests
 import os
-import json
+import shutil
 from threading import Thread
 
 class Downloader(Thread):
     def __init__(self, queue):
+        Thread.__init__(self)
         self.queue = queue
 
     def run(self):
         while True:
             try:
-                (dest,url) = self.queue.pop()
+                (dest,url) = self.queue.get()
 
                 if os.path.exists(dest):
                     print "Something else is writing / has already written: %s" % dest


### PR DESCRIPTION
I have it run after fixing some problems. The most exciting outcome is it does produce some mismatch files. It sounds like we have a way to reproduce the jar/sha/md5 mismatch issues. What I did: 1. start up a local indy, and run the multibuild script to do some builds, 2. run this script "$ tracking-check http://localhost:8080". There I can see some mismatch.json files. 