### PR TITLE
Use file listing in promotion to narrow scope of NFC clear-out (#933)

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -41,9 +41,12 @@ import org.commonjava.indy.promote.model.GroupPromoteResult;
 import org.commonjava.indy.promote.model.PathsPromoteRequest;
 import org.commonjava.indy.promote.model.PathsPromoteResult;
 import org.commonjava.indy.promote.model.ValidationResult;
+import org.commonjava.indy.promote.validate.PromotionValidationException;
 import org.commonjava.indy.promote.validate.PromotionValidator;
+import org.commonjava.indy.promote.validate.model.ValidationRequest;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
@@ -64,6 +67,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.cdi.util.weft.ContextSensitiveWeakHashMap.newSynchronizedContextSensitiveWeakHashMap;
@@ -177,7 +181,8 @@ public class PromotionManager
             locked = lock.tryLock( config.getLockTimeoutSeconds(), TimeUnit.SECONDS );
             if ( locked )
             {
-                validator.validate( request, validation, baseUrl );
+                ValidationRequest validationRequest = validator.validate( request, validation, baseUrl );
+
                 if ( validation.isValid() )
                 {
                     if ( !request.isDryRun() && !target.getConstituents().contains( request.getSource() ) )
@@ -193,7 +198,7 @@ public class PromotionManager
                                                                                            + target.getKey() );
 
                             storeManager.storeArtifactStore( target, changeSummary, false, true, new EventMetadata() );
-                            clearStoreNFC( target );
+                            clearStoreNFC( validationRequest.getSourcePaths(), target );
 
                             if ( hosted == request.getSource().getType() && config.isAutoLockHostedRepos() )
                             {
@@ -356,7 +361,7 @@ public class PromotionManager
         }
 
         ValidationResult validation = new ValidationResult();
-        validator.validate( request, validation, baseUrl );
+        ValidationRequest validationRequest = validator.validate( request, validation, baseUrl );
         if ( request.isDryRun() )
         {
             return new PathsPromoteResult( request, pending, Collections.emptySet(), Collections.emptySet(),
@@ -364,7 +369,8 @@ public class PromotionManager
         }
         else if ( validation.isValid() )
         {
-            return runPathPromotions( request, pending, Collections.emptySet(), Collections.emptySet(), contents, validation );
+            return runPathPromotions( request, pending, Collections.emptySet(), Collections.emptySet(), contents,
+                                      validation, validationRequest );
         }
         else
         {
@@ -387,14 +393,16 @@ public class PromotionManager
      * @throws PromotionException
      * @throws IndyWorkflowException
      */
-    public PathsPromoteResult resumePathsPromote( final PathsPromoteResult result )
+    public PathsPromoteResult resumePathsPromote( final PathsPromoteResult result, final String baseUrl )
             throws PromotionException, IndyWorkflowException
     {
         final List<Transfer> contents =
                 getTransfersForPaths( result.getRequest().getSource(), result.getPendingPaths() );
 
+        ValidationResult validation = new ValidationResult();
+        ValidationRequest validationRequest = validator.validate( result.getRequest(), validation, baseUrl );
         return runPathPromotions( result.getRequest(), result.getPendingPaths(), result.getCompletedPaths(),
-                                  result.getSkippedPaths(), contents, result.getValidations() );
+                                  result.getSkippedPaths(), contents, result.getValidations(), validationRequest );
     }
 
     /**
@@ -514,7 +522,8 @@ public class PromotionManager
 
     private PathsPromoteResult runPathPromotions( final PathsPromoteRequest request, final Set<String> pending,
                                                   final Set<String> prevComplete, final Set<String> prevSkipped,
-                                                  final List<Transfer> contents, ValidationResult validation )
+                                                  final List<Transfer> contents, ValidationResult validation,
+                                                  final ValidationRequest validationRequest )
     {
         if ( pending == null || pending.isEmpty() )
         {
@@ -622,9 +631,9 @@ public class PromotionManager
                                         logger.error( msg, e );
                                     }
                                 }
-                                clearStoreNFC( targetStore );
+                                clearStoreNFC( validationRequest.getSourcePaths(), targetStore );
                             }
-                            catch ( final IndyWorkflowException | IndyDataException e )
+                            catch ( final IndyWorkflowException | IndyDataException | PromotionValidationException e )
                             {
                                 String msg = String.format( "Failed to promote path: %s to: %s. Reason: %s", transfer,
                                                             targetStore, e.getMessage() );
@@ -695,14 +704,37 @@ public class PromotionManager
         return contents;
     }
 
-    private void clearStoreNFC( ArtifactStore store )
+    /**
+     * NOTE: Adding sourcePaths parameter here to cut down on number of paths for clearing from NFC.
+     *
+     * @param sourcePaths The set of paths that need to be cleared from the NFC.
+     * @param store The store whose affected groups should have their NFC entries cleared
+     * @throws IndyDataException
+     */
+    private void clearStoreNFC( final Set<String> sourcePaths, ArtifactStore store )
             throws IndyDataException
     {
-        nfc.clearMissing( LocationUtils.toLocation( store ) );
+        Set<String> paths = sourcePaths.stream()
+                                       .map( sp -> sp.startsWith( "/" ) && sp.length() > 1 ? sp.substring( 1 ) : sp )
+                                       .collect( Collectors.toSet() );
+
+        paths.forEach( path -> {
+            ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( store ), path );
+
+            logger.debug( "Clearing NFC path: {} from: {}\n\tResource: {}", path, store.getKey(), resource );
+            nfc.clearMissing( resource );
+        } );
+
         Set<Group> groups = storeManager.query().getGroupsAffectedBy( store.getKey() );
         if ( groups != null )
         {
-            groups.forEach( group -> nfc.clearMissing( LocationUtils.toLocation( group ) ) );
+            groups.forEach( group -> paths.forEach(
+                    path -> {
+                        ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( group ), path );
+
+                        logger.debug( "Clearing NFC path: {} from: {}\n\tResource: {}", path, group.getKey(), resource );
+                        nfc.clearMissing( resource );
+                    } ) );
         }
     }
 

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/model/ValidationRequest.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/model/ValidationRequest.java
@@ -74,23 +74,12 @@ public class ValidationRequest
 
             if ( paths == null )
             {
-                ArtifactStore store = null;
-                try
-                {
-                    store = tools.getArtifactStore( promoteRequest.getSource() );
-                }
-                catch ( IndyDataException e )
-                {
-                    throw new PromotionValidationException( "Failed to retrieve source ArtifactStore: {}. Reason: {}",
-                                                            e, promoteRequest.getSource(), e.getMessage() );
-                }
-
-                if ( store != null )
+                if ( sourceRepository != null )
                 {
                     try
                     {
                         paths = new HashSet<>();
-                        listRecursively( store, "/", paths );
+                        listRecursively( sourceRepository, "/", paths );
                     }
                     catch ( IndyWorkflowException e )
                     {

--- a/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteResource.java
+++ b/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteResource.java
@@ -200,7 +200,7 @@ public class PromoteResource
     @Path( "/paths/resume" )
     @POST
     @Consumes( ApplicationContent.application_json )
-    public Response resumePaths( @Context final HttpServletRequest request )
+    public Response resumePaths( @Context final HttpServletRequest request, final @Context UriInfo uriInfo )
     {
         PathsPromoteResult result = null;
         Response response = null;
@@ -220,7 +220,18 @@ public class PromoteResource
 
         try
         {
-            result = manager.resumePathsPromote( result );
+            PathsPromoteRequest req = result.getRequest();
+
+            PackageTypeDescriptor packageTypeDescriptor =
+                    PackageTypes.getPackageTypeDescriptor( req.getSource().getPackageType() );
+
+            final String baseUrl = uriInfo.getBaseUriBuilder()
+                                          .path( packageTypeDescriptor.getContentRestBasePath() )
+                                          .build( req.getSource().getType().singularEndpointName(),
+                                                  req.getSource().getName() )
+                                          .toString();
+
+            result = manager.resumePathsPromote( result, baseUrl );
 
             // TODO: Amend response status code based on presence of error? This would have consequences for client API...
             response = formatOkResponseWithJsonEntity( result, mapper );


### PR DESCRIPTION
* Refactor to provide the list of paths from the promotion request to invalidate in NFC

Groups have access to very large sets of content, and correspondingly, may have
very large not-found caches. When we promote artifacts into the reach of a group
we need to invalidate any NFC entries related to those promoted artifacts. Up to now
we've been invalidating the whole NFC presence for a group, on the assumption that
this would be cheaper than determining exactly which paths need to be invalidated.

However, because groups have such a huge reach at times, and because the NFC's
repo- or group-wide clear method is pretty inefficient currently (owing to the
path-centric data model used), this turns out to be a very bad assumption. It gets
much, much worse when you have a few layers of groups stacked on top of each other.

On the other hand, in order for even the most basic promotion validations to happen,
it's highly likely that the paths subject to promotion have already been discovered.
In fact, during the validation process, if this listing is discovered once, it is
cached for future use by subsequent validation rule executions.

Exposing this cached list of affected paths enables the PromotionManager to fine-tune
its operation to clear the NFC of affected groups, and should save a boatload of time.

* Fixing problems with leading slash in NFC clear call, derived from recursive listing from repo root.

* Forgot to refactor one clearMissing() call for the target store itself. Adding that here.

* clearing of NFC still wrong a little bit. Removed leftover code for target group

Conflicts:
	addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java