### PR TITLE
Use NFC in DownloadManager to record missing resources for hosted

### DIFF
--- a/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
@@ -31,6 +31,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
 import org.commonjava.indy.boot.BootOptions;
+import org.commonjava.indy.conf.DefaultIndyConfiguration;
 import org.commonjava.indy.content.ContentDigester;
 import org.commonjava.indy.content.ContentGenerator;
 import org.commonjava.indy.content.ContentManager;
@@ -41,6 +42,7 @@ import org.commonjava.indy.core.content.DefaultContentManager;
 import org.commonjava.indy.core.content.DefaultDirectContentAccess;
 import org.commonjava.indy.core.content.DefaultDownloadManager;
 import org.commonjava.indy.core.ctl.ContentController;
+import org.commonjava.indy.core.inject.ExpiringMemoryNotFoundCache;
 import org.commonjava.indy.httprox.conf.HttproxConfig;
 import org.commonjava.indy.httprox.handler.ProxyAcceptHandler;
 import org.commonjava.indy.httprox.keycloak.KeycloakProxyAuthenticator;
@@ -161,19 +163,23 @@ public class HttpProxyTest
 
         final IndyObjectMapper mapper = new IndyObjectMapper( true );
 
+        final DefaultIndyConfiguration indyConfig = new DefaultIndyConfiguration();
+        indyConfig.setNotFoundCacheTimeoutSeconds( 1 );
+        final ExpiringMemoryNotFoundCache nfc = new ExpiringMemoryNotFoundCache( indyConfig );
+
         final DownloadManager downloadManager =
                 new DefaultDownloadManager( storeManager, core.getTransferManager(), core.getLocationExpander(),
-                                            new MockInstance<>( new MockContentAdvisor() ) );
+                                            new MockInstance<>( new MockContentAdvisor() ), nfc );
 
         DirectContentAccess dca =
                 new DefaultDirectContentAccess( downloadManager );
 
-        ContentDigester contentDigester = new DefaultContentDigester( dca, new CacheHandle<String, TransferMetadata>(
+        ContentDigester contentDigester = new DefaultContentDigester( dca, new CacheHandle<>(
                 "content-metadata", contentMetadata ) );
 
         final ContentManager contentManager =
                 new DefaultContentManager( storeManager, downloadManager, mapper, new SpecialPathManagerImpl(),
-                                           new MemoryNotFoundCache(), contentDigester, Collections.<ContentGenerator>emptySet() );
+                                           new MemoryNotFoundCache(), contentDigester, Collections.emptySet() );
 
         DataFileManager dfm = new DataFileManager( temp.newFolder(), new DataFileEventManager() );
         final TemplatingEngine templates = new TemplatingEngine( new GStringTemplateEngine(), dfm );
@@ -207,7 +213,7 @@ public class HttpProxyTest
             throws Exception
     {
         final String testRepo = "test";
-        final PomRef pom = loadPom( "simple.pom", Collections.<String, String>emptyMap() );
+        final PomRef pom = loadPom( "simple.pom", Collections.emptyMap() );
         final String url = server.formatUrl( testRepo, pom.path );
         server.expect( url, 200, pom.pom );
 
@@ -243,7 +249,7 @@ public class HttpProxyTest
             throws Exception
     {
         final String testRepo = "test";
-        final PomRef pom = loadPom( "simple.pom", Collections.<String, String>emptyMap() );
+        final PomRef pom = loadPom( "simple.pom", Collections.emptyMap() );
         final String url = server.formatUrl( testRepo, pom.path );
 
         final HttpGet get = new HttpGet( url );
@@ -275,7 +281,7 @@ public class HttpProxyTest
             throws Exception
     {
         final String testRepo = "test";
-        final PomRef pom = loadPom( "simple.pom", Collections.<String, String>emptyMap() );
+        final PomRef pom = loadPom( "simple.pom", Collections.emptyMap() );
         final String url = server.formatUrl( testRepo, pom.path );
         server.registerException( new File( "/" + testRepo, pom.path ).getPath(), "Expected exception", 500 );
 

--- a/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGeneratorTest.java
+++ b/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGeneratorTest.java
@@ -17,12 +17,14 @@ package org.commonjava.indy.pkg.maven.content;
 
 import org.apache.commons.lang.StringUtils;
 import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.conf.DefaultIndyConfiguration;
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.IndyLocationExpander;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.content.DefaultDirectContentAccess;
 import org.commonjava.indy.core.content.DefaultDownloadManager;
 import org.commonjava.indy.core.content.group.GroupMergeHelper;
+import org.commonjava.indy.core.inject.ExpiringMemoryNotFoundCache;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.galley.KeyedLocation;
@@ -83,7 +85,11 @@ public class MavenMetadataGeneratorTest
 
         final LocationExpander locations = new IndyLocationExpander( stores );
 
-        final DownloadManager downloads = new DefaultDownloadManager( stores, fixture.getTransferManager(), locations );
+        final DefaultIndyConfiguration config = new DefaultIndyConfiguration();
+        config.setNotFoundCacheTimeoutSeconds( 1 );
+        final ExpiringMemoryNotFoundCache nfc = new ExpiringMemoryNotFoundCache( config );
+
+        final DownloadManager downloads = new DefaultDownloadManager( stores, fixture.getTransferManager(), locations, null, nfc );
 
         final XMLInfrastructure xml = new XMLInfrastructure();
         final TypeMapper types = new StandardTypeMapper();

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.promote.data;
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.conf.DefaultIndyConfiguration;
 import org.commonjava.indy.content.ContentDigester;
 import org.commonjava.indy.content.ContentGenerator;
 import org.commonjava.indy.content.ContentManager;
@@ -28,6 +29,7 @@ import org.commonjava.indy.core.content.DefaultContentDigester;
 import org.commonjava.indy.core.content.DefaultContentManager;
 import org.commonjava.indy.core.content.DefaultDirectContentAccess;
 import org.commonjava.indy.core.content.DefaultDownloadManager;
+import org.commonjava.indy.core.inject.ExpiringMemoryNotFoundCache;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
@@ -132,9 +134,13 @@ public class PromotionManagerTest
 
         storeManager = new MemoryStoreDataManager( true );
 
+        final DefaultIndyConfiguration indyConfig = new DefaultIndyConfiguration();
+        indyConfig.setNotFoundCacheTimeoutSeconds( 1 );
+        final ExpiringMemoryNotFoundCache nfc = new ExpiringMemoryNotFoundCache( indyConfig );
+
         downloadManager = new DefaultDownloadManager( storeManager, galleyParts.getTransferManager(),
                                                       new IndyLocationExpander( storeManager ),
-                                                      new MockInstance<>( new MockContentAdvisor() ) );
+                                                      new MockInstance<>( new MockContentAdvisor() ), nfc );
 
         DirectContentAccess dca =
                 new DefaultDirectContentAccess( downloadManager );

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.client.core;
 import com.fasterxml.jackson.databind.Module;
 import org.commonjava.indy.client.core.auth.IndyClientAuthenticator;
 import org.commonjava.indy.client.core.module.IndyContentClientModule;
+import org.commonjava.indy.client.core.module.IndyNfcClientModule;
 import org.commonjava.indy.client.core.module.IndySchedulerClientModule;
 import org.commonjava.indy.client.core.module.IndyStatsClientModule;
 import org.commonjava.indy.client.core.module.IndyStoresClientModule;
@@ -235,6 +236,7 @@ public class Indy
         standardModules.add( new IndyContentClientModule() );
         standardModules.add( new IndySchedulerClientModule() );
         standardModules.add( new IndyStatsClientModule() );
+        standardModules.add( new IndyNfcClientModule() );
 
         for ( final IndyClientModule module : standardModules )
         {

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyNfcClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyNfcClientModule.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.client.core.module;
+
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.core.dto.NotFoundCacheDTO;
+
+public class IndyNfcClientModule
+        extends IndyClientModule
+{
+    private static final String BASE_URL = "/nfc";
+
+    public NotFoundCacheDTO getAllNfcContent()
+            throws IndyClientException
+    {
+        return getHttp().get( BASE_URL, NotFoundCacheDTO.class );
+    }
+
+    public NotFoundCacheDTO getAllNfcContentInStore( final StoreType type, final String name )
+            throws IndyClientException
+    {
+        return getHttp().get( BASE_URL + "/" + type.singularEndpointName() + "/" + name, NotFoundCacheDTO.class );
+    }
+
+    public void clearAll()
+            throws IndyClientException
+    {
+        getHttp().delete( BASE_URL );
+    }
+
+    public void clearInStore( final StoreType type, final String name, final String path )
+            throws IndyClientException
+    {
+        getHttp().delete( BASE_URL + "/" + type.singularEndpointName() + "/" + name + path );
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -100,13 +100,13 @@ public class DefaultContentManager
         this.specialPathManager = specialPathManager;
         this.nfc = nfc;
         this.contentDigester = contentDigester;
-        this.contentGenerators = contentProducers == null ? new HashSet<ContentGenerator>() : contentProducers;
+        this.contentGenerators = contentProducers == null ? new HashSet<>() : contentProducers;
     }
 
     @PostConstruct
     public void initialize()
     {
-        contentGenerators = new HashSet<ContentGenerator>();
+        contentGenerators = new HashSet<>();
         if ( contentProducerInstances != null )
         {
             for ( final ContentGenerator producer : contentProducerInstances )
@@ -153,7 +153,7 @@ public class DefaultContentManager
                                        final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {
-        final List<Transfer> txfrs = new ArrayList<Transfer>();
+        final List<Transfer> txfrs = new ArrayList<>();
         for ( final ArtifactStore store : stores )
         {
             if ( group == store.getKey().getType() )
@@ -169,7 +169,7 @@ public class DefaultContentManager
                                                       e.getMessage() );
                 }
 
-                final List<Transfer> storeTransfers = new ArrayList<Transfer>();
+                final List<Transfer> storeTransfers = new ArrayList<>();
                 for ( final ContentGenerator generator : contentGenerators )
                 {
                     final Transfer txfr =
@@ -560,7 +560,7 @@ public class DefaultContentManager
                                                   e.getMessage() );
             }
 
-            listed = new ArrayList<StoreResource>();
+            listed = new ArrayList<>();
             for ( final ContentGenerator generator : contentGenerators )
             {
                 final List<StoreResource> generated =
@@ -611,7 +611,7 @@ public class DefaultContentManager
     public List<StoreResource> list( final List<? extends ArtifactStore> stores, final String path )
             throws IndyWorkflowException
     {
-        final List<StoreResource> listed = new ArrayList<StoreResource>();
+        final List<StoreResource> listed = new ArrayList<>();
         for ( final ArtifactStore store : stores )
         {
             List<StoreResource> storeListing = null;
@@ -692,7 +692,7 @@ public class DefaultContentManager
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.debug( "Looking for path: '{}' in stores: {}", path,
-                      stores.stream().map( ( store ) -> store.getKey() ).collect( Collectors.toList() ) );
+                      stores.stream().map( ArtifactStore::getKey ).collect( Collectors.toList() ) );
 
         return downloadManager.getStorageReference( stores, path, op );
     }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -50,6 +50,7 @@ import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.model.VirtualResource;
+import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.commonjava.maven.galley.spi.transport.LocationExpander;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,6 +107,9 @@ public class DefaultDownloadManager
     private StoreDataManager storeManager;
 
     @Inject
+    private NotFoundCache nfc;
+
+    @Inject
     @Any
     private Instance<ContentAdvisor> contentAdvisors;
 
@@ -128,6 +132,13 @@ public class DefaultDownloadManager
     {
         this(storeManager, transfers, locationExpander);
         this.contentAdvisors = contentAdvisors;
+    }
+
+    public DefaultDownloadManager( final StoreDataManager storeManager, final TransferManager transfers,
+                                   final LocationExpander locationExpander, Instance<ContentAdvisor> contentAdvisors, final NotFoundCache nfc)
+    {
+        this(storeManager, transfers, locationExpander, contentAdvisors);
+        this.nfc = nfc;
     }
 
     @Override
@@ -158,26 +169,17 @@ public class DefaultDownloadManager
             }
             catch ( final BadGatewayException e )
             {
-                Location location = e.getLocation();
-                KeyedLocation kl = (KeyedLocation) location;
-
-                fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+                fireIndyStoreErrorEvent( e );
                 logger.warn( "Bad gateway: " + e.getMessage(), e );
             }
             catch ( final TransferTimeoutException e )
             {
-                Location location = e.getLocation();
-                KeyedLocation kl = (KeyedLocation) location;
-
-                fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+                fireIndyStoreErrorEvent( e );
                 logger.warn( "Timeout: " + e.getMessage(), e );
             }
             catch ( final TransferLocationException e )
             {
-                Location location = e.getLocation();
-                KeyedLocation kl = (KeyedLocation) location;
-
-                fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+                fireIndyStoreErrorEvent( e );
                 logger.warn( "Location Error: " + e.getMessage(), e );
             }
             catch ( final TransferException e )
@@ -211,26 +213,17 @@ public class DefaultDownloadManager
                 }
                 catch ( final BadGatewayException e )
                 {
-                    Location location = e.getLocation();
-                    KeyedLocation kl = (KeyedLocation) location;
-
-                    fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+                    fireIndyStoreErrorEvent( e );
                     logger.warn( "Bad gateway: " + e.getMessage(), e );
                 }
                 catch ( final TransferTimeoutException e )
                 {
-                    Location location = e.getLocation();
-                    KeyedLocation kl = (KeyedLocation) location;
-
-                    fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+                    fireIndyStoreErrorEvent( e );
                     logger.warn( "Timeout: " + e.getMessage(), e );
                 }
                 catch ( final TransferLocationException e )
                 {
-                    Location location = e.getLocation();
-                    KeyedLocation kl = (KeyedLocation) location;
-
-                    fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+                    fireIndyStoreErrorEvent( e );
                     logger.warn( "Location Error: " + e.getMessage(), e );
                 }
                 catch ( final TransferException e )
@@ -255,11 +248,8 @@ public class DefaultDownloadManager
                 }
                 catch ( final TransferLocationException e )
                 {
-                    Location location = res.getLocation();
-                    KeyedLocation kl = (KeyedLocation) location;
-
+                    fireIndyStoreErrorEvent( e );
                     logger.warn( "Timeout  / bad gateway: " + e.getMessage(), e );
-                    fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
                 }
                 catch ( final TransferException e )
                 {
@@ -298,26 +288,17 @@ public class DefaultDownloadManager
         }
         catch ( final BadGatewayException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Bad gateway: " + e.getMessage(), e );
         }
         catch ( final TransferTimeoutException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Timeout: " + e.getMessage(), e );
         }
         catch ( final TransferLocationException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Location Error: " + e.getMessage(), e );
         }
         catch ( final TransferException e )
@@ -350,26 +331,17 @@ public class DefaultDownloadManager
         }
         catch ( final BadGatewayException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Bad gateway: " + e.getMessage(), e );
         }
         catch ( final TransferTimeoutException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Timeout: " + e.getMessage(), e );
         }
         catch ( final TransferLocationException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Location Error: " + e.getMessage(), e );
         }
         catch ( final TransferException e )
@@ -404,9 +376,18 @@ public class DefaultDownloadManager
     {
         try
         {
-            return transfers.retrieveAll(
+            List<Transfer> txfrs = transfers.retrieveAll(
                     locationExpander.expand( new VirtualResource( LocationUtils.toLocations( stores ), path ) ),
                     eventMetadata );
+            txfrs.forEach( txfr ->
+                           {
+                               if ( !txfr.exists() )
+                               {
+                                   logger.debug( "DM: resource not found when retrieve and added to NFC: {}", txfr.getResource() );
+                                   nfc.addMissing( txfr.getResource() );
+                               }
+                           } );
+            return txfrs;
         }
         catch ( final TransferException e )
         {
@@ -454,7 +435,7 @@ public class DefaultDownloadManager
             return null;
         }
 
-        Transfer target = null;
+        Transfer target;
         try
         {
             final ConcreteResource res = new ConcreteResource( LocationUtils.toLocation( store ), path );
@@ -465,8 +446,10 @@ public class DefaultDownloadManager
             else
             {
                 target = transfers.getCacheReference( res );
-                if ( !target.exists() )
+                if ( target == null || !target.exists() )
                 {
+                    logger.debug( "DM: resource not found when retrieve and added to NFC: {}", res );
+                    nfc.addMissing( res );
                     target = null;
                 }
             }
@@ -610,35 +593,28 @@ public class DefaultDownloadManager
 
         try
         {
-            return transfers.store( new ConcreteResource( LocationUtils.toLocation( store ), path ), stream,
-                                    eventMetadata );
+            final ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( store ), path );
+            Transfer txfr = transfers.store( resource, stream, eventMetadata );
+            nfc.clearMissing( resource );
+            return txfr;
         }
         catch ( final BadGatewayException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Bad gateway: " + e.getMessage(), e );
             throw new IndyWorkflowException( "Failed to store path: {} in: {}. Reason: {}", e, path, store,
                                              e.getMessage() );
         }
         catch ( final TransferTimeoutException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Timeout: " + e.getMessage(), e );
             throw new IndyWorkflowException( "Failed to store path: {} in: {}. Reason: {}", e, path, store,
                                              e.getMessage() );
         }
         catch ( final TransferLocationException e )
         {
-            Location location = e.getLocation();
-            KeyedLocation kl = (KeyedLocation) location;
-
-            fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
+            fireIndyStoreErrorEvent( e );
             logger.warn( "Location Error: " + e.getMessage(), e );
             throw new IndyWorkflowException( "Failed to store path: {} in: {}. Reason: {}", e, path, store,
                                              e.getMessage() );
@@ -855,7 +831,8 @@ public class DefaultDownloadManager
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.trace( "Retrieving cache reference (Transfer) to: {} in: {}", Arrays.asList( path ), store.getKey() );
-        return transfers.getCacheReference( new ConcreteResource( LocationUtils.toLocation( store ), path ) );
+
+        return getCacheReferenceWithNFC( store, path );
     }
 
     @Override
@@ -878,7 +855,19 @@ public class DefaultDownloadManager
             throw new IndyWorkflowException( ApplicationStatus.NOT_FOUND.code(), "Cannot find store: {}", key );
         }
 
-        return transfers.getCacheReference( new ConcreteResource( LocationUtils.toLocation( store ), path ) );
+        return getCacheReferenceWithNFC( store, path );
+    }
+
+    private Transfer getCacheReferenceWithNFC( final ArtifactStore store, final String... path )
+    {
+        ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( store ), path );
+        Transfer txfr = transfers.getCacheReference( resource );
+        if ( txfr == null || !txfr.exists() )
+        {
+            logger.debug( "DM: resource not found when get cached and added to NFC: {}", resource );
+            nfc.addMissing( resource );
+        }
+        return txfr;
     }
 
     @Override
@@ -932,7 +921,9 @@ public class DefaultDownloadManager
     {
         try
         {
-            transfers.delete( item.getResource(), eventMetadata );
+            final ConcreteResource res = item.getResource();
+            transfers.delete( res, eventMetadata );
+            nfc.addMissing( res );
         }
         catch ( final TransferException e )
         {
@@ -1202,6 +1193,14 @@ public class DefaultDownloadManager
     private boolean isRegexPattern( String pattern )
     {
         return pattern != null && pattern.startsWith( "r|" ) && pattern.endsWith( "|" );
+    }
+
+    private void fireIndyStoreErrorEvent( TransferLocationException e )
+    {
+        Location location = e.getLocation();
+        KeyedLocation kl = (KeyedLocation) location;
+
+        fileEventManager.fire( new IndyStoreErrorEvent( kl.getKey(), e ) );
     }
 
 

--- a/core/src/main/java/org/commonjava/indy/core/inject/ExpiringMemoryNotFoundCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/ExpiringMemoryNotFoundCache.java
@@ -30,7 +30,6 @@ import javax.enterprise.inject.Default;
 import javax.inject.Inject;
 
 import org.commonjava.indy.conf.IndyConfiguration;
-import org.commonjava.indy.inject.Production;
 import org.commonjava.indy.model.galley.RepositoryLocation;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
@@ -52,7 +51,8 @@ public class ExpiringMemoryNotFoundCache
     @Inject
     protected IndyConfiguration config;
 
-    protected final Map<ConcreteResource, Long> missingWithTimeout = new HashMap<ConcreteResource, Long>();
+    // TODO: Now using a simple hashmap, need to take attention here to see if need ISPN instead if it is a mem eater.
+    protected final Map<ConcreteResource, Long> missingWithTimeout = new HashMap<>();
 
     protected ExpiringMemoryNotFoundCache()
     {
@@ -116,7 +116,7 @@ public class ExpiringMemoryNotFoundCache
     @Override
     public void clearMissing( final Location location )
     {
-        for ( final ConcreteResource resource : new HashSet<ConcreteResource>( missingWithTimeout.keySet() ) )
+        for ( final ConcreteResource resource : new HashSet<>( missingWithTimeout.keySet() ) )
         {
             if ( resource.getLocation()
                          .equals( location ) )
@@ -142,16 +142,11 @@ public class ExpiringMemoryNotFoundCache
     public Map<Location, Set<String>> getAllMissing()
     {
         clearAllExpiredMissing();
-        final Map<Location, Set<String>> result = new HashMap<Location, Set<String>>();
+        final Map<Location, Set<String>> result = new HashMap<>();
         for ( final ConcreteResource resource : missingWithTimeout.keySet() )
         {
             final Location loc = resource.getLocation();
-            Set<String> paths = result.get( loc );
-            if ( paths == null )
-            {
-                paths = new HashSet<String>();
-                result.put( loc, paths );
-            }
+            Set<String> paths = result.computeIfAbsent( loc, k -> new HashSet<>() );
 
             paths.add( resource.getPath() );
         }
@@ -163,7 +158,7 @@ public class ExpiringMemoryNotFoundCache
     public Set<String> getMissing( final Location location )
     {
         clearAllExpiredMissing();
-        final Set<String> paths = new HashSet<String>();
+        final Set<String> paths = new HashSet<>();
         for ( final ConcreteResource resource : missingWithTimeout.keySet() )
         {
             final Location loc = resource.getLocation();

--- a/core/src/test/java/org/commonjava/indy/core/content/DefaultDownloadManagerTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/content/DefaultDownloadManagerTest.java
@@ -17,7 +17,9 @@ package org.commonjava.indy.core.content;
 
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.conf.DefaultIndyConfiguration;
 import org.commonjava.indy.content.IndyLocationExpander;
+import org.commonjava.indy.core.inject.ExpiringMemoryNotFoundCache;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
@@ -25,13 +27,10 @@ import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.maven.galley.GalleyCore;
 import org.commonjava.maven.galley.GalleyCoreBuilder;
 import org.commonjava.maven.galley.GalleyInitException;
-import org.commonjava.maven.galley.TransferManager;
 import org.commonjava.maven.galley.cache.FileCacheProviderFactory;
-import org.commonjava.maven.galley.internal.TransferManagerImpl;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.spi.transport.LocationExpander;
-import org.commonjava.maven.galley.transport.NoOpLocationExpander;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,7 +66,11 @@ public class DefaultDownloadManagerTest
 
         LocationExpander locationExpander = new IndyLocationExpander( storeManager );
 
-        downloadManager = new DefaultDownloadManager( storeManager, core.getTransferManager(), locationExpander );
+        final DefaultIndyConfiguration config = new DefaultIndyConfiguration();
+        config.setNotFoundCacheTimeoutSeconds( 1 );
+        final ExpiringMemoryNotFoundCache nfc = new ExpiringMemoryNotFoundCache( config );
+
+        downloadManager = new DefaultDownloadManager( storeManager, core.getTransferManager(), locationExpander,null, nfc);
     }
 
     @Test

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentRescheduleTimeoutTest.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.Date;
 
 import static org.commonjava.indy.model.core.StoreType.remote;
@@ -66,7 +67,11 @@ public class ContentRescheduleTimeoutTest
 
         // first time trigger normal content storage with timeout, should be 6s
         PathInfo pomResult = client.content().getInfo( remote, repoId, pomPath );
-        client.content().get(remote, repoId, pomPath).close(); // force storage
+        InputStream is = client.content().get( remote, repoId, pomPath); // force storage
+        if ( is != null )
+        {
+            is.close();
+        }
         assertThat( "no pom result", pomResult, notNullValue() );
         assertThat( "pom doesn't exist", pomResult.exists(), equalTo( true ) );
         String pomFilePath = String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(),

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMissingAddToNFCTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMissingAddToNFCTest.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.module.IndyNfcClientModule;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.core.dto.NotFoundCacheDTO;
+import org.commonjava.indy.model.core.dto.NotFoundCacheSectionDTO;
+import org.hamcrest.core.IsNull;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>A hosted with some content</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Access a missing content in the hosted</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>The content is missing</li>
+ *     <li>The missing content is added to the NFC</li>
+ * </ul>
+ */
+public class HostedMissingAddToNFCTest
+        extends AbstractContentManagementTest
+{
+    private HostedRepository hosted;
+
+    private static final String HOSTED = "hosted";
+
+    private static final String JAR_PATH = "org/foo/bar/1/bar-1.jar";
+
+    private static final String POM_PATH = "org/foo/bar/1/bar-1.pom";
+
+    @Before
+    public void setupTest()
+            throws Exception
+    {
+        String change = "test setup";
+        hosted = client.stores().create( new HostedRepository( HOSTED ), change, HostedRepository.class );
+        client.content().store( hosted.getKey(), JAR_PATH, new ByteArrayInputStream( "This is the jar".getBytes() ) );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        try (InputStream inputStream = client.content().get( hosted.getKey(), JAR_PATH ))
+        {
+            assertThat( inputStream, notNullValue() );
+        }
+
+        try (InputStream inputStream = client.content().get( hosted.getKey(), POM_PATH ))
+        {
+            assertThat( inputStream, IsNull.nullValue() );
+        }
+
+        NotFoundCacheDTO dto = client.module( IndyNfcClientModule.class )
+                                     .getAllNfcContentInStore( StoreType.hosted, hosted.getName() );
+
+        assertThat( dto, notNullValue() );
+        assertThat( dto.getSections(), notNullValue() );
+
+        NotFoundCacheSectionDTO nfcSectionDto = dto.getSections()
+                                                   .stream()
+                                                   .filter( d -> d.getKey().equals( hosted.getKey() ) )
+                                                   .findFirst()
+                                                   .orElse( null );
+        assertThat( nfcSectionDto, notNullValue() );
+        assertThat( nfcSectionDto.getPaths(), notNullValue() );
+        assertThat( nfcSectionDto.getPaths().contains( POM_PATH ), equalTo( true ) );
+
+    }
+}


### PR DESCRIPTION
   Currently the NFC only applies on group level and remote but not on
hosted, so we will add NFC in DownloadManager to give the support on
hosted too to reduce the cost on missing resource check.

   And also did some code optimization in this commit, like diamond
operator using and map.computeIfAbsent using.