### PR TITLE
[1.2.x] backport metadata fixes and stop throwing errors from member metadata

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
@@ -123,6 +123,8 @@ public class IndyKojiConfig
 
     private Integer connectionPoolTimeoutSeconds;
 
+    private String versionFilter;
+
     @Override
     public SiteConfig getKojiSiteConfig()
             throws IOException
@@ -429,6 +431,16 @@ public class IndyKojiConfig
         return result.isPresent();
     }
 
+    public String getVersionFilter()
+    {
+        return versionFilter;
+    }
+
+    public void setVersionFilterer( String versionFilter )
+    {
+        this.versionFilter = versionFilter;
+    }
+
     @Override
     public void parameter( final String name, final String value )
             throws ConfigurationException
@@ -550,6 +562,11 @@ public class IndyKojiConfig
             case "naming.format.binary":
             {
                 this.binayNamingFormat = value;
+                break;
+            }
+            case "version.filter":
+            {
+                this.versionFilter = value;
                 break;
             }
             default:

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -26,11 +26,13 @@ import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
 import org.codehaus.plexus.interpolation.InterpolationException;
 import org.codehaus.plexus.interpolation.ObjectBasedValueSource;
 import org.codehaus.plexus.interpolation.StringSearchInterpolator;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.IndyMetricsNames;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.index.ContentIndexManager;
+import org.commonjava.indy.core.inject.GroupMembershipLocks;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
@@ -67,10 +69,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
+import static org.commonjava.indy.model.core.StoreType.group;
 
 /**
  * {@link ContentManager} decorator that watches the retrieve() methods. If the result is going to be a null {@link Transfer}
@@ -138,6 +142,10 @@ public abstract class KojiContentManagerDecorator
 
     @Inject
     private ContentIndexManager indexManager;
+
+    @GroupMembershipLocks
+    @Inject
+    private Locker<StoreKey> groupMembershipLocker;
 
     public KojiRepositoryCreator createRepoCreator()
     {
@@ -591,7 +599,7 @@ public abstract class KojiContentManagerDecorator
         }
     }
 
-    private Group adjustTargetGroup( final RemoteRepository buildRepo, final Group group )
+    private Group adjustTargetGroup( final RemoteRepository buildRepo, final Group srcGroup )
             throws IndyWorkflowException
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
@@ -599,50 +607,71 @@ public abstract class KojiContentManagerDecorator
         // try to lookup the group -> targetGroup mapping in config, using the
         // entry-point group as the lookup key. If that returns null, the targetGroup is
         // the entry-point group.
-        Group targetGroup = group;
-
         boolean isBinaryBuild = KOJI_ORIGIN_BINARY.equals( buildRepo.getMetadata( ArtifactStore.METADATA_ORIGIN) );
 
-        String targetName = isBinaryBuild ? config.getTargetBinaryGroup( group.getName() )
-                : config.getTargetGroup( group.getName() );
+        String targetName = isBinaryBuild ? config.getTargetBinaryGroup( srcGroup.getName() )
+                : config.getTargetGroup( srcGroup.getName() );
+
+        StoreKey targetKey = srcGroup.getKey();
 
         if ( targetName != null )
         {
+            targetKey = new StoreKey( srcGroup.getPackageType(), group, targetName );
+        }
+
+        StoreKey tk = targetKey;
+        AtomicReference<IndyWorkflowException> wfEx = new AtomicReference<>();
+
+        Group result = groupMembershipLocker.lockAnd( targetKey, config.getLockTimeoutSeconds(), k->{
+            Group targetGroup = null;
             try
             {
-                targetGroup = storeDataManager.query().packageType( group.getPackageType() ).getGroup( targetName );
+                targetGroup = (Group) storeDataManager.getArtifactStore( tk );
             }
             catch ( IndyDataException e )
             {
-                throw new IndyWorkflowException(
+                wfEx.set( new IndyWorkflowException(
                         "Cannot lookup koji-addition target group: %s (source group: %s). Reason: %s", e, targetName,
-                        group.getName(), e.getMessage() );
+                        srcGroup.getName(), e.getMessage() ) );
+
+                return null;
             }
-        }
 
-        logger.info( "Adding Koji build proxy: {} to group: {}", buildRepo.getKey(), targetGroup.getKey() );
+            logger.info( "Adding Koji build proxy: {} to group: {}", buildRepo.getKey(), targetGroup.getKey() );
 
-        // Append the new remote repo as a member of the targetGroup.
-        targetGroup.addConstituent( buildRepo );
-        try
+            // Append the new remote repo as a member of the targetGroup.
+            targetGroup.addConstituent( buildRepo );
+            try
+            {
+                final ChangeSummary changeSummary = new ChangeSummary( ChangeSummary.SYSTEM_USER,
+                                                                       "Adding remote repository for Koji build: "
+                                                                               + buildRepo.getMetadata( NVR ) );
+
+                storeDataManager.storeArtifactStore( targetGroup, changeSummary, false, true, new EventMetadata() );
+            }
+            catch ( IndyDataException e )
+            {
+                wfEx.set( new IndyWorkflowException( "Cannot store target-group: %s changes for: %s. Error: %s", e,
+                                                        targetGroup.getName(), buildRepo.getMetadata( NVR ),
+                                                        e.getMessage() ) );
+                return null;
+            }
+
+            logger.info( "Retrieving GAV: {} from: {}", buildRepo.getMetadata( CREATION_TRIGGER_GAV ), buildRepo );
+
+            return targetGroup;
+        }, (k, lock)->{
+            return false;
+        } );
+
+        IndyWorkflowException ex = wfEx.get();
+        if ( ex != null )
         {
-            final ChangeSummary changeSummary = new ChangeSummary( ChangeSummary.SYSTEM_USER,
-                                                                   "Adding remote repository for Koji build: "
-                                                                           + buildRepo.getMetadata( NVR ) );
-
-            storeDataManager.storeArtifactStore( targetGroup, changeSummary, false, true, new EventMetadata() );
+            throw ex;
         }
-        catch ( IndyDataException e )
-        {
-            throw new IndyWorkflowException( "Cannot store target-group: %s changes for: %s. Error: %s", e,
-                                             targetGroup.getName(), buildRepo.getMetadata( NVR ), e.getMessage() );
-        }
-
-        logger.info( "Retrieving GAV: {} from: {}", buildRepo.getMetadata( CREATION_TRIGGER_GAV ), buildRepo );
-
-        return targetGroup;
 
         // TODO: how to index it for the group...?
+        return result;
     }
 
     private String formatStorageUrl( final KojiBuildInfo buildInfo )

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -61,6 +61,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.commonjava.cdi.util.weft.ContextSensitiveWeakHashMap.newSynchronizedContextSensitiveWeakHashMap;
@@ -194,6 +195,13 @@ public class KojiMavenMetadataProvider
                                 logger.debug( "Skipping non-POM: {}", archive.getFilename() );
                                 continue;
                             }
+
+                            if ( !isVerSignedAllowed( archive.getVersion() ) )
+                            {
+                                logger.debug( "version filter pattern not matched: {}", archive.getVersion() );
+                                continue;
+                            }
+
                             SingleVersion singleVersion = null;
                             try
                             {
@@ -205,6 +213,7 @@ public class KojiMavenMetadataProvider
                                              archive.getVersion(), archive.getRelPath(), archive.getBuildId() );
                                 continue;
                             }
+
                             if ( versions.contains( singleVersion ) )
                             {
                                 logger.debug( "Skipping already collected version: {}", archive.getVersion() );
@@ -350,5 +359,21 @@ public class KojiMavenMetadataProvider
 
         logger.debug( "Returning null metadata result for unknown reason (path: '{}')", path );
         return null;
+    }
+
+    private boolean isVerSignedAllowed ( String version )
+    {
+        final String versionFilter = kojiConfig.getVersionFilter();
+
+        if ( versionFilter == null )
+        {
+            return true;
+        }
+
+        if ( Pattern.compile( versionFilter ).matcher( version ).matches())
+        {
+            return true;
+        }
+        return false;
     }
 }

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -151,7 +151,7 @@ public class KojiMavenMetadataProvider
         }
         catch ( InvalidRefException e )
         {
-            logger.debug( "Not a valid Maven GA: {}:{}. Skipping Koji metadata retrieval.", groupId, artifactId );
+            logger.warn( "Not a valid Maven GA: {}:{}. Skipping Koji metadata retrieval.", groupId, artifactId );
         }
 
         if ( ga == null )
@@ -327,15 +327,16 @@ public class KojiMavenMetadataProvider
                 }
                 catch ( KojiClientException e )
                 {
-                    throw new IndyWorkflowException(
-                            "Failed to retrieve version metadata for: %s from Koji. Reason: %s", e, ga,
-                            e.getMessage() );
+                    logger.error(
+                            String.format( "Failed to retrieve version metadata for: %s from Koji. Reason: %s", ga,
+                                           e.getMessage() ), e );
+                    metadata = null;
                 }
-
-                Metadata md = metadata;
 
                 if ( metadata != null )
                 {
+                    Metadata md = metadata;
+
                     // FIXME: Need a way to listen for cache expiration and re-request this?
                     versionMetadata.execute( ( cache ) -> cache.getAdvancedCache()
                                                                .put( ref, md, kojiConfig.getMetadataTimeoutSeconds(),

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiMavenVersionMetadataLocks.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiMavenVersionMetadataLocks.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.koji.inject;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply "folo-in-progress" cache in infinispan.xml.
+ */
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD } )
+@Retention( RetentionPolicy.RUNTIME )
+@Documented
+public @interface KojiMavenVersionMetadataLocks
+{
+}

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
@@ -17,11 +17,13 @@ package org.commonjava.indy.koji.inject;
 
 import com.redhat.red.build.koji.KojiClient;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.indy.action.ShutdownAction;
 import org.commonjava.indy.action.StartupAction;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 import org.commonjava.rwx.binding.error.BindException;
 import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordManager;
@@ -49,6 +51,8 @@ public class KojijiProvider
 
     private PasswordManager kojiPasswordManager;
 
+    private Locker<ProjectRef> versionMetadataLocks;
+
     @Inject
     @WeftManaged
     @ExecutorConfig( named = "koji-queries", threads = 4 )
@@ -58,6 +62,14 @@ public class KojijiProvider
     public KojiClient getKojiClient()
     {
         return kojiClient;
+    }
+
+    @KojiMavenVersionMetadataLocks
+    @Produces
+    @ApplicationScoped
+    public Locker<ProjectRef> getVersionMetadataLocks()
+    {
+        return versionMetadataLocks;
     }
 
     @Override
@@ -88,6 +100,8 @@ public class KojijiProvider
         {
             throw new IndyLifecycleException( "Failed to start koji client: %s", e, e.getMessage() );
         }
+
+        versionMetadataLocks = new Locker<>();
     }
 
     @Override

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -15,32 +15,32 @@
  */
 package org.commonjava.indy.pkg.maven.content;
 
-import org.commonjava.indy.IndyMetricsNames;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
-import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.WeftManaged;
+import org.commonjava.indy.IndyMetricsNames;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.DirectContentAccess;
+import org.commonjava.indy.content.MergedContentAction;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.content.AbstractMergedContentGenerator;
-import org.commonjava.indy.content.MergedContentAction;
 import org.commonjava.indy.core.content.group.GroupMergeHelper;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.measure.annotation.IndyMetrics;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.measure.annotation.MetricNamed;
-import org.commonjava.indy.data.IndyDataException;
-import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger;
-import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
-import org.commonjava.indy.pkg.maven.metrics.IndyMetricsPkgMavenNames;
 import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger;
+import org.commonjava.indy.pkg.maven.metrics.IndyMetricsPkgMavenNames;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.atlas.ident.ref.SimpleTypeAndClassifier;
@@ -87,13 +87,10 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
-import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_EXISTS;
-import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_GENERATED;
+import static org.commonjava.cdi.util.weft.ContextSensitiveWeakHashMap.newSynchronizedContextSensitiveWeakHashMap;
 import static org.commonjava.maven.galley.io.SpecialPathConstants.HTTP_METADATA_EXT;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
-
-import org.apache.commons.lang.StringUtils;
 
 public class MavenMetadataGenerator
     extends AbstractMergedContentGenerator

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -572,6 +572,13 @@ public class MavenMetadataGenerator
         // Try to generate missed meta
         missing = generateMissingMemberMetadata( group, missing, memberMetas, toMergePath );
 
+        if ( !missing.isEmpty() )
+        {
+            logger.warn(
+                    "After download and generation attempts, metadata is still missing from the following stores: {}",
+                    missing );
+        }
+
         List<Metadata> metas = members.stream()
                                       .map( mem -> memberMetas.get(mem.getKey()) )
                                       .filter( mmeta -> mmeta != null )
@@ -610,7 +617,7 @@ public class MavenMetadataGenerator
         Set<ArtifactStore> ret = new HashSet<>(); // return stores which failed generation
 
         CountDownLatch latch = new CountDownLatch( missing.size() );
-        List<String> errors = new ArrayList<>();
+//        List<String> errors = new ArrayList<>();
 
         /* @formatter:off */
         missing.forEach( (store)->{
@@ -642,13 +649,13 @@ public class MavenMetadataGenerator
                 }
                 catch ( final Exception e )
                 {
-                    String msg = String.format( "Failed to generate metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
+                    String msg = String.format( "EXCLUDING Failed generated metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
                                                  e.getMessage() );
                     logger.error( msg, e );
-                    synchronized ( errors )
-                    {
-                        errors.add( msg );
-                    }
+//                    synchronized ( errors )
+//                    {
+//                        errors.add( msg );
+//                    }
                 }
                 finally
                 {
@@ -660,11 +667,11 @@ public class MavenMetadataGenerator
 
         waitOnLatch(group, toMergePath, latch);
 
-        if ( !errors.isEmpty() )
-        {
-            throw new IndyWorkflowException( "Failed to generate one or more member metadata files for: %s:%s. Errors were:\n  %s",
-                            group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
-        }
+//        if ( !errors.isEmpty() )
+//        {
+//            throw new IndyWorkflowException( "Failed to generate one or more member metadata files for: %s:%s. Errors were:\n  %s",
+//                            group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
+//        }
 
         return ret;
     }
@@ -740,7 +747,7 @@ public class MavenMetadataGenerator
         Set<ArtifactStore> ret = new HashSet<>(  ); // return stores which failed download
 
         CountDownLatch latch = new CountDownLatch( missing.size() );
-        List<String> errors = Collections.synchronizedList( new ArrayList<>() );
+//        List<String> errors = Collections.synchronizedList( new ArrayList<>() );
 
         /* @formatter:off */
         missing.forEach( (store)->{
@@ -771,10 +778,10 @@ public class MavenMetadataGenerator
                 }
                 catch ( final Exception e )
                 {
-                    String msg = String.format( "Failed to retrieve metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
+                    String msg = String.format( "EXCLUDING Failed to metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
                                                  e.getMessage() );
                     logger.error( msg, e );
-                    errors.add( msg );
+//                    errors.add( msg );
                 }
                 finally
                 {
@@ -786,12 +793,12 @@ public class MavenMetadataGenerator
 
         waitOnLatch(group, toMergePath, latch);
 
-        if ( !errors.isEmpty() )
-        {
-            throw new IndyWorkflowException(
-                    "Failed to retrieve one or more member metadata files for: %s:%s. Errors were:\n  %s",
-                    group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
-        }
+//        if ( !errors.isEmpty() )
+//        {
+//            throw new IndyWorkflowException(
+//                    "Failed to retrieve one or more member metadata files for: %s:%s. Errors were:\n  %s",
+//                    group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
+//        }
 
         return ret;
     }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -491,16 +491,18 @@ public class MavenMetadataGenerator
         logger.trace( "Start write .info file based on if the cache exists for group {} of members {} in path. ",
                       group.getKey(), contributingMembers, path );
         final Transfer mergeInfoTarget = fileManager.getTransfer( group, path + GroupMergeHelper.MERGEINFO_SUFFIX );
-        logger.trace( ".info file not found for {} of members {} in path {}", group.getKey(), contributingMembers, path );
 
         logger.trace(
-                "metadata merge info not cached for group {} of members {} in path {}, will regenerate.",
+                "Regenerating metadata merge info for group {} of members {} in path {}",
                 group.getKey(), contributingMembers, path );
+
         String metaMergeInfo = helper.generateMergeInfoFromKeys( contributingMembers );
 
         logger.trace( "Metadata merge info for {} of members {} in path {} is {}", group.getKey(), contributingMembers,
                       path, metaMergeInfo );
+
         helper.writeMergeInfo( metaMergeInfo, group, path );
+
         logger.trace( ".info file regenerated for group {} of members {} in path. Full path: {}", group.getKey(), contributingMembers,
                       path, mergeInfoTarget.getDetachedFile() );
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMembershipListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMembershipListener.java
@@ -1,0 +1,148 @@
+package org.commonjava.indy.pkg.maven.content;
+
+import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;
+import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class MetadataMembershipListener
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private MavenMetadataGenerator metadataGenerator;
+
+    @Inject
+    @MavenVersionMetadataCache
+    private CacheHandle<StoreKey, Map> versionMetadataCache;
+
+    /**
+     * Listen to an #{@link ArtifactStorePreUpdateEvent} and clear the metadata cache due to changed memeber in that event
+     *
+     * @param event
+     */
+    public void onStoreUpdate( @Observes final ArtifactStorePreUpdateEvent event )
+    {
+        logger.trace( "Got store-update event: {}", event );
+
+        if ( ArtifactStoreUpdateType.UPDATE == event.getType() )
+        {
+            for ( ArtifactStore store : event )
+            {
+                removeMetadataCacheContent( store, event.getChangeMap() );
+            }
+        }
+    }
+
+    private void removeMetadataCacheContent( final ArtifactStore store,
+                                             final Map<ArtifactStore, ArtifactStore> changeMap )
+    {
+        handleStoreDisableOrEnable( store, changeMap );
+
+        handleGroupMembersChanged( store, changeMap );
+    }
+
+    // if a store is disabled/enabled, we should clear its metadata cache and all of its affected groups cache too.
+    private void handleStoreDisableOrEnable(final ArtifactStore store,
+                                            final Map<ArtifactStore, ArtifactStore> changeMap){
+        final ArtifactStore oldStore = changeMap.get( store );
+        if ( store.isDisabled() != oldStore.isDisabled() )
+        {
+            final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( store.getKey() );
+            if ( metadataMap != null && !metadataMap.isEmpty() )
+            {
+                versionMetadataCache.remove( store.getKey() );
+//                try
+//                {
+//                    storeManager.query().getGroupsAffectedBy( store.getKey() ).forEach( g -> clearGroupMetaCache( g ) );
+//                }
+//                catch ( IndyDataException e )
+//                {
+//                    logger.error( String.format( "Can not get affected groups of %s", store.getKey() ), e );
+//                }
+            }
+        }
+    }
+
+    // If group members changed, should clear the cascading groups metadata cache
+    private void handleGroupMembersChanged(final ArtifactStore store,
+                                           final Map<ArtifactStore, ArtifactStore> changeMap)
+    {
+        final StoreKey key = store.getKey();
+        if ( StoreType.group == key.getType() )
+        {
+            final List<StoreKey> newMembers = ( (Group) store ).getConstituents();
+            logger.trace( "New members of: {} are: {}", store.getKey(), newMembers );
+
+            final Group group = (Group) changeMap.get( store );
+            final List<StoreKey> oldMembers = group.getConstituents();
+            logger.trace( "Old members of: {} are: {}", group.getName(), oldMembers );
+
+            boolean membersChanged = false;
+
+            if ( newMembers.size() != oldMembers.size() )
+            {
+                membersChanged = true;
+            }
+            else
+            {
+                for ( StoreKey storeKey : newMembers )
+                {
+                    if ( !oldMembers.contains( storeKey ) )
+                    {
+                        membersChanged = true;
+                    }
+                }
+            }
+
+            if ( membersChanged )
+            {
+                clearGroupMetaCache( group );
+                //                try
+                //                {
+                //                    storeManager.query().getGroupsAffectedBy( group.getKey() ).forEach( g -> clearGroupMetaCache( g ) );
+                //                }
+                //                catch ( IndyDataException e )
+                //                {
+                //                    logger.error( String.format( "Can not get affected groups of %s", group.getKey()), e );
+                //                }
+            }
+            else
+            {
+                logger.trace( "No members changed, no need to expunge merged metadata" );
+            }
+        }
+    }
+
+    private void clearGroupMetaCache( final Group group )
+    {
+        final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( group.getKey() );
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Clearing metadata for group: {}\n{}", group.getKey(), metadataMap );
+
+        if ( metadataMap != null && !metadataMap.isEmpty() )
+        {
+            String[] paths = new String[metadataMap.size()];
+            paths = metadataMap.keySet().toArray( paths );
+
+            metadataGenerator.clearAllMerged( group, paths );
+        }
+
+        versionMetadataCache.remove( group.getKey() );
+    }
+
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
@@ -44,12 +44,11 @@ import java.util.Set;
 /**
  * This listener will do these tasks:
  * <ul>
- *     <li>When there are member changes for a group, or some members disabled/enabled in a group, delete group metadata caches to force next regeneration of the metadata files of the group(cascaded)</li>
  *     <li>When the metadata file changed of a member in a group, delete correspond cache of that file path of the member and group (cascaded)</li>
  * </ul>
  */
 @ApplicationScoped
-public class MetadataMergeListner
+public class MetadataMergeListener
         implements MergedContentAction
 {
     final Logger logger = LoggerFactory.getLogger( getClass() );
@@ -58,44 +57,8 @@ public class MetadataMergeListner
     private DirectContentAccess fileManager;
 
     @Inject
-    private StoreDataManager storeManager;
-
-    @Inject
     @MavenVersionMetadataCache
     private CacheHandle<StoreKey, Map> versionMetadataCache;
-
-    private void clearTempMetaFile( final Group group, final String path )
-    {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-        logger.trace( "Clearing merged metadata: {} from group: {}", path, group );
-
-        try
-        {
-            final Transfer tempMetaTxfr = fileManager.getTransfer( group, path );
-            if ( tempMetaTxfr != null && tempMetaTxfr.exists() )
-            {
-                tempMetaTxfr.delete();
-            }
-        }
-        catch ( IndyWorkflowException | IOException e )
-        {
-            logger.error( "Can not delete temp metadata file for group. Group: {}, file path: {}", group, path );
-        }
-
-        try
-        {
-            final Transfer tempMetaMergeInfoTxfr =
-                    fileManager.getTransfer( group, path + GroupMergeHelper.MERGEINFO_SUFFIX );
-            if ( tempMetaMergeInfoTxfr != null && tempMetaMergeInfoTxfr.exists() )
-            {
-                tempMetaMergeInfoTxfr.delete();
-            }
-        }
-        catch ( IndyWorkflowException | IOException e )
-        {
-            logger.error( "Can not delete temp metadata file for group. Group: {}, file path: {}", group, path );
-        }
-    }
 
     /**
      * Will clear the both merge path and merge info file of member and group contains that member(cascaded) if that path of file changed in the member of #originatingStore

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -16,11 +16,14 @@
 package org.commonjava.indy.promote.data;
 
 import org.apache.commons.lang.StringUtils;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.IndyMetricsNames;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.DownloadManager;
+import org.commonjava.indy.core.inject.GroupMembershipLocks;
+import org.commonjava.indy.core.inject.StoreContentLocks;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.measure.annotation.IndyMetrics;
@@ -62,12 +65,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.io.IOUtils.closeQuietly;
-import static org.commonjava.cdi.util.weft.ContextSensitiveWeakHashMap.newSynchronizedContextSensitiveWeakHashMap;
 import static org.commonjava.indy.model.core.StoreType.hosted;
 
 /**
@@ -97,9 +97,13 @@ public class PromotionManager
     @Inject
     private PromotionValidator validator;
 
-    private Map<StoreKey, ReentrantLock> byPathTargetLocks = newSynchronizedContextSensitiveWeakHashMap();
+    @StoreContentLocks
+    @Inject
+    private Locker<StoreKey> byPathTargetLocks;
 
-    private Map<StoreKey, ReentrantLock> byGroupTargetLocks = newSynchronizedContextSensitiveWeakHashMap();
+    @GroupMembershipLocks
+    @Inject
+    private Locker<StoreKey> byGroupTargetLocks;
 
     private Map<String, StoreKey> targetGroupKeyMap = new ConcurrentHashMap<>( 1 );
 
@@ -111,20 +115,17 @@ public class PromotionManager
     }
 
     public PromotionManager( PromotionValidator validator, final ContentManager contentManager,
-                             final DownloadManager downloadManager, final StoreDataManager storeManager, PromoteConfig config )
+                             final DownloadManager downloadManager, final StoreDataManager storeManager,
+                             Locker<StoreKey> byPathTargetLocks, Locker<StoreKey> byGroupTargetLocks,
+                             PromoteConfig config, NotFoundCache nfc )
     {
         this.validator = validator;
         this.contentManager = contentManager;
         this.downloadManager = downloadManager;
         this.storeManager = storeManager;
+        this.byPathTargetLocks = byPathTargetLocks;
+        this.byGroupTargetLocks = byGroupTargetLocks;
         this.config = config;
-    }
-
-    public PromotionManager( PromotionValidator validator, final ContentManager contentManager,
-                             final DownloadManager downloadManager, final StoreDataManager storeManager,
-                             PromoteConfig config, NotFoundCache nfc )
-    {
-        this( validator, contentManager, downloadManager, storeManager, config );
         this.nfc = nfc;
     }
 
@@ -144,18 +145,9 @@ public class PromotionManager
             return new GroupPromoteResult( request, error );
         }
 
-        Group target;
-        try
-        {
-            target = (Group) storeManager.getArtifactStore( request.getTargetKey() );
-        }
-        catch ( IndyDataException e )
-        {
-            throw new PromotionException( "Cannot retrieve target group: %s. Reason: %s", e, request.getTargetGroup(),
-                                          e.getMessage() );
-        }
+        final StoreKey targetKey = getTargetKey( request.getTargetGroup() );
 
-        if ( target == null )
+        if ( !storeManager.hasArtifactStore( targetKey ) )
         {
             String error = String.format( "No such target group: %s.", request.getTargetGroup() );
             logger.warn( error );
@@ -166,13 +158,22 @@ public class PromotionManager
         ValidationResult validation = new ValidationResult();
         logger.info( "Running validations for promotion of: {} to group: {}", request.getSource(),
                      request.getTargetGroup() );
-        final StoreKey targetKey = getTargetKey( request.getTargetGroup() );
-        final ReentrantLock lock = byGroupTargetLocks.computeIfAbsent( targetKey, k -> new ReentrantLock() );
-        Boolean locked = false;
-        try
-        {
-            locked = lock.tryLock( config.getLockTimeoutSeconds(), TimeUnit.SECONDS );
-            if ( locked )
+
+        AtomicReference<PromotionException> error = new AtomicReference<>();
+        byGroupTargetLocks.lockAnd( targetKey, config.getLockTimeoutSeconds(), k-> {
+            Group target;
+            try
+            {
+                target = (Group) storeManager.getArtifactStore( request.getTargetKey() );
+            }
+            catch ( IndyDataException e )
+            {
+                error.set( new PromotionException( "Cannot retrieve target group: %s. Reason: %s", e,
+                                                   request.getTargetGroup(), e.getMessage() ) );
+                return null;
+            }
+
+            try
             {
                 ValidationRequest validationRequest = validator.validate( request, validation, baseUrl );
 
@@ -209,32 +210,34 @@ public class PromotionManager
                         }
                         catch ( IndyDataException e )
                         {
-                            throw new PromotionException(
-                                    "Failed to store group: %s with additional member: %s. Reason: %s", e,
-                                    target.getKey(), request.getSource(), e.getMessage() );
+                            error.set( new PromotionException(
+                                    "Failed to store group: %s with additional member: %s. Reason: %s", e, target.getKey(),
+                                    request.getSource(), e.getMessage() ) );
                         }
                     }
                 }
             }
-            else
+            catch ( PromotionValidationException e )
             {
-                //FIXME: should we consider to repeat the promote process several times when lock failed?
-                String error = String.format(
-                        "Failed to acquire group promotion lock on target when promote: %s in %d seconds.", targetKey,
-                        config.getLockTimeoutSeconds() );
-                logger.error( error );
+                error.set( e );
             }
-        }
-        catch ( InterruptedException e )
+
+            return null;
+        }, (k,lock)-> {
+            //FIXME: should we consider to repeat the promote process several times when lock failed?
+            String errorMsg = String.format(
+                    "Failed to acquire group promotion lock on target when promote: %s in %d seconds.", targetKey,
+                    config.getLockTimeoutSeconds() );
+            logger.error( errorMsg );
+            error.set( new PromotionException( errorMsg ) );
+
+            return Boolean.FALSE;
+        } );
+
+        PromotionException e = error.get();
+        if ( e != null )
         {
-            logger.warn( "Interrupted waiting for promotion lock on target: {}", targetKey );
-        }
-        finally
-        {
-            if ( locked )
-            {
-                lock.unlock();
-            }
+            throw e;
         }
 
         return new GroupPromoteResult( request, validation );
@@ -417,8 +420,6 @@ public class PromotionManager
     {
         StoreKey targetKey = result.getRequest().getTarget();
 
-        ReentrantLock lock = byPathTargetLocks.computeIfAbsent( targetKey, k -> new ReentrantLock() );
-
         final List<Transfer> contents = getTransfersForPaths( targetKey, result.getCompletedPaths() );
         final Set<String> completed = result.getCompletedPaths();
         final Set<String> skipped = result.getSkippedPaths();
@@ -429,10 +430,10 @@ public class PromotionManager
             return result;
         }
 
-        Set<String> pending = result.getPendingPaths();
-        pending = pending == null ? new HashSet<>() : new HashSet<>( pending );
+        Set<String> pending =
+                result.getPendingPaths() == null ? new HashSet<>() : new HashSet<>( result.getPendingPaths() );
 
-        String error = null;
+        final AtomicReference<String> error = new AtomicReference<>();
         final boolean copyToSource = result.getRequest().isPurgeSource();
 
         ArtifactStore source = null;
@@ -442,41 +443,38 @@ public class PromotionManager
         }
         catch ( final IndyDataException e )
         {
-            error = String.format( "Failed to retrieve artifact store: %s. Reason: %s",
-                                   result.getRequest().getSource(), e.getMessage() );
-            logger.error( error, e );
+            String msg =
+                    String.format( "Failed to retrieve artifact store: %s. Reason: %s", result.getRequest().getSource(),
+                                   e.getMessage() );
+
+            logger.error( msg, e );
+            error.set( msg );
         }
 
-        boolean locked = false;
-        try
+        AtomicReference<IndyWorkflowException> wfEx = new AtomicReference<>();
+        if ( error.get() == null )
         {
-            if ( error == null )
-            {
-                locked= lock.tryLock( config.getLockTimeoutSeconds(), TimeUnit.SECONDS );
-                if ( !locked )
-                {
-                    error = String.format( "Failed to acquire promotion lock on target: %s in %d seconds.", targetKey,
-                                           config.getLockTimeoutSeconds() );
-                    logger.warn( error );
-                }
-            }
-
-            if ( error == null )
-            {
+            ArtifactStore src = source;
+            byPathTargetLocks.lockAnd( targetKey, config.getLockTimeoutSeconds(), k->{
                 for ( final Transfer transfer : contents )
                 {
                     if ( transfer != null && transfer.exists() )
                     {
-                        InputStream stream = null;
                         try
                         {
                             if ( copyToSource )
                             {
-                                stream = transfer.openInputStream( true );
                                 final String path = transfer.getPath();
-                                contentManager.store( source, path, stream, TransferOperation.UPLOAD,
-                                                      new EventMetadata() );
-                                stream.close();
+                                try(InputStream stream = transfer.openInputStream( true ))
+                                {
+                                    contentManager.store( src, path, stream, TransferOperation.UPLOAD,
+                                                          new EventMetadata() );
+                                }
+                                catch ( IndyWorkflowException e )
+                                {
+                                    wfEx.set( e );
+                                    return null;
+                                }
                             }
 
                             transfer.delete( true );
@@ -485,32 +483,33 @@ public class PromotionManager
                         }
                         catch ( final IOException e )
                         {
-                            error = String.format( "Failed to rollback path promotion of: %s from: %s. Reason: %s",
+                            String msg = String.format( "Failed to rollback path promotion of: %s from: %s. Reason: %s",
                                                    transfer, result.getRequest().getSource(), e.getMessage() );
-                            logger.error( error, e );
-                        }
-                        finally
-                        {
-                            closeQuietly( stream );
+                            logger.error( msg, e );
+                            error.set( msg );
                         }
                     }
                 }
-            }
-        }
-        catch ( InterruptedException e )
-        {
-            error = String.format( "Interrupted waiting for promotion lock on target: %s", targetKey );
-            logger.warn( error );
-        }
-        finally
-        {
-            if ( locked )
+
+                return null;
+            }, (k,lock)->{
+                String msg = String.format( "Failed to acquire promotion lock on target: %s in %d seconds.", targetKey,
+                                       config.getLockTimeoutSeconds() );
+                logger.warn( msg );
+                error.set( msg );
+
+                return false;
+            } );
+
+            IndyWorkflowException wfException = wfEx.get();
+            if ( wfException != null )
             {
-                lock.unlock();
+                throw wfException;
             }
+
         }
 
-        return new PathsPromoteResult( result.getRequest(), pending, completed, skipped, error, new ValidationResult() );
+        return new PathsPromoteResult( result.getRequest(), pending, completed, skipped, error.get(), new ValidationResult() );
     }
 
     private PathsPromoteResult runPathPromotions( final PathsPromoteRequest request, final Set<String> pending,
@@ -525,139 +524,121 @@ public class PromotionManager
 
         StoreKey targetKey= request.getTarget();
 
-        ReentrantLock lock = byPathTargetLocks.computeIfAbsent( targetKey, k -> new ReentrantLock() );
-
         final Set<String> complete = prevComplete == null ? new HashSet<>() : new HashSet<>( prevComplete );
         final Set<String> skipped = prevSkipped == null ? new HashSet<>() : new HashSet<>( prevSkipped );
 
         List<String> errors = new ArrayList<>();
-        boolean locked = false;
+
+        ArtifactStore sourceStore = null;
         try
         {
-            if ( !storeManager.hasArtifactStore( request.getSource() ) )
-            {
-                String msg = String.format(
-                        "Failed to retrieve source artifact store: %s. Seems it does not exist in indy store definitions",
-                        request.getSource() );
-                errors.add( msg );
-                logger.error( msg );
-            }
-
-            if ( !storeManager.hasArtifactStore( request.getTarget() ) )
-            {
-                String msg = String.format(
-                        "Failed to retrieve target artifact store: %s. Seems it does not exist in indy store definitions",
-                        request.getSource() );
-                errors.add( msg );
-                logger.error( msg );
-            }
-
-            if ( errors.isEmpty() )
-            {
-                ArtifactStore sourceStore = storeManager.getArtifactStore( request.getSource() );
-                ArtifactStore targetStore = storeManager.getArtifactStore( request.getTarget() );
-                locked = lock.tryLock( config.getLockTimeoutSeconds(), TimeUnit.SECONDS );
-                if ( !locked )
-                {
-                    String error =
-                            String.format( "Failed to acquire promotion lock on target: %s in %d seconds.", targetKey,
-                                           config.getLockTimeoutSeconds() );
-
-                    errors.add( error );
-                    logger.warn( error );
-                }
-
-                if ( errors.isEmpty() )
-                {
-                    logger.info( "Running promotions from: {} (key: {})\n  to: {} (key: {})", sourceStore,
-                                 request.getSource(), targetStore, request.getTarget() );
-
-                    final boolean purgeSource = request.isPurgeSource();
-                    contents.forEach( ( transfer ) -> {
-                        final String path = transfer.getPath();
-
-                        if ( !transfer.exists() )
-                        {
-                            pending.remove( path );
-                            skipped.add( path );
-                        }
-                        else
-                        {
-                            try
-                            {
-                                Transfer target =
-                                        contentManager.getTransfer( targetStore, path, TransferOperation.UPLOAD );
-                                //                        synchronized ( target )
-                                //                        {
-                                // TODO: Should the request object have an overwrite attribute? Is that something the user is qualified to decide?
-                                if ( target != null && target.exists() )
-                                {
-                                    logger.warn( "NOT promoting: {} from: {} to: {}. Target file already exists.", path,
-                                                 request.getSource(), request.getTarget() );
-
-                                    // TODO: There's no guarantee that the pre-existing content is the same!
-                                    pending.remove( path );
-                                    skipped.add( path );
-                                }
-                                else
-                                {
-                                    try (InputStream stream = transfer.openInputStream( true ))
-                                    {
-                                        contentManager.store( targetStore, path, stream, TransferOperation.UPLOAD,
-                                                              new EventMetadata() );
-
-                                        pending.remove( path );
-                                        complete.add( path );
-
-                                        stream.close();
-
-                                        if ( purgeSource )
-                                        {
-                                            contentManager.delete( sourceStore, path, new EventMetadata() );
-                                        }
-                                    }
-                                    catch ( final IOException e )
-                                    {
-                                        String msg = String.format( "Failed to open input stream for: %s. Reason: %s",
-                                                                    transfer, e.getMessage() );
-                                        errors.add( msg );
-                                        logger.error( msg, e );
-                                    }
-                                }
-                                clearStoreNFC( validationRequest.getSourcePaths(), targetStore );
-                            }
-                            catch ( final IndyWorkflowException | IndyDataException | PromotionValidationException e )
-                            {
-                                String msg = String.format( "Failed to promote path: %s to: %s. Reason: %s", transfer,
-                                                            targetStore, e.getMessage() );
-                                errors.add( msg );
-                                logger.error( msg, e );
-                            }
-                        }
-                    } );
-                }
-            }
-
+            sourceStore = storeManager.getArtifactStore( request.getSource() );
         }
-        catch ( InterruptedException e )
-        {
-            String error = String.format( "Interrupted waiting for promotion lock on target: %s", targetKey );
-            errors.add( error );
-            logger.warn( error );
-        }
-        catch ( final IndyDataException e )
+        catch ( IndyDataException e )
         {
             String msg = String.format( "Failed to retrieve artifact store: %s. Reason: %s", request.getSource(),
                                         e.getMessage() );
             errors.add( msg );
             logger.error( msg, e );
         }
-        finally
+
+        ArtifactStore targetStore = null;
+        try
         {
-            if ( locked )
-            {
-                lock.unlock();
-            }
+            targetStore = storeManager.getArtifactStore( request.getTarget() );
+        }
+        catch ( IndyDataException e )
+        {
+            String msg = String.format( "Failed to retrieve artifact store: %s. Reason: %s", request.getTarget(),
+                                        e.getMessage() );
+            errors.add( msg );
+            logger.error( msg, e );
+        }
+
+        if ( errors.isEmpty() )
+        {
+            ArtifactStore src = sourceStore;
+            ArtifactStore tgt = targetStore;
+
+            byPathTargetLocks.lockAnd( targetKey, config.getLockTimeoutSeconds(), k->{
+                logger.info( "Running promotions from: {} (key: {})\n  to: {} (key: {})", src,
+                             request.getSource(), tgt, request.getTarget() );
+
+                final boolean purgeSource = request.isPurgeSource();
+                contents.forEach( ( transfer ) -> {
+                    final String path = transfer.getPath();
+
+                    if ( !transfer.exists() )
+                    {
+                        pending.remove( path );
+                        skipped.add( path );
+                    }
+                    else
+                    {
+                        try
+                        {
+                            Transfer target =
+                                    contentManager.getTransfer( tgt, path, TransferOperation.UPLOAD );
+                            //                        synchronized ( target )
+                            //                        {
+                            // TODO: Should the request object have an overwrite attribute? Is that something the user is qualified to decide?
+                            if ( target != null && target.exists() )
+                            {
+                                logger.warn( "NOT promoting: {} from: {} to: {}. Target file already exists.", path,
+                                             request.getSource(), request.getTarget() );
+
+                                // TODO: There's no guarantee that the pre-existing content is the same!
+                                pending.remove( path );
+                                skipped.add( path );
+                            }
+                            else
+                            {
+                                try (InputStream stream = transfer.openInputStream( true ))
+                                {
+                                    contentManager.store( tgt, path, stream, TransferOperation.UPLOAD,
+                                                          new EventMetadata() );
+
+                                    pending.remove( path );
+                                    complete.add( path );
+
+                                    stream.close();
+
+                                    if ( purgeSource )
+                                    {
+                                        contentManager.delete( src, path, new EventMetadata() );
+                                    }
+                                }
+                                catch ( final IOException e )
+                                {
+                                    String msg = String.format( "Failed to open input stream for: %s. Reason: %s",
+                                                                transfer, e.getMessage() );
+                                    errors.add( msg );
+                                    logger.error( msg, e );
+                                }
+                            }
+                            clearStoreNFC( validationRequest.getSourcePaths(), tgt );
+                        }
+                        catch ( final IndyWorkflowException | IndyDataException | PromotionValidationException e )
+                        {
+                            String msg = String.format( "Failed to promote path: %s to: %s. Reason: %s", transfer,
+                                                        tgt, e.getMessage() );
+                            errors.add( msg );
+                            logger.error( msg, e );
+                        }
+                    }
+                } );
+
+                return null;
+            }, (k,lock)->{
+                String error =
+                        String.format( "Failed to acquire promotion lock on target: %s in %d seconds.", targetKey,
+                                       config.getLockTimeoutSeconds() );
+
+                errors.add( error );
+                logger.warn( error );
+
+                return false;
+            } );
         }
 
         String error = null;

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.promote.data;
 
 import org.apache.commons.io.IOUtils;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.conf.DefaultIndyConfiguration;
@@ -34,6 +35,7 @@ import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
 import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.promote.conf.PromoteConfig;
 import org.commonjava.indy.promote.model.PathsPromoteRequest;
@@ -172,7 +174,9 @@ public class PromotionManagerTest
 
         PromoteConfig config = new PromoteConfig();
 
-        manager = new PromotionManager( validator, contentManager, downloadManager, storeManager, config, nfc );
+        manager =
+                new PromotionManager( validator, contentManager, downloadManager, storeManager, new Locker<StoreKey>(),
+                                      new Locker<StoreKey>(), config, nfc );
 
         executor = Executors.newCachedThreadPool();
     }

--- a/api/src/main/java/org/commonjava/indy/change/EventUtils.java
+++ b/api/src/main/java/org/commonjava/indy/change/EventUtils.java
@@ -32,21 +32,21 @@ public class EventUtils
 {
     public static <T> void fireEvent( Event<T> dispatcher, T event )
     {
+        Logger logger = LoggerFactory.getLogger( EventUtils.class );
         try
         {
             if ( dispatcher != null )
             {
+                logger.trace( "Firing event: {}", event );
                 dispatcher.fire( event );
             }
             else
             {
-                Logger logger = LoggerFactory.getLogger( EventUtils.class );
                 logger.error( "Cannot fire event: {}. Reason: Event dispatcher is null!", event );
             }
         }
         catch ( RuntimeException e )
         {
-            Logger logger = LoggerFactory.getLogger( EventUtils.class );
             logger.error( String.format( "Error processing event: %s. Reason: %s", event, e.getMessage() ), e );
         }
     }

--- a/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
@@ -110,8 +111,7 @@ public abstract class AbstractMergedContentGenerator
 
     protected abstract String getMergedMetadataName();
 
-    protected void clearAllMerged( final ArtifactStore store, final String path )
-            throws IndyWorkflowException
+    protected void clearAllMerged( final ArtifactStore store, final String... paths )
     {
         final Set<Group> groups = new HashSet<>();
 
@@ -133,12 +133,12 @@ public abstract class AbstractMergedContentGenerator
 
         }
 
-        groups.stream().forEach( group -> clearMergedFile( group, path ) );
+        groups.stream().forEach( group -> Stream.of(paths).forEach( path->clearMergedFile( group, path ) ));
 
         if ( mergedContentActions != null )
         {
             StreamSupport.stream( mergedContentActions.spliterator(), true )
-                         .forEach( action -> action.clearMergedPath( store, groups, path ) );
+                         .forEach( action -> Stream.of(paths).forEach( path->action.clearMergedPath( store, groups, path ) ) );
         }
     }
 

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
 
 import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.util.ContentUtils.dedupeListing;
+import static org.commonjava.maven.galley.io.SpecialPathConstants.HTTP_METADATA_EXT;
 
 public class DefaultContentManager
         implements ContentManager
@@ -330,6 +331,17 @@ public class DefaultContentManager
                     item = generator.generateFileContent( store, path, eventMetadata );
                     if ( item != null )
                     {
+                        logger.debug( "Resource generated for {}, clean NFC and delete obsolete http-metadata.json", item.getResource() );
+                        nfc.clearMissing( item.getResource() );
+                        Transfer httpMeta = item.getSiblingMeta( HTTP_METADATA_EXT );
+                        try
+                        {
+                            httpMeta.delete();
+                        }
+                        catch ( IOException e )
+                        {
+                            logger.warn( "Failed to delete {}", httpMeta.getResource() );
+                        }
                         break;
                     }
                 }

--- a/core/src/main/java/org/commonjava/indy/core/content/group/GroupMergeHelper.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/group/GroupMergeHelper.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.slf4j.Logger;
@@ -67,17 +68,29 @@ public class GroupMergeHelper
             logger.debug( "Deleting: {}", targetSha );
             targetSha.delete();
         }
+        else
+        {
+            logger.trace( "{} does not exist. Not deleting.", targetSha );
+        }
 
         if ( targetMd5 != null )
         {
             logger.debug( "Deleting: {}", targetMd5 );
             targetMd5.delete();
         }
+        else
+        {
+            logger.trace( "{} does not exist. Not deleting.", targetMd5 );
+        }
 
         if ( targetInfo != null )
         {
             logger.debug( "Deleting: {}", targetInfo );
             targetInfo.delete();
+        }
+        else
+        {
+            logger.trace( "{} does not exist. Not deleting.", targetInfo );
         }
     }
 
@@ -99,10 +112,19 @@ public class GroupMergeHelper
         return mergeInfoBuilder.toString();
     }
 
+    public final String generateMergeInfoFromKeys( final List<StoreKey> sources )
+    {
+        final StringBuilder mergeInfoBuilder = new StringBuilder();
+        sources.forEach( src->mergeInfoBuilder.append(src).append('\n') );
+        return mergeInfoBuilder.toString();
+    }
+
     public final void writeMergeInfo( final String mergeInfo, final Group group, final String path )
     {
         final String infoPath = path+MERGEINFO_SUFFIX;
-        logger.trace( ".info file path is {} for group {}, content is {}", infoPath, group.getKey(), mergeInfo );
+        logger.trace( ".info file path is {} for group {} (members: {}), content is {}", infoPath, group.getKey(),
+                      group.getConstituents(), mergeInfo );
+
         final Transfer targetInfo = downloadManager.getStorageReference( group, infoPath );
         Writer fw = null;
         try

--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreLockerProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreLockerProducer.java
@@ -1,0 +1,40 @@
+package org.commonjava.indy.core.inject;
+
+import org.commonjava.cdi.util.weft.Locker;
+import org.commonjava.indy.model.core.StoreKey;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+public class CoreLockerProducer
+{
+
+    private Locker<StoreKey> groupMembershipLocker;
+
+    private Locker<StoreKey> storeContentLocker;
+
+    @PostConstruct
+    public void init()
+    {
+        groupMembershipLocker = new Locker<>();
+        storeContentLocker = new Locker<>();
+    }
+
+    @GroupMembershipLocks
+    @Produces
+    @ApplicationScoped
+    public Locker<StoreKey> getGroupMembershipLocker()
+    {
+        return groupMembershipLocker;
+    }
+
+    @StoreContentLocks
+    @Produces
+    @ApplicationScoped
+    public Locker<StoreKey> getStoreContentLocker()
+    {
+        return storeContentLocker;
+    }
+
+}

--- a/core/src/main/java/org/commonjava/indy/core/inject/GroupMembershipLocks.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/GroupMembershipLocks.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.inject;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply "content-metadata" cache in infinispan.xml.
+ */
+@Qualifier
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface GroupMembershipLocks
+{
+}

--- a/core/src/main/java/org/commonjava/indy/core/inject/StoreContentLocks.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/StoreContentLocks.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.inject;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply "content-metadata" cache in infinispan.xml.
+ */
+@Qualifier
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface StoreContentLocks
+{
+}

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -15,14 +15,15 @@
  */
 package org.commonjava.indy.mem.data;
 
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
 import org.commonjava.indy.conf.DefaultIndyConfiguration;
 import org.commonjava.indy.conf.IndyConfiguration;
+import org.commonjava.indy.data.ArtifactStoreQuery;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
 import org.commonjava.indy.data.StoreDataManager;
-import org.commonjava.indy.data.ArtifactStoreQuery;
 import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -41,10 +42,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import static org.commonjava.cdi.util.weft.ContextSensitiveWeakHashMap.newSynchronizedContextSensitiveWeakHashMap;
 import static org.commonjava.indy.model.core.StoreType.hosted;
 
 @ApplicationScoped
@@ -52,11 +52,14 @@ import static org.commonjava.indy.model.core.StoreType.hosted;
 public class MemoryStoreDataManager
         implements StoreDataManager
 {
+    private static final long LOCK_TIMEOUT_SECONDS = 10;
+
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     private final Map<StoreKey, ArtifactStore> stores = new ConcurrentHashMap<>();
 
-    private final Map<StoreKey, ReentrantLock> opLocks = newSynchronizedContextSensitiveWeakHashMap();
+    // no need to inject since this is only used internally.
+    private final Locker<StoreKey> opLocks = new Locker<>();
 
     @Inject
     private StoreEventDispatcher dispatcher;
@@ -177,37 +180,47 @@ public class MemoryStoreDataManager
             throws IndyDataException
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
-        ReentrantLock opLock = opLocks.computeIfAbsent( key, k -> new ReentrantLock() );
-        try
-        {
-            logger.info( "DELETE operation starting for store: {}", key );
-            opLock.lock();
-
-            final ArtifactStore store = stores.get( key );
-            if ( store == null )
+        AtomicReference<IndyDataException> error = new AtomicReference<>();
+        opLocks.lockAnd( key, LOCK_TIMEOUT_SECONDS, k->{
+            try
             {
-                logger.warn( "No store found for: {}", key );
-                return;
+                final ArtifactStore store = stores.get( key );
+                if ( store == null )
+                {
+                    logger.warn( "No store found for: {}", key );
+                    return null;
+                }
+
+                if ( isReadonly( store ) )
+                {
+                    throw new IndyDataException( ApplicationStatus.METHOD_NOT_ALLOWED.code(),
+                                                 "The store {} is readonly. If you want to delete this store, please modify it to non-readonly",
+                                                 store.getKey() );
+                }
+
+                preDelete( store, summary, true, eventMetadata );
+
+                ArtifactStore removed = stores.remove( key );
+                logger.info( "REMOVED store: {}", removed );
+
+                postDelete( store, summary, true, eventMetadata );
+            }
+            catch ( IndyDataException e )
+            {
+                error.set( e );
             }
 
-            if ( isReadonly( store ) )
-            {
-                throw new IndyDataException( ApplicationStatus.METHOD_NOT_ALLOWED.code(),
-                                             "The store {} is readonly. If you want to delete this store, please modify it to non-readonly",
-                                             store.getKey() );
-            }
+            return null;
+        }, (k,lock)->{
+            error.set( new IndyDataException( "Failed to lock: %s for DELETE after %d seconds.", key,
+                                              LOCK_TIMEOUT_SECONDS ) );
+            return false;
+        } );
 
-            preDelete( store, summary, true, eventMetadata );
-
-            ArtifactStore removed = stores.remove( key );
-            logger.info( "REMOVED store: {}", removed );
-
-            postDelete( store, summary, true, eventMetadata );
-        }
-        finally
+        IndyDataException ex = error.get();
+        if ( ex != null )
         {
-            opLock.unlock();
-            logger.trace( "Delete operation complete: {}", key );
+            throw ex;
         }
     }
 
@@ -289,11 +302,8 @@ public class MemoryStoreDataManager
                            final boolean fireEvents, final EventMetadata eventMetadata )
             throws IndyDataException
     {
-        ReentrantLock opLock = opLocks.computeIfAbsent( store.getKey(), k -> new ReentrantLock() );
-        try
-        {
-            opLock.lock();
-
+        AtomicReference<IndyDataException> error = new AtomicReference<>();
+        boolean result = opLocks.lockAnd( store.getKey(), LOCK_TIMEOUT_SECONDS, k-> {
             ArtifactStore original = stores.get( store.getKey() );
             if ( original == store )
             {
@@ -305,7 +315,16 @@ public class MemoryStoreDataManager
 
             if ( !skipIfExists || original == null )
             {
-                preStore( store, original, summary, original != null, fireEvents, eventMetadata );
+                try
+                {
+                    preStore( store, original, summary, original != null, fireEvents, eventMetadata );
+                }
+                catch ( IndyDataException e )
+                {
+                    error.set( e );
+                    return false;
+                }
+
                 final ArtifactStore old = stores.put( store.getKey(), store );
                 try
                 {
@@ -320,11 +339,19 @@ public class MemoryStoreDataManager
             }
 
             return false;
-        }
-        finally
+        }, (k,lock)->{
+            error.set( new IndyDataException( "Failed to lock: %s for STORE after %d seconds.", k,
+                                              LOCK_TIMEOUT_SECONDS ) );
+            return false;
+        });
+
+        IndyDataException ex = error.get();
+        if ( ex != null )
         {
-            opLock.unlock();
+            throw ex;
         }
+
+        return result;
     }
 
 }

--- a/ftests/common/src/main/resources/logback-test.xml
+++ b/ftests/common/src/main/resources/logback-test.xml
@@ -18,6 +18,10 @@
     </encoder>
   </appender>
 
+  <logger name="io.swagger" level="ERROR"/>
+  <logger name="org.commonjava.util.partyline" level="ERROR"/>
+  <logger name="org.commonjava.maven.galley.io.checksum" level="ERROR"/>
+
   <root level="TRACE">
     <appender-ref ref="STDOUT" />
   </root>  

--- a/ftests/core/pom.xml
+++ b/ftests/core/pom.xml
@@ -72,6 +72,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-pkg-maven-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
       <scope>compile</scope>

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreGeneratedMetadataInRemoteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreGeneratedMetadataInRemoteTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+/**
+ *
+ * Store generated metadata in remote repos storage when requested as part of a group metadata generation.
+ *
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Remote repo A which contains path_1 foo/bar/1/bar-1.pom</li>
+ *     <li>Hosted repo B which contains path_2 foo/bar/2/bar-2.pom and foo/bar/maven-metadata.xml</li>
+ *     <li>Group G contains A and B.</li>
+ </li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Path foo/bar/maven-metadata.xml is requested from G</li>
+ *     <li>Path foo/bar/maven-metadata.xml is requested from A</li>
+ *     <li>Repo A is deleted</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>Indy generates the meta files and stores it for both A and G.</li>
+ *     <li>Indy can get maven-metadata.xml from A</li>
+ *     <li>Group G metadata is updated after deleting A</li>
+ * </ul>
+ */
+public class StoreGeneratedMetadataInRemoteTest
+                extends AbstractIndyFunctionalTest //ContentManagementTest
+{
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "repos" );
+
+    private final String REMOTE = "remote-A";
+
+    private final String HOSTED = "hosted-B";
+
+    private final String GROUP = "group-G";
+
+    private final String path_1 = "org/foo/bar/1.0/bar-1.0.pom";
+
+    private final String path_2 = "org/foo/bar/2.0/bar-2.0.pom";
+
+    private final String metaPath = "org/foo/bar/maven-metadata.xml";
+
+    /* @formatter:off */
+    final String metaContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>2.0</latest>\n" +
+        "    <release>2.0</release>\n" +
+        "    <versions>\n" +
+        "      <version>2.0</version>\n" +
+        "    </versions>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    private final String pomContent_1 = "<project><modelVersion>4.0.0</modelVersion>"
+                    + "<groupId>org.foo</groupId><artifactId>bar</artifactId><version>1.0</version></project>";
+
+    private final String pomContent_2 = "<project><modelVersion>4.0.0</modelVersion>"
+                    + "<groupId>org.foo</groupId><artifactId>bar</artifactId><version>2.0</version></project>";
+
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+
+    @Test
+    public void run() throws Exception
+    {
+        server.expect( server.formatUrl( REMOTE, path_1 ), 200, pomContent_1 );
+
+        RemoteRepository remote1 = new RemoteRepository( REMOTE, server.formatUrl( REMOTE ) );
+        remote1 = client.stores().create( remote1, "remote A", RemoteRepository.class );
+
+        HostedRepository hosted1 = client.stores().create( new HostedRepository( HOSTED ), "hosted B", HostedRepository.class );
+        client.content().store( hosted1.getKey(), path_2, new ByteArrayInputStream( pomContent_2.getBytes() ) );
+        client.content().store( hosted1.getKey(), metaPath, new ByteArrayInputStream( metaContent.getBytes() ) );
+
+        Group g = new Group( GROUP, remote1.getKey(), hosted1.getKey() );
+        g = client.stores().create( g, "group G", Group.class );
+
+        // MUST hit the .pom first. This is needed to populate org/foo/bar/1.0 folder in order to generate metadata.xml
+        try (final InputStream stream = client.content().get( remote1.getKey(), path_1 ))
+        {
+        }
+
+        // Get meta from group. Contains both version 1.0 and 2.0
+        try (final InputStream stream = client.content().get( g.getKey(), metaPath ))
+        {
+            String meta = IOUtils.toString( stream );
+            logger.debug( "Group meta >>>>\n" + meta );
+            assertTrue( meta.contains( "<version>1.0</version>" ) );
+            assertTrue( meta.contains( "<version>2.0</version>" ) );
+        }
+
+        // Get meta from remote. Contains version 1.0
+        try (final InputStream stream = client.content().get( remote1.getKey(), metaPath ))
+        {
+            assertThat( stream, notNullValue() );
+            String meta = IOUtils.toString( stream );
+            logger.debug( "Remote A meta >>>>\n" + meta );
+            assertTrue( meta.contains( "<version>1.0</version>" ) );
+        }
+
+        // Delete remote A
+        /*client.stores().delete( remote1.getKey(), "delete A" );
+        waitForEventPropagation();
+
+        // Get meta from group again. Contains only version 2
+        try (final InputStream stream = client.content().get( g.getKey(), metaPath ))
+        {
+            assertThat( stream, notNullValue() );
+            logger.debug( "Group meta after deleting A >>>>\n" + IOUtils.toString( stream ) );
+        }*/
+    }
+}

--- a/ftests/core/src/main/resources/logback-test.xml
+++ b/ftests/core/src/main/resources/logback-test.xml
@@ -18,7 +18,9 @@
     </encoder>
   </appender>
 
-  <root level="TRACE">
+  <logger name="org.commonjava.indy" level="TRACE" />
+
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
   </root>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <jhttpcVersion>1.7</jhttpcVersion>
     <kojijiVersion>1.9</kojijiVersion>
     <rwxVersion>1.1</rwxVersion>
-    <weftVersion>1.6</weftVersion>
+    <weftVersion>1.7-SNAPSHOT</weftVersion>
     <httpTestserverVersion>1.3</httpTestserverVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->


### PR DESCRIPTION
We have two basic problems reported that triggered this PR, and I've rolled them together to try to get it all done in one sweep of the CI PR builder...or rather, one set of builds to get the PR build + the snapshot built.

First is the invalid metadata coming from ibiblio.org, which was an index.html file, and caused the metadata merge to fail. I've reviewed code from the master branch and looked at how we throw exceptions when member metadata fails. I have some hesitance here, since caching partial metadata in the event a member repo is temporarily throwing 503's is a problem if we ignore failed member metadatas...but in the end, it's **probably** less disruptive, especially after I fixed the listing in the maven-metadata.xml.info file. This file will **ONLY** contain contributing member repos now, reflecting the metadata that actually got merged. In the future, we might also want to include an EXCLUDED section to this file...and possibly structure it, I'm not sure about that.

Second problem is when multiple promotions happen simultaneously. While we do lock the process to prevent validation executions from passing when another colliding promotion is also in progress...we don't do the same thing to protect group membership. We load the group instance **before** locking, which means we might have a stale copy of the group when we add a new member. This resulted in several concurrent promotions effectively erasing each other's membership additions. To address this problem, I moved the group retrieval inside the lock.

At the same time, I had to acknowledge that we have ReentrantLocks all over the place, and they're all handled in slightly different ways. To address this, I added a new class, called Locker, in Weft, which provides consistent behavior and supports flexible locked logic via lambdas. It also supports flexible logic for determining whether to retry a failed lock. Finally, in the metadata merge case where we want to try to lock and fail quickly, then wait on a lock to signal the other thread is finished, I added two methods to support that in the Locker.

I also noticed the Koji content manager decorator doesn't lock at all when it modifies group memberships...so I added locking to this process as well, to avoid vulnerability there.

While I was debugging failed tests, I pulled apart MetadataMergeListner into one that's focused on store changes, and one that's a generated content action implementation. The new class is called MetadataStoreListener. 

This is a big patch, partly from cherry-picking over from master for a couple of metadata fixes...and partly for the refactor of lock handling. There is a LOT of new trace calls in the metadata merge code, and the separation of the former MetadataMergeListner class into two new ones makes for a fairly large patch too.