### PR TITLE
Rebuild 1.2 indy snapshot using new partyline latest 1.3 snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ After building, a variety of standalone application launchers are available:
 To use a launcher, simply unpack it to the directory of your choice (it will create an `indy` subdirectory). Then, run `bin/indy.sh`.
 
 For more information, see [the Indy Docs](http://commonjava.github.io/indy/).
+


### PR DESCRIPTION
This is to force rebuild Indy 1.2 snapshot after "turn off stream finalizer registration". 