### PR TITLE
NPE when clearing artifact from NFC due to missing NPM package type

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
@@ -20,7 +20,6 @@ import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
-import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
@@ -67,7 +66,7 @@ class NFCContentListener
         {
             IndexedStorePath isp = e.getValue();
             final StoreKey key =
-                    new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, isp.getStoreType(), isp.getStoreName() );
+                    new StoreKey( isp.getPackageType(), isp.getStoreType(), isp.getStoreName() );
             logger.debug( "New artifact created in store {} of path {}, will start to clear nfc cache for it.", key,
                           isp.getPath() );
             try
@@ -98,7 +97,7 @@ class NFCContentListener
         {
             IndexedStorePath isp = e.getValue();
             final StoreKey key =
-                    new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, isp.getStoreType(), isp.getStoreName() );
+                    new StoreKey( isp.getPackageType(), isp.getStoreType(), isp.getStoreName() );
             // Only care about group level, as remote repo nfc is handled by remote timeout handler(see galley DownloadHandler),
             // and hosted is handled by DownloadManager
             if ( key.getType() == StoreType.group )

--- a/core/src/main/java/org/commonjava/indy/core/inject/IspnNotFoundCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/IspnNotFoundCache.java
@@ -291,6 +291,8 @@ public class IspnNotFoundCache
 
     private String getResourceKey( ConcreteResource resource )
     {
-        return md5Hex( ((KeyedLocation)resource.getLocation()).getKey().toString() + ":" + resource.getPath() );
+        KeyedLocation location = (KeyedLocation) resource.getLocation();
+        StoreKey key = location.getKey();
+        return md5Hex( key.toString() + ":" + resource.getPath() );
     }
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
@@ -15,18 +15,14 @@
  */
 package org.commonjava.indy.model.core;
 
-import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
 
 public final class StoreKey
@@ -34,20 +30,11 @@ public final class StoreKey
 {
     private static final long serialVersionUID = 1L;
 
-    // private static final Logger logger = new Logger( StoreKey.class );
-
     private String packageType;
 
     private final StoreType type;
 
     private final String name;
-
-    protected StoreKey()
-    {
-        this.packageType = null;
-        this.type = null;
-        this.name = null;
-    }
 
     public StoreKey( final String packageType, final StoreType type, final String name )
     {


### PR DESCRIPTION
The package type is missing in IndexedStorePath and cause the store not found when generating NFC keys. 