### PR TITLE
Make jboss-logging lib import first in classpath to avoid import from weld with old version

### DIFF
--- a/deployments/launcher/src/main/bin/indy.sh
+++ b/deployments/launcher/src/main/bin/indy.sh
@@ -37,9 +37,17 @@ do
   CP=${CP}:${f}
 done
 
+# To avoid jboss logging import from weld with old version.
+jb_logging=$(find $BASEDIR/lib/thirdparty/jboss-logging-*.jar -type f)
+if [ -f $jb_logging ]; then
+  CP=${CP}:$jb_logging
+fi
+
 for f in $(find $BASEDIR/lib/thirdparty -type f)
 do
-  CP=${CP}:${f}
+  if [[ $f != *jboss-logging* ]]; then
+    CP=${CP}:${f}
+  fi
 done
 
 # echo "Classpath: ${CP}"


### PR DESCRIPTION
When indy start I found that it is importing jboss logging classes from weld-se with old version, which will make infinispan debug logging incompatible. So I make the jboss-logging jar placed before weld-se in classpath settings, and seems it works. 