### PR TITLE
[MASTER] Add some potential NPE checking in ScheduleManager

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -699,34 +699,54 @@ public class ScheduleManager
     @CacheEntryCreated
     public void scheduled( final CacheEntryCreatedEvent<ScheduleKey, Map> e )
     {
-        final ScheduleKey expiredKey = e.getKey();
-        final Map expiredContent = e.getValue();
-        if ( expiredKey != null && expiredContent != null )
+        if ( e == null )
         {
-            logger.debug( "Expiration Created: {}", expiredKey );
-            final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
-            final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
-            eventDispatcher.fire( new SchedulerScheduleEvent( type, data ) );
+            throw new IllegalArgumentException( "[FATAL]The infinispan cache created event for indy schedule manager is null." );
+        }
+
+        if ( !e.isPre() )
+        {
+            final ScheduleKey expiredKey = e.getKey();
+            final Map expiredContent = e.getValue();
+            if ( expiredKey != null && expiredContent != null )
+            {
+                logger.debug( "Expiration Created: {}", expiredKey );
+                final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
+                final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
+                eventDispatcher.fire( new SchedulerScheduleEvent( type, data ) );
+            }
         }
     }
 
     @CacheEntryExpired
     public void expired( CacheEntryExpiredEvent<ScheduleKey, Map> e )
     {
-        final ScheduleKey expiredKey = e.getKey();
-        final Map expiredContent = e.getValue();
-        if ( expiredKey != null && expiredContent != null )
+        if ( e == null )
         {
-            logger.debug( "EXPIRED: {}", expiredKey );
-            final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
-            final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
-            eventDispatcher.fire( new SchedulerTriggerEvent( type, data ) );
+            throw new IllegalArgumentException( "[FATAL]The infinispan cache expired event for indy schedule manager is null." );
+        }
+
+        if ( !e.isPre() )
+        {
+            final ScheduleKey expiredKey = e.getKey();
+            final Map expiredContent = e.getValue();
+            if ( expiredKey != null && expiredContent != null )
+            {
+                logger.debug( "EXPIRED: {}", expiredKey );
+                final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
+                final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
+                eventDispatcher.fire( new SchedulerTriggerEvent( type, data ) );
+            }
         }
     }
 
     @CacheEntryRemoved
     public void cancelled( CacheEntryRemovedEvent<ScheduleKey, Map> e )
     {
+        if ( e == null )
+        {
+            throw new IllegalArgumentException( "[FATAL]The infinispan cache removed event for indy schedule manager is null." );
+        }
         logger.info( "Cache removed to cancel scheduling, Key is {}, Value is {}", e.getKey(), e.getValue() );
     }
 

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -701,7 +701,8 @@ public class ScheduleManager
     {
         if ( e == null )
         {
-            throw new IllegalArgumentException( "[FATAL]The infinispan cache created event for indy schedule manager is null." );
+            logger.error( "[FATAL]The infinispan cache created event for indy schedule manager is null.", new NullPointerException( "CacheEntryCreatedEvent is null" ) );
+            return;
         }
 
         if ( !e.isPre() )
@@ -723,7 +724,8 @@ public class ScheduleManager
     {
         if ( e == null )
         {
-            throw new IllegalArgumentException( "[FATAL]The infinispan cache expired event for indy schedule manager is null." );
+            logger.error( "[FATAL]The infinispan cache expired event for indy schedule manager is null.", new NullPointerException( "CacheEntryExpiredEvent is null" ) );
+            return;
         }
 
         if ( !e.isPre() )
@@ -745,7 +747,8 @@ public class ScheduleManager
     {
         if ( e == null )
         {
-            throw new IllegalArgumentException( "[FATAL]The infinispan cache removed event for indy schedule manager is null." );
+            logger.error( "[FATAL]The infinispan cache removed event for indy schedule manager is null.", new NullPointerException( "CacheEntryRemovedEvent is null" ) );
+            return;
         }
         logger.info( "Cache removed to cancel scheduling, Key is {}, Value is {}", e.getKey(), e.getValue() );
     }


### PR DESCRIPTION
  PNC devel env found that there were NPE happening in
ScheduleManager.expired of the infinispan cache timeout working, so
added some code to check potential NPE and rethrow
IllegalArgumentException to make sure the NPE location. And also added
the event.isPre to make sure the event instance is passed in after the real event happening