### PR TITLE
Fix missing scripts/multibuild/mb/util.py

### DIFF
--- a/scripts/multibuild/mb/builder.py
+++ b/scripts/multibuild/mb/builder.py
@@ -190,7 +190,7 @@ class Builder(Thread):
         resp.raise_for_status()
 
     def build(self, builddir):
-        mb.util.run_cmd("mvn -f %(d)s/pom.xml -s %(d)s/settings.xml clean deploy 2>&1 | tee %(d)s/build.log" % {'d': builddir}, fail=False)
+        mb.util.run_cmd("mvn -DskipTests -f %(d)s/pom.xml -s %(d)s/settings.xml clean deploy 2>&1 | tee %(d)s/build.log" % {'d': builddir}, fail=False)
 
     def setup(self, builddir, params):
         """Create the hosted repo and group, then pull the Indy-generated Maven

--- a/scripts/multibuild/mb/util.py
+++ b/scripts/multibuild/mb/util.py
@@ -14,3 +14,28 @@
 # limitations under the License.
 #
 
+import os
+import sys
+from datetime import datetime as dt
+
+def run_cmd(cmd, fail=True):
+    """Run the specified command. If fail == True, and a non-zero exit value 
+       is returned from the process, raise an exception
+    """
+    print cmd
+    ret = os.system(cmd)
+    if ret != 0:
+        print "Error running command: %s (return value: %s)" % (cmd, ret)
+        if fail:
+            raise Exception("Failed to run: '%s' (return value: %s)" % (cmd, ret))
+
+
+def setup_builddir(builds_dir, projectdir, branch, tid_base, idx):
+    if os.path.isdir(builds_dir) is False:
+        os.makedirs(builds_dir)
+
+    builddir="%s/%s-%s-%s" % (builds_dir, tid_base, dt.now().strftime("%Y%m%dT%H%M%S"), idx)
+
+    run_cmd("git clone -l -b %s file://%s %s" % (branch, projectdir, builddir))
+    
+    return os.path.join(os.getcwd(), builddir)


### PR DESCRIPTION
I happened to find that scripts/multibuild/mb/util.py is missing in 1.1.x branch. Add it back. Also add "-DskipTests" to bultibuild/mb/build script to do build fast.