### PR TITLE
[1.1.x][NOS-1054] Remove automatic store re-enablement when disabling manually

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
@@ -18,7 +18,6 @@ package org.commonjava.indy.core.change;
 import org.apache.commons.lang.StringUtils;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.change.event.ArtifactStoreEnablementEvent;
-import org.commonjava.indy.change.event.ArtifactStorePostUpdateEvent;
 import org.commonjava.indy.change.event.IndyStoreErrorEvent;
 import org.commonjava.indy.conf.IndyConfiguration;
 import org.commonjava.indy.core.expire.IndySchedulerException;
@@ -38,8 +37,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import java.io.IOException;
-
-import static org.apache.commons.lang.StringUtils.isNotEmpty;
 
 @ApplicationScoped
 public class StoreEnablementManager
@@ -73,19 +70,7 @@ public class StoreEnablementManager
 
         for ( ArtifactStore store : event )
         {
-            if ( event.isDisabling() )
-            {
-                try
-                {
-                    setReEnablementTimeout( store.getKey() );
-                }
-                catch ( IndySchedulerException e )
-                {
-                    Logger logger = LoggerFactory.getLogger( getClass() );
-                    logger.error( String.format( "Failed to schedule re-enablement of %s.", store.getKey() ), e );
-                }
-            }
-            else
+            if ( ! event.isDisabling() )
             {
                 try
                 {


### PR DESCRIPTION
When a store is unavailale and requests end by timeouts an
IndyStoreErrorEvent is fired, so in case of ArtifactStoreEnablementEvent
it is always a manual action triggered by a client and hence it does not
make sense to schedule an automatic re-enablement.