### PR TITLE
[1.2.x] Minor test script changes, and make ArtifactStore Locations sticky

### DIFF
--- a/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
@@ -41,11 +41,14 @@ public class CacheOnlyLocation
 
     private final boolean isAllowReleases;
 
+    private final boolean isReadOnly;
+
     public CacheOnlyLocation( final HostedRepository repo )
     {
         this.isHosted = true;
         this.isAllowReleases = repo.isAllowReleases();
         this.isAllowSnapshots = repo.isAllowSnapshots();
+        this.isReadOnly = repo.isReadonly();
 
         if ( repo.getStorage() != null )
         {
@@ -60,6 +63,7 @@ public class CacheOnlyLocation
         this.isHosted = false;
         this.isAllowReleases = true;
         this.isAllowSnapshots = false;
+        this.isReadOnly = true;
 
         this.key = key;
     }
@@ -78,7 +82,7 @@ public class CacheOnlyLocation
     @Override
     public boolean allowsStoring()
     {
-        return repo != null && !repo.isReadonly();
+        return isReadOnly;
     }
 
     @Override
@@ -96,7 +100,7 @@ public class CacheOnlyLocation
     @Override
     public boolean allowsDeletion()
     {
-        return repo != null && !repo.isReadonly();
+        return isReadOnly;
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
@@ -82,7 +82,7 @@ public class CacheOnlyLocation
     @Override
     public boolean allowsStoring()
     {
-        return isReadOnly;
+        return !isReadOnly;
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
@@ -19,6 +19,8 @@ import org.commonjava.indy.content.IndyLocationExpander;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.model.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -82,7 +84,7 @@ public class CacheOnlyLocation
     @Override
     public boolean allowsStoring()
     {
-        return !isReadOnly;
+        return isHosted && !isReadOnly;
     }
 
     @Override
@@ -100,7 +102,7 @@ public class CacheOnlyLocation
     @Override
     public boolean allowsDeletion()
     {
-        return !isReadOnly;
+        return isHosted && !isReadOnly;
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
@@ -31,15 +31,22 @@ public class CacheOnlyLocation
     implements KeyedLocation
 {
 
-    private final HostedRepository repo;
-
     private final Map<String, Object> attributes = new HashMap<String, Object>();
 
     private final StoreKey key;
 
+    private final boolean isHosted;
+
+    private final boolean isAllowSnapshots;
+
+    private final boolean isAllowReleases;
+
     public CacheOnlyLocation( final HostedRepository repo )
     {
-        this.repo = repo;
+        this.isHosted = true;
+        this.isAllowReleases = repo.isAllowReleases();
+        this.isAllowSnapshots = repo.isAllowSnapshots();
+
         if ( repo.getStorage() != null )
         {
             attributes.put( Location.ATTR_ALT_STORAGE_LOCATION, repo.getStorage() );
@@ -50,13 +57,16 @@ public class CacheOnlyLocation
 
     public CacheOnlyLocation( final StoreKey key )
     {
-        this.repo = null;
+        this.isHosted = false;
+        this.isAllowReleases = true;
+        this.isAllowSnapshots = false;
+
         this.key = key;
     }
 
     public boolean isHostedRepository()
     {
-        return repo != null;
+        return isHosted;
     }
 
     @Override
@@ -74,13 +84,13 @@ public class CacheOnlyLocation
     @Override
     public boolean allowsSnapshots()
     {
-        return repo != null && repo.isAllowSnapshots();
+        return isAllowSnapshots;
     }
 
     @Override
     public boolean allowsReleases()
     {
-        return repo == null || repo.isAllowReleases();
+        return isAllowReleases;
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
@@ -100,7 +100,7 @@ public class CacheOnlyLocation
     @Override
     public boolean allowsDeletion()
     {
-        return isReadOnly;
+        return !isReadOnly;
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/model/galley/LocationStoreUpdateListener.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/LocationStoreUpdateListener.java
@@ -1,0 +1,33 @@
+package org.commonjava.indy.model.galley;
+
+import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;
+import org.commonjava.indy.util.LocationUtils;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+/**
+ * This listener is responsible for clearing / re-creating {@link org.commonjava.maven.galley.model.Location}
+ * instances associated with {@link org.commonjava.indy.model.core.ArtifactStore}s when the store gets updated.
+ * Any number of configuration parameters on the store can change the way the location instance behaves, so the
+ * location has to be synchronized to the new store state.
+ *
+ * We're caching these location instances to avoid the need to re-create them for each new
+ * {@link org.commonjava.maven.galley.model.ConcreteResource}, which is often used as a key to a list of in-memory
+ * {@link org.commonjava.maven.galley.model.Transfer} instances, to help with file locking in Galley's
+ * {@link org.commonjava.maven.galley.spi.cache.CacheProvider} implementations.
+ *
+ * Created by jdcasey on 10/26/17.
+ */
+@ApplicationScoped
+public class LocationStoreUpdateListener
+{
+    public void storeUpdated( @Observes ArtifactStorePreUpdateEvent event )
+    {
+        event.forEach( (store)->{
+            // remove and re-initialize the associated KeyedLocation.
+            store.removeTransientMetadata( LocationUtils.KEYED_LOCATION_METADATA );
+            LocationUtils.toLocation( store );
+        } );
+    }
+}

--- a/api/src/main/java/org/commonjava/indy/util/LocationUtils.java
+++ b/api/src/main/java/org/commonjava/indy/util/LocationUtils.java
@@ -39,6 +39,8 @@ public final class LocationUtils
 {
     public static final String PATH_STYLE = "pathStyle";
 
+    public static final String KEYED_LOCATION_METADATA = "keyedLocation";
+
     private LocationUtils()
     {
     }
@@ -50,10 +52,15 @@ public final class LocationUtils
             return null;
         }
 
+        KeyedLocation location = (KeyedLocation) store.getTransientMetadata( KEYED_LOCATION_METADATA );
+        if ( location != null )
+        {
+            return location;
+        }
+
         final StoreType type = store.getKey()
                                     .getType();
 
-        KeyedLocation location = null;
         switch ( type )
         {
             case group:
@@ -96,6 +103,8 @@ public final class LocationUtils
                 } );
             }
         }
+
+        store.setTransientMetadata( KEYED_LOCATION_METADATA, location );
 
         return location;
     }

--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -35,14 +35,19 @@ rm -rf indy
 tar -zxvf indy-launcher-savant-*-launcher.tar.gz
 
 if [ "x${TEST_REPOS}" != "x" ]; then
+  echo "Copying repository/group definitions from: ${TEST_REPOS}"
   rm -rf $REPO_BASE/*
   mkdir -p $REPO_BASE
   cp -rvf $TEST_REPOS/* $REPO_BASE
+else
+  echo "No test repositories specified."
 fi
 
 if [ "x${TEST_ETC}" != "x" ]; then
+  echo "Copying test configuration from: ${TEST_ETC}"
   cp -rvf $TEST_ETC/* $ETC_BASE
 else
+  echo "No test configuration specified."
   INDY_HOME=$PWD/indy
   cat > $ETC_BASE/logging/logback.xml <<-EOF
 <configuration>
@@ -82,4 +87,4 @@ fi
 
 popd
 
-exec $DIR/bin/debug-launcher.rb -e
+exec $DIR/deployments/launchers/savant/target/indy/bin/indy.sh

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedRepositoryDeleteNotAllowedWhenReadonly.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedRepositoryDeleteNotAllowedWhenReadonly.java
@@ -1,0 +1,54 @@
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Copy of org.commonjava.indy.core.content.DefaultDownloadManagerTest#getTransferFromNotAllowedDeletionStore_DownloadOp_ThrowException()
+ * that uses fully loaded CDI environment to propagate JEE events and handle clearing the CacheOnlyLocation when
+ * a store is updated.
+ *
+ * Created by jdcasey on 10/26/17.
+ */
+public class HostedRepositoryDeleteNotAllowedWhenReadonly
+    extends AbstractContentManagementTest
+{
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+
+    @Test( expected = IOException.class )
+    public void getTransferFromNotAllowedDeletionStore_DownloadOp_ThrowException() throws Exception
+    {
+        ChangeSummary summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, "Test setup" );
+        HostedRepository hosted = new HostedRepository( MAVEN_PKG_KEY, "one" );
+
+        hosted = client.stores().create( hosted, "Test setup", HostedRepository.class );
+
+        String originalString = "This is a test";
+        final String path = "/path/path";
+
+        client.content().store( hosted.getKey(), path, new ByteArrayInputStream( originalString.getBytes() ) );
+
+        hosted.setReadonly( true );
+        client.stores().update( hosted, "make readonly" );
+
+        client.content().delete( hosted.getKey(), path );
+    }
+
+}

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -191,6 +191,16 @@ public abstract class ArtifactStore
         return metadata == null ? null : metadata.get( key );
     }
 
+    public synchronized Object removeTransientMetadata( final String key )
+    {
+        if ( transientMetadata == null || key == null )
+        {
+            return null;
+        }
+
+        return transientMetadata.remove( key );
+    }
+
     public synchronized Object setTransientMetadata( final String key, final Object value )
     {
         if ( key == null || value == null )

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -54,7 +54,7 @@ public abstract class ArtifactStore
 
     private String description;
 
-    private transient Map<String, String> transientMetadata;
+    private transient Map<String, Object> transientMetadata;
 
     private Map<String, String> metadata;
 
@@ -191,7 +191,7 @@ public abstract class ArtifactStore
         return metadata == null ? null : metadata.get( key );
     }
 
-    public synchronized String setTransientMetadata( final String key, final String value )
+    public synchronized Object setTransientMetadata( final String key, final Object value )
     {
         if ( key == null || value == null )
         {
@@ -206,7 +206,7 @@ public abstract class ArtifactStore
         return transientMetadata.put( key, value );
     }
 
-    public String getTransientMetadata( final String key )
+    public Object getTransientMetadata( final String key )
     {
         return transientMetadata == null ? null : transientMetadata.get( key );
     }
@@ -221,12 +221,12 @@ public abstract class ArtifactStore
         store.setDisableTimeout( getDisableTimeout() );
     }
 
-    protected void setTransientMetadata( Map<String, String> transientMetadata )
+    protected void setTransientMetadata( Map<String, Object> transientMetadata )
     {
         this.transientMetadata = transientMetadata;
     }
 
-    protected Map<String, String> getTransientMetadata()
+    protected Map<String, Object> getTransientMetadata()
     {
         return transientMetadata;
     }

--- a/scripts/multibuild/mb/command.py
+++ b/scripts/multibuild/mb/command.py
@@ -51,7 +51,7 @@ def build(testfile, indy_url, delay, vagrant_dir):
         tid_base = "build_%s" % os.path.basename(project_dir)
 
         build = build_config['build']
-        report = build_config['report']
+        report = build_config.get('report')
 
         if build_config.get('vagrant') is not None:
             mb.vagrant.init_ssh_config(vagrant_dir)
@@ -83,12 +83,16 @@ def build(testfile, indy_url, delay, vagrant_dir):
                 mb.vagrant.vagrant_env(build_config, 'post-build', indy_url, vagrant_dir, project_dir, builds_dir)
                 mb.vagrant.vagrant_env(build_config, 'pre-report', indy_url, vagrant_dir, project_dir, builds_dir)
 
-            for t in range(int(report['threads'])):
-                thread = mb.reporter.Reporter(report_queue)
-                thread.daemon = True
-                thread.start()
+            if report is not None:
+                if build_config.get('vagrant') is not None:
+                    mb.vagrant.vagrant_env(build_config, 'pre-report', indy_url, vagrant_dir, project_dir, builds_dir)
 
-            report_queue.join()
+                for t in range(int(report['threads'])):
+                    thread = mb.reporter.Reporter(report_queue)
+                    thread.daemon = True
+                    thread.start()
+
+                report_queue.join()
         except Exception as e:
             print e
             print "Quitting."


### PR DESCRIPTION
Main change here is to make ArtifactStore keep the associated Location object as a transient metadata attached to the store to prevent recreating it, and save on object instances in the CacheProvider Transfer map.