### PR TITLE
Handle case that metadata generated/exists but return null due to group membership change

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_EXISTS;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_GENERATED;
 
 /**
@@ -271,8 +272,14 @@ public abstract class IndexingContentManagerDecorator
                 transfer = delegate.retrieve( store, path, eventMetadata );
                 if ( !exists( transfer ) )
                 {
-                    Boolean isGenerated = (Boolean) eventMetadata.get( GROUP_METADATA_GENERATED );
-                    if ( isGenerated == null || !isGenerated ) // generated but missing, not add to nfc so next req can try again
+                    Boolean metadataGenerated = (Boolean) eventMetadata.get( GROUP_METADATA_GENERATED );
+                    Boolean metadataExists = (Boolean) eventMetadata.get( GROUP_METADATA_EXISTS );
+
+                    if ( Boolean.TRUE.equals( metadataGenerated ) || Boolean.TRUE.equals( metadataExists ) )
+                    {
+                        ; // metadata generated/exists but missing due to membership change, not add to nfc so next req can retry
+                    }
+                    else
                     {
                         nfc.addMissing( resource );
                     }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -87,6 +87,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
+import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_EXISTS;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_GENERATED;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
@@ -377,6 +378,7 @@ public class MavenMetadataGenerator
                     {
                         // Means there is no metadata change if this transfer exists, so directly return it.
                         logger.trace( "Metadata file exists for group {} of path {}, no need to regenerate.", group.getKey(), path );
+                        eventMetadata.set( GROUP_METADATA_EXISTS, true );
                         return target;
                     }
                     logger.trace( "Metadata file lost for group {} of path {}, will regenerate.", group.getKey(), path );

--- a/core/src/main/java/org/commonjava/indy/core/content/group/GroupMergeHelper.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/group/GroupMergeHelper.java
@@ -37,6 +37,8 @@ public class GroupMergeHelper
 
     public static final String GROUP_METADATA_GENERATED = "group-metadata-generated";
 
+    public static final String GROUP_METADATA_EXISTS = "group-metadata-exists";
+
     public static final String MERGEINFO_SUFFIX = ".info";
 
     public static final String SHA_SUFFIX = ".sha";

--- a/db/flat/src/main/java/org/commonjava/indy/flat/data/DataFileStoreDataManager.java
+++ b/db/flat/src/main/java/org/commonjava/indy/flat/data/DataFileStoreDataManager.java
@@ -72,6 +72,7 @@ public class DataFileStoreDataManager
         super( dispatcher, config );
         this.manager = manager;
         this.serializer = serializer;
+        this.started = true;
     }
 
     @PostConstruct

--- a/embedder-tests/savant/pom.xml
+++ b/embedder-tests/savant/pom.xml
@@ -113,22 +113,45 @@
     <plugins>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
-          <configuration>
-            <dependenciesToScan>
-              <dependency>org.commonjava.indy:indy-ftests-autoprox</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-core</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-dot-maven</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-folo</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-koji</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-httprox</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-implied-repos</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-promote</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-diagnostics</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-pkg-maven</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-relate</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-pkg-npm</dependency>
-            </dependenciesToScan> 
-          </configuration>
+        <configuration>
+          <dependenciesToScan>
+            <dependency>org.commonjava.indy:indy-ftests-autoprox</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-core</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-dot-maven</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-folo</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-koji</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-httprox</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-implied-repos</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-promote</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-diagnostics</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-pkg-maven</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-relate</dependency>
+            <dependency>org.commonjava.indy:indy-ftests-pkg-npm</dependency>
+          </dependenciesToScan>
+        </configuration>
+        <executions>
+          <execution>
+            <id>integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <excludedGroups>org.commonjava.indy.ftest.core.category.BytemanTest</excludedGroups>
+            </configuration>
+          </execution>
+          <execution>
+            <id>byteman-ftests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <forkCount>1</forkCount>
+              <groups>org.commonjava.indy.ftest.core.category.BytemanTest</groups>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMembershipAddMayDisruptMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMembershipAddMayDisruptMetadataTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.ftest.core.category.BytemanTest;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.jgroups.util.Util.assertTrue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>RemoteRepositories A, B, and C, each containing metadata paths P</li>
+ *     <li>Group G with A and B members</li>
+ *     <li>Group G metadata path P has NOT been generated</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Actions of Users 1 and 2 coordinated by Byteman to expose race condition</li>
+ *     <li>User 1 GET: path P from Group G</li>
+ *     <li>User 2 POST: add C to Group G membership</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>User 1 request get null due to the addition of C, which causes metadata being deleted</li>
+ *     <li>User 2 request deletes path P maven-metadata.xml</li>
+ *     <li>User 1 request the second time and get the right metadata</li>
+ * </ul>
+ */
+@RunWith( BMUnitRunner.class )
+@BMUnitConfig( debug = true )
+public class GroupMembershipAddMayDisruptMetadataTest
+        extends GroupMembershipChangeUpdateMetadataTest
+{
+    @BMRules( rules = {
+        @BMRule(
+            name = "Create Rendezvous",
+            targetClass = "MavenMetadataGenerator",
+            targetMethod = "<init>",
+            targetLocation = "ENTRY",
+            action = "createRendezvous(\"myRendezvous\", 2)" ),
+        @BMRule(
+            name = "Wait after generateGroupFileContent",
+            targetClass = "MavenMetadataGenerator",
+            targetMethod = "generateGroupFileContent",
+            targetLocation = "EXIT",
+            action = "debug(\"generateGroupFileContent waiting...\"); rendezvous(\"myRendezvous\"); debug(\"generateGroupFileContent go.\")" ),
+        @BMRule(
+            name = "Wait after storeArtifactStore",
+            targetClass = "MemoryStoreDataManager",
+            targetMethod = "storeArtifactStore",
+            targetLocation = "EXIT",
+            action = "debug(\"storeArtifactStore waiting...\"); rendezvous(\"myRendezvous\"); debug(\"storeArtifactStore go.\")" ),
+    } )
+    @Test
+    @Category( BytemanTest.class )
+    public void run()
+            throws Exception
+    {
+        prepare();
+
+        ExecutorService fixedPool = Executors.newFixedThreadPool( 2 );
+
+        Callable<String> groupMetaTask = new GroupMetaCallable( path_P );
+        Future<String> user1 = fixedPool.submit( groupMetaTask );
+
+        Thread.sleep( 3000 ); // wait for a while for user1 reach rendezvous
+
+        Callable<String> groupAddTask = new GroupAddCallable( remoteRepositoryC.getKey() );
+        Future<String> user2 = fixedPool.submit( groupAddTask );
+
+        String metadata = user1.get();
+        String retCode = user2.get();
+
+        assertThat( metadata, equalTo( null ) ); // return null due to the deletion of group metadata
+        assertThat( retCode, equalTo( "OK" ) );
+
+        // get it again and return right metadata
+        user1 = fixedPool.submit( groupMetaTask );
+        metadata = user1.get();
+        assertThat( metadata, equalTo( mergedContent_ABC ) );
+
+        fixedPool.shutdown(); // shut down
+    }
+
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMembershipChangeUpdateMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMembershipChangeUpdateMetadataTest.java
@@ -1,0 +1,315 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>RemoteRepositories A, B, and C, each containing metadata paths P</li>
+ *     <li>Group G with A and B members</li>
+ *     <li>Group G metadata path P has NOT been generated</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>User 1 GET: path P from Group G</li>
+ *     <li>User 1 POST: add C to Group G membership</li>
+ *     <li>User 1 GET: path P from Group G</li>
+ *     <li>User 1 POST: delete C from Group G membership</li>
+ *     <li>User 1 GET: path P from Group G</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>User 1 get merged content from (A, B) for the first time</li>
+ *     <li>User 1 get merged content from (A, B, C) after adding C to group G</li>
+ *     <li>User 1 get merged content from (A, B) after removing C from group G</li>
+ * </ul>
+ */
+public class GroupMembershipChangeUpdateMetadataTest
+        extends AbstractIndyFunctionalTest
+{
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    final String path_P = "org/foo/bar/maven-metadata.xml";
+
+    /* @formatter:off */
+    final String repoContent_A = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>1.0</latest>\n" +
+        "    <release>1.0</release>\n" +
+        "    <versions>\n" +
+        "      <version>1.0</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20150721164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    /* @formatter:off */
+    final String repoContent_B = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>2.0</latest>\n" +
+        "    <release>2.0</release>\n" +
+        "    <versions>\n" +
+        "      <version>2.0</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20160722164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    /* @formatter:off */
+    final String repoContent_C = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>3.0</latest>\n" +
+        "    <release>3.0</release>\n" +
+        "    <versions>\n" +
+        "      <version>3.0</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20170722164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    /* @formatter:off */
+    final String mergedContent_AB = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>2.0</latest>\n" +
+        "    <release>2.0</release>\n" +
+        "    <versions>\n" +
+        "      <version>1.0</version>\n" +
+        "      <version>2.0</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20160722164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    /* @formatter:off */
+    final String mergedContent_ABC = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>3.0</latest>\n" +
+        "    <release>3.0</release>\n" +
+        "    <versions>\n" +
+        "      <version>1.0</version>\n" +
+        "      <version>2.0</version>\n" +
+        "      <version>3.0</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20170722164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    RemoteRepository remoteRepositoryA, remoteRepositoryB, remoteRepositoryC;
+
+    Group g;
+
+    /**
+     * Create remote repo A, B and C; register content for path P; add repo A and B to group G.
+     */
+    protected void prepare() throws Exception
+    {
+        final String repoA = "remote-A";
+        final String repoB = "remote-B";
+        final String repoC = "remote-C";
+
+        final String groupName = "group-1";
+
+        server.expect( server.formatUrl( repoA, path_P ), 200, repoContent_A );
+        server.expect( server.formatUrl( repoB, path_P ), 200, repoContent_B );
+        server.expect( server.formatUrl( repoC, path_P ), 200, repoContent_C );
+
+        remoteRepositoryA = new RemoteRepository( repoA, server.formatUrl( repoA ) );
+        remoteRepositoryB = new RemoteRepository( repoB, server.formatUrl( repoB ) );
+        remoteRepositoryC = new RemoteRepository( repoC, server.formatUrl( repoC ) );
+
+        client.stores().create( remoteRepositoryA, "adding remote-A", RemoteRepository.class );
+        client.stores().create( remoteRepositoryB, "adding remote-B", RemoteRepository.class );
+        client.stores().create( remoteRepositoryC, "adding remote-C", RemoteRepository.class );
+
+        g = new Group( groupName, remoteRepositoryA.getKey(), remoteRepositoryB.getKey() );
+        client.stores().create( g, "adding group (with repo A and B)", Group.class );
+    }
+
+    class GroupMetaCallable
+                    implements Callable<String>
+    {
+        private String path;
+
+        GroupMetaCallable( String path )
+        {
+            this.path = path;
+        }
+
+        @Override
+        public String call() throws Exception
+        {
+            try (InputStream in = client.content().get( g.getKey(), path ))
+            {
+                if ( in != null )
+                {
+                    return IOUtils.toString( in );
+                }
+                return null;
+            }
+        }
+    }
+
+    class GroupAddCallable
+                    implements Callable<String>
+    {
+        private StoreKey storeKey;
+
+        GroupAddCallable( StoreKey key )
+        {
+            this.storeKey = key;
+        }
+
+        @Override
+        public String call() throws Exception
+        {
+            try
+            {
+                g.addConstituent( storeKey );
+                client.stores().update( g, "add to group" );
+            }
+            catch ( IndyClientException e )
+            {
+                e.printStackTrace();
+                return "ERROR";
+            }
+            return "OK";
+        }
+    }
+
+    class GroupDeleteCallable
+                    implements Callable<String>
+    {
+        private StoreKey storeKey;
+
+        GroupDeleteCallable( StoreKey key )
+        {
+            this.storeKey = key;
+        }
+
+        @Override
+        public String call() throws Exception
+        {
+            try
+            {
+                g.removeConstituent( storeKey );
+                client.stores().update( g, "remove from group" );
+            }
+            catch ( IndyClientException e )
+            {
+                e.printStackTrace();
+                return "ERROR";
+            }
+            return "OK";
+        }
+    }
+
+    @Test
+    public void run()
+                    throws Exception
+    {
+        prepare();
+
+        ExecutorService fixedPool = Executors.newFixedThreadPool( 1 );
+
+        // Get merged from A, B
+        Callable<String> groupMetaTask = new GroupMetaCallable( path_P );
+        Future<String> user1 = fixedPool.submit( groupMetaTask );
+        String metadata = user1.get();
+        assertThat( metadata, equalTo( mergedContent_AB ) );
+
+        // Add remote repo C to group
+        Callable<String> groupAddTask = new GroupAddCallable( remoteRepositoryC.getKey() );
+        user1 = fixedPool.submit( groupAddTask );
+        String retCode = user1.get();
+        assertThat( retCode, equalTo( "OK" ) );
+
+        checkGroupMembership( remoteRepositoryA.getKey(), remoteRepositoryB.getKey(), remoteRepositoryC.getKey() );
+
+        // Get merged from A, B, C
+        user1 = fixedPool.submit( groupMetaTask );
+        metadata = user1.get();
+        assertThat( metadata, equalTo( mergedContent_ABC ) ); // FAILS! should merge all remote repo's metadata
+
+        // Remove remote repo C from group
+        Callable<String> groupDeleteTask = new GroupDeleteCallable( remoteRepositoryC.getKey() );
+        user1 = fixedPool.submit( groupDeleteTask );
+        retCode = user1.get();
+        assertThat( retCode, equalTo( "OK" ) );
+
+        checkGroupMembership( remoteRepositoryA.getKey(), remoteRepositoryB.getKey() );
+
+        // Get merged from A, B
+        user1 = fixedPool.submit( groupMetaTask );
+        metadata = user1.get();
+        assertThat( metadata, equalTo( mergedContent_AB ) );
+
+        fixedPool.shutdown(); // shut down
+    }
+
+    private void checkGroupMembership( StoreKey ... keys )
+                    throws Exception
+    {
+        Group retrieved = client.stores().listGroups().getItems().stream()
+                                .filter( grp -> grp.getName().equals( g.getName() ) ).findFirst().get();
+        assertThat( retrieved.getConstituents().containsAll( Arrays.asList( keys ) ), equalTo( true ) );
+    }
+
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMembershipDeletionMayDisruptMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMembershipDeletionMayDisruptMetadataTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.ftest.core.category.BytemanTest;
+import org.jboss.byteman.contrib.bmunit.BMRule;
+import org.jboss.byteman.contrib.bmunit.BMRules;
+import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
+import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>RemoteRepositories A and B, each containing metadata paths P</li>
+ *     <li>Group G with A and B members</li>
+ *     <li>Group G metadata path P has been generated</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Actions of Users 1 and 2 coordinated by Byteman to expose race condition</li>
+ *     <li>User 1 GET: path P from Group G</li>
+ *     <li>User 2 DELETE: remove repository B</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>User 1 request get null due to the deletion of B, which causes metadata being deleted</li>
+ *     <li>User 2 deletes path P metadata.xml from Group G</li>
+ *     <li>User 1 request the second time and get the right metadata</li>
+ * </ul>
+ */
+@RunWith( BMUnitRunner.class )
+@BMUnitConfig( debug = true )
+public class GroupMembershipDeletionMayDisruptMetadataTest
+        extends GroupMembershipChangeUpdateMetadataTest
+{
+    /*
+     * This flag is used to indicate the path_P has been generated.
+     * This is different from GroupMembershipAddMayDisruptMetadataTest to cover another case where the group metadata
+     * has been generated but GET request can still get null due to group membership change.
+     */
+    static boolean prepareDone = false;
+
+    public static boolean isPrepareDone()
+    {
+        return prepareDone;
+    }
+
+    @BMRules( rules = {
+        @BMRule(
+            name = "Create Rendezvous",
+            targetClass = "MavenMetadataGenerator",
+            targetMethod = "<init>",
+            targetLocation = "ENTRY",
+            action = "createRendezvous(\"myRendezvous\", 2)" ),
+        @BMRule(
+            name = "Wait after generateGroupFileContent",
+            targetClass = "MavenMetadataGenerator",
+            targetMethod = "generateGroupFileContent",
+            targetLocation = "EXIT",
+            condition = "org.commonjava.indy.ftest.core.content.GroupMembershipDeletionMayDisruptMetadataTest.isPrepareDone()",
+            action = "debug(\"generateGroupFileContent waiting...\"); rendezvous(\"myRendezvous\"); debug(\"generateGroupFileContent go.\")" ),
+        @BMRule(
+            name = "Wait after storeArtifactStore",
+            targetClass = "MemoryStoreDataManager",
+            targetMethod = "storeArtifactStore",
+            targetLocation = "EXIT",
+            action = "debug(\"storeArtifactStore waiting...\"); rendezvous(\"myRendezvous\"); debug(\"storeArtifactStore go.\")" ),
+    } )
+    @Test
+    @Category( BytemanTest.class )
+    public void run()
+            throws Exception
+    {
+        prepare();
+
+        ExecutorService fixedPool = Executors.newFixedThreadPool( 2 );
+
+        // Send request for path_P to force group metadata generation
+        GroupMetaCallable groupMetaTask = new GroupMetaCallable( path_P );
+        Future<String> user1 = fixedPool.submit( groupMetaTask );
+        user1.get();
+
+        prepareDone = true;
+
+        // request for path_P again, this time rendezvous come in
+        user1 = fixedPool.submit( groupMetaTask );
+
+        Callable<String> deleteTask = new GroupDeleteCallable( remoteRepositoryB.getKey() );
+        Future<String> user2 = fixedPool.submit( deleteTask );
+
+        String metadata = user1.get();
+        String retCode = user2.get();
+
+        assertThat( metadata, equalTo( null ) ); // return null due to the deletion of B
+        assertThat( retCode, equalTo( "OK" ) );
+
+        // get it again and return right metadata
+        user1 = fixedPool.submit( groupMetaTask );
+        metadata = user1.get();
+        assertThat( metadata, equalTo( repoContent_A ) );
+
+        fixedPool.shutdown(); // shut down
+    }
+
+}


### PR DESCRIPTION
 1. Allow return null but not add the result to NFC so next req can try again
 2. Add positive test GroupMembershipChangeUpdateMetadataTest
 3. Add Byteman tests GroupMembershipAdd/DeletionMayDisruptMetadataTest