### PR TITLE
Add storage file size check to scripts/folo-repair/folofix/command.tracking-check

### DIFF
--- a/scripts/folo-repair/folofix/command.py
+++ b/scripts/folo-repair/folofix/command.py
@@ -7,7 +7,8 @@ from Queue import Queue
 @click.command()
 @click.argument('indy_url')
 @click.option('--threads', '-T', type=click.INT, default=4, help='Number of threads to use in verifying reports')
-def check(indy_url, threads):
+@click.option('--storage_dir', '-S', help='Indy storage folder, e.g., ${indy.home}/var/lib/indy/storage. This is to check files in storage folder')
+def check(indy_url, threads, storage_dir):
     cwd = os.getcwd()
     reports_dir = os.path.join(cwd, 'mismatched')
     content_cache = os.path.join(cwd, 'content-cache')
@@ -55,7 +56,7 @@ def check(indy_url, threads):
 
         # threads for verifying content checksums / sizes
         for t in range(threads):
-            thread = reporter.Reporter(report_queue, reports_dir)
+            thread = reporter.Reporter(report_queue, reports_dir, storage_dir)
             thread.daemon = True
             thread.start()
 

--- a/scripts/folo-repair/folofix/downloader.py
+++ b/scripts/folo-repair/folofix/downloader.py
@@ -32,12 +32,16 @@ class Downloader(Thread):
                 print "Writing to disk: %s" % url
                 with open(dest, 'wb') as f:
                     #r.raw.decode_content = True
-                    shutil.copyfileobj(r.raw, f)
-            except (KeyboardInterrupt,SystemExit,Exception) as e:
-                print e
-                break
-            except:
+                    try:
+                        shutil.copyfileobj(r.raw, f)
+                    finally:
+                        f.close()
+            #except (KeyboardInterrupt,SystemExit,Exception) as e:
+            #    print e
+            #    break
+            except Exception as e:
                 print "Failed to download: %s" % url
+                raise e
             finally:
                 self.queue.task_done()
 

--- a/scripts/multibuild/mb/builder.py
+++ b/scripts/multibuild/mb/builder.py
@@ -174,7 +174,7 @@ class Builder(Thread):
         resp.raise_for_status()
 
     def build(self, builddir):
-        mb.util.run_cmd("mvn -f %(d)s/pom.xml -s %(d)s/settings.xml clean deploy 2>&1 | tee %(d)s/build.log" % {'d': builddir}, fail=False)
+        mb.util.run_cmd("mvn -DskipTests -f %(d)s/pom.xml -s %(d)s/settings.xml clean deploy 2>&1 | tee %(d)s/build.log" % {'d': builddir}, fail=False)
 
     def setup(self, builddir, params):
         """Create the hosted repo and group, then pull the Indy-generated Maven


### PR DESCRIPTION
Usage example:
tracking-check http://localhost:8080 --storage_dir ${indy.home}/var/lib/indy/storage

It will print something like:
      ... 
      "size": {
        "record": 19686, 
        "calculated": 19685, 
        "storage": 19686, 
        "success": false
      }, 