### PR TITLE
fix potential NPE problem for metadata timeout schedule caused by ScheduleKey missing (empty values) in cache

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleKey.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleKey.java
@@ -96,4 +96,9 @@ public class ScheduleKey
     {
         return toStringKey();
     }
+
+    public boolean exists()
+    {
+        return this.storeKey != null && this.type != null;
+    }
 }

--- a/core/src/main/java/org/commonjava/indy/core/expire/StoreKeyMatcher.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/StoreKeyMatcher.java
@@ -48,7 +48,7 @@ public class StoreKeyMatcher
     {
         return cacheHandle.execute( Cache::keySet )
                           .stream()
-                          .filter( key -> key.groupName().equals( ScheduleManager.groupName( storeKey, eventType ) ) )
+                          .filter( key -> key != null && key.exists() && key.groupName().equals( ScheduleManager.groupName( storeKey, eventType ) ) )
                           .collect( Collectors.toSet() );
     }
 }


### PR DESCRIPTION
This is going to fix the bug of NOS-1108, although didn't catch the real configs to cause this when  maven-metadata download, it has been checked that this should occur in the process of cancelling/removing existed timeout schedules from cache, the code could prevent the NPE throw during that in some extent.