### PR TITLE
Apply NFC of nested groups too, not just concrete repos

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -246,12 +246,8 @@ public abstract class IndexingContentManagerDecorator
                                                                 return null;
                                                             }
                                                         } );
-                if ( exists( transfer ) )
-                {
-                    return transfer;
-                }
-
-                logger.debug( "No index hits. Delegating to main content manager for: {} in: {}", path, store );
+                nfcForGroup( store, transfer, resource );
+                return transfer;
             }
             else
             {
@@ -423,10 +419,10 @@ public abstract class IndexingContentManagerDecorator
                                                                 return null;
                                                             }
                                                         } );
-                if ( exists( transfer ) )
-                {
-                    return transfer;
-                }
+
+                nfcForGroup( store, transfer, resource );
+
+                return transfer;
             }
             else
             {
@@ -568,10 +564,10 @@ public abstract class IndexingContentManagerDecorator
             logger.debug( "No group index hits. Devolving to member store indexes." );
             transfer = getTransferFromConstituents( g.getConstituents(), resource, path, g,
                                                     memberKey -> getTransfer( memberKey, path, op ) );
-            if ( exists( transfer ) )
-            {
-                return transfer;
-            }
+
+            nfcForGroup( store, transfer, resource );
+
+            return transfer;
         }
 
         transfer = delegate.getTransfer( storeKey, path, op );
@@ -582,6 +578,26 @@ public abstract class IndexingContentManagerDecorator
         }
 
         return transfer;
+    }
+
+    private void nfcForGroup( final ArtifactStore store, final Transfer transfer, final ConcreteResource resource )
+    {
+        if ( store.getKey().getType() == StoreType.group )
+        {
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            if ( exists( transfer ) )
+            {
+                nfc.clearMissing( resource );
+            }
+            else
+            {
+                logger.debug( "No index hits. Delegating to main content manager for: {} in: {}", resource.getPath(),
+                              store );
+                logger.debug( "No transfer hit at group level of group {}, will add to NFC for this group resource",
+                              store );
+                nfc.addMissing( resource );
+            }
+        }
     }
 
     @Override

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -63,6 +63,8 @@ import java.util.Set;
 public abstract class IndexingContentManagerDecorator
         implements ContentManager
 {
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
     @Inject
     private StoreDataManager storeDataManager;
 
@@ -152,7 +154,6 @@ public abstract class IndexingContentManagerDecorator
             }
             catch ( IndyWorkflowException e )
             {
-                Logger logger = LoggerFactory.getLogger( getClass() );
                 logger.error(
                         String.format( "Failed to retrieve indexed content: %s:%s. Reason: %s", store.getKey(), path,
                                        e.getMessage() ), e );
@@ -180,8 +181,6 @@ public abstract class IndexingContentManagerDecorator
     public Transfer retrieve( final ArtifactStore store, final String path, final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-
         logger.trace( "Looking for indexed path: {} in: {}", path, store.getKey() );
 
         Transfer transfer = getIndexedTransfer( store.getKey(), null, path, TransferOperation.DOWNLOAD );
@@ -267,7 +266,6 @@ public abstract class IndexingContentManagerDecorator
         if ( exists( transfer ) )
         {
             logger.debug( "Got transfer from delegate: {} (will index)", transfer );
-
             indexManager.indexTransferIn( transfer, store.getKey() );
         }
 
@@ -282,7 +280,6 @@ public abstract class IndexingContentManagerDecorator
     private Transfer getTransferFromConstituents( Collection<StoreKey> constituents, ConcreteResource resource, String path,
                                                   ArtifactStore parentStore, TransferSupplier<Transfer> transferSupplier )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
         List<StoreKey> members = new ArrayList<>( constituents );
         Transfer transfer = null;
         for ( StoreKey memberKey : members )
@@ -329,7 +326,6 @@ public abstract class IndexingContentManagerDecorator
     public Transfer getIndexedTransfer( final StoreKey storeKey, final StoreKey topKey, final String path, final TransferOperation op )
             throws IndyWorkflowException
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
         logger.trace( "Looking for indexed path: {} in: {} (entry point: {})", path, storeKey, topKey );
 
         try
@@ -380,8 +376,6 @@ public abstract class IndexingContentManagerDecorator
     public Transfer getTransfer( final ArtifactStore store, final String path, final TransferOperation op )
             throws IndyWorkflowException
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-
         Transfer transfer = getIndexedTransfer( store.getKey(), null, path, TransferOperation.DOWNLOAD );
         if ( exists( transfer ) )
         {
@@ -476,7 +470,6 @@ public abstract class IndexingContentManagerDecorator
             }
             catch ( IndyDataException e )
             {
-                Logger logger = LoggerFactory.getLogger( getClass() );
                 logger.error(
                         String.format( "Failed to lookup store: %s (in membership of: %s). Reason: %s", key, topKey,
                                        e.getMessage() ), e );
@@ -517,8 +510,6 @@ public abstract class IndexingContentManagerDecorator
     public Transfer getTransfer( final StoreKey storeKey, final String path, final TransferOperation op )
             throws IndyWorkflowException
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-
         Transfer transfer = getIndexedTransfer( storeKey, null, path, TransferOperation.DOWNLOAD );
         if ( exists( transfer ) )
         {
@@ -584,7 +575,6 @@ public abstract class IndexingContentManagerDecorator
     {
         if ( store.getKey().getType() == StoreType.group )
         {
-            Logger logger = LoggerFactory.getLogger( getClass() );
             if ( exists( transfer ) )
             {
                 nfc.clearMissing( resource );
@@ -599,6 +589,7 @@ public abstract class IndexingContentManagerDecorator
             }
         }
     }
+
 
     @Override
     public Transfer getTransfer( final List<ArtifactStore> stores, final String path, final TransferOperation op )
@@ -631,7 +622,7 @@ public abstract class IndexingContentManagerDecorator
             throws IndyWorkflowException
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
-        logger.trace( "Storing: {} in: {}", path, store.getKey() );
+        logger.trace( "Storing: {} in: {} from indexing level", path, store.getKey() );
         Transfer transfer = delegate.store( store, path, stream, op, eventMetadata );
         if ( transfer != null )
         {
@@ -643,6 +634,7 @@ public abstract class IndexingContentManagerDecorator
                 nfc.clearMissing( new ConcreteResource( LocationUtils.toLocation( store ), path ) );
             }
         }
+//        nfcClearByContaining( store, path );
 
         return transfer;
     }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.content.index;
+
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+/**
+ * This listener is used to bind the content index cache event to nfc content clearing/adding. The following cases:
+ * <ul>
+ *     <li>When new content index entry added, it means that a new resource is available in repo(s),
+ *     so all nfc content for this resource of the cascaded repos(low level concrete repo to higher group which contains it)
+ *     should be cleared</li>
+ *     <li>When content index entry removed, it means that the resource is missing in repo(s), so this resource with specified repo</li>
+ * </ul>
+ *
+ * So here we used ISPN event listener to handle these types of logic, by CacheEntryCreatedEvent and CacheEntryRemovedEvent
+ */
+@ApplicationScoped
+@Listener
+class NFCContentListener
+{
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    @Inject
+    private StoreDataManager storeDataManager;
+
+    @Inject
+    private NotFoundCache nfc;
+
+    @CacheEntryCreated
+    public void newIndex( final CacheEntryCreatedEvent<IndexedStorePath, IndexedStorePath> e )
+    {
+        if ( !e.isPre() )
+        {
+            IndexedStorePath isp = e.getValue();
+            final StoreKey key =
+                    new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, isp.getStoreType(), isp.getStoreName() );
+            logger.debug( "New artifact created in store {} of path {}, will start to clear nfc cache for it.", key,
+                          isp.getPath() );
+            try
+            {
+                final ArtifactStore store = storeDataManager.getArtifactStore( key );
+                nfc.clearMissing( new ConcreteResource( LocationUtils.toLocation( store ), isp.getPath() ) );
+                nfcClearByContaining( store, isp.getPath() );
+            }
+            catch ( IndyDataException ex )
+            {
+                logger.error( String.format(
+                        "When clear nfc missing for indexed artifact of path %s in store %s, failed to lookup store. Reason: %s",
+                        isp.getPath(), key, ex.getMessage() ), ex );
+            }
+        }
+    }
+
+    // Not sure if this entry modified event should be watched, need some further check
+    //    @CacheEntryModified
+    //    public void updateIndex( final CacheEntryModifiedEvent<IndexedStorePath, IndexedStorePath> e){
+    //
+    //    }
+
+    @CacheEntryRemoved
+    public void removeIndex( final CacheEntryRemovedEvent<IndexedStorePath, IndexedStorePath> e )
+    {
+        if ( e.isPre() )
+        {
+            IndexedStorePath isp = e.getValue();
+            final StoreKey key =
+                    new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, isp.getStoreType(), isp.getStoreName() );
+            try
+            {
+                final ArtifactStore store = storeDataManager.getArtifactStore( key );
+                final ConcreteResource r = new ConcreteResource( LocationUtils.toLocation( store ), isp.getPath() );
+                logger.debug( "Add NFC of resource {} in store {}", r, store );
+                nfc.addMissing( r );
+            }
+            catch ( IndyDataException ex )
+            {
+                logger.error( String.format(
+                        "When add nfc missing for indexed artifact of path %s in store %s, failed to lookup store. Reason: %s",
+                        isp.getPath(), key, ex.getMessage() ), ex );
+            }
+        }
+    }
+
+    private void nfcClearByContaining( final ArtifactStore store, final String path )
+    {
+        try
+        {
+            logger.debug( "Start to clear nfc for groups affected by {} of path {}", store, path );
+            storeDataManager.query()
+                            .packageType( store.getKey().getPackageType() )
+                            .getGroupsAffectedBy( store.getKey() )
+                            .forEach( g -> {
+                                final ConcreteResource r = new ConcreteResource( LocationUtils.toLocation( g ), path );
+                                logger.debug( "Clear NFC in terms of containing {} in {} for resource {}", store, g,
+                                              r );
+                                nfc.clearMissing( r );
+                            } );
+
+        }
+        catch ( IndyDataException e )
+        {
+            logger.error( String.format( "Failed to lookup parent stores which contain %s. Reason: %s", store.getKey(),
+                                         e.getMessage() ), e );
+        }
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NestedStoreInGroupWithErrorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NestedStoreInGroupWithErrorTest.java
@@ -38,6 +38,26 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Correct remote repo1 which can return content correctly</li>
+ *     <li>Incorrect remote repo2 which will return 401 error</li>
+ *     <li>Group which contains these repos which the repo2 is the first member and repo1 is the last</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Client requests the content through group</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>The content can be fetched correctly from the group as repo1 has the content, even the repo2 returns 401 error</li>
+ * </ul>
+ */
 public class NestedStoreInGroupWithErrorTest
         extends AbstractContentManagementTest
 {

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/TwoGroupsWithSameHostedNFCTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/TwoGroupsWithSameHostedNFCTest.java
@@ -150,12 +150,6 @@ public class TwoGroupsWithSameHostedNFCTest
 
         nfcSectionDto =
                 dto.getSections().stream().filter( d -> d.getKey().equals( a.getKey() ) ).findFirst().orElse( null );
-        assertThat( nfcSectionDto, notNullValue() );
-        assertThat( nfcSectionDto.getPaths(), nullValue() );
-
-        nfcSectionDto =
-                dto.getSections().stream().filter( d -> d.getKey().equals( x.getKey() ) ).findFirst().orElse( null );
-        assertThat( nfcSectionDto, notNullValue() );
-        assertThat( nfcSectionDto.getPaths(), nullValue() );
+        assertThat( nfcSectionDto, nullValue() );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/TwoGroupsWithSameHostedNFCTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/TwoGroupsWithSameHostedNFCTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.module.IndyNfcClientModule;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.PackageTypes;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.core.dto.NotFoundCacheDTO;
+import org.commonjava.indy.model.core.dto.NotFoundCacheSectionDTO;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.hamcrest.core.IsNull;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Groups A and B</li>
+ *     <li>Hosted repository X</li>
+ *     <li>Both A and B contain X as a member</li>
+ *     <li>Path P doesn't exist in X</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>1: Resolve P from A</li>
+ *     <li>2: Upload P to X via B</li>
+ *     <li>3: Resolve P from A again</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>1: Both X and A should get NFC entries for P</li>
+ *     <li>2: NFC entry for P in X should be cleared</li>
+ *     <li>3: NFC entry for P in A should have been cleared too</li>
+ * </ul>
+ */
+public class TwoGroupsWithSameHostedNFCTest
+        extends AbstractContentManagementTest
+{
+    private HostedRepository x;
+
+    private static final String NAME_X = "hosted_x";
+
+    private Group a;
+
+    private static final String NAME_A = "group_a";
+
+    private Group b;
+
+    private static final String NAME_B = "group_b";
+
+    private static final String PATH = "org/foo/bar/1/bar-1.jar";
+
+    @Before
+    public void setupTest()
+            throws Exception
+    {
+        String change = "test setup";
+        x = client.stores()
+                  .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, NAME_X ), change,
+                           HostedRepository.class );
+
+        a = client.stores()
+                  .create( new Group( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, NAME_A, x.getKey() ), change,
+                           Group.class );
+        b = client.stores()
+                  .create( new Group( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, NAME_B, x.getKey() ), change,
+                           Group.class );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        try (InputStream inputStream = client.content().get( a.getKey(), PATH ))
+        {
+            assertThat( inputStream, nullValue() );
+        }
+
+        NotFoundCacheDTO dto = client.module( IndyNfcClientModule.class ).getAllNfcContent();
+
+        assertThat( dto, notNullValue() );
+        assertThat( dto.getSections(), notNullValue() );
+
+        NotFoundCacheSectionDTO nfcSectionDto =
+                dto.getSections().stream().filter( d -> d.getKey().equals( a.getKey() ) ).findFirst().orElse( null );
+        assertThat( nfcSectionDto, notNullValue() );
+        assertThat( nfcSectionDto.getPaths(), notNullValue() );
+        assertThat( nfcSectionDto.getPaths().contains( PATH ), equalTo( true ) );
+
+        nfcSectionDto =
+                dto.getSections().stream().filter( d -> d.getKey().equals( x.getKey() ) ).findFirst().orElse( null );
+        assertThat( nfcSectionDto, notNullValue() );
+        assertThat( nfcSectionDto.getPaths(), notNullValue() );
+        assertThat( nfcSectionDto.getPaths().contains( PATH ), equalTo( true ) );
+
+        client.content().store( b.getKey(), PATH, new ByteArrayInputStream( "This is the pom".getBytes() ) );
+
+        try (InputStream inputStream = client.content().get( b.getKey(), PATH ))
+        {
+            assertThat( inputStream, notNullValue() );
+        }
+
+        dto = client.module( IndyNfcClientModule.class ).getAllNfcContentInStore( StoreType.hosted, x.getName() );
+
+        assertThat( dto, notNullValue() );
+        assertThat( dto.getSections(), notNullValue() );
+
+        nfcSectionDto =
+                dto.getSections().stream().filter( d -> d.getKey().equals( x.getKey() ) ).findFirst().orElse( null );
+        assertThat( nfcSectionDto, notNullValue() );
+        assertThat( nfcSectionDto.getPaths(), nullValue() );
+
+        try (InputStream inputStream = client.content().get( a.getKey(), PATH ))
+        {
+            assertThat( inputStream, notNullValue() );
+        }
+
+        dto = client.module( IndyNfcClientModule.class ).getAllNfcContent();
+
+        assertThat( dto, notNullValue() );
+        assertThat( dto.getSections(), notNullValue() );
+
+        nfcSectionDto =
+                dto.getSections().stream().filter( d -> d.getKey().equals( a.getKey() ) ).findFirst().orElse( null );
+        assertThat( nfcSectionDto, notNullValue() );
+        assertThat( nfcSectionDto.getPaths(), nullValue() );
+
+        nfcSectionDto =
+                dto.getSections().stream().filter( d -> d.getKey().equals( x.getKey() ) ).findFirst().orElse( null );
+        assertThat( nfcSectionDto, notNullValue() );
+        assertThat( nfcSectionDto.getPaths(), nullValue() );
+    }
+}


### PR DESCRIPTION
When group loop fetching with recursion done, if the transfer is not found, should cached it in NFC, and clear it from NFC vice versa. 
Also did a refactor:
* Extracts the group constituents loop part into one single method, with a supplier lambda definition.