### PR TITLE
Move path-mask checking to DefaultDownloadManager from DefaultContetManager

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -285,113 +285,10 @@ public class DefaultContentManager
         return item;
     }
 
-    private boolean checkListingMask( final ArtifactStore store, final String path )
-    {
-        if ( !( store instanceof AbstractRepository ) )
-        {
-            return true;
-        }
-
-        AbstractRepository repo = (AbstractRepository) store;
-        Set<String> maskPatterns = repo.getPathMaskPatterns();
-
-        if ( logger.isTraceEnabled() )
-        {
-            logger.trace( "Checking mask in: {}, type: {}, patterns: {}", repo.getName(), repo.getKey().getType(),
-                          maskPatterns );
-        }
-        else
-        {
-            logger.debug( "Checking mask in: {}, type: {}", repo.getName(), repo.getKey().getType() );
-        }
-
-        if (maskPatterns == null || maskPatterns.isEmpty())
-        {
-            logger.debug( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
-            return true;
-        }
-
-        for ( String pattern : maskPatterns )
-        {
-            if ( isRegexPattern( pattern ) )
-            {
-                // if there is a regexp pattern we cannot check presence of directory listing, because we would have to
-                // check only the beginning of the regexp and that's impossible, so we have to assume that the path is
-                // present
-                return true;
-            }
-        }
-
-        for ( String pattern : maskPatterns )
-        {
-            if ( path.startsWith( pattern ) || pattern.startsWith( path ) )
-            {
-                logger.debug( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean checkMask( final ArtifactStore store, final String path )
-    {
-        if ( !( store instanceof AbstractRepository ) )
-        {
-            return true;
-        }
-
-        AbstractRepository repo = (AbstractRepository) store;
-        Set<String> maskPatterns = repo.getPathMaskPatterns();
-
-        if ( logger.isTraceEnabled() )
-        {
-            logger.trace( "Checking mask in: {}, type: {}, patterns: {}", repo.getName(), repo.getKey().getType(),
-                          maskPatterns );
-        }
-        else
-        {
-            logger.debug( "Checking mask in: {}, type: {}", repo.getName(), repo.getKey().getType() );
-        }
-
-        if (maskPatterns == null || maskPatterns.isEmpty())
-        {
-            logger.debug( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
-            return true;
-        }
-
-        for ( String pattern : maskPatterns )
-        {
-            // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
-            if ( isRegexPattern( pattern ) )
-            {
-                if ( path.matches( pattern.substring( 2, pattern.length() - 1 ) ) )
-                {
-                    return true;
-                }
-            }
-            else if ( path.startsWith( pattern ) )
-            {
-                logger.debug( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isRegexPattern( String pattern )
-    {
-        return pattern != null && pattern.startsWith( "r|" ) && pattern.endsWith( "|" );
-    }
-
     private Transfer doRetrieve( final ArtifactStore store, final String path, final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {
         logger.info( "Attempting to retrieve: {} from: {}", path, store.getKey() );
-
-        if ( !checkMask(store, path))
-        {
-            return null;
-        }
 
         if ( store.isDisabled() )
         {
@@ -694,14 +591,7 @@ public class DefaultContentManager
         }
         else
         {
-            if ( checkListingMask( store, path ) )
-            {
-                listed = downloadManager.list( store, path );
-            }
-            else
-            {
-                listed = new ArrayList<>();
-            }
+            listed = downloadManager.list( store, path );
 
             for ( final ContentGenerator producer : contentGenerators )
             {
@@ -775,16 +665,8 @@ public class DefaultContentManager
                 {
                     final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName(), true );
 
-                    if ( logger.isTraceEnabled() )
-                    {
-                        logger.trace( "Trying to retrieve suitable transfer for: {} in group: {} members:\n{}", path,
-                                      store.getName(), allMembers );
-                    }
-                    else
-                    {
-                        logger.debug( "Trying to retrieve suitable transfer for: {} in group: {}", path,
-                                      store.getName() );
-                    }
+                    logger.debug( "Trying to retrieve suitable transfer for: {} in group: {}", path, store.getName() );
+                    logger.trace( "Members in group {}: {}", store.getName(), allMembers );
 
                     return getTransfer( allMembers, path, op );
                 }
@@ -845,11 +727,6 @@ public class DefaultContentManager
     public boolean exists(ArtifactStore store, String path)
         throws IndyWorkflowException
     {
-        if ( !checkMask(store, path))
-        {
-            return false;
-        }
-
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.debug( "Checking existence of: {} in: {}", path, store.getKey() );
         if ( store instanceof Group )
@@ -858,15 +735,8 @@ public class DefaultContentManager
             {
                 final List<ArtifactStore> allMembers = storeManager.getOrderedConcreteStoresInGroup( store.getName(), true );
 
-                if ( logger.isTraceEnabled() )
-                {
-                    logger.trace( "Trying to retrieve suitable transfer for: {} in group: {} members:\n{}", path,
-                                  store.getName(), allMembers );
-                }
-                else
-                {
-                    logger.debug( "Trying to retrieve suitable transfer for: {} in group: {}", path, store.getName() );
-                }
+                logger.debug( "Trying to retrieve suitable transfer for: {} in group: {}", path, store.getName() );
+                logger.trace( "Members in group {}: {}", store.getName(), allMembers );
 
                 for ( ArtifactStore member : allMembers )
                 {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -25,6 +25,7 @@ import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.AbstractRepository;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
@@ -64,6 +65,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.ConcurrentHashMap;
@@ -187,6 +189,11 @@ public class DefaultDownloadManager
         }
         else
         {
+            if ( ! checkListingMask( store, path ) )
+            {
+                return result; // if list not permitted for the path, return empty list
+            }
+
             final KeyedLocation loc = LocationUtils.toLocation( store );
             final StoreResource res = new StoreResource( loc, path );
             if ( store instanceof RemoteRepository )
@@ -442,6 +449,11 @@ public class DefaultDownloadManager
             return null;
         }
 
+        if ( !checkMask(store, path))
+        {
+            return null;
+        }
+
         Transfer target = null;
         try
         {
@@ -494,6 +506,11 @@ public class DefaultDownloadManager
     public boolean exists(final ArtifactStore store, String path)
             throws IndyWorkflowException
     {
+        if ( !checkMask( store, path ) )
+        {
+            return false;
+        }
+
         final ConcreteResource res = new ConcreteResource( LocationUtils.toLocation( store ), path );
         if ( store instanceof RemoteRepository )
         {
@@ -1100,5 +1117,92 @@ public class DefaultDownloadManager
 
         return null;
     }
+
+    // path mask checking
+    private boolean checkListingMask( final ArtifactStore store, final String path )
+    {
+        if ( !( store instanceof AbstractRepository ) )
+        {
+            return true;
+        }
+
+        AbstractRepository repo = (AbstractRepository) store;
+        Set<String> maskPatterns = repo.getPathMaskPatterns();
+
+        logger.debug( "Checking mask in: {}, type: {}", repo.getName(), repo.getKey().getType() );
+        logger.trace( "Mask patterns in {}: {}", repo.getName(), maskPatterns );
+
+        if (maskPatterns == null || maskPatterns.isEmpty())
+        {
+            logger.debug( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
+            return true;
+        }
+
+        for ( String pattern : maskPatterns )
+        {
+            if ( isRegexPattern( pattern ) )
+            {
+                // if there is a regexp pattern we cannot check presence of directory listing, because we would have to
+                // check only the beginning of the regexp and that's impossible, so we have to assume that the path is
+                // present
+                return true;
+            }
+        }
+
+        for ( String pattern : maskPatterns )
+        {
+            if ( path.startsWith( pattern ) || pattern.startsWith( path ) )
+            {
+                logger.debug( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // slightly different from checkListingMask in that for regex pattern the pattern.match() is called
+    private boolean checkMask( final ArtifactStore store, final String path )
+    {
+        if ( !( store instanceof AbstractRepository ) )
+        {
+            return true;
+        }
+
+        AbstractRepository repo = (AbstractRepository) store;
+        Set<String> maskPatterns = repo.getPathMaskPatterns();
+
+        logger.debug( "Checking mask in: {}, type: {}", repo.getName(), repo.getKey().getType() );
+        logger.trace( "Mask patterns in {}: {}", repo.getName(), maskPatterns );
+
+        if (maskPatterns == null || maskPatterns.isEmpty())
+        {
+            logger.debug( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
+            return true;
+        }
+
+        for ( String pattern : maskPatterns )
+        {
+            // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
+            if ( isRegexPattern( pattern ) )
+            {
+                if ( path.matches( pattern.substring( 2, pattern.length() - 1 ) ) )
+                {
+                    return true;
+                }
+            }
+            else if ( path.startsWith( pattern ) )
+            {
+                logger.debug( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isRegexPattern( String pattern )
+    {
+        return pattern != null && pattern.startsWith( "r|" ) && pattern.endsWith( "|" );
+    }
+
 
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataExcludeTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataExcludeTest.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.commonjava.indy.model.core.StoreType.group;
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class RepositoryPathMaskMetadataExcludeTest
+        extends AbstractContentManagementTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    final static String meta1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<metadata>\n" +
+            "  <groupId>org.bar</groupId>\n" +
+            "  <artifactId>bar-project</artifactId>\n" +
+            "  <versioning>\n" +
+            "    <versions>\n" +
+            "      <version>1.0</version>\n" +
+            "    </versions>\n" +
+            "    <lastUpdated>20161027054508</lastUpdated>\n" +
+            "  </versioning>\n" +
+            "</metadata>";
+
+    final static String meta2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<metadata>\n" +
+            "  <groupId>org.bar</groupId>\n" +
+            "  <artifactId>bar-project</artifactId>\n" +
+            "  <versioning>\n" +
+            "    <versions>\n" +
+            "      <version>2.0</version>\n" +
+            "    </versions>\n" +
+            "    <lastUpdated>20161028054508</lastUpdated>\n" +
+            "  </versioning>\n" +
+            "</metadata>";
+
+    final static String aggregatedMeta = meta2;
+
+    /**
+     *  Case where user requests maven-metadata.xml from a group. The group contains two repositories.
+     *  One repository have path masks to exclude the metadata paths, but the other repository shouldn't mask any paths.
+     *
+     *  The group maven-metadata.xml should exclude versions from the member that un-mask the path
+     */
+    @Test
+    public void run()
+            throws Exception
+    {
+        final String path_metadata = "org/bar/bar-project/maven-metadata.xml";
+
+        final String remote1 = "remote1";
+        final String hosted1 = "hosted1";
+
+        server.expect( server.formatUrl( remote1, path_metadata ), 200, meta1 );
+
+        RemoteRepository remoteRepo1 = new RemoteRepository( remote1, server.formatUrl( remote1 ) );
+        Set<String> pathMaskPatterns = new HashSet<>();
+        pathMaskPatterns.add("r|org/foo.*|"); // regex patterns, un-mask org/bar
+        remoteRepo1.setPathMaskPatterns(pathMaskPatterns);
+        remoteRepo1 = client.stores().create( remoteRepo1, "adding remote 1", RemoteRepository.class );
+
+        HostedRepository hostedRepo1 = new HostedRepository( hosted1 );
+        hostedRepo1 = client.stores().create( hostedRepo1, "adding hosted 1", HostedRepository.class );
+        client.content().store( hosted, hosted1, path_metadata, new ByteArrayInputStream( meta2.getBytes() ) );
+
+        Group g = new Group( "group1", remoteRepo1.getKey(), hostedRepo1.getKey() );
+        g = client.stores().create( g, "adding group1", Group.class );
+        System.out.printf( "\n\nGroup constituents are:\n  %s\n\n", StringUtils.join( g.getConstituents(), "\n  " ) );
+
+        InputStream stream = null;
+        String str = null;
+
+        // get metadata from hosted1
+        stream = client.content().get( hosted, hostedRepo1.getName(), path_metadata );
+        assertThat( stream, notNullValue() );
+
+        str = IOUtils.toString( stream );
+        System.out.println("hosted1.metadata >>>> " + str);
+        stream.close();
+
+        // get metadata from remote1
+        stream = client.content().get( remote, remoteRepo1.getName(), path_metadata );
+        assertThat( stream, nullValue() );
+
+        // get metadata from group1
+        stream = client.content().get( group, g.getName(), path_metadata );
+        assertThat( stream, notNullValue() );
+
+        // return aggregated versions from all repositories with valid mask
+        str = IOUtils.toString( stream );
+        System.out.println("group1.metadata >>>> " + str);
+
+        assertThat( str.trim(), equalTo( aggregatedMeta ));
+        stream.close();
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
The RepositoryPathMaskMetadataTest and the new RepositoryPathMaskMetadataExcludeTest should have covered both cases. 