### PR TITLE
Implement conditional support for authoritative indexing

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -102,7 +102,6 @@ public class ContentIndexManager
     }
 
     public IndexedStorePath getIndexedStorePath( final StoreKey key, final String path )
-            throws IndyWorkflowException
     {
         return contentIndex.get( new IndexedStorePath( key, path ) );
     }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -189,7 +189,7 @@ public abstract class IndexingContentManagerDecorator
             logger.debug( "Found indexed transfer: {}. Returning.", transfer );
             return transfer;
         }
-        else if ( indexCfg.isAuthoritativeIndex() )
+        else if ( indexCfg.isAuthoritativeIndex() && store.isAuthoritativeIndex() )
         {
             logger.debug(
                     "Not found indexed transfer: {} and authoritative index switched on. Considering not found and return null." );
@@ -345,7 +345,7 @@ public abstract class IndexingContentManagerDecorator
         {
             return transfer;
         }
-        else if ( indexCfg.isAuthoritativeIndex() )
+        else if ( indexCfg.isAuthoritativeIndex() && store.isAuthoritativeIndex() )
         {
             logger.info(
                     "Not found indexed transfer: {} and authoritative index switched on. Considering not found and return null." );
@@ -479,12 +479,6 @@ public abstract class IndexingContentManagerDecorator
             logger.debug( "Returning indexed transfer: {}", transfer );
             return transfer;
         }
-        else if ( indexCfg.isAuthoritativeIndex() )
-        {
-            logger.debug(
-                    "Not found indexed transfer: {} and authoritative index switched on. Return null." );
-            return null;
-        }
 
         ArtifactStore store;
         try
@@ -495,6 +489,12 @@ public abstract class IndexingContentManagerDecorator
         {
             throw new IndyWorkflowException( "Failed to lookup ArtifactStore: %s for NFC handling. Reason: %s", e,
                                              storeKey, e.getMessage() );
+        }
+
+        if ( indexCfg.isAuthoritativeIndex() && store.isAuthoritativeIndex() )
+        {
+            logger.debug( "Not found indexed transfer: {} and authoritative index switched on. Return null." );
+            return null;
         }
 
         ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( store ), path );

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.content.index;
 import org.commonjava.indy.IndyMetricsNames;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.ContentManager;
+import org.commonjava.indy.content.index.conf.ContentIndexConfig;
 import org.commonjava.indy.content.metrics.IndyMetricsContentIndexNames;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
@@ -78,6 +79,9 @@ public abstract class IndexingContentManagerDecorator
     @Inject
     private NotFoundCache nfc;
 
+    @Inject
+    private ContentIndexConfig indexCfg;
+
     protected IndexingContentManagerDecorator()
     {
     }
@@ -91,6 +95,15 @@ public abstract class IndexingContentManagerDecorator
         this.specialPathManager = specialPathManager;
         this.indexManager = indexManager;
         this.nfc = nfc;
+    }
+
+    protected IndexingContentManagerDecorator( final ContentManager delegate, final StoreDataManager storeDataManager,
+                                               final SpecialPathManager specialPathManager,
+                                               final ContentIndexManager indexManager, final NotFoundCache nfc,
+                                               final ContentIndexConfig indexCfg)
+    {
+        this(delegate, storeDataManager, specialPathManager, indexManager, nfc);
+        this.indexCfg = indexCfg;
     }
 
     @Override
@@ -175,6 +188,12 @@ public abstract class IndexingContentManagerDecorator
         {
             logger.debug( "Found indexed transfer: {}. Returning.", transfer );
             return transfer;
+        }
+        else if ( indexCfg.isAuthoritativeIndex() )
+        {
+            logger.debug(
+                    "Not found indexed transfer: {} and authoritative index switched on. Considering not found and return null." );
+            return null;
         }
 
         StoreType type = store.getKey().getType();
@@ -326,6 +345,12 @@ public abstract class IndexingContentManagerDecorator
         {
             return transfer;
         }
+        else if ( indexCfg.isAuthoritativeIndex() )
+        {
+            logger.info(
+                    "Not found indexed transfer: {} and authoritative index switched on. Considering not found and return null." );
+            return null;
+        }
 
         ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( store ), path );
         StoreType type = store.getKey().getType();
@@ -453,6 +478,12 @@ public abstract class IndexingContentManagerDecorator
         {
             logger.debug( "Returning indexed transfer: {}", transfer );
             return transfer;
+        }
+        else if ( indexCfg.isAuthoritativeIndex() )
+        {
+            logger.debug(
+                    "Not found indexed transfer: {} and authoritative index switched on. Return null." );
+            return null;
         }
 
         ArtifactStore store;

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
@@ -63,7 +63,7 @@ public abstract class IndexingDirectContentAccessDecorator
         {
             return transfer;
         }
-        else if ( indexCfg.isAuthoritativeIndex() )
+        else if ( indexCfg.isAuthoritativeIndex() && store.isAuthoritativeIndex() )
         {
             logger.debug(
                     "Not found indexed transfer: {} and authoritative index switched on. Considering not found and return null." );
@@ -145,7 +145,7 @@ public abstract class IndexingDirectContentAccessDecorator
 
 
         List<StoreResource> raws = delegate.listRaw( store, parentPath );
-        if ( indexCfg.isAuthoritativeIndex() )
+        if ( indexCfg.isAuthoritativeIndex() && store.isAuthoritativeIndex() )
         {
             // Here we will filter the resources if authoritative index set on. Only these indexed resources will be return.
             return raws.stream()

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/AuthoritativeIndexSettingManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/AuthoritativeIndexSettingManager.java
@@ -44,7 +44,7 @@ public class AuthoritativeIndexSettingManager
 
     public void setAuthoritativeManager( @Observes final ArtifactStorePostUpdateEvent event )
     {
-        if ( indexCfg == null || !indexCfg.isAuthIndex() )
+        if ( indexCfg == null || !indexCfg.isAuthoritativeIndex() )
         {
             return;
         }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/ContentIndexConfig.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/ContentIndexConfig.java
@@ -33,7 +33,7 @@ public class ContentIndexConfig
 
     private static final Boolean DEFAULT_AUTHORITATIVE_INDEXES = Boolean.FALSE;
 
-    private Boolean authIndex;
+    private Boolean authoritativeIndex;
 
     public ContentIndexConfig()
     {
@@ -41,18 +41,18 @@ public class ContentIndexConfig
 
     public ContentIndexConfig( final boolean authIndex )
     {
-        this.authIndex = authIndex;
+        this.authoritativeIndex = authIndex;
     }
 
-    public Boolean isAuthIndex()
+    public Boolean isAuthoritativeIndex()
     {
-        return authIndex == null ? DEFAULT_AUTHORITATIVE_INDEXES : authIndex;
+        return authoritativeIndex == null ? DEFAULT_AUTHORITATIVE_INDEXES : authoritativeIndex;
     }
 
     @ConfigName( ContentIndexConfig.AUTH_INDEX_PARAM )
-    public void setAuthIndex( Boolean authIndex )
+    public void setAuthoritativeIndex( Boolean authoritativeIndex )
     {
-        this.authIndex = authIndex;
+        this.authoritativeIndex = authoritativeIndex;
     }
 
     @Override

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInHostedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInHostedTest.java
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertThat;
  * <b>THEN:</b>
  * <ul>
  *     <li>When repo is readonly first time, the cached artifact can be fetched, but the direct writing one can not</li>
- *     <li>When repo is non-readonly, both artifacts are available</li>
+ *     <li>When repo is non-readonly, both artifacts are available, and after fetching they are both indexed</li>
  *     <li>When repo is readonly again, both artifacts are still available</li>
  * </ul>
  */

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInHostedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInHostedTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>PREREQUISITES:</b>
+ * <ul>
+ *     <li>org.commonjava.indy.ftest.core.store.HostedAuthIndexWithReadonly must pass</li>
+ * </ul>
+ *
+ * <br />
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Authoritative index of content index enabled</li>
+ *     <li>A hosted repo</li>
+ *     <li>Store one artifact in repo, so this artifact will be cached in index</li>
+ *     <li>Store another artifact in repo through direct file writing, so this artifact will not be cached</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Change the hosted repo to readonly</li>
+ *     <li>Change the hosted repo back to non-readonly</li>
+ *     <li>Change the hosted repo to readonly again</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>When repo is readonly first time, the cached artifact can be fetched, but the direct writing one can not</li>
+ *     <li>When repo is non-readonly, both artifacts are available</li>
+ *     <li>When repo is readonly again, both artifacts are still available</li>
+ * </ul>
+ */
+public class AuthoritativeIndexedContentInHostedTest
+        extends AbstractIndyFunctionalTest
+{
+
+    private static final String CACHED_AFACT_PATH = "org/foo/bar/1/cached.txt";
+
+    private static final String NON_CACHED_AFACT_PATH = "org/foo/bar/2/non_cached.txt";
+
+    private static final String CACHED_CONTENT = "cached content";
+
+    private static final String NON_CACHED_CONTENT = "non cached content";
+
+    @Category( EventDependent.class )
+    @Test
+    public void bypassNotIndexedContentWithAuthoritativeIndex()
+            throws Exception
+    {
+        final String repoName = newName();
+        HostedRepository repo = new HostedRepository( MAVEN_PKG_KEY, repoName );
+        repo = client.stores().create( repo, name.getMethodName(), HostedRepository.class );
+
+        client.content()
+              .store( repo.getKey(), CACHED_AFACT_PATH, new ByteArrayInputStream( CACHED_CONTENT.getBytes() ) );
+
+        final Path nonCachedFile =
+                Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage", MAVEN_PKG_KEY,
+                           hosted.singularEndpointName() + "-" + repoName, NON_CACHED_AFACT_PATH );
+        Files.createDirectories( nonCachedFile.getParent() );
+        Files.createFile( nonCachedFile );
+
+        try (FileOutputStream stream = new FileOutputStream( nonCachedFile.toFile() ))
+        {
+            stream.write( NON_CACHED_CONTENT.getBytes() );
+        }
+
+        repo.setReadonly( true );
+        assertThat( client.stores().update( repo, name.getMethodName() ), equalTo( true ) );
+
+        Thread.sleep( 500 );
+
+        try (InputStream cached = client.content().get( repo.getKey(), CACHED_AFACT_PATH ))
+        {
+            assertThat( IOUtils.toString( cached ), equalTo( CACHED_CONTENT ) );
+        }
+
+        try (InputStream cached = client.content().get( repo.getKey(), NON_CACHED_AFACT_PATH ))
+        {
+            assertThat( cached, equalTo( null ) );
+        }
+
+        repo.setReadonly( false );
+        assertThat( client.stores().update( repo, name.getMethodName() ), equalTo( true ) );
+
+        Thread.sleep( 500 );
+
+        try (InputStream cached = client.content().get( repo.getKey(), CACHED_AFACT_PATH ))
+        {
+            assertThat( IOUtils.toString( cached ), equalTo( CACHED_CONTENT ) );
+        }
+
+        try (InputStream nonCached = client.content().get( repo.getKey(), NON_CACHED_AFACT_PATH ))
+        {
+            assertThat( IOUtils.toString( nonCached ), equalTo( NON_CACHED_CONTENT ) );
+        }
+
+        repo.setReadonly( true );
+        assertThat( client.stores().update( repo, name.getMethodName() ), equalTo( true ) );
+
+        Thread.sleep( 500 );
+
+        try (InputStream cached = client.content().get( repo.getKey(), CACHED_AFACT_PATH ))
+        {
+            assertThat( IOUtils.toString( cached ), equalTo( CACHED_CONTENT ) );
+        }
+
+        try (InputStream nonCached = client.content().get( repo.getKey(), NON_CACHED_AFACT_PATH ))
+        {
+            assertThat( IOUtils.toString( nonCached ), equalTo( NON_CACHED_CONTENT ) );
+        }
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nsupport.authoritative.indexes=true" );
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInRemoteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInRemoteTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Authoritative index of content index enabled</li>
+ *     <li>A remote repo</li>
+ *     <li>Remote path one, will be available before repo set to authoritative index enabled first time</li>
+ *     <li>Remote path two, will be available after repo set to authoritative index enabled first time</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Fetch first path once but not second one</li>
+ *     <li>Enable authoritative index of the remote repo</li>
+ *     <li>Fetch first and second path</li>
+ *     <li>Disable authoritative index of the remote repo</li>
+ *     <li>Enable authoritative index of the remote repo again</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>When repo is authoritative index enabled first time, the first path can be fetched, but the second path can not</li>
+ *     <li>When repo is authoritative index disabled, both path are available</li>
+ *     <li>When repo is authoritative index enabled again, both path are still available</li>
+ * </ul>
+ */
+public class AuthoritativeIndexedContentInRemoteTest
+        extends AbstractIndyFunctionalTest
+{
+
+    private static final String FIRST_PATH = "org/foo/bar/1/first.txt";
+
+    private static final String SECOND_PATH = "org/foo/bar/2/second.txt";
+
+    private static final String FIRST_PATH_CONTENT = "first content";
+
+    private static final String SECOND_PATH_CONTENT = "second content";
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    @Test
+    public void bypassNotIndexedContentWithAuthoritativeIndex()
+            throws Exception
+    {
+
+        final String repoName = newName();
+        RemoteRepository repo = new RemoteRepository( MAVEN_PKG_KEY, repoName, server.formatUrl( repoName ) );
+        repo = client.stores().create( repo, name.getMethodName(), RemoteRepository.class );
+
+        server.expect( server.formatUrl( repoName, FIRST_PATH ), 200, FIRST_PATH_CONTENT );
+
+        try (InputStream first = client.content().get( repo.getKey(), FIRST_PATH ))
+        {
+            assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
+        }
+
+        repo.setAuthoritativeIndex( true );
+        assertThat( client.stores().update( repo, name.getMethodName() ), equalTo( true ) );
+
+        server.expect( server.formatUrl( repoName, SECOND_PATH ), 200, SECOND_PATH_CONTENT );
+
+        try (InputStream first = client.content().get( repo.getKey(), FIRST_PATH ))
+        {
+            assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
+        }
+
+        try (InputStream second = client.content().get( repo.getKey(), SECOND_PATH ))
+        {
+            assertThat( second, equalTo( null ) );
+        }
+
+        repo.setAuthoritativeIndex( false );
+        assertThat( client.stores().update( repo, name.getMethodName() ), equalTo( true ) );
+
+
+        try (InputStream first = client.content().get( repo.getKey(), FIRST_PATH ))
+        {
+            assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
+        }
+
+        try (InputStream second = client.content().get( repo.getKey(), SECOND_PATH ))
+        {
+            assertThat( IOUtils.toString( second ), equalTo( SECOND_PATH_CONTENT ) );
+        }
+
+        repo.setAuthoritativeIndex( true );
+        assertThat( client.stores().update( repo, name.getMethodName() ), equalTo( true ) );
+
+        try (InputStream first = client.content().get( repo.getKey(), FIRST_PATH ))
+        {
+            assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
+        }
+
+        try (InputStream second = client.content().get( repo.getKey(), SECOND_PATH ))
+        {
+            assertThat( IOUtils.toString( second ), equalTo( SECOND_PATH_CONTENT ) );
+        }
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nsupport.authoritative.indexes=true" );
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInRemoteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInRemoteTest.java
@@ -53,7 +53,7 @@ import static org.junit.Assert.assertThat;
  * <b>THEN:</b>
  * <ul>
  *     <li>When repo is authoritative index enabled first time, the first path can be fetched, but the second path can not</li>
- *     <li>When repo is authoritative index disabled, both path are available</li>
+ *     <li>When repo is authoritative index disabled, both path are available, and after fetching they are both indexed</li>
  *     <li>When repo is authoritative index enabled again, both path are still available</li>
  * </ul>
  */

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/HostedAuthIndexWithReadonly.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/HostedAuthIndexWithReadonly.java
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertThat;
  *     <li>The hosted repo will set to authoritative index off when changed back to non-readonly</li>
  * </ul>
  */
-    public class HostedAuthIndexWithReadonly
+public class HostedAuthIndexWithReadonly
         extends AbstractStoreManagementTest
 {
     @Test


### PR DESCRIPTION
The authoritative index support will let all store which
enabled the authoritative fetch the artifacts which are only
cached in content index. By doing this, it will enhance the
performance by avoid meaningless artifact path findings in repo
(all existed artifacts will be cached in content index firstly)