### PR TITLE
[NOS-1054] Remove automatic store re-enablement when disabling manually

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
@@ -77,19 +77,7 @@ public class StoreEnablementManager
 
         for ( ArtifactStore store : event )
         {
-            if ( event.isDisabling() )
-            {
-                try
-                {
-                    setReEnablementTimeout( store.getKey() );
-                }
-                catch ( IndySchedulerException e )
-                {
-                    Logger logger = LoggerFactory.getLogger( getClass() );
-                    logger.error( String.format( "Failed to schedule re-enablement of %s.", store.getKey() ), e );
-                }
-            }
-            else
+            if ( ! event.isDisabling() )
             {
                 try
                 {


### PR DESCRIPTION
When a store is unavailale and requests end by timeouts an
IndyStoreErrorEvent is fired, so in case of ArtifactStoreEnablementEvent
it is always a manual action triggered by a client and hence it does not
make sense to schedule an automatic re-enablement.