### PR TITLE
Add authoritativeIndex field to AbstractRepository - koji remote part

### DIFF
--- a/addons/koji/common/pom.xml
+++ b/addons/koji/common/pom.xml
@@ -71,6 +71,10 @@
       <artifactId>indy-subsys-groovy</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-index</artifactId>
+    </dependency>
+    <dependency>
     	<groupId>junit</groupId>
     	<artifactId>junit</artifactId>
     	<scope>test</scope>


### PR DESCRIPTION
   We will set all koji remote repo athoritative index enabled, which means
all brew artifacts will only be fetched if they have been indexed in cache.
That should let all koji artifacts pre-indexed in the content index cache.