### PR TITLE
Set jboss logging provider to slf4j in start script

### DIFF
--- a/deployments/launchers/base/src/main/bin/indy.sh
+++ b/deployments/launchers/base/src/main/bin/indy.sh
@@ -59,4 +59,4 @@ JAVA_OPTS="$JAVA_OPTS $JAVA_DEBUG_OPTS"
 
 MAIN_CLASS=org.commonjava.indy.boot.jaxrs.JaxRsBooter
 
-exec "$JAVA" ${JAVA_OPTS} -cp "${CP}" -Dindy.home="${BASEDIR}" -Dindy.boot.defaults=${BASEDIR}/bin/boot.properties ${MAIN_CLASS} "$@"
+exec "$JAVA" ${JAVA_OPTS} -cp "${CP}" -Dindy.home="${BASEDIR}" -Dindy.boot.defaults=${BASEDIR}/bin/boot.properties -Dorg.jboss.logging.provider=slf4j ${MAIN_CLASS}  "$@"


### PR DESCRIPTION
We found that there are always some unhandled exception directed to the system log but not indy log file, which make some very fatal error flushed in system journal and makes it hard to trace. After check, I think it is caused by the jboss-weld-logging provider issue. So set it in start script.
@jdcasey I'm not sure if this is the good place to set the logger, if it is not, you can point out where is the best place. 