### PR TITLE
update NFC on file storage, and sync changes from 1.2.x branch

### DIFF
--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleEventManager.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleEventManager.java
@@ -15,10 +15,12 @@
  */
 package org.commonjava.indy.action;
 
+import org.commonjava.indy.change.event.IndyLifecycleEvent;
+
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
-import org.commonjava.indy.change.event.IndyLifecycleEvent;
+import static org.commonjava.indy.change.EventUtils.fireEvent;
 
 public class IndyLifecycleEventManager
 {
@@ -32,10 +34,7 @@ public class IndyLifecycleEventManager
 
     private void fire( final IndyLifecycleEvent event )
     {
-        if ( events != null )
-        {
-            events.fire( event );
-        }
+        fireEvent( events, event );
     }
 
 }

--- a/api/src/main/java/org/commonjava/indy/change/EventUtils.java
+++ b/api/src/main/java/org/commonjava/indy/change/EventUtils.java
@@ -1,0 +1,38 @@
+package org.commonjava.indy.change;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.event.Event;
+
+/**
+ * Common way to insulate the system from event processing failures. Event handling is derivative or peripheral
+ * to the main user workflows, even though it can harm long-term operation of the system. However, we can still
+ * serve content if even handling is malfunctioning...and errors in event handling cannot be fixed by the user
+ * anyway.
+ *
+ * Created by jdcasey on 11/1/17.
+ */
+public class EventUtils
+{
+    public static <T> void fireEvent( Event<T> dispatcher, T event )
+    {
+        try
+        {
+            if ( dispatcher != null )
+            {
+                dispatcher.fire( event );
+            }
+            else
+            {
+                Logger logger = LoggerFactory.getLogger( EventUtils.class );
+                logger.error( "Cannot fire event: {}. Reason: Event dispatcher is null!", event );
+            }
+        }
+        catch ( RuntimeException e )
+        {
+            Logger logger = LoggerFactory.getLogger( EventUtils.class );
+            logger.error( String.format( "Error processing event: %s. Reason: %s", event, e.getMessage() ), e );
+        }
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/change/event/IndyFileEventManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/event/IndyFileEventManager.java
@@ -15,8 +15,6 @@
  */
 package org.commonjava.indy.core.change.event;
 
-import org.commonjava.cdi.util.weft.ExecutorConfig;
-import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.change.event.IndyStoreErrorEvent;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -31,7 +29,8 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
-import java.util.concurrent.Executor;
+
+import static org.commonjava.indy.change.EventUtils.fireEvent;
 
 /**
  * Helper class to provide simple methods to handle null-checking, etc. around the firing of Indy filesystem events.
@@ -71,70 +70,55 @@ public class IndyFileEventManager
     @Override
     public void fire( final FileNotFoundEvent evt )
     {
-        if ( fireEvent( evt.getEventMetadata() ) ){
-            doFire( notFoundEvent, evt );
+        if ( shouldFireEvent( evt.getEventMetadata() ) ){
+            fireEvent( notFoundEvent, evt );
         }
     }
 
     @Override
     public void fire( final FileStorageEvent evt )
     {
-        if ( fireEvent( evt.getEventMetadata() ) )
+        if ( shouldFireEvent( evt.getEventMetadata() ) )
         {
-            doFire( storageEvent, evt );
+            fireEvent( storageEvent, evt );
         }
     }
 
     @Override
     public void fire( final FileAccessEvent evt )
     {
-        if ( fireEvent( evt.getEventMetadata() ) )
+        if ( shouldFireEvent( evt.getEventMetadata() ) )
         {
-            doFire( accessEvent, evt );
+            fireEvent( accessEvent, evt );
         }
     }
 
     @Override
     public void fire( final FileDeletionEvent evt )
     {
-        if ( fireEvent( evt.getEventMetadata() ) )
+        if ( shouldFireEvent( evt.getEventMetadata() ) )
         {
-            doFire( deleteEvent, evt );
+            fireEvent( deleteEvent, evt );
         }
     }
 
     @Override
     public void fire( final FileErrorEvent evt )
     {
-        if ( fireEvent( evt.getEventMetadata() ) )
+        if ( shouldFireEvent( evt.getEventMetadata() ) )
         {
-            doFire( errorEvent, evt );
+            fireEvent( errorEvent, evt );
         }
     }
 
     public void fire( final IndyStoreErrorEvent evt )
     {
-        doFire( storeErrorEvent, evt );
+        fireEvent( storeErrorEvent, evt );
     }
 
-    private boolean fireEvent( EventMetadata eventMetadata )
+    private boolean shouldFireEvent( EventMetadata eventMetadata )
     {
         return ( eventMetadata == null || !Boolean.TRUE.equals( eventMetadata.get( ContentManager.SUPPRESS_EVENTS ) ) );
     }
 
-    private <T> void doFire( final Event<T> eventQ, final T evt )
-    {
-//        executor.execute( () -> {
-//        logger.trace( "Firing {} event: {}", evt.getClass().getSimpleName(), evt );
-        if ( eventQ != null )
-        {
-            eventQ.fire( evt );
-        }
-        else
-        {
-            logger.warn( "ERROR: No event queue available for firing: {}", evt );
-        }
-//        logger.trace( "Done firing {} event: {}", evt.getClass().getSimpleName(), evt );
-//        } );
-    }
 }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -1038,7 +1038,7 @@ public class DefaultDownloadManager
 
         private final Transfer start;
 
-        private final Event<ArtifactStoreRescanEvent> rescanEventPublisher;
+        private final Event<ArtifactStoreRescanEvent> rescanEvent;
 
         private final IndyFileEventManager fileEventManager;
 
@@ -1054,7 +1054,7 @@ public class DefaultDownloadManager
             this.start = start;
             this.rescansInProgress = rescansInProgress;
             this.fileEventManager = fileEventManager;
-            this.rescanEventPublisher = rescanEvent;
+            this.rescanEvent = rescanEvent;
             this.eventMetadata = eventMetadata;
         }
 
@@ -1075,14 +1075,11 @@ public class DefaultDownloadManager
 
             try
             {
-                fireEvent( rescanEvent, new ArtifactStoreRescanEvent( eventMetadata, store ) );
+                fireEvent( rescanEvent, new ArtifactStorePreRescanEvent( eventMetadata, store ) );
 
                 doRescan( start );
 
-                if ( rescanEventPublisher != null )
-                {
-                    rescanEventPublisher.fire( new ArtifactStorePostRescanEvent( eventMetadata, store ) );
-                }
+                fireEvent( rescanEvent, new ArtifactStorePostRescanEvent( eventMetadata, store ) );
             }
             finally
             {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -79,6 +79,7 @@ import java.util.stream.StreamSupport;
 
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.change.EventUtils.fireEvent;
 import static org.commonjava.indy.util.ContentUtils.dedupeListing;
 
 @javax.enterprise.context.ApplicationScoped
@@ -1074,10 +1075,7 @@ public class DefaultDownloadManager
 
             try
             {
-                if ( rescanEventPublisher != null )
-                {
-                    rescanEventPublisher.fire( new ArtifactStorePreRescanEvent( eventMetadata, store ) );
-                }
+                fireEvent( rescanEvent, new ArtifactStoreRescanEvent( eventMetadata, store ) );
 
                 doRescan( start );
 

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -71,6 +71,7 @@ import java.util.Spliterators;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.StreamSupport;
 
+import static org.commonjava.indy.change.EventUtils.fireEvent;
 import static org.commonjava.indy.core.change.StoreEnablementManager.DISABLE_TIMEOUT;
 import static org.commonjava.indy.core.change.StoreEnablementManager.TIMEOUT_USE_DEFAULT;
 
@@ -714,7 +715,7 @@ public class ScheduleManager
                 logger.debug( "Expiration Created: {}", expiredKey );
                 final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
                 final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
-                eventDispatcher.fire( new SchedulerScheduleEvent( type, data ) );
+                fireEvent( eventDispatcher, new SchedulerScheduleEvent( type, data ) );
             }
         }
     }
@@ -737,7 +738,7 @@ public class ScheduleManager
                 logger.debug( "EXPIRED: {}", expiredKey );
                 final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
                 final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
-                eventDispatcher.fire( new SchedulerTriggerEvent( type, data ) );
+                fireEvent( eventDispatcher, new SchedulerTriggerEvent( type, data ) );
             }
         }
     }

--- a/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/change/DataFileEventManager.java
+++ b/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/change/DataFileEventManager.java
@@ -15,13 +15,14 @@
  */
 package org.commonjava.indy.subsys.datafile.change;
 
-import java.io.File;
+import org.commonjava.indy.audit.ChangeSummary;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
+import java.io.File;
 
-import org.commonjava.indy.audit.ChangeSummary;
+import static org.commonjava.indy.change.EventUtils.fireEvent;
 
 /**
  * Helper class to provide simple methods to handle null-checking, etc. around the firing of Indy filesystem events.
@@ -35,10 +36,7 @@ public class DataFileEventManager
 
     public void fire( final DataFileEvent evt )
     {
-        if ( events != null )
-        {
-            events.fire( evt );
-        }
+        fireEvent( events, evt );
     }
 
     public void accessed( final File file )


### PR DESCRIPTION
This PR enables NFC management when files are uploaded. It also cherry-picks two commits from the indy-1.2.x branch which were not ported over to the master branch. These are:

* Consolidate event firing behind EventUtils
* Synchronize retrieval of ReentrantLock in MavenMetadataGenerator to make it safer