### PR TITLE
Implement http-metadata generation for file uploading

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
@@ -23,7 +23,7 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
-import org.commonjava.indy.core.ctl.ContentController;
+import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.folo.model.TrackingKey;
 import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -43,9 +43,11 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
 
+
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.folo.ctl.FoloConstants.ACCESS_CHANNEL;
 import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_KEY;
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
 
 /**
  * Collects a tracking ID in addition to store type and name, then hands this off to
@@ -92,7 +94,8 @@ public class FoloContentAccessResource
         final TrackingKey tk = new TrackingKey( id );
 
         EventMetadata metadata =
-                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO );
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO ).set(
+                        STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
         return handler.doCreate( packageType, type, name, path, request, metadata, () -> uriInfo.getBaseUriBuilder()
                                                                                    .path( getClass() )
                                                                                    .path( path )

--- a/addons/pkg-maven/jaxrs/src/main/java/org/commonjava/indy/pkg/maven/jaxrs/MavenContentAccessResource.java
+++ b/addons/pkg-maven/jaxrs/src/main/java/org/commonjava/indy/pkg/maven/jaxrs/MavenContentAccessResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.bind.jaxrs.PackageContentAccessResource;
+import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.util.PathUtils;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ import javax.ws.rs.core.UriInfo;
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_CONTENT_REST_BASE_PATH;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
 
 @Api( value = "Maven Content Access and Storage",
       description = "Handles retrieval and management of Maven artifact content. This is the main point of access for Maven/Gradle users." )
@@ -78,8 +80,10 @@ public class MavenContentAccessResource
             final @PathParam( "path" ) String path, final @Context UriInfo uriInfo,
             final @Context HttpServletRequest request )
     {
+        final EventMetadata metadata = new EventMetadata().set( STORE_HTTP_HEADERS,
+                                                                RequestUtils.extractRequestHeadersToMap( request ) );
         return handler.doCreate( MAVEN_PKG_KEY, type, name, path, request,
-                                 new EventMetadata(), () -> uriInfo.getBaseUriBuilder()
+                                 metadata, () -> uriInfo.getBaseUriBuilder()
                                                                    .path( getClass() )
                                                                    .path( path )
                                                                    .build( MAVEN_PKG_KEY, type, name ) );

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
@@ -20,8 +20,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.bind.jaxrs.PackageContentAccessResource;
+import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.pkg.npm.inject.NPMContentHandler;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
@@ -47,6 +47,7 @@ import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_CONTENT_REST_BASE_PATH;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
 
 @Api( value = "NPM Content Access and Storage", description = "Handles retrieval and management of NPM artifact content. This is the main point of access for NPM users." )
 @Path( "/api/content/npm/{type: (hosted|group|remote)}/{name}" )
@@ -83,8 +84,9 @@ public class NPMContentAccessResource
             final @PathParam( "packageName" ) String packageName, final @Context UriInfo uriInfo,
             final @Context HttpServletRequest request )
     {
-        EventMetadata eventMetadata = new EventMetadata();
-        eventMetadata.set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() );
+        EventMetadata eventMetadata =
+                new EventMetadata().set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() )
+                                                         .set( STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
 
         return handler.doCreate( NPM_PKG_KEY, type, name, packageName, request, eventMetadata,
                                  () -> uriInfo.getBaseUriBuilder()

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/AbstractPromotionManagerTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/AbstractPromotionManagerTest.java
@@ -23,6 +23,7 @@ import org.commonjava.indy.client.core.IndyClientModule;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.indy.promote.client.IndyPromoteClientModule;
 import org.junit.Before;
 
@@ -49,16 +50,15 @@ public class AbstractPromotionManagerTest
         System.out.printf( "\n\n\n\nBASE-URL: %s\nPROMOTE-URL: %s\nRESUME-URL: %s\nROLLBACK-URL: %s\n\n\n\n",
                            client.getBaseUrl(), module.promoteUrl(), module.resumeUrl(), module.rollbackUrl() );
 
-        source = new HostedRepository( "source" );
+        source = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, "source" );
         client.stores()
               .create( source, changelog, HostedRepository.class );
 
         client.content()
-              .store( source.getKey().getType(), source.getName(), first,
+              .store( source.getKey(), first,
                       new ByteArrayInputStream( "This is a test".getBytes() ) );
         client.content()
-              .store( source.getKey()
-                            .getType(), source.getName(), second,
+              .store( source.getKey(), second,
                       new ByteArrayInputStream( "This is a test".getBytes() ) );
 
         target = createTarget( changelog );
@@ -67,7 +67,7 @@ public class AbstractPromotionManagerTest
     protected ArtifactStore createTarget( String changelog )
             throws Exception
     {
-        HostedRepository target = new HostedRepository( "target" );
+        HostedRepository target = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, "target" );
         client.stores()
               .create( target, changelog, HostedRepository.class );
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteAllTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteAllTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.commonjava.indy.promote.client.IndyPromoteClientModule;
 import org.commonjava.indy.promote.model.PathsPromoteRequest;
 import org.commonjava.indy.promote.model.PathsPromoteResult;
+import org.commonjava.maven.galley.io.SpecialPathConstants;
 import org.junit.Test;
 
 public class PromoteAllTest
@@ -48,15 +49,16 @@ public class PromoteAllTest
 
         final Set<String> completed = result.getCompletedPaths();
         assertThat( completed, notNullValue() );
-        assertThat( completed.size(), equalTo( 2 ) );
+        // Because NOS-1166 implementation, here we will have 4 promotion results: artifacts and their accompanied http metadata
+        assertThat( completed.size(), equalTo( 4 ) );
 
         assertThat( result.getError(), nullValue() );
 
-        assertThat( client.content()
-                          .exists( target.getKey()
-                                         .getType(), target.getName(), first ), equalTo( true ) );
-        assertThat( client.content()
-                          .exists( target.getKey()
-                                         .getType(), target.getName(), second ), equalTo( true ) );
+        assertThat( client.content().exists( target.getKey(), first ), equalTo( true ) );
+        assertThat( client.content().exists( target.getKey(), first + SpecialPathConstants.HTTP_METADATA_EXT ),
+                    equalTo( true ) );
+        assertThat( client.content().exists( target.getKey(), second ), equalTo( true ) );
+        assertThat( client.content().exists( target.getKey(), second + SpecialPathConstants.HTTP_METADATA_EXT ),
+                    equalTo( true ) );
     }
 }

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteDryRunTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteDryRunTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.commonjava.indy.promote.client.IndyPromoteClientModule;
 import org.commonjava.indy.promote.model.PathsPromoteRequest;
 import org.commonjava.indy.promote.model.PathsPromoteResult;
+import org.commonjava.maven.galley.io.SpecialPathConstants;
 import org.junit.Test;
 
 public class PromoteDryRunTest
@@ -49,15 +50,16 @@ public class PromoteDryRunTest
 
         final Set<String> pending = result.getPendingPaths();
         assertThat( pending, notNullValue() );
-        assertThat( pending.size(), equalTo( 2 ) );
+        // Because NOS-1166 implementation, here we will have 4 promotion results: artifacts and their accompanied http metadata
+        assertThat( pending.size(), equalTo( 4 ) );
 
         assertThat( result.getError(), nullValue() );
 
-        assertThat( client.content()
-                          .exists( target.getKey()
-                                         .getType(), target.getName(), first ), equalTo( false ) );
-        assertThat( client.content()
-                          .exists( target.getKey()
-                                         .getType(), target.getName(), second ), equalTo( false ) );
+        assertThat( client.content().exists( target.getKey(), first ), equalTo( false ) );
+        assertThat( client.content().exists( target.getKey(), first + SpecialPathConstants.HTTP_METADATA_EXT ),
+                    equalTo( false ) );
+        assertThat( client.content().exists( target.getKey(), second ), equalTo( false ) );
+        assertThat( client.content().exists( target.getKey(), second + SpecialPathConstants.HTTP_METADATA_EXT ),
+                    equalTo( false ) );
     }
 }

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RollbackTwoArtifactsTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RollbackTwoArtifactsTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.commonjava.indy.promote.client.IndyPromoteClientModule;
 import org.commonjava.indy.promote.model.PathsPromoteRequest;
 import org.commonjava.indy.promote.model.PathsPromoteResult;
+import org.commonjava.maven.galley.io.SpecialPathConstants;
 import org.junit.Test;
 
 public class RollbackTwoArtifactsTest
@@ -48,7 +49,8 @@ public class RollbackTwoArtifactsTest
 
         Set<String> completed = result.getCompletedPaths();
         assertThat( completed, notNullValue() );
-        assertThat( completed.size(), equalTo( 2 ) );
+        // Because NOS-1166 implementation, here we will have 4 promotion results: artifacts and their accompanied http metadata
+        assertThat( completed.size(), equalTo( 4 ) );
 
         assertThat( result.getError(), nullValue() );
 
@@ -65,15 +67,16 @@ public class RollbackTwoArtifactsTest
 
         pending = result.getPendingPaths();
         assertThat( pending, notNullValue() );
-        assertThat( pending.size(), equalTo( 2 ) );
+        // Because NOS-1166 implementation, here we will have 4 promotion results: artifacts and their accompanied http metadata
+        assertThat( pending.size(), equalTo( 4 ) );
 
         assertThat( result.getError(), nullValue() );
 
-        assertThat( client.content()
-                          .exists( target.getKey()
-                                         .getType(), target.getName(), first ), equalTo( false ) );
-        assertThat( client.content()
-                          .exists( target.getKey()
-                                         .getType(), target.getName(), second ), equalTo( false ) );
+        assertThat( client.content().exists( target.getKey(), first ), equalTo( false ) );
+        assertThat( client.content().exists( target.getKey(), first + SpecialPathConstants.HTTP_METADATA_EXT ),
+                    equalTo( false ) );
+        assertThat( client.content().exists( target.getKey(), second ), equalTo( false ) );
+        assertThat( client.content().exists( target.getKey(), second + SpecialPathConstants.HTTP_METADATA_EXT ),
+                    equalTo( false ) );
     }
 }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/DeprecatedContentAccessResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/DeprecatedContentAccessResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.maven.galley.event.EventMetadata;
 
@@ -46,6 +47,7 @@ import java.util.function.Supplier;
 
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.markDeprecated;
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
 
 @Api( value = "DEPRECATED: Content Access and Storage",
       description = "Handles retrieval and management of file/artifact content. This is the main point of access for most users." )
@@ -54,7 +56,6 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.markDeprecated;
 public class DeprecatedContentAccessResource
         implements IndyResources
 {
-
     @Inject
     private ContentAccessHandler handler;
 
@@ -89,7 +90,10 @@ public class DeprecatedContentAccessResource
             markDeprecated( builder, alt );
         };
 
-        return handler.doCreate( packageType, type, name, path, request, new EventMetadata(), uriSupplier, deprecated );
+        final EventMetadata metadata = new EventMetadata().set( STORE_HTTP_HEADERS,
+                                                                RequestUtils.extractRequestHeadersToMap( request ) );
+
+        return handler.doCreate( packageType, type, name, path, request, metadata, uriSupplier, deprecated );
     }
 
     @ApiOperation( "Delete file/artifact content under the given artifact store (type/name) and path." )

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/RequestUtils.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/RequestUtils.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.bind.jaxrs.util;
+
+import org.slf4j.Logger;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class RequestUtils
+{
+    public static Map<String, List<String>> extractRequestHeadersToMap( HttpServletRequest request )
+    {
+        final Map<String, List<String>> headersMap = new HashMap<>();
+        if ( request != null )
+        {
+            for ( String headerKey : Collections.list( request.getHeaderNames() ) )
+            {
+                Enumeration<String> headerValues = request.getHeaders( headerKey );
+                List<String> headerValuesList=  new ArrayList<>();
+                while(headerValues.hasMoreElements()){
+                    headerValuesList.add( headerValues.nextElement() );
+                }
+                headersMap.put( headerKey, headerValuesList );
+            }
+
+        }
+        return Collections.unmodifiableMap( headersMap );
+    }
+}

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/util/UrlUtils.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/util/UrlUtils.java
@@ -52,7 +52,7 @@ public final class UrlUtils
 
         final StringBuilder urlBuilder = new StringBuilder();
 
-        final List<String> list = new ArrayList<String>();
+        final List<String> list = new ArrayList<>();
 
         if ( baseUrl != null && !"null".equals( baseUrl ) )
         {

--- a/core/src/main/java/org/commonjava/indy/core/content/HttpMetadataCleanupGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/HttpMetadataCleanupGenerator.java
@@ -72,23 +72,25 @@ public class HttpMetadataCleanupGenerator
         return null;
     }
 
+    //This method is out of date which will block aritfacts uploading http-metadata generation, so remove the code
     @Override
+    @Deprecated
     public void handleContentStorage( final ArtifactStore store, final String path, final Transfer result,
                                       final EventMetadata eventMetadata )
         throws IndyWorkflowException
     {
-        final Transfer meta = result.getSiblingMeta( HttpExchangeMetadata.FILE_EXTENSION );
-        if ( meta.exists() )
-        {
-            try
-            {
-                meta.delete( false );
-            }
-            catch ( final IOException e )
-            {
-                logger.debug( "Failed to delete HTTP exchange metadata: " + meta, e );
-            }
-        }
+//        final Transfer meta = result.getSiblingMeta( HttpExchangeMetadata.FILE_EXTENSION );
+//        if ( meta.exists() )
+//        {
+//            try
+//            {
+//                meta.delete( false );
+//            }
+//            catch ( final IOException e )
+//            {
+//                logger.debug( "Failed to delete HTTP exchange metadata: " + meta, e );
+//            }
+//        }
     }
 
     @Override

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -45,6 +45,7 @@ import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.spi.io.TransferDecorator;
 import org.commonjava.maven.galley.transport.htcli.ContentsFilteringTransferDecorator;
+import org.commonjava.maven.galley.transport.htcli.UploadMetadataGenTransferDecorator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,12 +54,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 
@@ -87,7 +84,7 @@ public class DefaultGalleyStorageProvider
     @Inject
     private SpecialPathManager specialPathManager;
 
-    @ExecutorConfig( named = "indy-fast-local-executor", threads = 5, priority = 2, daemon = true )
+    @ExecutorConfig( named = "indy-fast-local-executor", threads = 5, priority = 2 )
     @WeftManaged
     @Inject
     private ExecutorService fastLocalExecutors;
@@ -197,7 +194,8 @@ public class DefaultGalleyStorageProvider
                                                    new Md5GeneratorFactory(), new Sha1GeneratorFactory(),
                                                    new Sha256GeneratorFactory() ),
                 new ContentsFilteringTransferDecorator(),
-                new NoCacheTransferDecorator( specialPathManager ) );
+                new NoCacheTransferDecorator( specialPathManager ),
+                new UploadMetadataGenTransferDecorator( specialPathManager ) );
 
         final File storeRoot = config.getStorageRootDirectory();
 

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreArtifactsAndRemoveThenHttpMetaDeletedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreArtifactsAndRemoveThenHttpMetaDeletedTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.maven.galley.io.SpecialPathConstants;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies that when deletes any real artifacts through http, the accompanied
+ * http-metadata.json will also be deleted.
+ * <br/>
+ * When:
+ * <ul>
+ *     <li>A real artifact but not metadata are stored in a hosted repository</li>
+ *     <li>Then the artifact is deleted</li>
+ * </ul>
+ * <br/>
+ * Then:
+ * <ul>
+ *     <li>The accompanied http-metadata.json for the artifact will be generated after artifact storing</li>
+ *     <li>The accompanied http-metadata.json for the artifact will be deleted after artifact deleting</li>
+ * </ul>
+ */
+public class StoreArtifactsAndRemoveThenHttpMetaDeletedTest
+        extends AbstractContentManagementTest
+{
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final String content = "This is a test: " + System.nanoTime();
+        final InputStream stream = new ByteArrayInputStream( content.getBytes() );
+
+        final String dirPath = "/org/foo/bar/1";
+        final String path = dirPath + "/bar-1.pom";
+        final String httpMetaPath = path + SpecialPathConstants.HTTP_METADATA_EXT;
+
+        StoreKey store = new StoreKey( MAVEN_PKG_KEY, hosted, STORE );
+        assertThat( client.content().exists( store, path ), equalTo( false ) );
+
+        client.content().store( store, path, stream );
+
+        assertThat( client.content().exists( store, path ), equalTo( true ) );
+        assertThat( client.content().exists( store, httpMetaPath ), equalTo( true ) );
+
+        client.content().delete( store, path );
+
+        assertThat( client.content().exists( store, path ), equalTo( false ) );
+        assertThat( client.content().exists( store, httpMetaPath ), equalTo( false ) );
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreArtifactsThenHttpMetaGeneratedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreArtifactsThenHttpMetaGeneratedTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.maven.galley.io.SpecialPathConstants;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+
+/**
+ * Verifies that when stores any real artifacts through http, the accompanied
+ * http-metadata.json will be generated with the http request headers
+ * <br/>
+ * When:
+ * <ul>
+ *     <li>Real artifacts but not metadata are stored in a hosted repository</li>
+ * </ul>
+ * <br/>
+ * Then:
+ * <ul>
+ *     <li>The accompanied http-metadata.json for the artifacts will be generated</li>
+ * </ul>
+ */
+public class StoreArtifactsThenHttpMetaGeneratedTest
+        extends AbstractContentManagementTest
+{
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final String content = "This is a test: " + System.nanoTime();
+        final InputStream stream = new ByteArrayInputStream( content.getBytes() );
+
+        final String dirPath = "/org/foo/bar/1";
+        final String pomPath = dirPath + "/bar-1.pom";
+        final String jarPath = dirPath + "/bar-1.jar";
+        final String pomHttpMetaPath = pomPath + SpecialPathConstants.HTTP_METADATA_EXT;
+        final String jarHttpMetaPath = jarPath + SpecialPathConstants.HTTP_METADATA_EXT;
+
+        StoreKey store = new StoreKey( MAVEN_PKG_KEY, hosted, STORE );
+
+        assertThat( client.content().exists( store, pomPath ), equalTo( false ) );
+        assertThat( client.content().exists( store, jarPath ), equalTo( false ) );
+
+        client.content().store( store, pomPath, stream );
+        assertThat( client.content().exists( store, pomPath ), equalTo( true ) );
+        assertThat( client.content().exists( store, pomHttpMetaPath ), equalTo( true ) );
+
+        client.content().store( store, jarPath, stream );
+        assertThat( client.content().exists( store, jarPath ), equalTo( true ) );
+        assertThat( client.content().exists( store, jarHttpMetaPath ), equalTo( true ) );
+
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreMetaThenHttpMetaNotGeneratedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreMetaThenHttpMetaNotGeneratedTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.maven.galley.io.SpecialPathConstants;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies that when stores any metadata through http, the accompanied
+ * http-metadata.json will NOT be generated with the http request headers
+ * <br/>
+ * When:
+ * <ul>
+ *     <li>Metadatas but not artifacts are stored in a hosted repository</li>
+ * </ul>
+ * <br/>
+ * Then:
+ * <ul>
+ *     <li>The accompanied http-metadata.json for the metadata will not be generated</li>
+ * </ul>
+ */
+public class StoreMetaThenHttpMetaNotGeneratedTest
+        extends AbstractContentManagementTest
+{
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final String content = "This is a test: " + System.nanoTime();
+        final InputStream stream = new ByteArrayInputStream( content.getBytes() );
+
+        final String dirPath = "/org/foo/bar";
+        final String metadataPath = dirPath + "/maven-metadata.xml";
+        final String archetypePath = dirPath + "/archetype-catalog.xml";
+        final String metadataHttpMetaPath = metadataPath + SpecialPathConstants.HTTP_METADATA_EXT;
+        final String archetypeHttpMetaPath = archetypePath + SpecialPathConstants.HTTP_METADATA_EXT;
+
+        StoreKey store = new StoreKey( MAVEN_PKG_KEY, hosted, STORE );
+
+        assertThat( client.content().exists( store, metadataPath ), equalTo( false ) );
+        assertThat( client.content().exists( store, archetypePath ), equalTo( false ) );
+
+        client.content().store( store, metadataPath, stream );
+        assertThat( client.content().exists( store, metadataPath ), equalTo( true ) );
+        assertThat( client.content().exists( store, metadataHttpMetaPath ), equalTo( false ) );
+
+        client.content().store( store, archetypePath, stream );
+        assertThat( client.content().exists( store, archetypePath ), equalTo( true ) );
+        assertThat( client.content().exists( store, archetypeHttpMetaPath ), equalTo( false ) );
+
+    }
+}


### PR DESCRIPTION
For new FastLocalCacheProvider, sometimes when large file uploading not finished and some clients request these files, they will get incorrect file metadata like file length, which will cause file mismatch problem. So we need to store the correct file metadata before the file uploading in a http-metadata.json, like what we have done for the remote pulling of the artifacts. Something different is that these metadata is from client http request headers. 