### PR TITLE
Upgrade to Weft release; fix apparent race in maven metadata aggregation

### DIFF
--- a/deployments/docker/pom.xml
+++ b/deployments/docker/pom.xml
@@ -33,7 +33,7 @@
   <modules>
     <module>base</module>
     <module>savant</module>
-    <module>rest-min</module>
+    <!-- <module>rest-min</module> -->
   </modules>
 
   <properties>

--- a/deployments/launchers/pom.xml
+++ b/deployments/launchers/pom.xml
@@ -32,7 +32,7 @@
   
   <modules>
     <module>base</module>
-    <module>rest-min</module>
+    <!-- <module>rest-min</module> -->
     <module>savant</module>
   </modules>
   

--- a/embedders/pom.xml
+++ b/embedders/pom.xml
@@ -37,7 +37,7 @@
   
   <modules>
     <module>savant</module>
-    <module>rest-min</module>
+    <!-- <module>rest-min</module> -->
   </modules>
   
   <dependencies>

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -107,16 +107,16 @@ public abstract class ArtifactStore
     public abstract ArtifactStore copyOf( String packageType, String name );
 
     @Override
-    public int hashCode()
+    public final int hashCode()
     {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + ( ( key == null ) ? 0 : key.hashCode() );
+        result = prime * result + ( ( key == null ) ? 19 : key.hashCode() );
         return result;
     }
 
     @Override
-    public boolean equals( final Object obj )
+    public final boolean equals( final Object obj )
     {
         if ( this == obj )
         {

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
@@ -92,18 +92,18 @@ public final class StoreKey
     }
 
     @Override
-    public int hashCode()
+    public final int hashCode()
     {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ( ( packageType == null ) ? 0 : packageType.hashCode() );
-        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
-        result = prime * result + ( ( type == null ) ? 0 : type.hashCode() );
+        result = prime * result + ( ( packageType == null ) ? 7 : packageType.hashCode() );
+        result = prime * result + ( ( name == null ) ? 13 : name.hashCode() );
+        result = prime * result + ( ( type == null ) ? 17 : type.hashCode() );
         return result;
     }
 
     @Override
-    public boolean equals( final Object obj )
+    public final boolean equals( final Object obj )
     {
         if ( this == obj )
         {

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <jhttpcVersion>1.7</jhttpcVersion>
     <kojijiVersion>1.9</kojijiVersion>
     <rwxVersion>1.1</rwxVersion>
-    <weftVersion>1.7-SNAPSHOT</weftVersion>
+    <weftVersion>1.7</weftVersion>
     <httpTestserverVersion>1.3</httpTestserverVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->


### PR DESCRIPTION
It seems we had a race condition in the MavenMetadataGenerator. Actually, a couple things were wrong with it:

* the cache retrieval, which results in a set of ArtifactStore's that don't have cached metadata, seems to return a set with duplicates!
* there seems to be something that modifies the missing set when download / generate is starting, but AFTER the latch is created. It creates a periodic off-by-one problem in the latch.

We had a NPE after my refactor of the KojiMavenMetadataProvider, where the old short-circuit logic for disqualifying archives / builds wasn't preserved. I fixed that here.

Finally, to make the lock management more consistent I introduced the Locker class in Weft. This change uses the Weft 1.7 release, which includes that class.