### PR TITLE
re-add format jar for fix indy pr build failed

### DIFF
--- a/tools/assemblies/src/main/resources/assemblies/dataset.xml
+++ b/tools/assemblies/src/main/resources/assemblies/dataset.xml
@@ -11,6 +11,7 @@
 <assembly>
   <id>dataset</id>
   <formats>
+    <format>jar</format>
     <format>tar.gz</format>
   </formats>
   


### PR DESCRIPTION
@jdcasey   I find you remove format jar of dataset in 12/14/2017, so indy build can not find the dependency.
So I re-add it.
ruhan's PR maybe not correct.
https://github.com/Commonjava/indy/pull/910
Please review it