### PR TITLE
[master] Change the decorator ordering for ContentManager to make failover to koji work.

### DIFF
--- a/deployments/launchers/savant/src/main/resources/META-INF/beans.xml
+++ b/deployments/launchers/savant/src/main/resources/META-INF/beans.xml
@@ -21,10 +21,13 @@
   </alternatives>
   
   <decorators>
-    <class>org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator</class>
-    <class>org.commonjava.indy.content.index.IndexingContentManagerDecorator</class>
-    <class>org.commonjava.indy.content.index.IndexingDirectContentAccessDecorator</class>
+    <!-- ordering is CRITICAL here. First declaration is outermost in decoration chain -->
     <class>org.commonjava.indy.koji.content.KojiContentManagerDecorator</class>
+    <class>org.commonjava.indy.content.index.IndexingContentManagerDecorator</class>
+
+    <class>org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator</class>
+
+    <class>org.commonjava.indy.content.index.IndexingDirectContentAccessDecorator</class>
   </decorators>
       
 </beans>


### PR DESCRIPTION
KojiContentManagerDecorator is designed to execute ONLY when normal content
retrieval fails. In this case, it will query into Koji to see if a matching
build exists, then wire up a RemoteRepository to proxy that build. In subsequent
requests for that content, the normal content retrieval logic will apply, using
the new RemoteRepository.

Because of this, KojiContentManagerDecorator should be the outermost (or among
the outermost, in the event we implement another failover-style decorator).
Putting this inside other decorators risks exposing it to implementation details
of those decorators that can circumvent the failover behavior, which only works
in the context of group content retrieval.

This change reorders the ContentManager decorators, and adds a comment to the
beans.xml in deployments/launchers/savant to note the importance of ordering.