### PR TITLE
[npm] resolve npm response header customized content-type, http-meta mapping fetching path, and remote re-download mapping path issue

### DIFF
--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
@@ -257,7 +258,7 @@ public class NPMContentAccessHandler
 
                     final Response.ResponseBuilder builder = Response.ok();
 
-                    setInfoHeaders( builder, item, sk, path, true, contentController.getNPMContentType( path ),
+                    setInfoHeaders( builder, item, sk, path, true, getNPMContentType( path ),
                                     httpMetadata );
                     if ( builderModifier != null )
                     {
@@ -418,7 +419,7 @@ public class NPMContentAccessHandler
                         // open the stream here to prevent deletion while waiting for the transfer back to the user to start...
                         InputStream in = item.openInputStream( true, eventMetadata );
                         final Response.ResponseBuilder builder = Response.ok( new TransferStreamingOutput( in ) );
-                        setInfoHeaders( builder, item, sk, path, false, contentController.getNPMContentType( path ),
+                        setInfoHeaders( builder, item, sk, path, false, getNPMContentType( path ),
                                         contentController.getHttpMetadata( item ) );
                         response = responseWithBuilder( builder, builderModifier );
                         // generating .http-metadata.json for npm group and remote retrieve to resolve header requirements
@@ -611,5 +612,16 @@ public class NPMContentAccessHandler
             builderModifier.accept( builder );
         }
         return builder.build();
+    }
+
+
+    private String getNPMContentType( final String path )
+    {
+        String type = MediaType.APPLICATION_JSON;
+        if ( path.endsWith( ".tgz" ) )
+        {
+            type = MediaType.APPLICATION_OCTET_STREAM;
+        }
+        return type;
     }
 }

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -26,10 +26,12 @@ import org.commonjava.indy.core.model.StoreHttpExchangeMetadata;
 import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.util.HttpUtils;
 import org.commonjava.indy.pkg.npm.content.group.PackageMetadataMerger;
 import org.commonjava.indy.pkg.npm.inject.NPMContentHandler;
 import org.commonjava.indy.util.AcceptInfo;
 import org.commonjava.indy.util.ApplicationContent;
+import org.commonjava.indy.util.ApplicationHeader;
 import org.commonjava.maven.galley.TransferManager;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.ConcreteResource;
@@ -43,7 +45,6 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,8 +62,8 @@ import java.util.function.Supplier;
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithEntity;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
+import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponseFromMetadata;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.setInfoHeaders;
-import static org.commonjava.indy.core.ctl.ContentController.LISTING_HTML_FILE;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 
 @ApplicationScoped
@@ -157,6 +158,149 @@ public class NPMContentAccessHandler
     }
 
     @Override
+    public Response doHead( final String packageType, final String type, final String name, final String path,
+                            final Boolean cacheOnly, final String baseUri, final HttpServletRequest request,
+                            EventMetadata eventMetadata )
+    {
+        return doHead( packageType, type, name, path, cacheOnly, baseUri, request, eventMetadata, null );
+    }
+
+    @Override
+    public Response doHead( final String packageType, final String type, final String name, final String path,
+                            final Boolean cacheOnly, final String baseUri, final HttpServletRequest request,
+                            EventMetadata eventMetadata, final Consumer<Response.ResponseBuilder> builderModifier )
+    {
+        if ( !PackageTypes.contains( packageType ) )
+        {
+            Response.ResponseBuilder builder = Response.status( 400 );
+            if ( builderModifier != null )
+            {
+                builderModifier.accept( builder );
+            }
+            return builder.build();
+        }
+
+        final StoreType st = StoreType.get( type );
+        final StoreKey sk = new StoreKey( packageType, st, name );
+
+        eventMetadata = eventMetadata.set( ContentManager.ENTRY_POINT_STORE, sk );
+
+        final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.text_html );
+
+        Response response = null;
+
+        if ( path == null || path.equals( "" ) )
+        {
+            try
+            {
+                logger.info( "Getting listing at: {}", path );
+                final String content =
+                        contentController.renderListing( acceptInfo.getBaseAccept(), sk, path, baseUri, uriFormatter );
+
+                Response.ResponseBuilder builder = Response.ok()
+                                                           .header( ApplicationHeader.content_type.key(),
+                                                                    acceptInfo.getRawAccept() )
+                                                           .header( ApplicationHeader.content_length.key(),
+                                                                    Long.toString( content.length() ) )
+                                                           .header( ApplicationHeader.last_modified.key(),
+                                                                    HttpUtils.formatDateHeader( new Date() ) );
+                if ( builderModifier != null )
+                {
+                    builderModifier.accept( builder );
+                }
+                response = builder.build();
+            }
+            catch ( final IndyWorkflowException e )
+            {
+                logger.error(
+                        String.format( "Failed to list content: %s from: %s. Reason: %s", path, name, e.getMessage() ),
+                        e );
+                response = formatResponse( e, builderModifier );
+            }
+        }
+        else
+        {
+            try
+            {
+                Transfer item = null;
+                logger.info( "Checking existence of: {}:{} (cache only? {})", sk, path, cacheOnly );
+
+                boolean exists = false;
+                if ( Boolean.TRUE.equals( cacheOnly ) )
+                {
+                    logger.debug( "Calling getTransfer()" );
+                    item = contentController.getTransfer( sk, path, TransferOperation.DOWNLOAD );
+                    exists = item != null && item.exists();
+                    logger.debug( "Got transfer reference: {}", item );
+                }
+                else
+                {
+                    logger.debug( "Calling remote exists()" );
+                    exists = contentController.exists( sk, path );
+                    logger.debug( "Got remote exists: {}", exists );
+                }
+
+                if ( exists )
+                {
+                    // for npm will fetch the http-meta as the mapping path directly to get the headers info for further header set
+                    HttpExchangeMetadata httpMetadata =
+                            contentController.getHttpMetadata( sk, PathUtils.storagePath( path, eventMetadata ) );
+
+                    if ( item == null )
+                    {
+                        logger.info( "Retrieving: {}:{} for existence test", sk, path );
+                        item = contentController.get( sk, path, eventMetadata );
+                        logger.debug( "Got retrieved transfer reference: {}", item );
+                    }
+
+                    logger.debug( "Building 200 response. Using HTTP metadata: {}", httpMetadata );
+
+                    final Response.ResponseBuilder builder = Response.ok();
+
+                    setInfoHeaders( builder, item, sk, path, true, contentController.getNPMContentType( path ),
+                                    httpMetadata );
+                    if ( builderModifier != null )
+                    {
+                        builderModifier.accept( builder );
+                    }
+                    response = builder.build();
+                }
+                else
+                {
+                    logger.debug( "Building 404 (or error) response..." );
+                    if ( StoreType.remote == st )
+                    {
+                        final HttpExchangeMetadata metadata = contentController.getHttpMetadata( sk, path );
+                        if ( metadata != null )
+                        {
+                            logger.debug( "Using HTTP metadata to build negative response." );
+                            response = formatResponseFromMetadata( metadata );
+                        }
+                    }
+
+                    if ( response == null )
+                    {
+                        logger.debug( "No HTTP metadata; building generic 404 response." );
+                        Response.ResponseBuilder builder = Response.status( Response.Status.NOT_FOUND );
+                        if ( builderModifier != null )
+                        {
+                            builderModifier.accept( builder );
+                        }
+                        response = builder.build();
+                    }
+                }
+            }
+            catch ( final IndyWorkflowException e )
+            {
+                logger.error( String.format( "Failed to download artifact: %s from: %s. Reason: %s", path, name,
+                                             e.getMessage() ), e );
+                response = formatResponse( e, builderModifier );
+            }
+        }
+        return response;
+    }
+
+    @Override
     public Response doGet( String packageType, String type, String name, String path, String baseUri,
                            HttpServletRequest request, EventMetadata eventMetadata )
     {
@@ -193,8 +337,7 @@ public class NPMContentAccessHandler
                 "GET path: '{}' (RAW: '{}')\nIn store: '{}'\nUser addMetadata header is: '{}'\nStandard addMetadata header for that is: '{}'",
                 path, request.getPathInfo(), sk, acceptInfo.getRawAccept(), standardAccept );
 
-        if ( path == null || path.equals( "" ) || request.getPathInfo().endsWith( "/" ) || path.endsWith(
-                LISTING_HTML_FILE ) )
+        if ( path == null || path.equals( "" ) )
         {
             try
             {
@@ -221,7 +364,7 @@ public class NPMContentAccessHandler
                     path = PathUtils.storagePath( path, eventMetadata );
                 }
                 logger.info( "START: retrieval of content: {}:{}", sk, path );
-                final Transfer item = contentController.get( sk, path, eventMetadata );
+                Transfer item = contentController.get( sk, path, eventMetadata );
 
                 logger.info( "HANDLE: retrieval of content: {}:{}", sk, path );
                 if ( item == null )
@@ -242,7 +385,7 @@ public class NPMContentAccessHandler
                     {
                         return handleMissingContentQuery( sk, path, builderModifier );
                     }
-                    else if ( item.isDirectory() )
+                    else if ( item.isDirectory() && StoreType.remote != st )
                     {
                         try
                         {
@@ -264,15 +407,24 @@ public class NPMContentAccessHandler
                     }
                     else
                     {
+                        // for remote retrieve, when content has downloaded and cached in the mapping path,
+                        // the item here will be a directory, so reassign the path and item as the mapping one
+                        if ( item.isDirectory() && StoreType.remote == st )
+                        {
+                            path = PathUtils.storagePath( path, eventMetadata );
+                            item = contentController.get( sk, path, eventMetadata );
+                        }
                         logger.info( "RETURNING: retrieval of content: {}:{}", sk, path );
                         // open the stream here to prevent deletion while waiting for the transfer back to the user to start...
                         InputStream in = item.openInputStream( true, eventMetadata );
                         final Response.ResponseBuilder builder = Response.ok( new TransferStreamingOutput( in ) );
-                        setInfoHeaders( builder, item, sk, path, false, MediaType.APPLICATION_JSON,
+                        setInfoHeaders( builder, item, sk, path, false, contentController.getNPMContentType( path ),
                                         contentController.getHttpMetadata( item ) );
                         response = responseWithBuilder( builder, builderModifier );
-                        // generating .http-metadata.json for npm group retrieve to resolve header requirements
-                        if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.group == st )
+                        // generating .http-metadata.json for npm group and remote retrieve to resolve header requirements
+                        // hosted .http-metadata.json will be generated when publish
+                        // only package.json file will generate this customized http meta to satisfy npm client header check
+                        if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.hosted != st )
                         {
                             generateHttpMetadataHeaders( item, request, response );
                         }
@@ -397,8 +549,12 @@ public class NPMContentAccessHandler
             return;
         }
 
-        Response responseWithLastModified =
-                Response.fromResponse( response ).lastModified( new Date( transfer.lastModified() ) ).build();
+        Response customizedResponse = Response.fromResponse( response )
+                                              .header( ApplicationHeader.content_length.upperKey(), transfer.length() )
+                                              .header( ApplicationHeader.indy_origin.upperKey(), null )
+                                              .header( ApplicationHeader.transfer_encoding.upperKey(), null )
+                                              .lastModified( new Date( transfer.lastModified() ) )
+                                              .build();
 
         Transfer metaTxfr = transfer.getSiblingMeta( HttpExchangeMetadata.FILE_EXTENSION );
         if ( metaTxfr == null )
@@ -413,7 +569,7 @@ public class NPMContentAccessHandler
             }
         }
 
-        final HttpExchangeMetadata metadata = new StoreHttpExchangeMetadata( request, responseWithLastModified );
+        final HttpExchangeMetadata metadata = new StoreHttpExchangeMetadata( request, customizedResponse );
 
         try (OutputStream out = metaTxfr.openOutputStream( TransferOperation.GENERATE, false ))
         {

--- a/api/src/main/java/org/commonjava/indy/util/ApplicationHeader.java
+++ b/api/src/main/java/org/commonjava/indy/util/ApplicationHeader.java
@@ -31,7 +31,8 @@ public enum ApplicationHeader
     proxy_authorization( "Proxy-Authorization" ),
     cache_control( "Cache-Control" ),
     content_disposition( "Content-Disposition" ),
-    indy_origin("Indy-Origin");
+    indy_origin( "Indy-Origin" ),
+    transfer_encoding( "Transfer-Encoding" );
 
     private final String key;
 

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -152,16 +152,6 @@ public class ContentController
         return mimeTyper.getContentType( path );
     }
 
-    public String getNPMContentType( final String path )
-    {
-        String type = MediaType.APPLICATION_JSON;
-        if ( path.endsWith( ".tgz" ) )
-        {
-            type = MediaType.APPLICATION_OCTET_STREAM;
-        }
-        return type;
-    }
-
     public Transfer store( final StoreType type, final String name, final String path, final InputStream stream )
         throws IndyWorkflowException
     {

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -17,11 +17,9 @@ package org.commonjava.indy.core.ctl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.StoreResource;
-import org.commonjava.indy.core.model.StoreHttpExchangeMetadata;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
@@ -45,17 +43,14 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.core.Response;
+import javax.ws.rs.core.MediaType;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -155,6 +150,16 @@ public class ContentController
     public String getContentType( final String path )
     {
         return mimeTyper.getContentType( path );
+    }
+
+    public String getNPMContentType( final String path )
+    {
+        String type = MediaType.APPLICATION_JSON;
+        if ( path.endsWith( ".tgz" ) )
+        {
+            type = MediaType.APPLICATION_OCTET_STREAM;
+        }
+        return type;
     }
 
     public Transfer store( final StoreType type, final String name, final String path, final InputStream stream )


### PR DESCRIPTION
- npm response content-type should be distinctive for json and tarball.
- npm doHead method should fetch the http-meta as the mapping path directly to get the headers info for further header set.
- npm remote retrieves the content which has downloaded once, should turn to the content of mapping path.