### PR TITLE
[1.1.x] NOS-939: Differentiate between plaintext and regexps in path mask patterns

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -285,6 +285,45 @@ public class DefaultContentManager
         return item;
     }
 
+    private boolean checkListingMask( final ArtifactStore store, final String path )
+    {
+        if ( !( store instanceof AbstractRepository ) )
+        {
+            return true;
+        }
+
+        AbstractRepository repo = (AbstractRepository) store;
+        Set<String> maskPatterns = repo.getPathMaskPatterns();
+        logger.debug( "Checking mask in: {}, type: {}, patterns: {}", repo.getName(), repo.getKey().getType(), maskPatterns );
+
+        if (maskPatterns == null || maskPatterns.isEmpty())
+        {
+            logger.debug( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
+            return true;
+        }
+
+        for ( String pattern : maskPatterns )
+        {
+            if ( isRegexPattern( pattern ) )
+            {
+                // if there is a regexp pattern we cannot check presence of directory listing, because we would have to
+                // check only the beginning of the regexp and that's impossible, so we have to assume that the path is
+                // present
+                return true;
+            }
+        }
+
+        for ( String pattern : maskPatterns )
+        {
+            if ( path.startsWith( pattern ) || pattern.startsWith( path ) )
+            {
+                logger.debug( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
+                return true;
+            }
+        }
+        return false;
+    }
+
     private boolean checkMask( final ArtifactStore store, final String path )
     {
         if ( !( store instanceof AbstractRepository ) )
@@ -301,15 +340,29 @@ public class DefaultContentManager
             logger.debug( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
             return true;
         }
-        for (String pattern : maskPatterns)
+
+        for ( String pattern : maskPatterns )
         {
-            if (path.startsWith(pattern) || path.matches(pattern))
+            // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
+            if ( isRegexPattern( pattern ) )
+            {
+                if ( path.matches( pattern ) )
+                {
+                    return true;
+                }
+            }
+            else if ( path.startsWith( pattern ) )
             {
                 logger.debug( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
                 return true;
             }
         }
         return false;
+    }
+
+    private boolean isRegexPattern( String pattern )
+    {
+        return pattern.startsWith( "r|" ) && pattern.endsWith( "|" );
     }
 
     private Transfer doRetrieve( final ArtifactStore store, final String path, final EventMetadata eventMetadata )
@@ -623,7 +676,14 @@ public class DefaultContentManager
         }
         else
         {
-            listed = downloadManager.list( store, path );
+            if ( checkListingMask( store, path ) )
+            {
+                listed = downloadManager.list( store, path );
+            }
+            else
+            {
+                listed = new ArrayList<>();
+            }
 
             for ( final ContentGenerator producer : contentGenerators )
             {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -362,7 +362,7 @@ public class DefaultContentManager
 
     private boolean isRegexPattern( String pattern )
     {
-        return pattern.startsWith( "r|" ) && pattern.endsWith( "|" );
+        return pattern != null && pattern.startsWith( "r|" ) && pattern.endsWith( "|" );
     }
 
     private Transfer doRetrieve( final ArtifactStore store, final String path, final EventMetadata eventMetadata )

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -346,7 +346,7 @@ public class DefaultContentManager
             // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
             if ( isRegexPattern( pattern ) )
             {
-                if ( path.matches( pattern ) )
+                if ( path.matches( pattern.substring( 2, pattern.length() - 1 ) ) )
                 {
                     return true;
                 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskExtTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskExtTest.java
@@ -66,14 +66,14 @@ public class RepositoryPathMaskExtTest
 
         RemoteRepository remoteRepo1 = new RemoteRepository( remote1, server.formatUrl( remote1 ) );
         Set<String> pathMaskPatterns = new HashSet<>();
-        pathMaskPatterns.add("org/bar.*"); // regex patterns
+        pathMaskPatterns.add("r|org/bar.*|"); // regex patterns
         remoteRepo1.setPathMaskPatterns(pathMaskPatterns);
         remoteRepo1 = client.stores().create( remoteRepo1, "adding remote 1", RemoteRepository.class );
 
         HostedRepository hostedRepo1 = new HostedRepository( hosted1 );
         pathMaskPatterns = new HashSet<>();
         pathMaskPatterns.add("org/foo");
-        pathMaskPatterns.add("org/bar.*");
+        pathMaskPatterns.add("r|org/bar.*|");
         hostedRepo1.setPathMaskPatterns(pathMaskPatterns);
         hostedRepo1 = client.stores().create( hostedRepo1, "adding hosted 1", HostedRepository.class );
         client.content().store( hosted, hosted1, path_1, new ByteArrayInputStream( content2.getBytes() ) );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataTest.java
@@ -95,7 +95,7 @@ public class RepositoryPathMaskMetadataTest
 
         RemoteRepository remoteRepo1 = new RemoteRepository( remote1, server.formatUrl( remote1 ) );
         Set<String> pathMaskPatterns = new HashSet<>();
-        pathMaskPatterns.add("org/bar.*"); // regex patterns
+        pathMaskPatterns.add("r|org/bar.*|"); // regex patterns
         remoteRepo1.setPathMaskPatterns(pathMaskPatterns);
         remoteRepo1 = client.stores().create( remoteRepo1, "adding remote 1", RemoteRepository.class );
 


### PR DESCRIPTION
Backport #690 to 1.1.x in an attempt to have faster mask checking.