### PR TITLE
Guard against concurrent modification in NFC, add sweep configuration

### DIFF
--- a/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
@@ -39,6 +39,8 @@ public class DefaultIndyConfiguration
 
     public static final int DEFAULT_STORE_DISABLE_TIMEOUT_SECONDS = 1800; // 30 minutes
 
+    public static final int DEFAULT_NFC_EXPIRATION_SWEEP_MINUTES = 30;
+
     private Integer passthroughTimeoutSeconds;
 
     private Integer notFoundCacheTimeoutSeconds;
@@ -46,6 +48,8 @@ public class DefaultIndyConfiguration
     private Integer requestTimeoutSeconds;
 
     private Integer storeDisableTimeoutSeconds;
+
+    private Integer nfcExpirationSweepMinutes;
 
     public DefaultIndyConfiguration()
     {
@@ -91,6 +95,18 @@ public class DefaultIndyConfiguration
     public int getStoreDisableTimeoutSeconds()
     {
         return storeDisableTimeoutSeconds == null ? DEFAULT_STORE_DISABLE_TIMEOUT_SECONDS : storeDisableTimeoutSeconds;
+    }
+
+    @ConfigName( "nfc.sweep.minutes" )
+    public void setDefaultNfcExpirationSweepMinutes( final int minutes )
+    {
+        this.nfcExpirationSweepMinutes = nfcExpirationSweepMinutes;
+    }
+
+    @Override
+    public int getNfcExpirationSweepMinutes()
+    {
+        return nfcExpirationSweepMinutes == null ? DEFAULT_NFC_EXPIRATION_SWEEP_MINUTES : nfcExpirationSweepMinutes;
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/conf/IndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/IndyConfiguration.java
@@ -44,6 +44,12 @@ public interface IndyConfiguration
 
     int getStoreDisableTimeoutSeconds();
 
+    /**
+     * Number of minutes between sweeps of the NFC expiration reaper thread.
+     * @since 1.1.15
+     */
+    int getNfcExpirationSweepMinutes();
+
     File getIndyHomeDir();
 
     File getIndyConfDir();

--- a/core/src/main/resources/default-main.conf
+++ b/core/src/main/resources/default-main.conf
@@ -1,5 +1,6 @@
 # passthrough.timeout=300
 # nfc.timeout=300
+# nfc.sweep.minutes=30
 
 # Include addon-specific configurations (or really any configuration) from:
 Include conf.d/*.conf

--- a/deployments/launchers/base/src/main/conf/main.conf
+++ b/deployments/launchers/base/src/main/conf/main.conf
@@ -1,5 +1,6 @@
 # passthrough.timeout=300
 # nfc.timeout=300
+# nfc.sweep.minutes=30
 
 [ui]
 


### PR DESCRIPTION
We had a problem waiting to happen in the NFC. If the expiration reaper thread
was executing and iterating over a large set of entries, it might still be in
progress when Indy tried to add a new NFC entry. This would have resulted in
ConcurrentModificationException on the missingWithTimeout map. I have added
code to make defensive copies of the map keys whenever we need to iterate, and
to synchronize for any modification or large access of the map (including copying
the set of keys).

Additionally, the reaper thread was hard-coded to run every 8 hours, which is
really infrequent compared to the default 5-minute timeout of NFC entries. I
made this configurable in the Indy main.conf (nfc.sweep.minutes parameter),
and set the default value to 30 minutes. I also updated the default config
file and the baked-in default config file to reflect the new default param.