### PR TITLE
Move log for printing group members from DEBUG to TRACE in retrieve()

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -256,7 +256,8 @@ public class DefaultContentManager
 
             if ( logger.isDebugEnabled() )
             {
-                logger.debug( "{} is a group. Attempting downloads from (in order):\n  {}", store.getKey(), StringUtils.join(members, "\n  ") );
+                logger.debug( "{} is a group. Attempting downloads from {} members", store.getKey(), (members != null ? members.size() : 0) );
+                logger.trace( "Group members (in order):\n  {}", StringUtils.join(members, "\n  ") );
             }
 
             item = null;


### PR DESCRIPTION
Sometimes it prints thousands of lines of group members in DEBUG log. It is not necessary since we can easily get the members of a group via UI or api. 