### PR TITLE
add version (pom) upload/deletion change listener to align the versions in maven meta file

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.change;
+
+import org.commonjava.cdi.util.weft.ExecutorConfig;
+import org.commonjava.cdi.util.weft.WeftManaged;
+import org.commonjava.indy.content.DownloadManager;
+import org.commonjava.indy.core.change.event.IndyFileEventManager;
+import org.commonjava.indy.core.content.group.GroupMergeHelper;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.event.FileAccessEvent;
+import org.commonjava.maven.galley.event.FileDeletionEvent;
+import org.commonjava.maven.galley.event.FileEvent;
+import org.commonjava.maven.galley.model.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.util.LocationUtils.getKey;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
+import static org.commonjava.maven.galley.util.PathUtils.parentPath;
+
+@javax.enterprise.context.ApplicationScoped
+public class MetadataMergePomChangeListener
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private StoreDataManager dataManager;
+
+    @Inject
+    private DownloadManager fileManager;
+
+    @Inject
+    private IndyFileEventManager fileEvent;
+
+    @Inject
+    @MavenVersionMetadataCache
+    private CacheHandle<StoreKey, Map> versionMetadataCache;
+
+    @Inject
+    @WeftManaged
+    @ExecutorConfig( daemon = true, priority = 7, named = "indy-events" )
+    private Executor executor;
+
+    public void metaClear( @Observes final FileEvent event )
+    {
+
+        final String path = event.getTransfer().getPath();
+
+        if ( event instanceof FileAccessEvent )
+        {
+            return;
+        }
+
+        if ( !path.endsWith( ".pom" ) )
+        {
+            return;
+        }
+
+        final StoreKey key = getKey( event );
+        final String versionPath = normalize( parentPath( path ) );
+        final String clearPath = normalize( normalize( parentPath( versionPath ) ), MavenMetadataMerger.METADATA_NAME );
+        try
+        {
+            if ( hosted == key.getType() )
+            {
+                HostedRepository hosted = dataManager.query().getHostedRepository( key.getName() );
+                try
+                {
+                    if ( doClear( hosted, clearPath ) )
+                    {
+                        versionMetadataCache.remove( hosted.getKey() );
+                    }
+                }
+                catch ( final IOException e )
+                {
+                    logger.error(
+                            String.format( "Failed to delete: %s from hosted: %s when pom version changed. Error: %s",
+                                           path, hosted, e.getMessage() ), e );
+                }
+
+                final Set<Group> groups = dataManager.query().getGroupsContaining( key );
+                if ( groups != null )
+                {
+                    for ( final Group group : groups )
+                    {
+                        try
+                        {
+                            if ( doClear( group, clearPath ) )
+                            {
+                                versionMetadataCache.remove( group.getKey() );
+                            }
+                        }
+                        catch ( final IOException e )
+                        {
+                            logger.error( String.format(
+                                    "Failed to delete: %s from its group: %s when pom version changed. Error: %s", path,
+                                    group, e.getMessage() ), e );
+                        }
+                    }
+                }
+            }
+        }
+        catch ( final IndyDataException e )
+        {
+            logger.warn( "Failed to regenerate maven-metadata.xml for artifacts after deployment to: {}"
+                                 + "\nCannot retrieve associated groups: {}", e, key, e.getMessage() );
+        }
+    }
+
+    private boolean doClear( final ArtifactStore group, final String path )
+            throws IOException
+    {
+        boolean isCleared = false;
+        logger.trace( "Updating merged metadata file: {} in group: {}", path, group.getKey() );
+
+        final Transfer[] toDelete = { fileManager.getStorageReference( group, path ),
+                fileManager.getStorageReference( group, path + GroupMergeHelper.MERGEINFO_SUFFIX ),
+                fileManager.getStorageReference( group, path + GroupMergeHelper.SHA_SUFFIX ),
+                fileManager.getStorageReference( group, path + GroupMergeHelper.MD5_SUFFIX ) };
+
+        for ( final Transfer item : toDelete )
+        {
+            logger.trace( "Attempting to delete: {}", item );
+
+            if ( item.exists() )
+            {
+                final boolean result = item.delete();
+                logger.trace( "Deleted: {} (success? {})", item, result );
+
+                if ( item.getPath().endsWith( MavenMetadataMerger.METADATA_NAME ) )
+                {
+                    isCleared = result;
+                }
+                if ( fileEvent != null )
+                {
+                    logger.trace( "Firing deletion event for: {}", item );
+                    fileEvent.fire( new FileDeletionEvent( item, new EventMetadata() ) );
+                }
+            }
+        }
+        return isCleared;
+    }
+}

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnNewMemberTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnNewMemberTest.java
@@ -171,15 +171,6 @@ public class GroupHostedMetadataRemergedOnNewMemberTest
         assertContent( g, METADATA_PATH, AFTER_GROUP_CONTENT );
     }
 
-    private void deployContent( HostedRepository repo, String pathTemplate, String template, String version )
-            throws IndyClientException
-    {
-        String path = pathTemplate.replaceAll( "%version%", version );
-        client.content()
-              .store( repo.getKey(), path, new ByteArrayInputStream(
-                      template.replaceAll( "%version%", version ).getBytes() ) );
-    }
-
     @Override
     protected boolean createStandardTestStructures()
     {

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomDeletionTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomDeletionTest.java
@@ -26,59 +26,77 @@ import org.junit.experimental.categories.Category;
 
 import java.io.ByteArrayInputStream;
 
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
-
 /**
- * Check that merged metadata in a group full of hosted repositories is updated when a new hosted repository is added to
- * the membership.
+ * Check that merged metadata in a group full of hosted repositories is updated when a version ( pom file )
+ * is deleted from the member.
  * <br/>
  * GIVEN:
  * <ul>
- *     <li>HostedRepositories A, B, and C</li>
+ *     <li>HostedRepositories A, B</li>
  *     <li>Group G with HostedRepository members A and B</li>
- *     <li>HostedRepositories A, B, and C all contain metadata path P</li>
+ *     <li>HostedRepositories A, B all contain metadata path P</li>
  *     <li>Each metadata file contains different versions of the same project</li>
  * </ul>
  * <br/>
  * WHEN:
  * <ul>
- *     <li>HostedRepository C is appended to the end of Group G's membership</li>
+ *     <li>delete a version (pom) from HostedRepository B</li>
  *     <li>Metadata path P is requested from Group G <b>after events of membership change have settled</b></li>
  * </ul>
  * <br/>
  * THEN:
  * <ul>
- *     <li>Group G's metadata path P should reflect values in HostedRepository C's metadata path P</li>
+ *     <li>Group G's metadata path P should reflect values in HostedRepository B's metadata path P</li>
  * </ul>
  */
-public class GroupHostedMetadataRemergedOnNewMemberTest
+public class GroupHostedMetadataRemergedOnPomDeletionTest
         extends AbstractContentManagementTest
 {
-    private static final String GROUP_G_NAME= "G";
-    private static final String HOSTED_A_NAME= "A";
-    private static final String HOSTED_B_NAME= "B";
-    private static final String HOSTED_C_NAME= "C";
+    private static final String GROUP_G_NAME = "G";
+
+    private static final String HOSTED_A_NAME = "A";
+
+    private static final String HOSTED_B_NAME = "B";
 
     private static final String A_VERSION = "1.0";
+
     private static final String B_VERSION = "1.1";
+
     private static final String C_VERSION = "1.2";
 
     private static final String METADATA_PATH = "/org/foo/bar/maven-metadata.xml";
+
     private static final String POM_PATH = "/org/foo/bar/%version%/bar-%version%.pom";
 
     /* @formatter:off */
-    private static final String REPO_METADATA_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+    private static final String BEFORE_HOSTED_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
         "<metadata>\n" +
         "  <groupId>org.foo</groupId>\n" +
         "  <artifactId>bar</artifactId>\n" +
         "  <versioning>\n" +
-        "    <latest>%version%</latest>\n" +
+        "    <lastUpdated>%lastUpdated%</lastUpdated>\n" +
+        "    <release>1.2</release>\n" +
+        "    <latest>1.2</latest>\n" +
+        "    <versions>\n" +
+        "      <version>1.1</version>\n" +
+        "      <version>1.2</version>\n" +
+        "    </versions>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    /* @formatter:off */
+    private static final String REPO_METADATA_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <lastUpdated>%lastUpdated%</lastUpdated>\n" +
         "    <release>%version%</release>\n" +
+        "    <latest>%version%</latest>\n" +
         "    <versions>\n" +
         "      <version>%version%</version>\n" +
         "    </versions>\n" +
-        "    <lastUpdated>20150722164334</lastUpdated>\n" +
         "  </versioning>\n" +
         "</metadata>\n";
     /* @formatter:on */
@@ -100,13 +118,14 @@ public class GroupHostedMetadataRemergedOnNewMemberTest
         "  <groupId>org.foo</groupId>\n" +
         "  <artifactId>bar</artifactId>\n" +
         "  <versioning>\n" +
-        "    <latest>1.1</latest>\n" +
-        "    <release>1.1</release>\n" +
+        "    <latest>1.2</latest>\n" +
+        "    <release>1.2</release>\n" +
         "    <versions>\n" +
         "      <version>1.0</version>\n" +
         "      <version>1.1</version>\n" +
+        "      <version>1.2</version>\n" +
         "    </versions>\n" +
-        "    <lastUpdated>20150722164334</lastUpdated>\n" +
+        "    <lastUpdated>%lastUpdated%</lastUpdated>\n" +
         "  </versioning>\n" +
         "</metadata>\n";
     /* @formatter:on */
@@ -117,14 +136,13 @@ public class GroupHostedMetadataRemergedOnNewMemberTest
         "  <groupId>org.foo</groupId>\n" +
         "  <artifactId>bar</artifactId>\n" +
         "  <versioning>\n" +
-        "    <latest>1.2</latest>\n" +
-        "    <release>1.2</release>\n" +
+        "    <latest>1.1</latest>\n" +
+        "    <release>1.1</release>\n" +
         "    <versions>\n" +
         "      <version>1.0</version>\n" +
         "      <version>1.1</version>\n" +
-        "      <version>1.2</version>\n" +
         "    </versions>\n" +
-        "    <lastUpdated>20150722164334</lastUpdated>\n" +
+        "    <lastUpdated>%lastUpdated%</lastUpdated>\n" +
         "  </versioning>\n" +
         "</metadata>\n";
     /* @formatter:on */
@@ -132,8 +150,8 @@ public class GroupHostedMetadataRemergedOnNewMemberTest
     private Group g;
 
     private HostedRepository a;
+
     private HostedRepository b;
-    private HostedRepository c;
 
     @Before
     public void setupRepos()
@@ -143,17 +161,16 @@ public class GroupHostedMetadataRemergedOnNewMemberTest
 
         a = client.stores().create( new HostedRepository( HOSTED_A_NAME ), message, HostedRepository.class );
         b = client.stores().create( new HostedRepository( HOSTED_B_NAME ), message, HostedRepository.class );
-        c = client.stores().create( new HostedRepository( HOSTED_C_NAME ), message, HostedRepository.class );
-
-        g = client.stores().create( new Group( GROUP_G_NAME, a.getKey(), b.getKey() ), message, Group.class );
 
         deployContent( a, POM_PATH, REPO_POM_TEMPLATE, A_VERSION );
         deployContent( b, POM_PATH, REPO_POM_TEMPLATE, B_VERSION );
-        deployContent( c, POM_PATH, REPO_POM_TEMPLATE, C_VERSION );
+        deployContent( b, POM_PATH, REPO_POM_TEMPLATE, C_VERSION );
 
         deployContent( a, METADATA_PATH, REPO_METADATA_TEMPLATE, A_VERSION );
-        deployContent( b, METADATA_PATH, REPO_METADATA_TEMPLATE, B_VERSION );
-        deployContent( c, METADATA_PATH, REPO_METADATA_TEMPLATE, C_VERSION );
+        client.content()
+              .store( b.getKey(), METADATA_PATH, new ByteArrayInputStream( BEFORE_HOSTED_CONTENT.getBytes() ) );
+
+        g = client.stores().create( new Group( GROUP_G_NAME, a.getKey(), b.getKey() ), message, Group.class );
     }
 
     @Test
@@ -163,12 +180,16 @@ public class GroupHostedMetadataRemergedOnNewMemberTest
     {
         assertContent( g, METADATA_PATH, BEFORE_GROUP_CONTENT );
 
-        g.addConstituent( c );
-        client.stores().update( g, "Adding hosted c to membership" );
+        client.content().delete( b.getKey(), POM_PATH.replaceAll( "%version%", C_VERSION ) );
 
         waitForEventPropagation();
 
-        assertContent( g, METADATA_PATH, AFTER_GROUP_CONTENT );
+        assertContent( b, METADATA_PATH, REPO_METADATA_TEMPLATE.replaceAll( "%version%", B_VERSION ).
+                replaceAll( "%lastUpdated%", getRealLastUpdated( b.getKey(), METADATA_PATH ) ) );
+
+        assertContent( g, METADATA_PATH, AFTER_GROUP_CONTENT.replaceAll( "%lastUpdated%",
+                                                                         getRealLastUpdated( g.getKey(),
+                                                                                             METADATA_PATH ) ) );
     }
 
     private void deployContent( HostedRepository repo, String pathTemplate, String template, String version )
@@ -176,8 +197,8 @@ public class GroupHostedMetadataRemergedOnNewMemberTest
     {
         String path = pathTemplate.replaceAll( "%version%", version );
         client.content()
-              .store( repo.getKey(), path, new ByteArrayInputStream(
-                      template.replaceAll( "%version%", version ).getBytes() ) );
+              .store( repo.getKey(), path,
+                      new ByteArrayInputStream( template.replaceAll( "%version%", version ).getBytes() ) );
     }
 
     @Override

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomDeletionTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomDeletionTest.java
@@ -54,6 +54,8 @@ public class GroupHostedMetadataRemergedOnPomDeletionTest
 {
     private static final String GROUP_G_NAME = "G";
 
+    private static final String GROUP_H_NAME = "H";
+
     private static final String HOSTED_A_NAME = "A";
 
     private static final String HOSTED_B_NAME = "B";
@@ -149,6 +151,8 @@ public class GroupHostedMetadataRemergedOnPomDeletionTest
 
     private Group g;
 
+    private Group h;
+
     private HostedRepository a;
 
     private HostedRepository b;
@@ -171,6 +175,7 @@ public class GroupHostedMetadataRemergedOnPomDeletionTest
               .store( b.getKey(), METADATA_PATH, new ByteArrayInputStream( BEFORE_HOSTED_CONTENT.getBytes() ) );
 
         g = client.stores().create( new Group( GROUP_G_NAME, a.getKey(), b.getKey() ), message, Group.class );
+        h = client.stores().create( new Group( GROUP_H_NAME, g.getKey() ), message, Group.class );
     }
 
     @Test
@@ -190,15 +195,9 @@ public class GroupHostedMetadataRemergedOnPomDeletionTest
         assertContent( g, METADATA_PATH, AFTER_GROUP_CONTENT.replaceAll( "%lastUpdated%",
                                                                          getRealLastUpdated( g.getKey(),
                                                                                              METADATA_PATH ) ) );
-    }
-
-    private void deployContent( HostedRepository repo, String pathTemplate, String template, String version )
-            throws IndyClientException
-    {
-        String path = pathTemplate.replaceAll( "%version%", version );
-        client.content()
-              .store( repo.getKey(), path,
-                      new ByteArrayInputStream( template.replaceAll( "%version%", version ).getBytes() ) );
+        assertContent( h, METADATA_PATH, AFTER_GROUP_CONTENT.replaceAll( "%lastUpdated%",
+                                                                         getRealLastUpdated( g.getKey(),
+                                                                                             METADATA_PATH ) ) );
     }
 
     @Override

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomUploadTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomUploadTest.java
@@ -54,6 +54,8 @@ public class GroupHostedMetadataRemergedOnPomUploadTest
 {
     private static final String GROUP_G_NAME = "G";
 
+    private static final String GROUP_H_NAME = "H";
+
     private static final String HOSTED_A_NAME = "A";
 
     private static final String HOSTED_B_NAME = "B";
@@ -149,6 +151,8 @@ public class GroupHostedMetadataRemergedOnPomUploadTest
 
     private Group g;
 
+    private Group h;
+
     private HostedRepository a;
 
     private HostedRepository b;
@@ -169,6 +173,7 @@ public class GroupHostedMetadataRemergedOnPomUploadTest
         deployContent( b, METADATA_PATH, REPO_METADATA_TEMPLATE, B_VERSION );
 
         g = client.stores().create( new Group( GROUP_G_NAME, a.getKey(), b.getKey() ), message, Group.class );
+        h = client.stores().create( new Group( GROUP_H_NAME, g.getKey() ), message, Group.class );
     }
 
     @Test
@@ -188,15 +193,9 @@ public class GroupHostedMetadataRemergedOnPomUploadTest
         assertContent( g, METADATA_PATH, AFTER_GROUP_CONTENT.replaceAll( "%lastUpdated%",
                                                                          getRealLastUpdated( g.getKey(),
                                                                                              METADATA_PATH ) ) );
-    }
-
-    private void deployContent( HostedRepository repo, String pathTemplate, String template, String version )
-            throws IndyClientException
-    {
-        String path = pathTemplate.replaceAll( "%version%", version );
-        client.content()
-              .store( repo.getKey(), path,
-                      new ByteArrayInputStream( template.replaceAll( "%version%", version ).getBytes() ) );
+        assertContent( h, METADATA_PATH, AFTER_GROUP_CONTENT.replaceAll( "%lastUpdated%",
+                                                                         getRealLastUpdated( g.getKey(),
+                                                                                             METADATA_PATH ) ) );
     }
 
     @Override

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadata401ErrorTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadata401ErrorTest.java
@@ -126,15 +126,6 @@ public class GroupMetadata401ErrorTest
         String metadataContent = assertContent( g, METADATA_PATH, GROUP_METADATA_CONTENT );
     }
 
-    private void deployContent( HostedRepository repo, String pathTemplate, String template, String version )
-            throws IndyClientException
-    {
-        String path = pathTemplate.replaceAll( "%version%", version );
-        client.content()
-              .store( repo.getKey(), path, new ByteArrayInputStream(
-                      template.replaceAll( "%version%", version ).getBytes() ) );
-    }
-
     @Override
     protected boolean createStandardTestStructures()
     {

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataChecksumRequestedFirstTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataChecksumRequestedFirstTest.java
@@ -137,15 +137,6 @@ public class GroupMetadataChecksumRequestedFirstTest
         assertThat( checksum, equalTo( DigestUtils.shaHex( metadataContent ) ) );
     }
 
-    private void deployContent( HostedRepository repo, String pathTemplate, String template, String version )
-            throws IndyClientException
-    {
-        String path = pathTemplate.replaceAll( "%version%", version );
-        client.content()
-              .store( repo.getKey(), path, new ByteArrayInputStream(
-                      template.replaceAll( "%version%", version ).getBytes() ) );
-    }
-
     @Override
     protected boolean createStandardTestStructures()
     {

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -27,12 +27,15 @@ import java.io.InputStream;
 import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -140,5 +143,12 @@ public class AbstractContentManagementTest
         }
     }
 
+    protected String getRealLastUpdated ( StoreKey key, String path )
+            throws Exception
+    {
+        InputStream meta = client.content().get( key, path );
+        Metadata merged = new MetadataXpp3Reader().read( meta );
+        return merged.getVersioning().getLastUpdated();
+    }
 
 }

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
@@ -151,4 +152,12 @@ public class AbstractContentManagementTest
         return merged.getVersioning().getLastUpdated();
     }
 
+    protected void deployContent( HostedRepository repo, String pathTemplate, String template, String version )
+            throws IndyClientException
+    {
+        String path = pathTemplate.replaceAll( "%version%", version );
+        client.content()
+              .store( repo.getKey(), path,
+                      new ByteArrayInputStream( template.replaceAll( "%version%", version ).getBytes() ) );
+    }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMissingAddToNFCTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMissingAddToNFCTest.java
@@ -66,6 +66,8 @@ public class HostedMissingAddToNFCTest
 
     private static final String POM_PATH = "org/foo/bar/1/bar-1.pom";
 
+    private static final String META_PATH = "org/foo/bar/maven-metadata.xml";
+
     @Before
     public void setupTest()
             throws Exception
@@ -123,6 +125,7 @@ public class HostedMissingAddToNFCTest
                            .findFirst()
                            .orElse( null );
         assertThat( nfcSectionDto, notNullValue() );
-        assertThat( nfcSectionDto.getPaths(), nullValue() );
+        assertThat( nfcSectionDto.getPaths(), notNullValue() );
+        assertThat( nfcSectionDto.getPaths().contains( META_PATH ), equalTo( true ) );
     }
 }


### PR DESCRIPTION
In bug NOS-1126 and NOS-1053, the maven-metadata.xml versioning/versions didn't align to the artifacts that should be existed, or sometimes it would appear less/more than the actuals.
Indy should handle the versions alignment: for a new version (pom) upload/deletion, clear the maven meta and version cache to trigger meta regen process, not only for the hosted or group constituents change or meta self change just as before (MetadataMergeListner).