### PR TITLE
Adopt kojiji2.0/RWX2.0 and use Kojiji multicall in KojiContentDecorator

### DIFF
--- a/addons/koji/common/pom.xml
+++ b/addons/koji/common/pom.xml
@@ -100,15 +100,7 @@
 
     <dependency>
       <groupId>org.commonjava.rwx</groupId>
-      <artifactId>rwx-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.rwx</groupId>
-      <artifactId>rwx-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.rwx</groupId>
-      <artifactId>rwx-bindings</artifactId>
+      <artifactId>rwx</artifactId>
     </dependency>
 
     <dependency>

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
@@ -191,6 +191,36 @@ public class IndyKojiConfig
         return KOJI_SITE_ID;
     }
 
+    @Override
+    public String getKrbCCache()
+    {
+        return null;
+    }
+
+    @Override
+    public String getKrbKeytab()
+    {
+        return null;
+    }
+
+    @Override
+    public String getKrbPassword()
+    {
+        return null;
+    }
+
+    @Override
+    public String getKrbPrincipal()
+    {
+        return null;
+    }
+
+    @Override
+    public String getKrbService()
+    {
+        return null;
+    }
+
     public Integer getMaxConnections()
     {
         return maxConnections == null ? DEFAULT_MAX_CONNECTIONS : maxConnections;

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
@@ -22,12 +22,10 @@ import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.indy.action.ShutdownAction;
 import org.commonjava.indy.action.StartupAction;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
-import org.commonjava.rwx.binding.error.BindException;
 import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordType;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -80,14 +78,7 @@ public class KojijiProvider
             kojiPasswordManager.bind( config.getKeyPassword(), config.getKojiSiteId(), PasswordType.KEY );
         }
 
-        try
-        {
-            kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor );
-        }
-        catch ( BindException e )
-        {
-            throw new IndyLifecycleException( "Failed to start koji client: %s", e, e.getMessage() );
-        }
+        kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor );
     }
 
     @Override

--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
@@ -46,7 +46,6 @@ import org.commonjava.maven.galley.maven.internal.type.StandardTypeMapper;
 import org.commonjava.maven.galley.transport.htcli.HttpClientTransport;
 import org.commonjava.maven.galley.transport.htcli.HttpImpl;
 import org.commonjava.maven.galley.transport.htcli.conf.GlobalHttpConfiguration;
-import org.commonjava.rwx.binding.error.BindException;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
 import org.hamcrest.CoreMatchers;
@@ -308,7 +307,7 @@ public class KojiMavenMetadataProviderTest
     public TemporaryFolder temp = new TemporaryFolder();
 
     private void initKojiClient( String exchangeName, boolean verifyArtifacts )
-            throws BindException, IOException, GalleyInitException, IndyDataException
+            throws IOException, GalleyInitException, IndyDataException
     {
         StoreDataManager storeDataManager = new MemoryStoreDataManager( true );
 

--- a/addons/koji/ftests/src/main/java/org/commonjava/indy/koji/ftest/AbstractKojiIT.java
+++ b/addons/koji/ftests/src/main/java/org/commonjava/indy/koji/ftest/AbstractKojiIT.java
@@ -15,11 +15,6 @@
  */
 package org.commonjava.indy.koji.ftest;
 
-import com.redhat.red.build.koji.model.xmlrpc.KojiXmlRpcBindery;
-import com.redhat.red.build.koji.KojiClient;
-import com.redhat.red.build.koji.config.KojiConfig;
-import com.redhat.red.build.koji.config.SimpleKojiConfigBuilder;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -37,10 +32,8 @@ import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.commonjava.util.jhttpc.HttpFactory;
 import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordManager;
-import org.commonjava.util.jhttpc.auth.PasswordType;
 import org.commonjava.util.jhttpc.util.UrlUtils;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -55,12 +48,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 public abstract class AbstractKojiIT

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.11</partylineVersion>
     <jhttpcVersion>1.5</jhttpcVersion>
-    <kojijiVersion>1.7.1</kojijiVersion>
-    <rwxVersion>1.1</rwxVersion>
+    <kojijiVersion>2.0-SNAPSHOT</kojijiVersion>
+    <rwxVersion>2.0-SNAPSHOT</rwxVersion>
     <weftVersion>1.4.1</weftVersion>
     <httpTestserverVersion>1.3</httpTestserverVersion>
     
@@ -997,17 +997,7 @@
 
       <dependency>
         <groupId>org.commonjava.rwx</groupId>
-        <artifactId>rwx-core</artifactId>
-        <version>${rwxVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.rwx</groupId>
-        <artifactId>rwx-http</artifactId>
-        <version>${rwxVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.rwx</groupId>
-        <artifactId>rwx-bindings</artifactId>
+        <artifactId>rwx</artifactId>
         <version>${rwxVersion}</version>
       </dependency>
       


### PR DESCRIPTION
Changes in KojiContentManagerDecorator: 
1. Two places are using multicall. I have commented them. 
The old flow is: KojiDecorator asks to listBuildsContaining ( inside it, Kojiji send listArchives by GAV; Koji return a list of builds; Kojiji then call getBuild for each of them to retrieve some details); for each build, it calls listTags to get the tags, do some check, etc. The new flow is: KojiDecorator asks to listBuildsContaining ( inside it, Kojiji send listArchives by GAV; Koji return a list of builds; Kojiji then use multicall to get buildInfo for all builds); KojiDecorator then calls multicall form of listTags( all build ids ... ) to get the tags for all builds in one RPC request.

2. I found patterns.addAll( ...a.getGroupId().replace...) threw an NPE when I tested it by ProxyRemoteKojiContentTest because a.getGroupId returned null. This is the response of listArchivesForBuild( buildId ). The same test worked before. I don't know whether it is due to Koji server side changes or other thing. New Kojiji 2.0 does not change anything relavent to this. So, I use a safer way to get GAV by just pull them from the request object. (This is certainly true in that if you ask for artifacts for "groupA:artifactB:1.0" the artifacts you've gotten must have same GAV). 