### PR TITLE
Adjust jhttpc version to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <bomVersion>21</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.11</partylineVersion>
-    <jhttpcVersion>1.7-SNAPSHOT</jhttpcVersion>
+    <jhttpcVersion>1.7</jhttpcVersion>
     <kojijiVersion>1.9</kojijiVersion>
     <rwxVersion>1.1</rwxVersion>
     <weftVersion>1.4.1</weftVersion>


### PR DESCRIPTION
The 1.7-SNAPSHOT artifact for jhttpc cannot be downloaded anymore. We can either put the version to the released version 1.7 or to 1.8-SNAPSHOT. This PR sets the version to the released version 1.7