### PR TITLE
Build on #750 by fixing ftests for http-metadata generation on content storage

### DIFF
--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteAllTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteAllTest.java
@@ -48,7 +48,7 @@ public class PromoteAllTest
 
         final Set<String> completed = result.getCompletedPaths();
         assertThat( completed, notNullValue() );
-        assertThat( completed.size(), equalTo( 2 ) );
+        assertThat( completed.size(), equalTo( 4 ) ); // account for http-metadata.json files
 
         assertThat( result.getError(), nullValue() );
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteDryRunTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteDryRunTest.java
@@ -49,7 +49,7 @@ public class PromoteDryRunTest
 
         final Set<String> pending = result.getPendingPaths();
         assertThat( pending, notNullValue() );
-        assertThat( pending.size(), equalTo( 2 ) );
+        assertThat( completed.size(), equalTo( 4 ) ); // account for http-metadata.json files
 
         assertThat( result.getError(), nullValue() );
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteDryRunTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteDryRunTest.java
@@ -49,7 +49,7 @@ public class PromoteDryRunTest
 
         final Set<String> pending = result.getPendingPaths();
         assertThat( pending, notNullValue() );
-        assertThat( completed.size(), equalTo( 4 ) ); // account for http-metadata.json files
+        assertThat( pending.size(), equalTo( 4 ) ); // account for http-metadata.json files
 
         assertThat( result.getError(), nullValue() );
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RollbackTwoArtifactsTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RollbackTwoArtifactsTest.java
@@ -48,7 +48,7 @@ public class RollbackTwoArtifactsTest
 
         Set<String> completed = result.getCompletedPaths();
         assertThat( completed, notNullValue() );
-        assertThat( completed.size(), equalTo( 2 ) );
+        assertThat( completed.size(), equalTo( 4 ) ); // account for http-metadata.json files
 
         assertThat( result.getError(), nullValue() );
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RollbackTwoArtifactsTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RollbackTwoArtifactsTest.java
@@ -65,7 +65,7 @@ public class RollbackTwoArtifactsTest
 
         pending = result.getPendingPaths();
         assertThat( pending, notNullValue() );
-        assertThat( pending.size(), equalTo( 2 ) );
+        assertThat( pending.size(), equalTo( 4 ) ); // account for http-metadata.json files
 
         assertThat( result.getError(), nullValue() );
 

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -238,22 +238,19 @@ public class ContentAccessHandler
                 Transfer item = null;
                 logger.info( "Checking existence of: {}:{} (cache only? {})", sk, path, cacheOnly );
 
-                boolean exists = false;
-                if ( Boolean.TRUE.equals( cacheOnly ) )
-                {
-                    logger.debug( "Calling getTransfer()" );
-                    item = contentController.getTransfer( sk, path, TransferOperation.DOWNLOAD );
-                    exists = item != null && item.exists();
-                    logger.debug( "Got transfer reference: {}", item );
-                }
-                else
+                logger.debug( "Calling getTransfer()" );
+                item = contentController.getTransfer( sk, path, TransferOperation.DOWNLOAD );
+                logger.debug( "Got transfer reference: {}", item );
+
+                boolean exists = item != null && item.exists();
+                if ( !exists && !Boolean.TRUE.equals( cacheOnly ) )
                 {
                     // Use exists for remote repo to avoid downloading file. Use getTransfer for everything else (hosted, cache-only).
                     // Response will be composed of metadata by getHttpMetadata which get metadata from .http-metadata.json (because HTTP transport always writes a .http-metadata.json
                     // file when it makes a request). This file stores the HTTP response status code and headers regardless exist returning true or false.
-                    logger.debug( "Calling exists()" );
+                    logger.debug( "Calling remote exists()" );
                     exists = contentController.exists( sk, path );
-                    logger.debug( "Got exists: {}", exists );
+                    logger.debug( "Got remote exists: {}", exists );
                 }
 
                 if ( exists )

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -55,6 +55,7 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponseFromMetadata;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.setInfoHeaders;
 import static org.commonjava.indy.core.ctl.ContentController.LISTING_HTML_FILE;
+import static org.commonjava.maven.galley.io.SpecialPathConstants.PKG_TYPE_NPM;
 
 public class ContentAccessHandler
         implements IndyResources
@@ -117,6 +118,7 @@ public class ContentAccessHandler
                 builderModifier.accept( builder );
             }
             response = builder.build();
+            contentController.generateHttpMetadataHeaders( transfer, request, response );
         }
         catch ( final IndyWorkflowException | IOException e )
         {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -141,6 +141,14 @@
           <groupId>org.commonjava.indy</groupId>
           <artifactId>indy-subsys-metrics</artifactId>
       </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+    </dependency>
   </dependencies>
   
   <build>

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.StoreResource;
+import org.commonjava.indy.core.model.StoreHttpExchangeMetadata;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
@@ -513,7 +514,7 @@ public class ContentController
             }
         }
 
-        final HttpExchangeMetadata metadata = new HttpExchangeMetadata( request, responseWithLastModified );
+        final HttpExchangeMetadata metadata = new StoreHttpExchangeMetadata( request, responseWithLastModified );
         OutputStream out = null;
         try
         {

--- a/core/src/main/java/org/commonjava/indy/core/model/StoreHttpExchangeMetadata.java
+++ b/core/src/main/java/org/commonjava/indy/core/model/StoreHttpExchangeMetadata.java
@@ -1,0 +1,73 @@
+package org.commonjava.indy.core.model;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+public class StoreHttpExchangeMetadata
+        extends HttpExchangeMetadata
+{
+    public StoreHttpExchangeMetadata()
+    {
+    }
+
+    public StoreHttpExchangeMetadata( HttpRequest request, HttpResponse response )
+    {
+        super( request, response );
+    }
+
+    public StoreHttpExchangeMetadata( final HttpServletRequest request, final Response response )
+    {
+        populateHeaders( requestHeaders, request );
+        populateHeaders( responseHeaders, response.getStringHeaders() );
+
+        final Response.StatusType st = response.getStatusInfo();
+        this.responseStatusCode = st.getStatusCode();
+        this.responseStatusMessage = st.getReasonPhrase();
+    }
+
+    private void populateHeaders( final Map<String, List<String>> headerMap,
+                                  final MultivaluedMap<String, String> allHeadersMap )
+    {
+        for ( final String name : allHeadersMap.keySet() )
+        {
+            List<String> values = headerMap.get( name );
+            if ( values == null )
+            {
+                values = new ArrayList<String>();
+                headerMap.put( name.toUpperCase(), values );
+            }
+
+            values.add( allHeadersMap.getFirst( name ) );
+        }
+    }
+
+    private void populateHeaders( final Map<String, List<String>> headerMap, final HttpServletRequest request )
+    {
+        if ( request == null )
+        {
+            return;
+        }
+
+        Enumeration<String> en = request.getHeaderNames();
+        while ( en.hasMoreElements() )
+        {
+            String name = en.nextElement();
+            List<String> values = headerMap.get( name );
+            if ( values == null )
+            {
+                values = new ArrayList<String>();
+                headerMap.put( name.toUpperCase(), values );
+            }
+            values.add( request.getHeader( name ) );
+        }
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadContentHasLengthHeaderHostedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadContentHasLengthHeaderHostedTest.java
@@ -15,15 +15,10 @@
  */
 package org.commonjava.indy.ftest.core.content;
 
-import org.apache.http.HttpResponse;
 import org.commonjava.indy.client.core.IndyClientModule;
-import org.commonjava.indy.client.core.helper.HttpResources;
 import org.commonjava.indy.client.core.helper.PathInfo;
 import org.commonjava.indy.client.core.module.IndyRawHttpModule;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
-import org.commonjava.indy.model.core.RemoteRepository;
-import org.commonjava.test.http.expect.ExpectationServer;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -34,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
-import static org.commonjava.indy.model.core.StoreType.remote;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
@@ -247,6 +247,18 @@ public final class ResponseUtils
                 builder.header( ApplicationHeader.content_length.key(), item.length() );
             }
         }
+        else
+        {
+            if ( !lastModSet )
+            {
+                logger.debug( "CANNOT SET: {}", ApplicationHeader.last_modified.key() );
+            }
+
+            if ( includeContentLength && !lenSet )
+            {
+                logger.debug( "CANNOT SET: {}", ApplicationHeader.content_length.key() );
+            }
+        }
 
         return builder;
     }


### PR DESCRIPTION
@jdcasey 

The build for PR#750 tests failed, and seem the ContentAccessHandler head handling still has some problems. http://pastebin.test.redhat.com/505685

1. Make all kinds of items getting from getTransfer regardless with its cacheOnly value, will result the content could still be retrieved from the disabled stores by the physical transfer? That’s why ContentNotAvailableInGroupWithDisabledRemoteTest failed.

2. ContentLength was not aligned, reason in Line https://github.com/Commonjava/indy/blob/master/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java#L264 , group/hosted has no httpMetadata generated before, but now we have it, so item will still be kept as null by the judgment ‘if ( httpMetadata == null )’, this will make Content-Length 0 when calling ResponseUtils#setInfoHeaders. That’s Why GroupHttpHeadersFromSameRepoAsPomTest failed.

3. Other Promote/Rollback** was caused by the wrong pending size assert errors with the addition of http-metadata.json.

I make the changes and build this PR locally, it passed, will wait for the CI result.