### PR TITLE
Generated metadata in remote repo during group meta request and surrounding fixes

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -48,7 +48,9 @@ import org.commonjava.indy.subsys.template.ScriptEngine;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
+import org.commonjava.maven.atlas.ident.ref.SimpleProjectRef;
 import org.commonjava.maven.atlas.ident.util.ArtifactPathInfo;
+import org.commonjava.maven.galley.TransferException;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
@@ -73,6 +75,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
+import static org.commonjava.maven.galley.maven.util.ArtifactPathUtils.formatMetadataPath;
 
 /**
  * {@link ContentManager} decorator that watches the retrieve() methods. If the result is going to be a null {@link Transfer}
@@ -569,7 +572,10 @@ public abstract class KojiContentManagerDecorator
         if ( !patterns.isEmpty() )
         {
             String meta = getMetaString( artifactRef ); // Add metadata.xml to path mask patterns
-            patterns.add( meta );
+            if ( meta != null )
+            {
+                patterns.add( meta );
+            }
         }
         return patterns;
     }
@@ -601,8 +607,16 @@ public abstract class KojiContentManagerDecorator
             logger.trace( "Meta ignored, gId: {}, artiId: {}", gId, artiId );
             return null;
         }
-        String meta = gId.replace( '.', '/' ) + "/" + artiId + "/" + METADATA_NAME;
-        logger.trace( "Meta: {}", meta );
+        String meta = null;
+        try
+        {
+            meta = formatMetadataPath( new SimpleProjectRef( gId, artiId ), METADATA_NAME );
+            logger.trace( "Meta: {}", meta );
+        }
+        catch ( TransferException e )
+        {
+            logger.error( "Format metadata path failed", e );
+        }
         return meta;
     }
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -20,7 +20,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.IndyWorkflowException;
@@ -80,7 +79,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -503,8 +501,6 @@ public class MavenMetadataGenerator
             toMergePath = normalize( normalize( parentPath( toMergePath ) ), MavenMetadataMerger.METADATA_NAME );
         }
 
-        final String tmp = toMergePath;
-
         Metadata meta = getMetaFromCache( group.getKey(), toMergePath );
 
         if ( meta != null )
@@ -579,7 +575,7 @@ public class MavenMetadataGenerator
                             Metadata memberMeta = reader.read( new StringReader( content ), false );
                             memberMetas.put( store.getKey(), memberMeta );
 
-                            putToMetadataCache( group.getKey(), toMergePath, memberMeta );
+                            putToMetadataCache( store.getKey(), toMergePath, memberMeta );
                             clearObsoleteFiles( memberMetaTxfr );
                         }
                     }
@@ -709,7 +705,7 @@ public class MavenMetadataGenerator
                             Metadata memberMeta = reader.read( new StringReader( content ), false );
                             memberMetas.put( store.getKey(), memberMeta );
 
-                            putToMetadataCache( group.getKey(), toMergePath, memberMeta );
+                            putToMetadataCache( store.getKey(), toMergePath, memberMeta );
                         }
                     }
                     else

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -89,6 +89,7 @@ import java.util.stream.Collectors;
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_EXISTS;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_GENERATED;
+import static org.commonjava.maven.galley.io.SpecialPathConstants.HTTP_METADATA_EXT;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
 
@@ -191,8 +192,7 @@ public class MavenMetadataGenerator
         throws IndyWorkflowException
     {
         // metadata merging is something else...don't handle it here.
-        if ( StoreType.group == store.getKey()
-                                     .getType() )
+        if ( StoreType.group == store.getKey().getType() )
         {
             return null;
         }
@@ -347,6 +347,15 @@ public class MavenMetadataGenerator
         return null;
     }
 
+    /**
+     *
+     * @param group
+     * @param members Concrete stores in group
+     * @param path
+     * @param eventMetadata
+     * @return
+     * @throws IndyWorkflowException
+     */
     @Override
     @IndyMetrics( measure = @Measure( timers = @MetricNamed( name =
                     IndyMetricsPkgMavenNames.METHOD_MAVENMETADATAGENERATOR_GENERATEGROUPILECONTENT
@@ -475,7 +484,7 @@ public class MavenMetadataGenerator
      * files will be cached. In terms of cache clearing, see #{@link MetadataMergeListner}
      *
      * @param group
-     * @param members
+     * @param members concrete store in group
      * @param path
      * @return
      * @throws IndyWorkflowException
@@ -506,7 +515,11 @@ public class MavenMetadataGenerator
         Map<StoreKey, Metadata> memberMetas = new ConcurrentHashMap<>( members.size() );
         Set<ArtifactStore> missing = retrieveCachedMemberMetadata( memberMetas, members, toMergePath );
 
-        downloadMissingMemberMetadata( group, missing, memberMetas, toMergePath );
+        // Try to download missed meta
+        missing = downloadMissingMemberMetadata( group, missing, memberMetas, toMergePath );
+
+        // Try to generate missed meta
+        missing = generateMissingMemberMetadata( group, missing, memberMetas, toMergePath );
 
         List<Metadata> metas = members.stream()
                                       .map( mem -> memberMetas.get(mem.getKey()) )
@@ -517,13 +530,109 @@ public class MavenMetadataGenerator
 
         if ( master != null )
         {
-            Map<String, MetadataInfo> cacheMap = new HashMap<>();
-            cacheMap.put( toMergePath, new MetadataInfo( master ) );
-            versionMetadataCache.put( group.getKey(), cacheMap );
+            putToMetadataCache( group.getKey(), toMergePath, master );
             return master;
         }
 
         return null;
+    }
+
+    private void putToMetadataCache( StoreKey key, String toMergePath, Metadata meta )
+    {
+        synchronized ( versionMetadataCache )
+        {
+            Map cacheMap = versionMetadataCache.get( key );
+            if ( cacheMap == null )
+            {
+                cacheMap = new HashMap<>();
+                versionMetadataCache.put( key, cacheMap );
+            }
+            cacheMap.put( toMergePath, new MetadataInfo( meta ) );
+        }
+    }
+
+    private Set<ArtifactStore> generateMissingMemberMetadata( Group group, Set<ArtifactStore> missing,
+                                                Map<StoreKey, Metadata> memberMetas, String toMergePath )
+                    throws IndyWorkflowException
+    {
+        Set<ArtifactStore> ret = new HashSet<>(); // return stores which failed generation
+
+        CountDownLatch latch = new CountDownLatch( missing.size() );
+        List<String> errors = new ArrayList<>();
+
+        /* @formatter:off */
+        missing.forEach( (store)->{
+            logger.debug( "Submitting generation task for {} metadata: {}", store.getKey(), toMergePath );
+            executorService.execute( ()->{
+                try
+                {
+                    logger.trace( "Starting metadata generation: {}:{}", store.getKey(), toMergePath);
+                    Transfer memberMetaTxfr = generateFileContent( store, toMergePath, new EventMetadata() );
+
+                    if ( exists( memberMetaTxfr ) )
+                    {
+                        final MetadataXpp3Reader reader = new MetadataXpp3Reader();
+
+                        try (InputStream in = memberMetaTxfr.openInputStream())
+                        {
+                            String content = IOUtils.toString( in );
+                            Metadata memberMeta = reader.read( new StringReader( content ), false );
+                            memberMetas.put( store.getKey(), memberMeta );
+
+                            putToMetadataCache( group.getKey(), toMergePath, memberMeta );
+                            clearObsoleteFiles( memberMetaTxfr );
+                        }
+                    }
+                    else
+                    {
+                        ret.add( store );
+                    }
+                }
+                catch ( final Exception e )
+                {
+                    String msg = String.format( "Failed to generate metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
+                                                 e.getMessage() );
+                    logger.error( msg, e );
+                    synchronized ( errors )
+                    {
+                        errors.add( msg );
+                    }
+                }
+                finally
+                {
+                    latch.countDown();
+                }
+            } );
+        } );
+        /* @formatter:on */
+
+        waitOnLatch(group, toMergePath, latch);
+
+        if ( !errors.isEmpty() )
+        {
+            throw new IndyWorkflowException( "Failed to generate one or more member metadata files for: %s:%s. Errors were:\n  %s",
+                            group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
+        }
+
+        return ret;
+    }
+
+    /**
+     * Clear obsolete files after a meta is generated. This may be http download metadata, etc.
+     * @param item
+     */
+    private void clearObsoleteFiles( Transfer item )
+    {
+        Transfer httpMeta = item.getSiblingMeta( HTTP_METADATA_EXT );
+        try
+        {
+            httpMeta.delete();
+        }
+        catch ( IOException e )
+        {
+            logger.warn( "Failed to delete {}", httpMeta.getResource() );
+        }
+
     }
 
     private Set<ArtifactStore> retrieveCachedMemberMetadata( final Map<StoreKey, Metadata> memberMetas,
@@ -572,16 +681,18 @@ public class MavenMetadataGenerator
         return missing;
     }
 
-    private void downloadMissingMemberMetadata( final Group group, final Set<ArtifactStore> missing,
+    private Set<ArtifactStore> downloadMissingMemberMetadata( final Group group, final Set<ArtifactStore> missing,
                                                 final Map<StoreKey, Metadata> memberMetas, final String toMergePath )
             throws IndyWorkflowException
     {
+        Set<ArtifactStore> ret = new HashSet<>(  ); // return stores which failed download
+
         CountDownLatch latch = new CountDownLatch( missing.size() );
         List<String> errors = new ArrayList<>();
 
         /* @formatter:off */
         missing.forEach( (store)->{
-            logger.debug( "Submitting download task for {} metadata: '{}'", store.getKey(), toMergePath );
+            logger.debug( "Submitting download task for {} metadata: {}", store.getKey(), toMergePath );
             executorService.execute( ()->{
                 try
                 {
@@ -598,32 +709,15 @@ public class MavenMetadataGenerator
                             Metadata memberMeta = reader.read( new StringReader( content ), false );
                             memberMetas.put( store.getKey(), memberMeta );
 
-                            Map<String, MetadataInfo> cacheMap = new HashMap<>();
-                            cacheMap.put( toMergePath, new MetadataInfo( memberMeta ) );
-                            versionMetadataCache.putIfAbsent( store.getKey(), cacheMap );
+                            putToMetadataCache( group.getKey(), toMergePath, memberMeta );
                         }
                     }
-                }
-                catch ( final IOException e )
-                {
-                    String msg = String.format( "Failed to retrieve metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
-                                                 e.getMessage() );
-                    logger.error( msg, e );
-                    synchronized ( errors )
+                    else
                     {
-                        errors.add( msg );
+                        ret.add( store );
                     }
                 }
-                catch ( final XmlPullParserException e )
-                {
-                    String msg = String.format( "Cannot parse metadata: %s:%s. Reason: %s", store.getKey(), toMergePath, e.getMessage() );
-                    logger.error( msg, e );
-                    synchronized ( errors )
-                    {
-                        errors.add( msg );
-                    }
-                }
-                catch ( IndyWorkflowException e )
+                catch ( final Exception e )
                 {
                     String msg = String.format( "Failed to retrieve metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
                                                  e.getMessage() );
@@ -641,6 +735,20 @@ public class MavenMetadataGenerator
         } );
         /* @formatter:on */
 
+        waitOnLatch(group, toMergePath, latch);
+
+        if ( !errors.isEmpty() )
+        {
+            throw new IndyWorkflowException(
+                    "Failed to retrieve one or more member metadata files for: %s:%s. Errors were:\n  %s",
+                    group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
+        }
+
+        return ret;
+    }
+
+    private void waitOnLatch( Group group, String toMergePath, CountDownLatch latch )
+    {
         do
         {
             logger.trace( "Latch count: {}", latch.getCount() );
@@ -656,13 +764,6 @@ public class MavenMetadataGenerator
             }
         }
         while ( latch.getCount() > 0 );
-
-        if ( !errors.isEmpty() )
-        {
-            throw new IndyWorkflowException(
-                    "Failed to retrieve one or more member metadata files for: %s:%s. Errors were:\n  %s",
-                    group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
-        }
     }
 
     private boolean exists( final Transfer target )

--- a/addons/pkg-maven/ftests/pom.xml
+++ b/addons/pkg-maven/ftests/pom.xml
@@ -44,6 +44,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-pkg-maven-jaxrs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.indy.boot</groupId>
       <artifactId>indy-booter-api</artifactId>
       <scope>provided</scope>

--- a/addons/pkg-maven/ftests/src/main/resources/logback-test.xml
+++ b/addons/pkg-maven/ftests/src/main/resources/logback-test.xml
@@ -21,7 +21,7 @@
   <logger name="org.jboss" level="WARN"/>
   <logger name="com.redhat.red.build.koji.model.xmlrpc.KojiXmlRpcBindery" level="WARN"/>
 
-  <logger name="org.commonjava.indy" level="DEBUG"/>
+  <logger name="org.commonjava.indy" level="TRACE"/>
   <logger name="org.apache.http" level="DEBUG"/>
 
   <!-- Strictly speaking, the level attribute is not necessary since -->

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 
 import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.util.ContentUtils.dedupeListing;
+import static org.commonjava.maven.galley.io.SpecialPathConstants.HTTP_METADATA_EXT;
 
 public class DefaultContentManager
         implements ContentManager
@@ -330,6 +331,17 @@ public class DefaultContentManager
                     item = generator.generateFileContent( store, path, eventMetadata );
                     if ( item != null )
                     {
+                        logger.debug( "Resource generated for {}, clean NFC and delete obsolete http-metadata.json", item.getResource() );
+                        nfc.clearMissing( item.getResource() );
+                        Transfer httpMeta = item.getSiblingMeta( HTTP_METADATA_EXT );
+                        try
+                        {
+                            httpMeta.delete();
+                        }
+                        catch ( IOException e )
+                        {
+                            logger.warn( "Failed to delete {}", httpMeta.getResource() );
+                        }
                         break;
                     }
                 }

--- a/ftests/common/src/main/resources/logback-test.xml
+++ b/ftests/common/src/main/resources/logback-test.xml
@@ -18,6 +18,10 @@
     </encoder>
   </appender>
 
+  <logger name="io.swagger" level="ERROR"/>
+  <logger name="org.commonjava.util.partyline" level="ERROR"/>
+  <logger name="org.commonjava.maven.galley.io.checksum" level="ERROR"/>
+
   <root level="TRACE">
     <appender-ref ref="STDOUT" />
   </root>  

--- a/ftests/common/src/main/resources/logback-test.xml
+++ b/ftests/common/src/main/resources/logback-test.xml
@@ -19,8 +19,6 @@
   </appender>
 
   <logger name="io.swagger" level="ERROR"/>
-  <logger name="org.commonjava.util.partyline" level="ERROR"/>
-  <logger name="org.commonjava.maven.galley.io.checksum" level="ERROR"/>
 
   <root level="TRACE">
     <appender-ref ref="STDOUT" />

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreGeneratedMetadataInRemoteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreGeneratedMetadataInRemoteTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+/**
+ *
+ * Store generated metadata in remote repos storage when requested as part of a group metadata generation.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Remote repo A which contains path_1 foo/bar/1/bar-1.pom</li>
+ *     <li>Hosted repo B which contains path_2 foo/bar/2/bar-2.pom and foo/bar/maven-metadata.xml</li>
+ *     <li>Group G contains A and B.</li>
+ </li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Path foo/bar/maven-metadata.xml is requested from G</li>
+ *     <li>Path foo/bar/maven-metadata.xml is requested from A</li>
+ *     <li>Repo A is deleted</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>Indy generates the meta files and stores it for both A and G.</li>
+ *     <li>Indy can get maven-metadata.xml from A</li>
+ *     <li>Group G metadata is updated after deleting A</li>
+ * </ul>
+ */
+public class StoreGeneratedMetadataInRemoteTest
+                extends AbstractIndyFunctionalTest //ContentManagementTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "repos" );
+
+    private final String REMOTE = "remote-A";
+
+    private final String HOSTED = "hosted-B";
+
+    private final String GROUP = "group-G";
+
+    private final String path_1 = "org/foo/bar/1.0/bar-1.0.pom";
+
+    private final String path_2 = "org/foo/bar/2.0/bar-2.0.pom";
+
+    private final String metaPath = "org/foo/bar/maven-metadata.xml";
+
+    /* @formatter:off */
+    final String metaContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>2.0</latest>\n" +
+        "    <release>2.0</release>\n" +
+        "    <versions>\n" +
+        "      <version>2.0</version>\n" +
+        "    </versions>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    private final String pomContent_1 = "<project><modelVersion>4.0.0</modelVersion>"
+                    + "<groupId>org.foo</groupId><artifactId>bar</artifactId><version>1.0</version></project>";
+
+    private final String pomContent_2 = "<project><modelVersion>4.0.0</modelVersion>"
+                    + "<groupId>org.foo</groupId><artifactId>bar</artifactId><version>2.0</version></project>";
+
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+
+    @Test
+    public void run() throws Exception
+    {
+        server.expect( server.formatUrl( REMOTE, path_1 ), 200, pomContent_1 );
+
+        RemoteRepository remote1 = new RemoteRepository( REMOTE, server.formatUrl( REMOTE ) );
+        remote1 = client.stores().create( remote1, "remote A", RemoteRepository.class );
+
+        HostedRepository hosted1 = client.stores().create( new HostedRepository( HOSTED ), "hosted B", HostedRepository.class );
+        client.content().store( hosted1.getKey(), path_2, new ByteArrayInputStream( pomContent_2.getBytes() ) );
+        client.content().store( hosted1.getKey(), metaPath, new ByteArrayInputStream( metaContent.getBytes() ) );
+
+        Group g = new Group( GROUP, remote1.getKey(), hosted1.getKey() );
+        g = client.stores().create( g, "group G", Group.class );
+
+        // MUST hit the .pom first. This is needed to populate org/foo/bar/1.0 folder in order to generate metadata.xml
+        try (final InputStream stream = client.content().get( remote1.getKey(), path_1 ))
+        {
+        }
+
+        // Get meta from group. Contains both version 1.0 and 2.0
+        try (final InputStream stream = client.content().get( g.getKey(), metaPath ))
+        {
+            String meta = IOUtils.toString( stream );
+            logger.debug( "Group meta >>>>\n" + meta );
+            assertTrue( meta.contains( "<version>1.0</version>" ) );
+            assertTrue( meta.contains( "<version>2.0</version>" ) );
+        }
+
+        // Get meta from remote. Contains version 1.0
+        try (final InputStream stream = client.content().get( remote1.getKey(), metaPath ))
+        {
+            assertThat( stream, notNullValue() );
+            String meta = IOUtils.toString( stream );
+            logger.debug( "Remote A meta >>>>\n" + meta );
+            assertTrue( meta.contains( "<version>1.0</version>" ) );
+        }
+
+        // Delete remote A
+        /*client.stores().delete( remote1.getKey(), "delete A" );
+        waitForEventPropagation();
+
+        // Get meta from group again. Contains only version 2
+        try (final InputStream stream = client.content().get( g.getKey(), metaPath ))
+        {
+            assertThat( stream, notNullValue() );
+            logger.debug( "Group meta after deleting A >>>>\n" + IOUtils.toString( stream ) );
+        }*/
+    }
+}


### PR DESCRIPTION
Basic fixes:
1. Generate meta for remote repositories when it is not available during group meta request
 - Make downloadMissingMemberMetadata return store where the meta downloading fails.
 - Add generateMissingMemberMetadata after it to generate those missings.

2. Listen to ArtifactStoreDeletePreEvent in MetadataMergeListner
 - Otherwise, when deleting a store, it won't trigger the cascade group meta update

Other fixes:
1. Clear obsolete HTTP download meta.json after a meta is generated. Otherwise, it will fail the rendering of group meta file due to Content-length 0 problem (which is caused by unsuccessfully attempting to download it in the previous try). 
2. Update maven-pkg add-on pom so that we can run ftest inside IDEA.
3. Comment the executor usage in DefaultStoreEventDispatcher. Align the trace message format. 
4. Update removeMetadataCache in MetadataMergeListner. Make it clear cache without checking if current stoke has entryMap. When a meta being generated in this issue, the current (remote) repository won't have metaMap in cache (refer to generateFileContent). But this should not block it from clearing the group caches anyway. 
5. Fix an problem with regard to putIfAbsent. Move to putToMetadataCache. The prev putIfAbsent has problem to add the mataMap to cache if there is one.
6. Update KojiContentManagerDecorator to add meta path to path masks so that it won't block the meta request in any case. 




