### PR TITLE
Catch up with production fixes in Indy 1.2.7.

### DIFF
--- a/addons/autoprox/client-java/pom.xml
+++ b/addons/autoprox/client-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/autoprox/client-java/src/main/java/org/commonjava/indy/autoprox/client/AutoProxCalculatorModule.java
+++ b/addons/autoprox/client-java/src/main/java/org/commonjava/indy/autoprox/client/AutoProxCalculatorModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/client-java/src/main/java/org/commonjava/indy/autoprox/client/AutoProxCatalogModule.java
+++ b/addons/autoprox/client-java/src/main/java/org/commonjava/indy/autoprox/client/AutoProxCatalogModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/pom.xml
+++ b/addons/autoprox/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/AutoProxAddOn.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/AutoProxAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/action/AutoProxAproxMigrationAction.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/action/AutoProxAproxMigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/conf/AutoProxConfig.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/conf/AutoProxConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AbstractAutoProxRule.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AbstractAutoProxRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxCatalogManager.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxCatalogManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxConstants.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecorator.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecorator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxRule.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxRuleException.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/AutoProxRuleException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/RuleMapping.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/data/RuleMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/rest/AutoProxAdminController.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/rest/AutoProxAdminController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/rest/AutoProxCalculatorController.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/rest/AutoProxCalculatorController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/util/ScriptRuleParser.java
+++ b/addons/autoprox/common/src/main/java/org/commonjava/indy/autoprox/util/ScriptRuleParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/ui/layover/ui-addons/autoprox/partials/calc.html
+++ b/addons/autoprox/common/src/main/ui/layover/ui-addons/autoprox/partials/calc.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/main/ui/layover/ui-addons/autoprox/partials/rules.html
+++ b/addons/autoprox/common/src/main/ui/layover/ui-addons/autoprox/partials/rules.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/test/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecoratorTest.java
+++ b/addons/autoprox/common/src/test/java/org/commonjava/indy/autoprox/data/AutoProxDataManagerDecoratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/test/java/org/commonjava/indy/autoprox/fixture/TestAutoProxFactory.java
+++ b/addons/autoprox/common/src/test/java/org/commonjava/indy/autoprox/fixture/TestAutoProxFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/common/src/test/java/org/commonjava/indy/autoprox/fixture/TestAutoProxyDataManager.java
+++ b/addons/autoprox/common/src/test/java/org/commonjava/indy/autoprox/fixture/TestAutoProxyDataManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/config-design.txt
+++ b/addons/autoprox/config-design.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/pom.xml
+++ b/addons/autoprox/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/AbstractAutoproxCalculatorTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/AbstractAutoproxCalculatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/CalculateGroupReturn400WhenDisabledTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/CalculateGroupReturn400WhenDisabledTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/CalculateGroupTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/CalculateGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/CalculateHostedRepoTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/CalculateHostedRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/CalculateRemoteRepoTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/calc/CalculateRemoteRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/AbstractAutoproxCatalogTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/AbstractAutoproxCatalogTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/CreateAndDeleteRuleTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/CreateAndDeleteRuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/CreateAndVerifyRuleTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/CreateAndVerifyRuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/CreateRuleAndVerifyInListingTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/CreateRuleAndVerifyInListingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/CreateRuleFailsWhenAutoProxDisabledTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/CreateRuleFailsWhenAutoProxDisabledTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/ListExistingCatalogTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/ListExistingCatalogTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/ReparsePicksUpNewRuleFileTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/catalog/ReparsePicksUpNewRuleFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/content/AbstractAutoproxContentTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/content/AbstractAutoproxContentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/content/AutoDefineAndUseRepoTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/content/AutoDefineAndUseRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/content/AutoproxDisabledAllowExistingUsageTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/content/AutoproxDisabledAllowExistingUsageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/content/AutoproxDisabledReturn404Test.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/content/AutoproxDisabledReturn404Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/del/AbstractAutoproxDeletionTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/del/AbstractAutoproxDeletionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/del/DeleteGroupMemberTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/del/DeleteGroupMemberTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/del/DeleteHostedRepoWithContentTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/del/DeleteHostedRepoWithContentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/del/DeleteRemoteRepoWithCachedContentTest.java
+++ b/addons/autoprox/ftests/src/main/java/org/commonjava/indy/autoprox/ftest/del/DeleteRemoteRepoWithCachedContentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/jaxrs/pom.xml
+++ b/addons/autoprox/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/autoprox/jaxrs/src/main/java/org/commonjava/indy/autoprox/jaxrs/AutoProxCalculatorResource.java
+++ b/addons/autoprox/jaxrs/src/main/java/org/commonjava/indy/autoprox/jaxrs/AutoProxCalculatorResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/jaxrs/src/main/java/org/commonjava/indy/autoprox/jaxrs/AutoProxCatalogResource.java
+++ b/addons/autoprox/jaxrs/src/main/java/org/commonjava/indy/autoprox/jaxrs/AutoProxCatalogResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/model-java/pom.xml
+++ b/addons/autoprox/model-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/autoprox/model-java/src/main/java/org/commonjava/indy/autoprox/rest/dto/AutoProxCalculation.java
+++ b/addons/autoprox/model-java/src/main/java/org/commonjava/indy/autoprox/rest/dto/AutoProxCalculation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/model-java/src/main/java/org/commonjava/indy/autoprox/rest/dto/CatalogDTO.java
+++ b/addons/autoprox/model-java/src/main/java/org/commonjava/indy/autoprox/rest/dto/CatalogDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/model-java/src/main/java/org/commonjava/indy/autoprox/rest/dto/RuleDTO.java
+++ b/addons/autoprox/model-java/src/main/java/org/commonjava/indy/autoprox/rest/dto/RuleDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/AutoProxCalculationTest.java
+++ b/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/AutoProxCalculationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/CatalogDTOTest.java
+++ b/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/CatalogDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/RuleDTOTest.java
+++ b/addons/autoprox/model-java/src/test/java/org/commonjava/indy/autoprox/rest/dto/RuleDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/autoprox/pom.xml
+++ b/addons/autoprox/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/content-index/pom.xml
+++ b/addons/content-index/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexActions.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexActions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexAddOn.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCache.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePathTransformer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePathTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -361,7 +361,7 @@ public abstract class IndexingContentManagerDecorator
             ArtifactStore store = storeDataManager.getArtifactStore( storeKey );
             if ( store.isDisabled() )
             {
-                logger.info( "Content not available in index caching layer due to store disabled for {} in group {}",
+                logger.debug( "Content not available in index caching layer due to store disabled for {} in group {}",
                              storeKey, topKey );
                 return null;
             }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/AuthoritativeIndexSettingManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/AuthoritativeIndexSettingManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/ContentIndexConfig.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/ContentIndexConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/metrics/IndyMetricsContentIndexNames.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/metrics/IndyMetricsContentIndexNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/diagnostics/client-java/pom.xml
+++ b/addons/diagnostics/client-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/diagnostics/client-java/src/main/java/org/commonjava/indy/diag/client/IndyDiagnosticsClientModule.java
+++ b/addons/diagnostics/client-java/src/main/java/org/commonjava/indy/diag/client/IndyDiagnosticsClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/diagnostics/common/pom.xml
+++ b/addons/diagnostics/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/diagnostics/common/src/main/java/org/commonjava/indy/diag/data/DiagnosticsManager.java
+++ b/addons/diagnostics/common/src/main/java/org/commonjava/indy/diag/data/DiagnosticsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/diagnostics/ftests/pom.xml
+++ b/addons/diagnostics/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/diagnostics/ftests/src/main/java/org/commonjava/indy/diags/ftest/DownloadDiagBundleTest.java
+++ b/addons/diagnostics/ftests/src/main/java/org/commonjava/indy/diags/ftest/DownloadDiagBundleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/diagnostics/jaxrs/pom.xml
+++ b/addons/diagnostics/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/diagnostics/jaxrs/src/main/java/org/commonjava/indy/diag/bind/jaxrs/DiagnosticsResource.java
+++ b/addons/diagnostics/jaxrs/src/main/java/org/commonjava/indy/diag/bind/jaxrs/DiagnosticsResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/diagnostics/pom.xml
+++ b/addons/diagnostics/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/pom.xml
+++ b/addons/dot-maven/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/DotMavenAddOn.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/DotMavenAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/DotMavenException.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/DotMavenException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/data/StorageAdvice.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/data/StorageAdvice.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/data/StorageAdvisor.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/data/StorageAdvisor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/inject/DotMavenApp.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/inject/DotMavenApp.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/inject/DotMavenProvider.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/inject/DotMavenProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/DotMavenStore.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/DotMavenStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/StoreTxn.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/StoreTxn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/SubStore.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/SubStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/ArtifactStoreSubStore.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/ArtifactStoreSubStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/SettingsSubStore.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/SettingsSubStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/NameUtils.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/NameUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/SettingsTemplate.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/SettingsTemplate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/SettingsURIMatcher.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/SettingsURIMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/StoreURIMatcher.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/StoreURIMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/URIMatcher.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/util/URIMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/webctl/DotMavenService.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/webctl/DotMavenService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/webctl/RequestInfo.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/webctl/RequestInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/test/java/org/commonjava/indy/dotmaven/util/NameUtilsTest.java
+++ b/addons/dot-maven/common/src/test/java/org/commonjava/indy/dotmaven/util/NameUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/common/src/test/java/org/commonjava/indy/dotmaven/util/SettingsURIMatcherTest.java
+++ b/addons/dot-maven/common/src/test/java/org/commonjava/indy/dotmaven/util/SettingsURIMatcherTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/ftests/pom.xml
+++ b/addons/dot-maven/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/dot-maven/ftests/src/main/java/org/commonjava/indy/dotmaven/settings/AbstractSettingsTest.java
+++ b/addons/dot-maven/ftests/src/main/java/org/commonjava/indy/dotmaven/settings/AbstractSettingsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/ftests/src/main/java/org/commonjava/indy/dotmaven/settings/SettingsGeneratedForRemoteRepoTest.java
+++ b/addons/dot-maven/ftests/src/main/java/org/commonjava/indy/dotmaven/settings/SettingsGeneratedForRemoteRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/jaxrs/pom.xml
+++ b/addons/dot-maven/jaxrs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/dot-maven/jaxrs/src/main/java/org/commonjava/indy/dotmaven/jaxrs/DotMavenDeploymentProvider.java
+++ b/addons/dot-maven/jaxrs/src/main/java/org/commonjava/indy/dotmaven/jaxrs/DotMavenDeploymentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/jaxrs/src/main/java/org/commonjava/indy/dotmaven/jaxrs/DotMavenServlet.java
+++ b/addons/dot-maven/jaxrs/src/main/java/org/commonjava/indy/dotmaven/jaxrs/DotMavenServlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/dot-maven/pom.xml
+++ b/addons/dot-maven/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/folo/client-java/pom.xml
+++ b/addons/folo/client-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/folo/client-java/src/main/java/org/commonjava/indy/folo/client/IndyFoloAdminClientModule.java
+++ b/addons/folo/client-java/src/main/java/org/commonjava/indy/folo/client/IndyFoloAdminClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/client-java/src/main/java/org/commonjava/indy/folo/client/IndyFoloContentClientModule.java
+++ b/addons/folo/client-java/src/main/java/org/commonjava/indy/folo/client/IndyFoloContentClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/client-java/src/test/java/org/commonjava/indy/folo/client/IndyFoloContentClientModuleTest.java
+++ b/addons/folo/client-java/src/test/java/org/commonjava/indy/folo/client/IndyFoloContentClientModuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/pom.xml
+++ b/addons/folo/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/data/folo/search/org.commonjava.indy.folo.model.TrackedContentEntry/placeholder.txt
+++ b/addons/folo/common/src/main/data/folo/search/org.commonjava.indy.folo.model.TrackedContentEntry/placeholder.txt
@@ -1,1 +1,17 @@
+====
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+====
+
 placeholder

--- a/addons/folo/common/src/main/data/folo/search/org.commonjava.indy.folo.model.TrackingKey/placeholder.txt
+++ b/addons/folo/common/src/main/data/folo/search/org.commonjava.indy.folo.model.TrackingKey/placeholder.txt
@@ -1,1 +1,17 @@
+====
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+====
+
 placeholder

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/FoloAddOn.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/FoloAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloPomDownloadListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloPomDownloadListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/conf/FoloConfig.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/conf/FoloConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/content/FoloChecksumAdvisor.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/content/FoloChecksumAdvisor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloConstants.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloContentException.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloContentException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloFileTypes.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloFileTypes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloFiler.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloFiler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloInprogressCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloInprogressCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloLifecycleParticipant.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloLifecycleParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloSealedCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloSealedCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/AffectedStoreRecordKey.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/AffectedStoreRecordKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/StoreKeyFieldBridge.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/StoreKeyFieldBridge.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/TrackedContentEntryTransformer.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/TrackedContentEntryTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/metrics/IndyMetricsFoloNames.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/metrics/IndyMetricsFoloNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/common/src/test/java/org/commonjava/indy/folo/data/FoloRecordCacheTest.java
+++ b/addons/folo/common/src/test/java/org/commonjava/indy/folo/data/FoloRecordCacheTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/pom.xml
+++ b/addons/folo/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/AbstractFoloContentManagementTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/AbstractFoloContentManagementTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/AutomaticPomDownloadTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/AutomaticPomDownloadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DownloadFromTrackedRemoteRepoTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DownloadFromTrackedRemoteRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DuplicateStoreAndVerifyTrackedRecordTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DuplicateStoreAndVerifyTrackedRecordTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/GroupMetadataExcludedFromTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/GroupMetadataExcludedFromTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/StoreAndRetrieveFileFromTrackedHostedRepoTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/StoreAndRetrieveFileFromTrackedHostedRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/StoreAndVerifyExistenceInTrackedHostedRepoTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/StoreAndVerifyExistenceInTrackedHostedRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/StoreAndVerifyReturnedPathInfoForTrackedHostedRepoTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/StoreAndVerifyReturnedPathInfoForTrackedHostedRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/StoreInTrackedMemberAndVerifyExistsInTrackedGroupTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/StoreInTrackedMemberAndVerifyExistsInTrackedGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/admin/DownloadFromTrackedAndRetrieveInRepoZipTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/admin/DownloadFromTrackedAndRetrieveInRepoZipTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/AbstractCacheReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/AbstractCacheReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/AbstractTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/AbstractTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/CachedReportWhenDeleteStoreTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/CachedReportWhenDeleteStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/CachedReportWhenDeleteTransferTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/CachedReportWhenDeleteTransferTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/InitTrackingRecordThenPullEmptyRecordTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/InitTrackingRecordThenPullEmptyRecordTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/PullReportWithoutContentAccess404Test.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/PullReportWithoutContentAccess404Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RecalculateMissingChecksumForTrackingRecordTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RecalculateMissingChecksumForTrackingRecordTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/ReportIdsGettingTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/ReportIdsGettingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RetrieveFileAndVerifyInTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RetrieveFileAndVerifyInTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RetrieveFileFromGroupAndVerifyInTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RetrieveFileFromGroupAndVerifyInTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RetrieveTrackingReportAfterCacheExpirationTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RetrieveTrackingReportAfterCacheExpirationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileAndRecalculateTrackingEntryTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileAndRecalculateTrackingEntryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileAndVerifyInTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileAndVerifyInTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileThenDownloadThenUploadAndVerifyInTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileThenDownloadThenUploadAndVerifyInTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileThenUploadThenDownloadAndVerifyInTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileThenUploadThenDownloadAndVerifyInTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileViaGroupAndVerifyInTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/StoreFileViaGroupAndVerifyInTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/UseChecksumFromTransferDecoratorForTrackingRecordTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/UseChecksumFromTransferDecoratorForTrackingRecordTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/UseChecksumFromTransferDecoratorForTrackingRecord_Sha1FileTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/UseChecksumFromTransferDecoratorForTrackingRecord_Sha1FileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/urls/AbstractFoloUrlsTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/urls/AbstractFoloUrlsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/urls/StoreOneAndSourceStoreUrlInHtmlListingTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/urls/StoreOneAndSourceStoreUrlInHtmlListingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/urls/StoreOneAndVerifyInHtmlListingTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/urls/StoreOneAndVerifyInHtmlListingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/urls/StoreOneTrackedAndVerifyUrlInReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/urls/StoreOneTrackedAndVerifyUrlInReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/jaxrs/pom.xml
+++ b/addons/folo/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/DeprecatedFoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/DeprecatedFoloContentAccessResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/pom.xml
+++ b/addons/folo/model-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentDTO.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackingIdsDTO.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackingIdsDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/AffectedStoreRecord.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/AffectedStoreRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/StoreEffect.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/StoreEffect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContent.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentRecord.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentRecord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackingKey.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackingKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentDTOTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTOTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/model/AffectedStoreRecordTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/model/AffectedStoreRecordTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/model/TrackedContentRecordTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/model/TrackedContentRecordTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/model/TrackingKeyTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/model/TrackingKeyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/folo/pom.xml
+++ b/addons/folo/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/httprox/common/pom.xml
+++ b/addons/httprox/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/HttProxAddOn.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/HttProxAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/HttpProxy.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/HttpProxy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/conf/HttproxConfig.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/conf/HttproxConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/conf/TrackingType.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/conf/TrackingType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/data/HttProxOriginMigrationAction.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/data/HttProxOriginMigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/data/HttProxRegisterSpecialPathStartupAction.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/data/HttProxRegisterSpecialPathStartupAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyAcceptHandler.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyAcceptHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRepositoryCreator.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRepositoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -70,6 +70,8 @@ import static org.commonjava.indy.httprox.util.HttpProxyConstants.OPTIONS_METHOD
 import static org.commonjava.indy.httprox.util.HttpProxyConstants.PROXY_AUTHENTICATE_FORMAT;
 import static org.commonjava.indy.model.core.ArtifactStore.TRACKING_ID;
 import static org.commonjava.indy.model.core.GenericPackageTypeDescriptor.GENERIC_PKG_KEY;
+import static org.commonjava.indy.util.ApplicationHeader.proxy_authenticate;
+import static org.commonjava.indy.util.ApplicationStatus.PROXY_AUTHENTICATION_REQUIRED;
 import static org.commonjava.maven.galley.io.SpecialPathConstants.PKG_TYPE_GENERIC_HTTP;
 
 public final class ProxyResponseWriter
@@ -176,9 +178,14 @@ public final class ProxyResponseWriter
                                 || TrackingType.ALWAYS == config.getTrackingType() ) )
                 {
 
-                    http.writeStatus( ApplicationStatus.PROXY_AUTHENTICATION_REQUIRED );
-                    http.writeHeader( ApplicationHeader.proxy_authenticate,
-                                      String.format( PROXY_AUTHENTICATE_FORMAT, config.getProxyRealm() ) );
+                    String realmInfo = String.format( PROXY_AUTHENTICATE_FORMAT, config.getProxyRealm() );
+
+                    logger.info( "Not authenticated to proxy. Sending response: {} / {}: {}",
+                                 PROXY_AUTHENTICATION_REQUIRED, proxy_authenticate, realmInfo );
+
+                    http.writeStatus( PROXY_AUTHENTICATION_REQUIRED );
+                    http.writeHeader( proxy_authenticate,
+                                      realmInfo );
                 }
                 else
                 {

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/keycloak/KeycloakProxyAuthenticator.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/keycloak/KeycloakProxyAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/metrics/IndyMetricsHttpProxyNames.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/metrics/IndyMetricsHttpProxyNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpProxyConstants.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpProxyConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/common/src/test/resources/simple.pom
+++ b/addons/httprox/common/src/test/resources/simple.pom
@@ -1,6 +1,5 @@
 <!--
-
-    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/pom.xml
+++ b/addons/httprox/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AbstractHttproxFunctionalTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AbstractHttproxFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AbstractHttproxTrackingFunctionalTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AbstractHttproxTrackingFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AutoCreateRepoAndRetrieveNoCacheFileTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AutoCreateRepoAndRetrieveNoCacheFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AutoCreateRepoAndRetrievePomTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/AutoCreateRepoAndRetrievePomTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/NPMStyleSuccessiveRetrievalTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/NPMStyleSuccessiveRetrievalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/Propagate404NotFoundTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/Propagate404NotFoundTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/Propagate500As502ErrorTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/Propagate500As502ErrorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/ProxyReleasesFileLockOnCompletionTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/ProxyReleasesFileLockOnCompletionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedContentMatchesContentLength_SlowClient_Test.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedContentMatchesContentLength_SlowClient_Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomInAlwaysOnTrackingReportTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomInAlwaysOnTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomInSuffixTrackingReportTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomInSuffixTrackingReportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomWithoutAuthTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomWithoutAuthTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomWithoutUserSuffixUntrackedTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/RetrievedPomWithoutUserSuffixUntrackedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/SuccessiveRetrievalWithRemoteRepoDeletionBetweenTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/SuccessiveRetrievalWithRemoteRepoDeletionBetweenTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/httprox/jaxrs/pom.xml
+++ b/addons/httprox/jaxrs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/httprox/pom.xml
+++ b/addons/httprox/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/implied-repos/client-java/pom.xml
+++ b/addons/implied-repos/client-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/implied-repos/client-java/src/main/java/org/commonjava/indy/implrepo/client/ImpliedRepoClientModule.java
+++ b/addons/implied-repos/client-java/src/main/java/org/commonjava/indy/implrepo/client/ImpliedRepoClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/pom.xml
+++ b/addons/implied-repos/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/ImpliedReposAddOn.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/ImpliedReposAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepoMaintainer.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepoMaintainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryCreator.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/conf/ImpliedRepoConfig.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/conf/ImpliedRepoConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposOriginMigrationAction.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposOriginMigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposQueryDelegate.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposQueryDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposQueryDelegate.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposQueryDelegate.java
@@ -114,22 +114,21 @@ public class ImpliedReposQueryDelegate
             throws IndyDataException
     {
         ArtifactStore store = dataManager.getArtifactStore( key );
-        if ( store == null )
+        if ( store != null )
         {
-            return Collections.emptySet();
+            boolean storeIsImplied = IMPLIED_REPO_ORIGIN.equals( store.getMetadata( METADATA_ORIGIN ) );
+            Set<Group> delegateGroups = delegate().getGroupsContaining( key );
+            if ( !storeIsImplied || delegateGroups == null || delegateGroups.isEmpty() )
+            {
+                return delegateGroups;
+            }
+
+            return delegateGroups.stream()
+                                              .filter( ( group ) -> config.isEnabledForGroup( group.getName() ) )
+                                              .collect( Collectors.toSet() );
         }
 
-        boolean storeIsImplied = IMPLIED_REPO_ORIGIN.equals( store.getMetadata( METADATA_ORIGIN ) );
-        Set<Group> delegateGroups = delegate().getGroupsContaining( key );
-        if ( !storeIsImplied || delegateGroups == null || delegateGroups.isEmpty() )
-        {
-            return delegateGroups;
-        }
-
-        Set<Group> result = delegateGroups.stream()
-                      .filter( ( group ) -> config.isEnabledForGroup( group.getName() ) )
-                      .collect( Collectors.toSet());
-
-        return result;
+        return delegate().getGroupsContaining( key );
     }
+
 }

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposStoreDataManagerDecorator.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposStoreDataManagerDecorator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/inject/ImpliedRepoProvider.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/inject/ImpliedRepoProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepoMaintainerTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepoMaintainerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetectorTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetectorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/conf/ImpliedRepoConfigTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/conf/ImpliedRepoConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/ftests/pom.xml
+++ b/addons/implied-repos/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/maint/AbstractMaintFunctionalTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/maint/AbstractMaintFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/maint/CreateGroupWithMemberImplicationsTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/maint/CreateGroupWithMemberImplicationsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/AbstractSkimFunctionalTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/AbstractSkimFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/PomWithPluginRepoAddsRepoToGroupTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/PomWithPluginRepoAddsRepoToGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/PomWithRepoAddsRepoToGroupTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/PomWithRepoAddsRepoToGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/ResolveDepViaSkimmedRepoInGroupTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/ResolveDepViaSkimmedRepoInGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/model-java/pom.xml
+++ b/addons/implied-repos/model-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/implied-repos/model-java/src/main/java/org/commonjava/indy/implrepo/ImpliedReposException.java
+++ b/addons/implied-repos/model-java/src/main/java/org/commonjava/indy/implrepo/ImpliedReposException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/model-java/src/main/java/org/commonjava/indy/implrepo/data/ImpliedRepoMetadataManager.java
+++ b/addons/implied-repos/model-java/src/main/java/org/commonjava/indy/implrepo/data/ImpliedRepoMetadataManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/implied-repos/pom.xml
+++ b/addons/implied-repos/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/koji/client-java/pom.xml
+++ b/addons/koji/client-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/koji/client-java/src/main/resources/META-INF/beans.xml
+++ b/addons/koji/client-java/src/main/resources/META-INF/beans.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2014 Red Hat, Inc..
-  All rights reserved. This program and the accompanying materials
-  are made available under the terms of the GNU Public License v3.0
-  which accompanies this distribution, and is available at
-  http://www.gnu.org/licenses/gpl.html
-  
-  Contributors:
-      Red Hat, Inc. - initial API and implementation
+
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 -->
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/addons/koji/common/pom.xml
+++ b/addons/koji/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/KojiAddOn.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/KojiAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -23,11 +23,13 @@ import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildState;
 import com.redhat.red.build.koji.model.xmlrpc.KojiSessionInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.IndyMetricsNames;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.index.ContentIndexManager;
+import org.commonjava.indy.core.inject.GroupMembershipLocks;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
@@ -66,10 +68,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
 
 import static org.commonjava.indy.koji.model.IndyKojiConstants.KOJI_ORIGIN;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.KOJI_ORIGIN_BINARY;
+import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
 import static org.commonjava.maven.galley.maven.util.ArtifactPathUtils.formatMetadataPath;
 
@@ -133,6 +137,10 @@ public abstract class KojiContentManagerDecorator
 
     @Inject
     private ContentIndexManager indexManager;
+
+    @GroupMembershipLocks
+    @Inject
+    private Locker<StoreKey> groupMembershipLocker;
 
     @Override
     @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsKojiNames.METHOD_CONTENTMANAGER_EXISTS
@@ -588,7 +596,7 @@ public abstract class KojiContentManagerDecorator
         return meta;
     }
 
-    private Group adjustTargetGroup( final RemoteRepository buildRepo, final Group group )
+    private Group adjustTargetGroup( final RemoteRepository buildRepo, final Group srcGroup )
             throws IndyWorkflowException
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
@@ -596,50 +604,71 @@ public abstract class KojiContentManagerDecorator
         // try to lookup the group -> targetGroup mapping in config, using the
         // entry-point group as the lookup key. If that returns null, the targetGroup is
         // the entry-point group.
-        Group targetGroup = group;
-
         boolean isBinaryBuild = KOJI_ORIGIN_BINARY.equals( buildRepo.getMetadata( ArtifactStore.METADATA_ORIGIN) );
 
-        String targetName = isBinaryBuild ? config.getTargetBinaryGroup( group.getName() )
-                : config.getTargetGroup( group.getName() );
+        String targetName = isBinaryBuild ? config.getTargetBinaryGroup( srcGroup.getName() )
+                : config.getTargetGroup( srcGroup.getName() );
+
+        StoreKey targetKey = srcGroup.getKey();
 
         if ( targetName != null )
         {
+            targetKey = new StoreKey( srcGroup.getPackageType(), group, targetName );
+        }
+
+        StoreKey tk = targetKey;
+        AtomicReference<IndyWorkflowException> wfEx = new AtomicReference<>();
+
+        Group result = groupMembershipLocker.lockAnd( targetKey, config.getLockTimeoutSeconds(), k->{
+            Group targetGroup = null;
             try
             {
-                targetGroup = storeDataManager.query().packageType( group.getPackageType() ).getGroup( targetName );
+                targetGroup = (Group) storeDataManager.getArtifactStore( tk );
             }
             catch ( IndyDataException e )
             {
-                throw new IndyWorkflowException(
+                wfEx.set( new IndyWorkflowException(
                         "Cannot lookup koji-addition target group: %s (source group: %s). Reason: %s", e, targetName,
-                        group.getName(), e.getMessage() );
+                        srcGroup.getName(), e.getMessage() ) );
+
+                return null;
             }
-        }
 
-        logger.info( "Adding Koji build proxy: {} to group: {}", buildRepo.getKey(), targetGroup.getKey() );
+            logger.info( "Adding Koji build proxy: {} to group: {}", buildRepo.getKey(), targetGroup.getKey() );
 
-        // Append the new remote repo as a member of the targetGroup.
-        targetGroup.addConstituent( buildRepo );
-        try
+            // Append the new remote repo as a member of the targetGroup.
+            targetGroup.addConstituent( buildRepo );
+            try
+            {
+                final ChangeSummary changeSummary = new ChangeSummary( ChangeSummary.SYSTEM_USER,
+                                                                       "Adding remote repository for Koji build: "
+                                                                               + buildRepo.getMetadata( NVR ) );
+
+                storeDataManager.storeArtifactStore( targetGroup, changeSummary, false, true, new EventMetadata() );
+            }
+            catch ( IndyDataException e )
+            {
+                wfEx.set( new IndyWorkflowException( "Cannot store target-group: %s changes for: %s. Error: %s", e,
+                                                        targetGroup.getName(), buildRepo.getMetadata( NVR ),
+                                                        e.getMessage() ) );
+                return null;
+            }
+
+            logger.info( "Retrieving GAV: {} from: {}", buildRepo.getMetadata( CREATION_TRIGGER_GAV ), buildRepo );
+
+            return targetGroup;
+        }, (k, lock)->{
+            return false;
+        } );
+
+        IndyWorkflowException ex = wfEx.get();
+        if ( ex != null )
         {
-            final ChangeSummary changeSummary = new ChangeSummary( ChangeSummary.SYSTEM_USER,
-                                                                   "Adding remote repository for Koji build: "
-                                                                           + buildRepo.getMetadata( NVR ) );
-
-            storeDataManager.storeArtifactStore( targetGroup, changeSummary, false, true, new EventMetadata() );
+            throw ex;
         }
-        catch ( IndyDataException e )
-        {
-            throw new IndyWorkflowException( "Cannot store target-group: %s changes for: %s. Error: %s", e,
-                                             targetGroup.getName(), buildRepo.getMetadata( NVR ), e.getMessage() );
-        }
-
-        logger.info( "Retrieving GAV: {} from: {}", buildRepo.getMetadata( CREATION_TRIGGER_GAV ), buildRepo );
-
-        return targetGroup;
 
         // TODO: how to index it for the group...?
+        return result;
     }
 
     private interface KojiBuildAction<T>

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -21,13 +21,16 @@ import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildArchiveCollection;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildState;
+import com.redhat.red.build.koji.model.xmlrpc.KojiSessionInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.IndyMetricsNames;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
 import org.commonjava.indy.koji.inject.KojiMavenVersionMetadataCache;
+import org.commonjava.indy.koji.inject.KojiMavenVersionMetadataLocks;
 import org.commonjava.indy.koji.metrics.IndyMetricsKojiNames;
 import org.commonjava.indy.measure.annotation.IndyMetrics;
 import org.commonjava.indy.measure.annotation.Measure;
@@ -60,11 +63,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static org.commonjava.cdi.util.weft.ContextSensitiveWeakHashMap.newSynchronizedContextSensitiveWeakHashMap;
 import static org.commonjava.indy.model.core.StoreType.group;
 
 /**
@@ -90,7 +91,9 @@ public class KojiMavenMetadataProvider
     @Inject
     private KojiBuildAuthority buildAuthority;
 
-    private final Map<ProjectRef, ReentrantLock> versionMetadataLocks = newSynchronizedContextSensitiveWeakHashMap();
+    @KojiMavenVersionMetadataLocks
+    @Inject
+    private Locker<ProjectRef> versionMetadataLocks;
 
     protected KojiMavenMetadataProvider(){}
 
@@ -144,219 +147,285 @@ public class KojiMavenMetadataProvider
         String groupId = groupDir.getPath().replace( File.separatorChar, '.' );
         String artifactId = artifactDir.getName();
 
-        ProjectRef ga = null;
+        ProjectRef ref = null;
         try
         {
-            ga = new SimpleProjectRef( groupId, artifactId );
+            ref = new SimpleProjectRef( groupId, artifactId );
         }
         catch ( InvalidRefException e )
         {
-            logger.debug( "Not a valid Maven GA: {}:{}. Skipping Koji metadata retrieval.", groupId, artifactId );
+            logger.warn( "Not a valid Maven GA: {}:{}. Skipping Koji metadata retrieval.", groupId, artifactId );
         }
 
-        if ( ga == null )
+        if ( ref == null )
         {
             logger.debug( "Could not render a valid Maven GA for path: '{}'", path );
             return null;
         }
 
-        ReentrantLock lock = versionMetadataLocks.computeIfAbsent( ga, k -> new ReentrantLock() );
-
-        boolean locked = false;
-        try
-        {
-            locked = lock.tryLock( kojiConfig.getLockTimeoutSeconds(), TimeUnit.SECONDS );
-            if ( !locked )
-            {
-                throw new IndyWorkflowException(
-                        "Failed to acquire Koji GA version metadata lock on: %s in %d seconds.", ga,
-                        kojiConfig.getLockTimeoutSeconds() );
-            }
-
+        ProjectRef ga = ref;
+        return versionMetadataLocks.lockAnd( ga, kojiConfig.getLockTimeoutSeconds(), k -> {
             Metadata metadata = versionMetadata.get( ga );
-            ProjectRef ref = ga;
             if ( metadata == null )
             {
                 try
                 {
-                    metadata = kojiClient.withKojiSession( ( session ) -> {
-
-                        // short-term caches to help improve performance a bit by avoiding xml-rpc calls.
-                        Map<Integer, KojiBuildArchiveCollection> seenBuildArchives = new HashMap<>();
-                        Set<Integer> seenBuilds = new HashSet<>();
-
-                        List<KojiArchiveInfo> archives = kojiClient.listArchivesMatching( ref, session );
-
-                        Set<SingleVersion> versions = new HashSet<>();
-                        for ( KojiArchiveInfo archive : archives )
-                        {
-                            if ( !archive.getFilename().endsWith( ".pom" ) )
-                            {
-                                logger.debug( "Skipping non-POM: {}", archive.getFilename() );
-                                continue;
-                            }
-                            if ( !isVerSignedAllowed( archive.getVersion() ) )
-                            {
-                                logger.debug( "version filter pattern not matched: {}", archive.getVersion() );
-                                continue;
-                            }
-
-                            SingleVersion singleVersion = null;
-                            try
-                            {
-                                singleVersion = VersionUtils.createSingleVersion( archive.getVersion() );
-                            }
-                            catch ( InvalidVersionSpecificationException ivse )
-                            {
-                                logger.warn( "Skipping mal-formatted version: {}, relPath: {}, buildId: {}",
-                                             archive.getVersion(), archive.getRelPath(), archive.getBuildId() );
-                                continue;
-                            }
-                            if ( versions.contains( singleVersion ) )
-                            {
-                                logger.debug( "Skipping already collected version: {}", archive.getVersion() );
-                                continue;
-                            }
-
-                            KojiBuildInfo build;
-                            if ( seenBuilds.contains( archive.getBuildId() ) )
-                            {
-                                logger.debug( "Skipping already seen build: {}", archive.getBuildId() );
-                                continue;
-                            }
-                            else
-                            {
-                                build = kojiClient.getBuildInfo( archive.getBuildId(), session );
-                                seenBuilds.add( archive.getBuildId() );
-                            }
-
-                            if ( build == null )
-                            {
-                                logger.debug( "Cannot retrieve build info: {}. Skipping: {}", archive.getBuildId(),
-                                              archive.getFilename() );
-                                continue;
-                            }
-
-                            if ( build.getBuildState() != KojiBuildState.COMPLETE )
-                            {
-                                logger.debug( "Build: {} is not completed. The state is {}. Skipping.",
-                                              build.getNvr(), build.getBuildState() );
-                                continue;
-                            }
-
-                            if ( build.getTaskId() == null )
-                            {
-                                logger.debug( "Build: {} is not a real build. It looks like a binary import. Skipping.",
-                                              build.getNvr() );
-                                // This is not a real build, it's a binary import.
-                                continue;
-                            }
-
-                            boolean buildAllowed = false;
-                            if ( !kojiConfig.isTagPatternsEnabled() )
-                            {
-                                buildAllowed = true;
-                            }
-                            else
-                            {
-                                logger.trace( "Checking for builds/tags of: {}", archive );
-
-                                List<KojiTagInfo> tags = kojiClient.listTags( build.getId(), session );
-                                for ( KojiTagInfo tag : tags )
-                                {
-                                    if ( kojiConfig.isTagAllowed( tag.getName() ) )
-                                    {
-                                        logger.debug( "Koji tag: {} is allowed for proxying.", tag.getName() );
-                                        buildAllowed = true;
-                                        break;
-                                    }
-                                    else
-                                    {
-                                        logger.debug( "Koji tag: {} is not allowed for proxying.", tag.getName() );
-                                    }
-                                }
-                            }
-
-                            logger.debug(
-                                    "Checking if build passed tag whitelist check and doesn't collide with something in authority store (if configured)..." );
-
-                            if ( buildAllowed && buildAuthority.isAuthorized( path, new EventMetadata(), ref, build, session, seenBuildArchives ) )
-                            {
-                                try
-                                {
-                                    logger.debug( "Adding version: {} for: {}", archive.getVersion(), path );
-                                    versions.add( singleVersion );
-                                }
-                                catch ( InvalidVersionSpecificationException e )
-                                {
-                                    logger.warn( String.format(
-                                            "Encountered invalid version: %s for archive: %s. Reason: %s",
-                                            archive.getVersion(), archive.getArchiveId(), e.getMessage() ), e );
-                                }
-                            }
-                        }
-
-                        if ( versions.isEmpty() )
-                        {
-                            logger.debug( "No versions found in Koji builds for metadata: {}", path );
-                            return null;
-                        }
-
-                        List<SingleVersion> sortedVersions = new ArrayList<>( versions );
-                        Collections.sort( sortedVersions );
-
-                        Metadata md = new Metadata();
-                        md.setGroupId( ref.getGroupId() );
-                        md.setArtifactId( ref.getArtifactId() );
-
-                        Versioning versioning = new Versioning();
-                        versioning.setRelease( sortedVersions.get( versions.size() - 1 ).renderStandard() );
-                        versioning.setLatest( sortedVersions.get( versions.size() - 1 ).renderStandard() );
-                        versioning.setVersions(
-                                sortedVersions.stream().map( SingleVersion::renderStandard ).collect( Collectors.toList() ) );
-
-                        Date lastUpdated = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ).getTime();
-                        versioning.setLastUpdated( new SimpleDateFormat( LAST_UPDATED_FORMAT ).format( lastUpdated ) );
-
-                        md.setVersioning( versioning );
-
-                        return md;
-                    } );
+                    metadata = executeKojiMetadataLookup( ga, path );
                 }
                 catch ( KojiClientException e )
                 {
-                    throw new IndyWorkflowException(
-                            "Failed to retrieve version metadata for: %s from Koji. Reason: %s", e, ga,
-                            e.getMessage() );
-                }
+                    Throwable cause = e.getCause();
+                    logger.error(
+                            String.format( "Failed to retrieve version metadata for: %s from Koji. Reason: %s", ga,
+                                           e.getMessage() ), e );
 
-                Metadata md = metadata;
+                    if ( cause instanceof RuntimeException )
+                    {
+                        logger.error( "Previous exception's nested cause was a RuntimeException variant:", cause );
+                    }
+
+                    metadata = null;
+                }
 
                 if ( metadata != null )
                 {
+                    Metadata md = metadata;
+
                     // FIXME: Need a way to listen for cache expiration and re-request this?
                     versionMetadata.execute( ( cache ) -> cache.getAdvancedCache()
-                                                               .put( ref, md, kojiConfig.getMetadataTimeoutSeconds(),
+                                                               .put( ga, md, kojiConfig.getMetadataTimeoutSeconds(),
                                                                      TimeUnit.SECONDS ) );
+                }
+                else
+                {
+                    logger.debug( "Returning null metadata result for unknown reason (path: '{}')", path );
                 }
             }
 
             return metadata;
-        }
-        catch ( InterruptedException e )
-        {
-            logger.warn( "Interrupted waiting for Koji GA version metadata lock on target: {}", ga );
-        }
-        finally
-        {
-            if ( locked )
+        }, (k,lock) -> {
+            logger.error( "Failed to acquire Koji GA version metadata lock on: '{}' in {} seconds.", ga,
+                          kojiConfig.getLockTimeoutSeconds() );
+            return false;
+        } );
+    }
+
+    private Metadata executeKojiMetadataLookup(ProjectRef ga, String path )
+            throws KojiClientException
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+
+        return kojiClient.withKojiSession( ( session ) -> {
+
+            // short-term caches to help improve performance a bit by avoiding xml-rpc calls.
+            Map<Integer, KojiBuildArchiveCollection> seenBuildArchives = new HashMap<>();
+            Set<Integer> seenBuilds = new HashSet<>();
+
+            List<KojiArchiveInfo> archives = kojiClient.listArchivesMatching( ga, session );
+
+            Set<SingleVersion> versions = new HashSet<>();
+            for ( KojiArchiveInfo archive : archives )
             {
-                lock.unlock();
+                ArchiveScan scan = scanArchive( archive, session, versions, seenBuilds );
+                if ( scan.isDisqualified() )
+                {
+                    continue;
+                }
+
+                KojiBuildInfo build = scan.getBuild();
+                SingleVersion singleVersion = scan.getSingleVersion();
+
+                boolean buildAllowed = false;
+                if ( !kojiConfig.isTagPatternsEnabled() )
+                {
+                    buildAllowed = true;
+                }
+                else
+                {
+                    logger.trace( "Checking for builds/tags of: {}", archive );
+
+                    List<KojiTagInfo> tags = kojiClient.listTags( build.getId(), session );
+                    for ( KojiTagInfo tag : tags )
+                    {
+                        if ( kojiConfig.isTagAllowed( tag.getName() ) )
+                        {
+                            logger.debug( "Koji tag: {} is allowed for proxying.", tag.getName() );
+                            buildAllowed = true;
+                            break;
+                        }
+                        else
+                        {
+                            logger.debug( "Koji tag: {} is not allowed for proxying.", tag.getName() );
+                        }
+                    }
+                }
+
+                logger.debug(
+                        "Checking if build passed tag whitelist check and doesn't collide with something in authority store (if configured)..." );
+
+                if ( buildAllowed && buildAuthority.isAuthorized( path, new EventMetadata(), ga, build,
+                                                                  session, seenBuildArchives ) )
+                {
+                    try
+                    {
+                        logger.debug( "Adding version: {} for: {}", archive.getVersion(), path );
+                        versions.add( singleVersion );
+                    }
+                    catch ( InvalidVersionSpecificationException e )
+                    {
+                        logger.warn( String.format(
+                                "Encountered invalid version: %s for archive: %s. Reason: %s",
+                                archive.getVersion(), archive.getArchiveId(), e.getMessage() ), e );
+                    }
+                }
             }
+
+            if ( versions.isEmpty() )
+            {
+                logger.debug( "No versions found in Koji builds for metadata: {}", path );
+                return null;
+            }
+
+            List<SingleVersion> sortedVersions = new ArrayList<>( versions );
+            Collections.sort( sortedVersions );
+
+            Metadata md = new Metadata();
+            md.setGroupId( ga.getGroupId() );
+            md.setArtifactId( ga.getArtifactId() );
+
+            Versioning versioning = new Versioning();
+            versioning.setRelease( sortedVersions.get( versions.size() - 1 ).renderStandard() );
+            versioning.setLatest( sortedVersions.get( versions.size() - 1 ).renderStandard() );
+            versioning.setVersions( sortedVersions.stream()
+                                                  .map( SingleVersion::renderStandard )
+                                                  .collect( Collectors.toList() ) );
+
+            Date lastUpdated = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) ).getTime();
+            versioning.setLastUpdated( new SimpleDateFormat( LAST_UPDATED_FORMAT ).format( lastUpdated ) );
+
+            md.setVersioning( versioning );
+
+            return md;
+        } );
+    }
+
+    private ArchiveScan scanArchive( final KojiArchiveInfo archive, final KojiSessionInfo session,
+                                       final Set<SingleVersion> versions, final Set<Integer> seenBuilds )
+            throws KojiClientException
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        ArchiveScan scan = new ArchiveScan();
+
+        if ( !archive.getFilename().endsWith( ".pom" ) )
+        {
+            logger.debug( "Skipping non-POM: {}", archive.getFilename() );
+            scan.setDisqualified( true );
+            return scan;
         }
 
-        logger.debug( "Returning null metadata result for unknown reason (path: '{}')", path );
-        return null;
+        if ( !isVerSignedAllowed( archive.getVersion() ) )
+        {
+            logger.debug( "version filter pattern not matched: {}", archive.getVersion() );
+            scan.setDisqualified( true );
+            return scan;
+        }
+
+        SingleVersion singleVersion = null;
+        try
+        {
+            singleVersion = VersionUtils.createSingleVersion( archive.getVersion() );
+            scan.setSingleVersion( singleVersion );
+        }
+        catch ( InvalidVersionSpecificationException ivse )
+        {
+            logger.warn( "Skipping mal-formatted version: {}, relPath: {}, buildId: {}", archive.getVersion(),
+                         archive.getRelPath(), archive.getBuildId() );
+            scan.setDisqualified( true );
+            return scan;
+        }
+
+        if ( versions.contains( singleVersion ) )
+        {
+            logger.debug( "Skipping already collected version: {}", archive.getVersion() );
+            scan.setDisqualified( true );
+            return scan;
+        }
+
+        KojiBuildInfo build = null;
+        if ( seenBuilds.contains( archive.getBuildId() ) )
+        {
+            logger.debug( "Skipping already seen build: {}", archive.getBuildId() );
+            scan.setDisqualified( true );
+            return scan;
+        }
+        else
+        {
+            build = kojiClient.getBuildInfo( archive.getBuildId(), session );
+            seenBuilds.add( archive.getBuildId() );
+            scan.setBuild( build );
+        }
+
+        if ( build == null )
+        {
+            logger.debug( "Cannot retrieve build info: {}. Skipping: {}", archive.getBuildId(), archive.getFilename() );
+            scan.setDisqualified( true );
+            return scan;
+        }
+
+        if ( build.getBuildState() != KojiBuildState.COMPLETE )
+        {
+            logger.debug( "Build: {} is not completed. The state is {}. Skipping.", build.getNvr(),
+                          build.getBuildState() );
+            scan.setDisqualified( true );
+            return scan;
+        }
+
+        if ( build.getTaskId() == null )
+        {
+            logger.debug( "Build: {} is not a real build. It looks like a binary import. Skipping.", build.getNvr() );
+            // This is not a real build, it's a binary import.
+            scan.setDisqualified( true );
+            return scan;
+        }
+
+        return scan;
+    }
+
+    private static final class ArchiveScan
+    {
+        private boolean disqualified = false;
+        private KojiBuildInfo build;
+        private SingleVersion singleVersion;
+
+        public boolean isDisqualified()
+        {
+            return disqualified;
+        }
+
+        public void setDisqualified( final boolean disqualified )
+        {
+            this.disqualified = disqualified;
+        }
+
+        public KojiBuildInfo getBuild()
+        {
+            return build;
+        }
+
+        public void setBuild( final KojiBuildInfo build )
+        {
+            this.build = build;
+        }
+
+        public SingleVersion getSingleVersion()
+        {
+            return singleVersion;
+        }
+
+        public void setSingleVersion( final SingleVersion singleVersion )
+        {
+            this.singleVersion = singleVersion;
+        }
     }
 
     private boolean isVerSignedAllowed ( String version )

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiRepositoryCreator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiRepositoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiOriginMigrationAction.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiOriginMigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiCacheProducer.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiCacheProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiMavenVersionMetadataCache.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiMavenVersionMetadataCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiMavenVersionMetadataLocks.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiMavenVersionMetadataLocks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiMavenVersionMetadataLocks.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiMavenVersionMetadataLocks.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.koji.inject;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply "folo-in-progress" cache in infinispan.xml.
+ */
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD } )
+@Retention( RetentionPolicy.RUNTIME )
+@Documented
+public @interface KojiMavenVersionMetadataLocks
+{
+}

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
@@ -18,11 +18,13 @@ package org.commonjava.indy.koji.inject;
 import com.redhat.red.build.koji.KojiClient;
 import com.redhat.red.build.koji.KojiClientException;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.indy.action.ShutdownAction;
 import org.commonjava.indy.action.StartupAction;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
 import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordType;
@@ -48,6 +50,8 @@ public class KojijiProvider
 
     private PasswordManager kojiPasswordManager;
 
+    private Locker<ProjectRef> versionMetadataLocks;
+
     @Inject
     @WeftManaged
     @ExecutorConfig( named = "koji-queries", threads = 4 )
@@ -57,6 +61,14 @@ public class KojijiProvider
     public KojiClient getKojiClient()
     {
         return kojiClient;
+    }
+
+    @KojiMavenVersionMetadataLocks
+    @Produces
+    @ApplicationScoped
+    public Locker<ProjectRef> getVersionMetadataLocks()
+    {
+        return versionMetadataLocks;
     }
 
     @Override
@@ -87,6 +99,8 @@ public class KojijiProvider
         {
             throw new IndyLifecycleException( "Init KojiClient failed", e );
         }
+
+        versionMetadataLocks = new Locker<>();
     }
 
     @Override

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/metrics/IndyMetricsKojiNames.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/metrics/IndyMetricsKojiNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/testutil/KojiMockHandlers.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/testutil/KojiMockHandlers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/testutil/MockScript.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/testutil/MockScript.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/ftests/pom.xml
+++ b/addons/koji/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/koji/ftests/src/main/java/org/commonjava/indy/koji/ftest/AbstractKojiIT.java
+++ b/addons/koji/ftests/src/main/java/org/commonjava/indy/koji/ftest/AbstractKojiIT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/ftests/src/main/java/org/commonjava/indy/koji/ftest/IK_LoginIT.java
+++ b/addons/koji/ftests/src/main/java/org/commonjava/indy/koji/ftest/IK_LoginIT.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/ftests/src/main/java/org/commonjava/indy/koji/ftest/ProxyRemoteKojiContentTest.java
+++ b/addons/koji/ftests/src/main/java/org/commonjava/indy/koji/ftest/ProxyRemoteKojiContentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/koji/jaxrs/pom.xml
+++ b/addons/koji/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/koji/model-java/pom.xml
+++ b/addons/koji/model-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/koji/pom.xml
+++ b/addons/koji/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/pom.xml
+++ b/addons/pkg-maven/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MergedFileUploadListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MergedFileUploadListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/sl/SnapshotFilter.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/sl/SnapshotFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/ArchetypeCatalogGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/ArchetypeCatalogGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/ArchetypeCatalogGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/ArchetypeCatalogGenerator.java
@@ -116,22 +116,14 @@ public class ArchetypeCatalogGenerator
             final byte[] merged = merger.merge( sources, group, toMergePath );
             if ( merged != null )
             {
-                OutputStream fos = null;
-                try
+                try(OutputStream fos = target.openOutputStream( TransferOperation.GENERATE, true, eventMetadata ))
                 {
-                    fos = target.openOutputStream( TransferOperation.GENERATE, true, eventMetadata );
                     fos.write( merged );
                 }
                 catch ( final IOException e )
                 {
                     throw new IndyWorkflowException( "Failed to write merged archetype catalog to: {}.\nError: {}", e, target, e.getMessage() );
                 }
-                finally
-                {
-                    closeQuietly( fos );
-                }
-
-                //                helper.writeChecksumsAndMergeInfo( merged, sources, group, toMergePath );
             }
         }
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenContentAdvisor.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenContentAdvisor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -21,6 +21,7 @@ import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
 import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Writer;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.DirectContentAccess;
@@ -45,7 +46,6 @@ import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.atlas.ident.ref.SimpleTypeAndClassifier;
 import org.commonjava.maven.atlas.ident.ref.TypeAndClassifier;
 import org.commonjava.maven.atlas.ident.util.ArtifactPathInfo;
-import org.commonjava.maven.atlas.ident.util.JoinString;
 import org.commonjava.maven.atlas.ident.util.SnapshotUtils;
 import org.commonjava.maven.atlas.ident.util.VersionUtils;
 import org.commonjava.maven.atlas.ident.version.SingleVersion;
@@ -83,11 +83,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
-import static org.commonjava.cdi.util.weft.ContextSensitiveWeakHashMap.newSynchronizedContextSensitiveWeakHashMap;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_EXISTS;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_GENERATED;
 import static org.commonjava.maven.galley.io.SpecialPathConstants.HTTP_METADATA_EXT;
@@ -159,7 +158,8 @@ public class MavenMetadataGenerator
     @ExecutorConfig( named="maven-metadata-generator", threads=8 )
     private ExecutorService executorService;
 
-    private final Map<String, ReentrantLock> mergerLocks = newSynchronizedContextSensitiveWeakHashMap();
+    // don't need to inject since it's only used internally
+    private final Locker<String> mergerLocks = new Locker<>();
 
     private static final int THREAD_WAITING_TIME_SECONDS = 300;
 
@@ -186,6 +186,11 @@ public class MavenMetadataGenerator
         {
             executorService = Executors.newFixedThreadPool( 8 );
         }
+    }
+
+    public void clearAllMerged( ArtifactStore store, String...paths )
+    {
+        super.clearAllMerged( store, paths );
     }
 
     @Override
@@ -388,17 +393,15 @@ public class MavenMetadataGenerator
             return target;
         }
 
-        final ReentrantLock mergerLock = getMergerLock( group, toMergePath );
-        final boolean locked = mergerLock.tryLock();
-        boolean mergingDone = false;
-
-        if ( locked )
-        {
+        AtomicReference<IndyWorkflowException> wfEx = new AtomicReference<>();
+        String mergePath = toMergePath;
+        boolean mergingDone = mergerLocks.ifUnlocked( computeKey(group, toMergePath), p->{
             try
             {
                 logger.debug( "Start metadata generation for the metadata file for this path {} in group {}", path,
                               group );
-                final Metadata md = generateGroupMetadata( group, members, path );
+                List<StoreKey> contributing = new ArrayList<>();
+                final Metadata md = generateGroupMetadata( group, members, contributing, path );
                 if ( md != null )
                 {
                     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -427,9 +430,12 @@ public class MavenMetadataGenerator
                                 closeQuietly( fos );
                             }
 
-                        writeGroupMergeInfo( group, members, toMergePath );
+                            String mergeInfo = writeGroupMergeInfo( md, group, contributing, mergePath );
+                            eventMetadata.set( GROUP_METADATA_GENERATED, true );
+                            MetadataInfo info = new MetadataInfo( md );
+                            info.setMetadataMergeInfo( mergeInfo );
 
-                        eventMetadata.set( GROUP_METADATA_GENERATED, true );
+                            putToMetadataCache( group.getKey(), mergePath, info );
                         }
                     }
                     catch ( final IOException e )
@@ -439,43 +445,29 @@ public class MavenMetadataGenerator
                     }
                 }
             }
-            finally
+            catch ( IndyWorkflowException e )
             {
-                mergingDone = true;
-                mergerLock.unlock();
+                wfEx.set( e );
+                return false;
             }
-        }
-        else
-        {
+
+            return true;
+        }, (p,mergerLock)->{
             logger.info(
                     "The metadata generation is still in process by another thread for the metadata file for this path {} in group {}, so block current thread to wait for result",
                     path, group );
-            boolean waitingLocked = false;
-            try
-            {
-                //TODO: will let non-working threads wait here for seconds for the result of the working thread processing. Need to evaluate how long should wait here in future.
-                waitingLocked = mergerLock.tryLock( THREAD_WAITING_TIME_SECONDS, TimeUnit.SECONDS );
-                if ( waitingLocked )
-                {
-                    mergingDone = true;
-                }
-            }
-            catch ( InterruptedException e )
-            {
-                logger.warn( "Thread interrupted by other threads for waiting processing result: {}", e.getMessage() );
-            }
-            finally
-            {
-                if ( waitingLocked )
-                {
-                    mergerLock.unlock();
-                }
-            }
+
+            return mergerLocks.waitForLock( THREAD_WAITING_TIME_SECONDS, mergerLock );
+        } );
+
+        IndyWorkflowException ex = wfEx.get();
+        if ( ex != null )
+        {
+            throw ex;
         }
 
         if ( exists( target ) )
         {
-            //                return target;
             // if this is a checksum file, we need to return the original path.
             Transfer original = fileManager.getTransfer( group, path );
             if ( exists( original ) )
@@ -500,60 +492,50 @@ public class MavenMetadataGenerator
         return null;
     }
 
-    private ReentrantLock getMergerLock( Group group, String path )
+    private String computeKey( final Group group, final String path )
     {
-        return mergerLocks.computeIfAbsent( group.getKey().toString() + "-" + path, k-> new ReentrantLock(  ) );
+        return group.getKey().toString() + "-" + path;
     }
 
-    private void writeGroupMergeInfo( final Group group, final List<ArtifactStore> members, final String path )
+    private String writeGroupMergeInfo( final Metadata md, final Group group, final List<StoreKey> contributingMembers, final String path )
             throws IndyWorkflowException
     {
         logger.trace( "Start write .info file based on if the cache exists for group {} of members {} in path. ",
-                      group.getKey(), members, path );
+                      group.getKey(), contributingMembers, path );
         final Transfer mergeInfoTarget = fileManager.getTransfer( group, path + GroupMergeHelper.MERGEINFO_SUFFIX );
-        if ( !exists( mergeInfoTarget ) )
-        {
-            logger.trace( ".info file not found for {} of members {} in path {}", group.getKey(), members, path );
-            final MetadataInfo metaInfo = getMetaInfoFromCache( group.getKey(), path );
-            if ( metaInfo != null )
-            {
-                String metaMergeInfo = metaInfo.getMetadataMergeInfo();
-                if ( StringUtils.isBlank( metaMergeInfo ) )
-                {
-                    logger.trace(
-                            "metadata merge info not cached for group {} of members {} in path {}, will regenerate.",
-                            group.getKey(), members, path );
-                    final List<Transfer> sources = fileManager.retrieveAllRaw( members, path, new EventMetadata() );
-                    metaMergeInfo = helper.generateMergeInfo( sources );
-                    metaInfo.setMetadataMergeInfo( metaMergeInfo );
-                }
-                logger.trace( "Metadata merge info for {} of members {} in path {} is {}", group.getKey(), members,
-                              path, metaMergeInfo );
-                helper.writeMergeInfo( metaMergeInfo, group, path );
-                logger.trace( ".info file regenerated for group {} of members {} in path. ", group.getKey(), members,
-                              path );
-            }
-        }
-        else
-        {
-            logger.trace( ".info file exists for group {} of members {} in path, no need to regenerate ",
-                          group.getKey(), members, path );
-        }
+        logger.trace( ".info file not found for {} of members {} in path {}", group.getKey(), contributingMembers, path );
+
+        logger.trace(
+                "metadata merge info not cached for group {} of members {} in path {}, will regenerate.",
+                group.getKey(), contributingMembers, path );
+        String metaMergeInfo = helper.generateMergeInfoFromKeys( contributingMembers );
+
+        logger.trace( "Metadata merge info for {} of members {} in path {} is {}", group.getKey(), contributingMembers,
+                      path, metaMergeInfo );
+        helper.writeMergeInfo( metaMergeInfo, group, path );
+        logger.trace( ".info file regenerated for group {} of members {} in path. Full path: {}", group.getKey(), contributingMembers,
+                      path, mergeInfoTarget.getDetachedFile() );
+
+        return metaMergeInfo;
     }
 
     /**
      * Will generate group related files(e.g maven-metadata.xml) from cache level, which means all the generation of the
-     * files will be cached. In terms of cache clearing, see #{@link MetadataMergeListner}
+     * files will be cached. In terms of cache clearing, see #{@link MetadataMergeListener}
      *
      * @param group
      * @param members concrete store in group
      * @param path
+     *
      * @return
+     *
      * @throws IndyWorkflowException
      */
-    private Metadata generateGroupMetadata( final Group group, final List<ArtifactStore> members, final String path )
+    private Metadata generateGroupMetadata( final Group group, final List<ArtifactStore> members,
+                                            final List<StoreKey> contributingMembers, final String path )
             throws IndyWorkflowException
     {
+
         if ( !canProcess( path ) )
         {
             logger.error( "The path is not a metadata file: {} ", path );
@@ -574,7 +556,12 @@ public class MavenMetadataGenerator
         }
 
         Map<StoreKey, Metadata> memberMetas = new ConcurrentHashMap<>( members.size() );
-        Set<ArtifactStore> missing = retrieveCachedMemberMetadata( memberMetas, members, toMergePath );
+        Set<ArtifactStore> missing = retrieveCachedMemberMetadata( memberMetas, members, contributingMembers, toMergePath );
+
+        // this is weird, but I found duplicates in the missing set! De-duplicating here before proceeding...
+        Map<StoreKey, ArtifactStore> missingMap = new HashMap<>();
+        missing.forEach( m->missingMap.put(m.getKey(), m) );
+        missing = new HashSet<>( missingMap.values() );
 
         // Try to download missed meta
         missing = downloadMissingMemberMetadata( group, missing, memberMetas, toMergePath );
@@ -582,16 +569,34 @@ public class MavenMetadataGenerator
         // Try to generate missed meta
         generateMissingMemberMetadata( group, missing, memberMetas, toMergePath );
 
+        if ( !missing.isEmpty() )
+        {
+            logger.warn(
+                    "After download and generation attempts, metadata is still missing from the following stores: {}",
+                    missing );
+        }
+
+        String tmp = toMergePath;
         List<Metadata> metas = members.stream()
-                                      .map( mem -> memberMetas.get(mem.getKey()) )
+                                      .map( mem -> {
+                                          Metadata memberMetadata = memberMetas.get( mem.getKey() );
+                                          if ( memberMetadata != null )
+                                          {
+                                              logger.trace("Recording contributing member: {} for metadata: {} in group: {}", mem.getKey(), tmp, group.getKey() );
+                                              contributingMembers.add( mem.getKey() );
+                                          }
+
+                                          return memberMetadata;
+                                      } )
                                       .filter( mmeta -> mmeta != null )
                                       .collect( Collectors.toList() );
+
+        logger.trace( "Metadata: {} in group: {} was generated from members: {}", toMergePath, group.getKey(), contributingMembers );
 
         final Metadata master = merger.mergeFromMetadatas( metas, group, toMergePath );
 
         if ( master != null )
         {
-            putToMetadataCache( group.getKey(), toMergePath, master );
             return master;
         }
 
@@ -599,20 +604,33 @@ public class MavenMetadataGenerator
         return null;
     }
 
-    private void putToMetadataCache( StoreKey key, String toMergePath, Metadata meta )
+    private void putToMetadataCache( StoreKey key, String toMergePath, MetadataInfo meta )
     {
-        Map cacheMap = versionMetadataCache.computeIfAbsent( key, k -> new ConcurrentHashMap() );
-        cacheMap.put( toMergePath, new MetadataInfo( meta ) );
+        synchronized ( versionMetadataCache )
+        {
+            Map cacheMap = versionMetadataCache.get( key );
+            if ( cacheMap == null )
+            {
+                cacheMap = new HashMap<>();
+            }
+
+            cacheMap.put( toMergePath, meta );
+            versionMetadataCache.put( key, cacheMap );
+
+            logger.trace( "Cached metadata: {} for: {}", toMergePath, key );
+        }
     }
 
-    private Set<ArtifactStore> generateMissingMemberMetadata( Group group, Set<ArtifactStore> missing,
+    private Set<ArtifactStore> generateMissingMemberMetadata( Group group, Set<ArtifactStore> missingOrig,
                                                 Map<StoreKey, Metadata> memberMetas, String toMergePath )
                     throws IndyWorkflowException
     {
         Set<ArtifactStore> ret = Collections.synchronizedSet( new HashSet<>() ); // return stores failed generation
 
+        Set<ArtifactStore> missing = Collections.synchronizedSet( new HashSet<>( missingOrig ) );
         CountDownLatch latch = new CountDownLatch( missing.size() );
-        List<String> errors = new ArrayList<>();
+
+        logger.trace( "Initial latch size: {}; initial missing size: {}", latch.getCount(), missing.size() );
 
         logger.debug( "Generate missing member metadata for {}, missing: {}, size: {}", group.getKey(), missing, missing.size() );
         Set<ArtifactStore> remaining = Collections.synchronizedSet( new HashSet<>( missing ) ); // for debug
@@ -636,7 +654,7 @@ public class MavenMetadataGenerator
                             Metadata memberMeta = reader.read( new StringReader( content ), false );
                             memberMetas.put( store.getKey(), memberMeta );
 
-                            putToMetadataCache( store.getKey(), toMergePath, memberMeta );
+                            putToMetadataCache( store.getKey(), toMergePath, new MetadataInfo( memberMeta ) );
                             clearObsoleteFiles( memberMetaTxfr );
                         }
                     }
@@ -647,13 +665,13 @@ public class MavenMetadataGenerator
                 }
                 catch ( final Exception e )
                 {
-                    String msg = String.format( "Failed to generate metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
+                    String msg = String.format( "EXCLUDING Failed generated metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
                                                  e.getMessage() );
                     logger.error( msg, e );
-                    synchronized ( errors )
-                    {
-                        errors.add( msg );
-                    }
+//                    synchronized ( errors )
+//                    {
+//                        errors.add( msg );
+//                    }
                 }
                 finally
                 {
@@ -665,35 +683,15 @@ public class MavenMetadataGenerator
         } );
         /* @formatter:on */
 
-        waitOnLatch( group, toMergePath, latch, remaining, "generations" );
+        waitOnLatch( group, toMergePath, latch, "GENERATE" );
 
-        if ( !errors.isEmpty() )
-        {
-            throw new IndyWorkflowException( "Failed to generate one or more member metadata files for: %s:%s. Errors were:\n  %s",
-                            group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
-        }
+//        if ( !errors.isEmpty() )
+//        {
+//            throw new IndyWorkflowException( "Failed to generate one or more member metadata files for: %s:%s. Errors were:\n  %s",
+//                            group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
+//        }
 
         return ret;
-    }
-
-    private void waitOnLatch( Group group, String toMergePath, CountDownLatch latch, Set<ArtifactStore> remaining,
-                              String operation )
-    {
-        do
-        {
-            try
-            {
-                logger.debug( "Waiting for {} member {} of: {}:{}, Remaining: {}", latch.getCount(), operation,
-                              group.getKey(), toMergePath, remaining );
-                latch.await( 1000, TimeUnit.MILLISECONDS );
-            }
-            catch ( InterruptedException e )
-            {
-                logger.debug( "Interrupted while waiting for member metadata {}.", operation );
-                break;
-            }
-        }
-        while ( latch.getCount() > 0 );
     }
 
     /**
@@ -715,9 +713,12 @@ public class MavenMetadataGenerator
     }
 
     private Set<ArtifactStore> retrieveCachedMemberMetadata( final Map<StoreKey, Metadata> memberMetas,
-                                                             final List<ArtifactStore> members, final String toMergePath )
+                                                             final List<ArtifactStore> members,
+                                                             final List<StoreKey> contributingMembers,
+                                                             final String toMergePath )
             throws IndyWorkflowException
     {
+
         Set<ArtifactStore> missing = new HashSet<>();
 
         for ( ArtifactStore store : members )
@@ -733,7 +734,7 @@ public class MavenMetadataGenerator
                                                                                    .stream()
                                                                                    .filter( st -> !st.isDisabled() )
                                                                                    .collect( Collectors.toList() ),
-                                                        toMergePath );
+                                                        contributingMembers, toMergePath );
                     memberMetas.put( store.getKey(), memberMeta );
                 }
                 catch ( IndyDataException e )
@@ -760,14 +761,14 @@ public class MavenMetadataGenerator
         return missing;
     }
 
-    private Set<ArtifactStore> downloadMissingMemberMetadata( final Group group, final Set<ArtifactStore> missing,
+    private Set<ArtifactStore> downloadMissingMemberMetadata( final Group group, final Set<ArtifactStore> missingOrig,
                                                 final Map<StoreKey, Metadata> memberMetas, final String toMergePath )
             throws IndyWorkflowException
     {
         Set<ArtifactStore> ret = Collections.synchronizedSet( new HashSet<>() ); // return stores failed download
 
+        Set<ArtifactStore> missing = Collections.synchronizedSet( new HashSet<>( missingOrig ) );
         CountDownLatch latch = new CountDownLatch( missing.size() );
-        List<String> errors = Collections.synchronizedList( new ArrayList<>() );
 
         logger.debug( "Download missing member metadata for {}, missing: {}, size: {}", group.getKey(), missing, missing.size() );
         Set<ArtifactStore> remaining = Collections.synchronizedSet( new HashSet<>( missing ) ); // for debug
@@ -791,7 +792,7 @@ public class MavenMetadataGenerator
                             Metadata memberMeta = reader.read( new StringReader( content ), false );
                             memberMetas.put( store.getKey(), memberMeta );
 
-                            putToMetadataCache( store.getKey(), toMergePath, memberMeta );
+                            putToMetadataCache( store.getKey(), toMergePath, new MetadataInfo( memberMeta ) );
                         }
                     }
                     else
@@ -801,10 +802,10 @@ public class MavenMetadataGenerator
                 }
                 catch ( final Exception e )
                 {
-                    String msg = String.format( "Failed to retrieve metadata: %s:%s. Reason: %s", store.getKey(), toMergePath,
+                    String msg = String.format( "EXCLUDING Failed metadata download: %s:%s. Reason: %s", store.getKey(), toMergePath,
                                                  e.getMessage() );
                     logger.error( msg, e );
-                    errors.add( msg );
+//                    errors.add( msg );
                 }
                 finally
                 {
@@ -816,16 +817,34 @@ public class MavenMetadataGenerator
         } );
         /* @formatter:on */
 
-        waitOnLatch( group, toMergePath, latch, remaining, "downloads" );
+        waitOnLatch( group, toMergePath, latch, "DOWNLOAD" );
 
-        if ( !errors.isEmpty() )
-        {
-            throw new IndyWorkflowException(
-                    "Failed to retrieve one or more member metadata files for: %s:%s. Errors were:\n  %s",
-                    group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
-        }
+//        if ( !errors.isEmpty() )
+//        {
+//            throw new IndyWorkflowException(
+//                    "Failed to retrieve one or more member metadata files for: %s:%s. Errors were:\n  %s",
+//                    group.getKey(), toMergePath, new JoinString( "\n  ", errors ) );
+//        }
 
         return ret;
+    }
+
+    private void waitOnLatch( Group group, String toMergePath, CountDownLatch latch, String step )
+    {
+        do
+        {
+            try
+            {
+                logger.debug( "[{} Step] Waiting for {} member downloads of: {}:{}", step, latch.getCount(), group.getKey(), toMergePath );
+                latch.await( 1000, TimeUnit.MILLISECONDS );
+            }
+            catch ( InterruptedException e )
+            {
+                logger.debug("Interrupted while waiting for member metadata downloads.");
+                break;
+            }
+        }
+        while ( latch.getCount() > 0 );
     }
 
     private boolean exists( final Transfer target )
@@ -838,6 +857,7 @@ public class MavenMetadataGenerator
         final MetadataInfo metaMergeInfo = getMetaInfoFromCache( key, path );
         if ( metaMergeInfo != null )
         {
+            logger.trace( "FOUND metadata: {} in group: {} with merge info:\n\n{}\n\n", path, key, metaMergeInfo.getMetadataMergeInfo() );
             return metaMergeInfo.getMetadata();
         }
         return null;

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataInfo.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.content;
+
+import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.change.event.ArtifactStoreDeletePreEvent;
+import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;
+import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
+import org.commonjava.indy.content.DirectContentAccess;
+import org.commonjava.indy.content.MergedContentAction;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.core.content.group.GroupMergeHelper;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.galley.KeyedLocation;
+import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.event.FileDeletionEvent;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.infinispan.cdi.ConfigureCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
+import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
+
+/**
+ * This listener will do these tasks:
+ * <ul>
+ *     <li>When the metadata file changed of a member in a group, delete correspond cache of that file path of the member and group (cascaded)</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class MetadataMergeListener
+        implements MergedContentAction
+{
+    final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private DirectContentAccess fileManager;
+
+    @Inject
+    @MavenVersionMetadataCache
+    private CacheHandle<StoreKey, Map> versionMetadataCache;
+
+    /**
+     * Will clear the both merge path and merge info file of member and group contains that member(cascaded)
+     * if that path of file changed in the member of #originatingStore
+     */
+    @Override
+    public void clearMergedPath( ArtifactStore originatingStore, Set<Group> affectedGroups, String path )
+    {
+        final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( originatingStore.getKey() );
+
+        if ( metadataMap != null && !metadataMap.isEmpty() )
+        {
+            if ( metadataMap.get( path ) != null )
+            {
+                metadataMap.remove( path );
+                affectedGroups.forEach( group -> {
+                    final Map<String, MetadataInfo> grpMetaMap = versionMetadataCache.get( group.getKey() );
+                    if ( grpMetaMap != null && !grpMetaMap.isEmpty() )
+                    {
+                        grpMetaMap.remove( path );
+                    }
+                } );
+            }
+        }
+    }
+
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
@@ -206,23 +206,16 @@ public class MetadataStoreListener
 
     private void removeMetadataCache( ArtifactStore store )
     {
-        final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( store.getKey() );
-        if ( metadataMap != null && !metadataMap.isEmpty() )
+        logger.trace( "Removing cached metadata for: {}", store.getKey() );
+
+        versionMetadataCache.remove( store.getKey() );
+        try
         {
-            logger.trace( "Removing cached metadata for: {}", store.getKey() );
-            versionMetadataCache.remove( store.getKey() );
-            try
-            {
-                storeManager.query().getGroupsAffectedBy( store.getKey() ).forEach( g -> clearGroupMetaCache( g, store ) );
-            }
-            catch ( IndyDataException e )
-            {
-                logger.error( String.format( "Can not get affected groups of %s", store.getKey() ), e );
-            }
+            storeManager.query().getGroupsAffectedBy( store.getKey() ).forEach( g -> clearGroupMetaCache( g, store ) );
         }
-        else
+        catch ( IndyDataException e )
         {
-            logger.trace( "Cached metadata map is empty or null for: {}", store.getKey() );
+            logger.error( String.format( "Can not get affected groups of %s", store.getKey() ), e );
         }
     }
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
@@ -1,28 +1,9 @@
-/**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.commonjava.indy.pkg.maven.content;
 
-import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.change.event.ArtifactStoreDeletePreEvent;
 import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
-import org.commonjava.indy.content.DirectContentAccess;
-import org.commonjava.indy.content.MergedContentAction;
 import org.commonjava.indy.data.IndyDataException;
-import org.commonjava.indy.core.content.group.GroupMergeHelper;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
@@ -35,17 +16,18 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.event.FileDeletionEvent;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
-import org.infinispan.cdi.ConfigureCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
@@ -53,31 +35,26 @@ import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.ME
 /**
  * This listener will do these tasks:
  * <ul>
- *     <li>When there are member changes for a group, or member disabled/enabled in a group,
- *     delete group metadata caches to force regeneration of the metadata of the group (cascaded)</li>
- *     <li>When the metadata file changed or deleted of a member in a group,
- *     delete correspond cache of that file path of the member and group (cascaded)</li>
+ *     <li>When there are member changes for a group, or some members disabled/enabled in a group, delete group metadata caches to force next regeneration of the metadata files of the group(cascaded)</li>
  * </ul>
  */
 @ApplicationScoped
-public class MetadataMergeListner
-        implements MergedContentAction
+public class MetadataStoreListener
 {
-    final Logger logger = LoggerFactory.getLogger( getClass() );
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     @Inject
-    private DirectContentAccess fileManager;
+    private MavenMetadataGenerator metadataGenerator;
 
     @Inject
     private StoreDataManager storeManager;
 
-    @ConfigureCache( "maven-version-metadata-cache" )
     @Inject
     @MavenVersionMetadataCache
     private CacheHandle<StoreKey, Map> versionMetadataCache;
 
     /**
-     * Listen to an #{@link ArtifactStorePreUpdateEvent} and clear the metadata cache of the changed member in event
+     * Listen to an #{@link ArtifactStorePreUpdateEvent} and clear the metadata cache due to changed memeber in that event
      *
      * @param event
      */
@@ -142,8 +119,7 @@ public class MetadataMergeListner
         try
         {
             ArtifactStore store = storeManager.getArtifactStore( storeKey );
-            Set<Group> affectedGroups = storeManager.query().getGroupsAffectedBy( store.getKey() );
-            clearMergedPath( store, affectedGroups, path );
+            metadataGenerator.clearAllMerged( store, path );
         }
         catch ( IndyDataException e )
         {
@@ -151,39 +127,36 @@ public class MetadataMergeListner
         }
     }
 
-    private void removeMetadataCache( ArtifactStore store )
-    {
-        versionMetadataCache.remove( store.getKey() );
-        try
-        {
-            storeManager.query().getGroupsAffectedBy( store.getKey() ).forEach( g -> clearGroupMetaCache( g ) );
-        }
-        catch ( IndyDataException e )
-        {
-            logger.error( String.format( "Can not get affected groups of %s", store.getKey() ), e );
-        }
-    }
-
     private void removeMetadataCacheContent( final ArtifactStore store,
                                              final Map<ArtifactStore, ArtifactStore> changeMap )
     {
+        logger.trace( "Processing update event for: {}", store.getKey() );
         handleStoreDisableOrEnable( store, changeMap );
+
         handleGroupMembersChanged( store, changeMap );
     }
 
     // if a store is disabled/enabled, we should clear its metadata cache and all of its affected groups cache too.
     private void handleStoreDisableOrEnable(final ArtifactStore store,
                                             final Map<ArtifactStore, ArtifactStore> changeMap){
+        logger.trace( "Processing en/disable event for: {}", store.getKey() );
+
         final ArtifactStore oldStore = changeMap.get( store );
         if ( store.isDisabled() != oldStore.isDisabled() )
         {
+            logger.trace( "En/disable state changed for: {}", store.getKey() );
             removeMetadataCache( store );
+        }
+        else
+        {
+            logger.trace( "En/disable state has not changed for: {}", store.getKey() );
         }
     }
 
     // If group members changed, should clear the cascading groups metadata cache
     private void handleGroupMembersChanged(final ArtifactStore store,
-                                           final Map<ArtifactStore, ArtifactStore> changeMap){
+                                           final Map<ArtifactStore, ArtifactStore> changeMap)
+    {
         final StoreKey key = store.getKey();
         if ( StoreType.group == key.getType() )
         {
@@ -213,87 +186,74 @@ public class MetadataMergeListner
 
             if ( membersChanged )
             {
-                clearGroupMetaCache( group );
+                logger.trace( "Membership change confirmed. Clearing caches for group: {} and groups affected by it.", group.getKey() );
+                clearGroupMetaCache( group, group );
                 try
                 {
-                    storeManager.query().getGroupsAffectedBy( group.getKey() ).forEach( g -> clearGroupMetaCache( g ) );
+                    storeManager.query().getGroupsAffectedBy( group.getKey() ).forEach( g -> clearGroupMetaCache( g, group ) );
                 }
                 catch ( IndyDataException e )
                 {
-                    logger.error( String.format( "Can not get affected groups of %s", group.getKey()), e );
+                    logger.error( String.format( "Can not get affected groups of %s", group.getKey() ), e );
                 }
+            }
+            else
+            {
+                logger.trace( "No members changed, no need to expunge merged metadata" );
             }
         }
     }
 
-    private void clearGroupMetaCache( final Group group )
+    private void removeMetadataCache( ArtifactStore store )
+    {
+        final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( store.getKey() );
+        if ( metadataMap != null && !metadataMap.isEmpty() )
+        {
+            logger.trace( "Removing cached metadata for: {}", store.getKey() );
+            versionMetadataCache.remove( store.getKey() );
+            try
+            {
+                storeManager.query().getGroupsAffectedBy( store.getKey() ).forEach( g -> clearGroupMetaCache( g, store ) );
+            }
+            catch ( IndyDataException e )
+            {
+                logger.error( String.format( "Can not get affected groups of %s", store.getKey() ), e );
+            }
+        }
+        else
+        {
+            logger.trace( "Cached metadata map is empty or null for: {}", store.getKey() );
+        }
+    }
+
+    private void clearGroupMetaCache( final Group group, final ArtifactStore store )
     {
         final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( group.getKey() );
 
-        if ( metadataMap != null && !metadataMap.isEmpty() )
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.trace( "Clearing metadata for group: {} after update of store: {}\n{}", group.getKey(), store.getKey(), metadataMap );
+
+        if ( metadataMap == null || metadataMap.isEmpty() )
         {
-            metadataMap.keySet().parallelStream().forEach( path -> {
-                clearTempMetaFile( group, path );
-            } );
+            logger.trace( "No cached metadata for: {}", group.getKey() );
+            return;
         }
+
+        String[] paths = new String[metadataMap.size()];
+        paths = metadataMap.keySet().toArray( paths );
+
+        List<String> pathsList = Arrays.asList( paths );
+
+        logger.trace(
+                "Clearing merged paths in MavenMetadataGenerator for: {} as a result of change in: {} (paths: {})",
+                group.getKey(), store.getKey(), pathsList );
+
+        metadataGenerator.clearAllMerged( group, paths );
+
+        logger.trace( "Clearing cached, merged paths for: {} as a result of change in: {} (paths: {})", group.getKey(),
+                      store.getKey(), pathsList );
 
         versionMetadataCache.remove( group.getKey() );
-    }
-
-    private void clearTempMetaFile( final Group group, final String path )
-    {
-        try
-        {
-            final Transfer tempMetaTxfr = fileManager.getTransfer( group, path );
-            if ( tempMetaTxfr != null && tempMetaTxfr.exists() )
-            {
-                tempMetaTxfr.delete();
-            }
-        }
-        catch ( IndyWorkflowException | IOException e )
-        {
-            logger.error( "Can not delete temp metadata file for group. Group: {}, file path: {}", group, path );
-        }
-
-        try
-        {
-            final Transfer tempMetaMergeInfoTxfr =
-                    fileManager.getTransfer( group, path + GroupMergeHelper.MERGEINFO_SUFFIX );
-            if ( tempMetaMergeInfoTxfr != null && tempMetaMergeInfoTxfr.exists() )
-            {
-                tempMetaMergeInfoTxfr.delete();
-            }
-        }
-        catch ( IndyWorkflowException | IOException e )
-        {
-            logger.error( "Can not delete temp metadata file for group. Group: {}, file path: {}", group, path );
-        }
-    }
-
-    /**
-     * Will clear the both merge path and merge info file of member and group contains that member(cascaded)
-     * if that path of file changed in the member of #originatingStore
-     */
-    @Override
-    public void clearMergedPath( ArtifactStore originatingStore, Set<Group> affectedGroups, String path )
-    {
-        final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( originatingStore.getKey() );
-
-        if ( metadataMap != null && !metadataMap.isEmpty() )
-        {
-            if ( metadataMap.get( path ) != null )
-            {
-                metadataMap.remove( path );
-                affectedGroups.forEach( group -> {
-                    final Map<String, MetadataInfo> grpMetaMap = versionMetadataCache.get( group.getKey() );
-                    if ( grpMetaMap != null && !grpMetaMap.isEmpty() )
-                    {
-                        clearTempMetaFile( group, path );
-                        grpMetaMap.remove( path );
-                    }
-                } );
-            }
-        }
     }
 
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
@@ -239,7 +239,7 @@ public class MetadataStoreListener
         final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( group.getKey() );
 
         Logger logger = LoggerFactory.getLogger( getClass() );
-        logger.trace( "Clearing metadata for group: {} after update of store: {}\n{}", group.getKey(), store.getKey(), metadataMap );
+        logger.trace( "Clearing metadata for group: {} on store update: {}\n{}", group.getKey(), store.getKey(), metadataMap );
 
         if ( metadataMap == null || metadataMap.isEmpty() )
         {

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.pkg.maven.content;
 
 import org.commonjava.indy.change.event.ArtifactStoreDeletePreEvent;

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MavenVersionMetadataCache.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MavenVersionMetadataCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/ArchetypeCatalogMerger.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/ArchetypeCatalogMerger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/ArchetypeCatalogMerger.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/ArchetypeCatalogMerger.java
@@ -60,16 +60,14 @@ public class ArchetypeCatalogMerger
         final ArchetypeCatalog master = new ArchetypeCatalog();
         final ArchetypeCatalogXpp3Reader reader = new ArchetypeCatalogXpp3Reader();
         final FileReader fr = null;
-        InputStream stream = null;
-
         boolean merged = false;
 
         final Set<String> seen = new HashSet<String>();
         for ( final Transfer src : sources )
         {
-            try
+            try(InputStream stream = src.openInputStream())
             {
-                stream = src.openInputStream();
+
                 final ArchetypeCatalog catalog = reader.read( stream, false );
 
                 for ( final Archetype arch : catalog.getArchetypes() )

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMerger.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMerger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataProvider.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/inject/GalleyProvider.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/inject/GalleyProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/metrics/IndyMetricsPkgMavenNames.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/metrics/IndyMetricsPkgMavenNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGeneratorTest.java
+++ b/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMergerTest.java
+++ b/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMergerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/pom.xml
+++ b/addons/pkg-maven/ftests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnNewMemberTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnNewMemberTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomDeletionTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomDeletionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomUploadTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupHostedMetadataRemergedOnPomUploadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetaOverlapWithMetaOfHostedReposTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetaOverlapWithMetaOfHostedReposTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetaOverlapWithNestedGroupOfHostRepoMetaTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetaOverlapWithNestedGroupOfHostRepoMetaTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetaOverlapWithNestedGroupOfHostRepoNoMetaTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetaOverlapWithNestedGroupOfHostRepoNoMetaTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetaOverlapWithoutMetaOfHostedReposTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetaOverlapWithoutMetaOfHostedReposTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadata401ErrorTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadata401ErrorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataChecksumRequestedFirstTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataChecksumRequestedFirstTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataMergeWithInvalidVersionTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataMergeWithInvalidVersionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnMemberAddTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnMemberAddTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnUploadTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnUploadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataFoundAfterMemberAddTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataFoundAfterMemberAddTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/StoreGeneratedMetadataInRemoteTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/StoreGeneratedMetadataInRemoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/StoreGeneratedMetadataInRemoteTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/StoreGeneratedMetadataInRemoteTest.java
@@ -113,7 +113,7 @@ public class StoreGeneratedMetadataInRemoteTest
         client.content().store( hosted1.getKey(), path_2, new ByteArrayInputStream( pomContent_2.getBytes() ) );
         client.content().store( hosted1.getKey(), metaPath, new ByteArrayInputStream( metaContent.getBytes() ) );
 
-        Group g = new Group( GROUP, remote1.getKey(), hosted1.getKey() );
+        Group g = new Group( MAVEN_PKG_KEY, GROUP, remote1.getKey(), hosted1.getKey() );
         g = client.stores().create( g, "group G", Group.class );
 
         // MUST hit the .pom first. This is needed to populate org/foo/bar/1.0 folder in order to generate metadata.xml

--- a/addons/pkg-maven/jaxrs/pom.xml
+++ b/addons/pkg-maven/jaxrs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/jaxrs/src/main/java/org/commonjava/indy/pkg/maven/jaxrs/MavenContentAccessResource.java
+++ b/addons/pkg-maven/jaxrs/src/main/java/org/commonjava/indy/pkg/maven/jaxrs/MavenContentAccessResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-maven/pom.xml
+++ b/addons/pkg-maven/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/common/pom.xml
+++ b/addons/pkg-npm/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGenerator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMerger.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMerger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataProvider.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/data/NPMSpecialPathProducer.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/data/NPMSpecialPathProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/inject/NPMContentHandler.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/inject/NPMContentHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/pom.xml
+++ b/addons/pkg-npm/ftests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupContentMergeRetrieveTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupContentMergeRetrieveTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupDeleteFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupDeleteFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupStoreFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupStoreFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMHostedReStoreContentTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMHostedReStoreContentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMHostedRetrieveFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMHostedRetrieveFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReaonlyHostedDeleteFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReaonlyHostedDeleteFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReaonlyHostedStoreFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReaonlyHostedStoreFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemoteDeleteFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemoteDeleteFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemoteMetadataContentRetrieveTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemoteMetadataContentRetrieveTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemotePackageContentRetrieveTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemotePackageContentRetrieveTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemotePathContentTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemotePathContentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemoteStoreFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemoteStoreFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMTarballContentGenerationWhenUploadTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMTarballContentGenerationWhenUploadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/jaxrs/pom.xml
+++ b/addons/pkg-npm/jaxrs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/pom.xml
+++ b/addons/pkg-npm/model-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Bugs.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Bugs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Commitplease.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Commitplease.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Directories.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Directories.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Dist.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Dist.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/DistTag.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/DistTag.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Engines.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Engines.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/License.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/License.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmJsonOpts.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmJsonOpts.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmOperationalInternal.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmOperationalInternal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/PackageMetadata.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/PackageMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Repository.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Repository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/UserInfo.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/UserInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/VersionMetadata.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/VersionMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/test/java/org/commonjava/indy/pkg/npm/model/PackageMetadataTest.java
+++ b/addons/pkg-npm/model-java/src/test/java/org/commonjava/indy/pkg/npm/model/PackageMetadataTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/model-java/src/test/java/org/commonjava/indy/pkg/npm/model/VersionMetadataTest.java
+++ b/addons/pkg-npm/model-java/src/test/java/org/commonjava/indy/pkg/npm/model/VersionMetadataTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/pom.xml
+++ b/addons/pkg-npm/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/promote/client-java/pom.xml
+++ b/addons/promote/client-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteClientModule.java
+++ b/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/client-java/src/test/java/org/commonjava/indy/promote/client/IndyPromoteClientModuleUrlsTest.java
+++ b/addons/promote/client-java/src/test/java/org/commonjava/indy/promote/client/IndyPromoteClientModuleUrlsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/pom.xml
+++ b/addons/promote/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/PromoteAddOn.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/PromoteAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/action/PromotionRuleAproxMigrationAction.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/action/PromotionRuleAproxMigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/conf/PromoteConfig.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/conf/PromoteConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionException.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/metrics/IndyMetricsPromoteNames.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/metrics/IndyMetricsPromoteNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromoteValidationsManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromoteValidationsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationException.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/ValidationRuleParser.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/ValidationRuleParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/model/ValidationRequest.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/model/ValidationRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/model/ValidationRule.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/model/ValidationRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/model/ValidationRuleMapping.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/model/ValidationRuleMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/util/ReadOnlyTransfer.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/util/ReadOnlyTransfer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/conf/PromoteConfigTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/conf/PromoteConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.promote.data;
 
 import org.apache.commons.io.IOUtils;
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.conf.DefaultIndyConfiguration;
@@ -34,6 +35,7 @@ import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
 import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.promote.conf.PromoteConfig;
 import org.commonjava.indy.promote.model.PathsPromoteRequest;
@@ -172,7 +174,9 @@ public class PromotionManagerTest
 
         PromoteConfig config = new PromoteConfig();
 
-        manager = new PromotionManager( validator, contentManager, downloadManager, storeManager, config, nfc );
+        manager =
+                new PromotionManager( validator, contentManager, downloadManager, storeManager, new Locker<StoreKey>(),
+                                      new Locker<StoreKey>(), config, nfc );
 
         executor = Executors.newCachedThreadPool();
     }

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/fixture/GalleyFixture.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/fixture/GalleyFixture.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/validate/PromoteValidationsManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/validate/PromoteValidationsManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/validate/ValidationRuleParserTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/validate/ValidationRuleParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/pom.xml
+++ b/addons/promote/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/AbstractPromotionManagerTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/AbstractPromotionManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/CacheCheckingforPromoteWithRemoteTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/CacheCheckingforPromoteWithRemoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupHostedMetadataRemergedOnPromoteTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupHostedMetadataRemergedOnPromoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupNFCEntryClearedOnByPathPromoteTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupNFCEntryClearedOnByPathPromoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupNFCEntryClearedOnPromoteTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupNFCEntryClearedOnPromoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteAndRollbackTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteAndRollbackTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteFailsValidationTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteFailsValidationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteMatchesSucceedingValidationTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteMatchesSucceedingValidationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteAllTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteAllTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteAllWithPurgeTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteAllWithPurgeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteDryRunTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteDryRunTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteWithPurgeThenRollbackTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteWithPurgeThenRollbackTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RecursiveGroupMetadataFoundAfterMemberPromotedTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RecursiveGroupMetadataFoundAfterMemberPromotedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RollbackTwoArtifactsTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/RollbackTwoArtifactsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/AbstractValidationRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/AbstractValidationRuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_DependencyInAnotherRepoInGroup_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_DependencyInAnotherRepoInGroup_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_DependencyTwoExtraGroups_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_DependencyTwoExtraGroups_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_PromoteWithParent_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_PromoteWithParent_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/FullRuleStack_GroupWithOneOfTwoHosts_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/FullRuleStack_GroupWithOneOfTwoHosts_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoPreExistingPaths_GroupWithOneOfTwoHosts_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoPreExistingPaths_GroupWithOneOfTwoHosts_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoPreExistingPaths_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoPreExistingPaths_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_DependencyVersion_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_DependencyVersion_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_PluginVersion_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_PluginVersion_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_ProjectVersion_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_ProjectVersion_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoVersionRanges_DependencyVersion_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoVersionRanges_DependencyVersion_RuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ParsablePomRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ParsablePomRuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRule_PomDeploymentTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRule_PomDeploymentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectVersionPatternRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectVersionPatternRuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/jaxrs/pom.xml
+++ b/addons/promote/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteResource.java
+++ b/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/pom.xml
+++ b/addons/promote/model-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/GroupPromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/GroupPromoteRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/GroupPromoteResult.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/GroupPromoteResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteResult.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PromoteRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationCatalogDTO.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationCatalogDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationResult.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationRuleDTO.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationRuleDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationRuleSet.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationRuleSet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/GroupPromoteRequestTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/GroupPromoteRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/GroupPromoteResultTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/GroupPromoteResultTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/PathsPromoteRequestTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/PathsPromoteRequestTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/PathsPromoteResultTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/PathsPromoteResultTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationCatalogDTOTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationCatalogDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationResultTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationResultTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationRuleDTOTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationRuleDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationRuleSetTest.java
+++ b/addons/promote/model-java/src/test/java/org/commonjava/indy/promote/model/ValidationRuleSetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/promote/pom.xml
+++ b/addons/promote/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/relate/common/pom.xml
+++ b/addons/relate/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/relate/common/src/main/java/org/commonjava/indy/relate/RelateAddOn.java
+++ b/addons/relate/common/src/main/java/org/commonjava/indy/relate/RelateAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/common/src/main/java/org/commonjava/indy/relate/change/RelatePomStorageListener.java
+++ b/addons/relate/common/src/main/java/org/commonjava/indy/relate/change/RelatePomStorageListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/common/src/main/java/org/commonjava/indy/relate/conf/RelateConfig.java
+++ b/addons/relate/common/src/main/java/org/commonjava/indy/relate/conf/RelateConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/common/src/main/java/org/commonjava/indy/relate/content/RelateContentGenerator.java
+++ b/addons/relate/common/src/main/java/org/commonjava/indy/relate/content/RelateContentGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/common/src/main/java/org/commonjava/indy/relate/util/RelateGenerationManager.java
+++ b/addons/relate/common/src/main/java/org/commonjava/indy/relate/util/RelateGenerationManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/ftests/pom.xml
+++ b/addons/relate/ftests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/AbstractRelateFunctionalTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/AbstractRelateFunctionalTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.relate.ftest;
 
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadDepFromParentTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadDepFromParentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadListenerTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadSimpleDepTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadSimpleDepTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadViaGroupListenerTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomDownloadViaGroupListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomUploadListenerTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/PomUploadListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/RelDownloadBeforePomTest.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/RelDownloadBeforePomTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/RelDownloadPomNotFound404Test.java
+++ b/addons/relate/ftests/src/main/java/org/commonjava/indy/relate/ftest/RelDownloadPomNotFound404Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/relate/pom.xml
+++ b/addons/relate/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/revisions/common/pom.xml
+++ b/addons/revisions/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/revisions/common/src/main/java/org/commonjava/indy/revisions/RevisionsAddOn.java
+++ b/addons/revisions/common/src/main/java/org/commonjava/indy/revisions/RevisionsAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/common/src/main/java/org/commonjava/indy/revisions/RevisionsManager.java
+++ b/addons/revisions/common/src/main/java/org/commonjava/indy/revisions/RevisionsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/common/src/main/java/org/commonjava/indy/revisions/conf/RevisionsConfig.java
+++ b/addons/revisions/common/src/main/java/org/commonjava/indy/revisions/conf/RevisionsConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/common/src/main/ui/layover/ui-addons/revisions/js/revisions.js
+++ b/addons/revisions/common/src/main/ui/layover/ui-addons/revisions/js/revisions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/common/src/main/ui/layover/ui-addons/revisions/partials/store-changelog.html
+++ b/addons/revisions/common/src/main/ui/layover/ui-addons/revisions/partials/store-changelog.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/revisions/common/src/test/java/org/commonjava/indy/revisions/RevisionsManagerTest.java
+++ b/addons/revisions/common/src/test/java/org/commonjava/indy/revisions/RevisionsManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/common/src/test/java/org/commonjava/indy/revisions/testutil/TestProvider.java
+++ b/addons/revisions/common/src/test/java/org/commonjava/indy/revisions/testutil/TestProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/jaxrs/pom.xml
+++ b/addons/revisions/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/ChangelogResource.java
+++ b/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/ChangelogResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/RevisionsAdminResource.java
+++ b/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/RevisionsAdminResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/dto/ChangeSummaryDTO.java
+++ b/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/dto/ChangeSummaryDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/revisions/pom.xml
+++ b/addons/revisions/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/setback/common/pom.xml
+++ b/addons/setback/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/setback/common/src/main/java/org/commonjava/indy/setback/SetBackAddOn.java
+++ b/addons/setback/common/src/main/java/org/commonjava/indy/setback/SetBackAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/setback/common/src/main/java/org/commonjava/indy/setback/conf/SetbackConfig.java
+++ b/addons/setback/common/src/main/java/org/commonjava/indy/setback/conf/SetbackConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackDataException.java
+++ b/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackDataException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackSettingsInitializer.java
+++ b/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackSettingsInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackSettingsManager.java
+++ b/addons/setback/common/src/main/java/org/commonjava/indy/setback/data/SetBackSettingsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/setback/common/src/main/java/org/commonjava/indy/setback/rest/SetBackController.java
+++ b/addons/setback/common/src/main/java/org/commonjava/indy/setback/rest/SetBackController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/setback/common/src/test/java/org/commonjava/indy/setback/data/SetBackSettingsManagerTest.java
+++ b/addons/setback/common/src/test/java/org/commonjava/indy/setback/data/SetBackSettingsManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/setback/jaxrs/pom.xml
+++ b/addons/setback/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/setback/jaxrs/src/main/java/org/commonjava/indy/setback/jaxrs/SetBackSettingsResource.java
+++ b/addons/setback/jaxrs/src/main/java/org/commonjava/indy/setback/jaxrs/SetBackSettingsResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/setback/pom.xml
+++ b/addons/setback/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/template/client-java/pom.xml
+++ b/addons/template/client-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/template/common/pom.xml
+++ b/addons/template/common/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/template/ftests/pom.xml
+++ b/addons/template/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/template/jaxrs/pom.xml
+++ b/addons/template/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/template/model-java/pom.xml
+++ b/addons/template/model-java/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/addons/template/pom.xml
+++ b/addons/template/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/IndyWorkflowException.java
+++ b/api/src/main/java/org/commonjava/indy/IndyWorkflowException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/BootupAction.java
+++ b/api/src/main/java/org/commonjava/indy/action/BootupAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleAction.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleEventManager.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleEventManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleException.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleManager.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/MigrationAction.java
+++ b/api/src/main/java/org/commonjava/indy/action/MigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/ShutdownAction.java
+++ b/api/src/main/java/org/commonjava/indy/action/ShutdownAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/StartupAction.java
+++ b/api/src/main/java/org/commonjava/indy/action/StartupAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/UserLifecycleManager.java
+++ b/api/src/main/java/org/commonjava/indy/action/UserLifecycleManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/action/fixture/AlternativeUserLifecycleManager.java
+++ b/api/src/main/java/org/commonjava/indy/action/fixture/AlternativeUserLifecycleManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/audit/ChangeSummary.java
+++ b/api/src/main/java/org/commonjava/indy/audit/ChangeSummary.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/AllEventsListener.java
+++ b/api/src/main/java/org/commonjava/indy/change/AllEventsListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/EventUtils.java
+++ b/api/src/main/java/org/commonjava/indy/change/EventUtils.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.change;
 
 import org.slf4j.Logger;

--- a/api/src/main/java/org/commonjava/indy/change/EventUtils.java
+++ b/api/src/main/java/org/commonjava/indy/change/EventUtils.java
@@ -17,21 +17,21 @@ public class EventUtils
 {
     public static <T> void fireEvent( Event<T> dispatcher, T event )
     {
+        Logger logger = LoggerFactory.getLogger( EventUtils.class );
         try
         {
             if ( dispatcher != null )
             {
+                logger.trace( "Firing event: {}", event );
                 dispatcher.fire( event );
             }
             else
             {
-                Logger logger = LoggerFactory.getLogger( EventUtils.class );
                 logger.error( "Cannot fire event: {}. Reason: Event dispatcher is null!", event );
             }
         }
         catch ( RuntimeException e )
         {
-            Logger logger = LoggerFactory.getLogger( EventUtils.class );
             logger.error( String.format( "Error processing event: %s. Reason: %s", event, e.getMessage() ), e );
         }
     }

--- a/api/src/main/java/org/commonjava/indy/change/event/AbstractIndyEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/AbstractIndyEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/AbstractStoreDeleteEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/AbstractStoreDeleteEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/AbstractStoreDeleteEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/AbstractStoreDeleteEvent.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.change.event;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -55,6 +56,12 @@ public abstract class AbstractStoreDeleteEvent
     public Map<ArtifactStore, Transfer> getStoreRoots()
     {
         return storeRoots;
+    }
+
+    @Override
+    public Set<ArtifactStore> getStores()
+    {
+        return storeRoots.keySet();
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreDeletePostEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreDeletePostEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreDeletePreEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreDeletePreEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreEnablementEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreEnablementEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStorePostUpdateEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStorePostUpdateEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStorePreUpdateEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStorePreUpdateEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreRescanEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreRescanEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreUpdateEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreUpdateEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreUpdateType.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/ArtifactStoreUpdateType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/CoreEventManagerConstants.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/CoreEventManagerConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/IndyLifecycleEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/IndyLifecycleEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/IndyStoreErrorEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/IndyStoreErrorEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/change/event/IndyStoreEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/IndyStoreEvent.java
@@ -17,6 +17,8 @@ package org.commonjava.indy.change.event;
 
 import org.commonjava.indy.model.core.ArtifactStore;
 
+import java.util.Collection;
+
 /**
  * Marker interface for events related to changes in {@link ArtifactStore} instances.
  */
@@ -24,4 +26,5 @@ public interface IndyStoreEvent
     extends Iterable<ArtifactStore>
 {
 
+    Collection<ArtifactStore> getStores();
 }

--- a/api/src/main/java/org/commonjava/indy/change/event/IndyStoreEvent.java
+++ b/api/src/main/java/org/commonjava/indy/change/event/IndyStoreEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/conf/IndyConfigFactory.java
+++ b/api/src/main/java/org/commonjava/indy/conf/IndyConfigFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/conf/IndyConfigInfo.java
+++ b/api/src/main/java/org/commonjava/indy/conf/IndyConfigInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/conf/IndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/IndyConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/conf/SystemPropertyProvider.java
+++ b/api/src/main/java/org/commonjava/indy/conf/SystemPropertyProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/conf/UIConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/UIConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/AbstractContentGenerator.java
+++ b/api/src/main/java/org/commonjava/indy/content/AbstractContentGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/ContentDigester.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentDigester.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/ContentGenerator.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/ContentManager.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
+++ b/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/DownloadManager.java
+++ b/api/src/main/java/org/commonjava/indy/content/DownloadManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/IndyChecksumAdvisor.java
+++ b/api/src/main/java/org/commonjava/indy/content/IndyChecksumAdvisor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/IndyLocationExpander.java
+++ b/api/src/main/java/org/commonjava/indy/content/IndyLocationExpander.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/IndyPathGenerator.java
+++ b/api/src/main/java/org/commonjava/indy/content/IndyPathGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/MergedContentAction.java
+++ b/api/src/main/java/org/commonjava/indy/content/MergedContentAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/StoreContentAction.java
+++ b/api/src/main/java/org/commonjava/indy/content/StoreContentAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/content/StoreResource.java
+++ b/api/src/main/java/org/commonjava/indy/content/StoreResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/data/ArtifactStoreQuery.java
+++ b/api/src/main/java/org/commonjava/indy/data/ArtifactStoreQuery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/data/ArtifactStoreValidator.java
+++ b/api/src/main/java/org/commonjava/indy/data/ArtifactStoreValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/data/DelegatingArtifactStoreQuery.java
+++ b/api/src/main/java/org/commonjava/indy/data/DelegatingArtifactStoreQuery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/data/IndyDataException.java
+++ b/api/src/main/java/org/commonjava/indy/data/IndyDataException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/data/NoOpStoreEventDispatcher.java
+++ b/api/src/main/java/org/commonjava/indy/data/NoOpStoreEventDispatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/data/StoreEventDispatcher.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreEventDispatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/inject/IndyData.java
+++ b/api/src/main/java/org/commonjava/indy/inject/IndyData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/inject/IndyVersioningProvider.java
+++ b/api/src/main/java/org/commonjava/indy/inject/IndyVersioningProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/inject/RestApp.java
+++ b/api/src/main/java/org/commonjava/indy/inject/RestApp.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/model/galley/GroupLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/GroupLocation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/model/galley/IndyLocationResolver.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/IndyLocationResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/model/galley/KeyedLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/KeyedLocation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/model/galley/LocationStoreUpdateListener.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/LocationStoreUpdateListener.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.commonjava.indy.model.galley;
 
 import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;

--- a/api/src/main/java/org/commonjava/indy/model/galley/RepositoryLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/RepositoryLocation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/spi/IndyAddOn.java
+++ b/api/src/main/java/org/commonjava/indy/spi/IndyAddOn.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/spi/pkg/ContentAdvisor.java
+++ b/api/src/main/java/org/commonjava/indy/spi/pkg/ContentAdvisor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/spi/pkg/ContentQuality.java
+++ b/api/src/main/java/org/commonjava/indy/spi/pkg/ContentQuality.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/spi/pkg/StoreAdvisor.java
+++ b/api/src/main/java/org/commonjava/indy/spi/pkg/StoreAdvisor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/AcceptInfo.java
+++ b/api/src/main/java/org/commonjava/indy/util/AcceptInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/AcceptInfoParser.java
+++ b/api/src/main/java/org/commonjava/indy/util/AcceptInfoParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/ApplicationContent.java
+++ b/api/src/main/java/org/commonjava/indy/util/ApplicationContent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/ApplicationHeader.java
+++ b/api/src/main/java/org/commonjava/indy/util/ApplicationHeader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/ApplicationStatus.java
+++ b/api/src/main/java/org/commonjava/indy/util/ApplicationStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/ChangeSynchronizer.java
+++ b/api/src/main/java/org/commonjava/indy/util/ChangeSynchronizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/ContentUtils.java
+++ b/api/src/main/java/org/commonjava/indy/util/ContentUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/LocationUtils.java
+++ b/api/src/main/java/org/commonjava/indy/util/LocationUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/MimeTyper.java
+++ b/api/src/main/java/org/commonjava/indy/util/MimeTyper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/PathUtils.java
+++ b/api/src/main/java/org/commonjava/indy/util/PathUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/UriFormatter.java
+++ b/api/src/main/java/org/commonjava/indy/util/UriFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/UrlInfo.java
+++ b/api/src/main/java/org/commonjava/indy/util/UrlInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/commonjava/indy/util/ValuePipe.java
+++ b/api/src/main/java/org/commonjava/indy/util/ValuePipe.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/commonjava/indy/data/ArtifactStoreValidatorTest.java
+++ b/api/src/test/java/org/commonjava/indy/data/ArtifactStoreValidatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/commonjava/indy/spi/IndyAddOnIDTest.java
+++ b/api/src/test/java/org/commonjava/indy/spi/IndyAddOnIDTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/commonjava/indy/util/AcceptInfoTest.java
+++ b/api/src/test/java/org/commonjava/indy/util/AcceptInfoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/commonjava/indy/util/UrlInfoTest.java
+++ b/api/src/test/java/org/commonjava/indy/util/UrlInfoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/pom.xml
+++ b/bindings/jaxrs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/DeprecatedContentAccessResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/DeprecatedContentAccessResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/GenericContentAccessResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/GenericContentAccessResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/NfcResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/NfcResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/PackageContentAccessResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/PackageContentAccessResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/RootResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/RootResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/DeprecatedStoreAdminHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/DeprecatedStoreAdminHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/ReplicationHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/ReplicationHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/SchedulerHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/SchedulerHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/StoreAdminHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/StoreAdminHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/metrics/IndyMetricsBindingsNames.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/metrics/IndyMetricsBindingsNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/stats/StatsHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/stats/StatsHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/boot/api/pom.xml
+++ b/boot/api/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/boot/api/src/main/java/org/commonjava/indy/boot/BootFinder.java
+++ b/boot/api/src/main/java/org/commonjava/indy/boot/BootFinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/api/src/main/java/org/commonjava/indy/boot/BootInterface.java
+++ b/boot/api/src/main/java/org/commonjava/indy/boot/BootInterface.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/api/src/main/java/org/commonjava/indy/boot/BootOptions.java
+++ b/boot/api/src/main/java/org/commonjava/indy/boot/BootOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/api/src/main/java/org/commonjava/indy/boot/BootStatus.java
+++ b/boot/api/src/main/java/org/commonjava/indy/boot/BootStatus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/api/src/main/java/org/commonjava/indy/boot/IndyBootException.java
+++ b/boot/api/src/main/java/org/commonjava/indy/boot/IndyBootException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/api/src/main/java/org/commonjava/indy/boot/PortFinder.java
+++ b/boot/api/src/main/java/org/commonjava/indy/boot/PortFinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/api/src/main/java/org/commonjava/indy/boot/WeldBootInterface.java
+++ b/boot/api/src/main/java/org/commonjava/indy/boot/WeldBootInterface.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/api/src/test/java/org/commonjava/indy/boot/BootOptionsTest.java
+++ b/boot/api/src/test/java/org/commonjava/indy/boot/BootOptionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/jaxrs/pom.xml
+++ b/boot/jaxrs/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/boot/jaxrs/src/main/java/org/commonjava/indy/boot/jaxrs/JaxRsBooter.java
+++ b/boot/jaxrs/src/main/java/org/commonjava/indy/boot/jaxrs/JaxRsBooter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/clients/core-java/pom.xml
+++ b/clients/core-java/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientException.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyResponseErrorDetails.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyResponseErrorDetails.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/auth/BasicAuthenticator.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/auth/BasicAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/auth/IndyClientAuthenticator.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/auth/IndyClientAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/auth/OAuth20BearerTokenAuthenticator.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/auth/OAuth20BearerTokenAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/helper/CloseBlockingConnectionManager.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/helper/CloseBlockingConnectionManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/helper/HttpResources.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/helper/HttpResources.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/helper/PathInfo.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/helper/PathInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyContentClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyContentClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyNfcClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyNfcClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyRawHttpModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyRawHttpModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyRawObjectMapperModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyRawObjectMapperModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndySchedulerClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndySchedulerClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyStatsClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyStatsClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyStoresClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyStoresClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/util/UrlUtils.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/util/UrlUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/contrib/github/gh_repo.sh
+++ b/contrib/github/gh_repo.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/change/GroupConsistencyListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/GroupConsistencyListener.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.core.change;
 
 import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.change.event.ArtifactStoreDeletePostEvent;
 import org.commonjava.indy.change.event.ArtifactStoreDeletePreEvent;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
@@ -68,7 +69,7 @@ public class GroupConsistencyListener
         }
     }
 
-    public void storeDeleted( @Observes final ArtifactStoreDeletePreEvent event )
+    public void storeDeleted( @Observes final ArtifactStoreDeletePostEvent event )
     {
         //        logger.info( "Processing proxy-manager store deletion: {}", event );
         for ( final ArtifactStore store : event )

--- a/core/src/main/java/org/commonjava/indy/core/change/GroupConsistencyListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/GroupConsistencyListener.java
@@ -48,6 +48,7 @@ public class GroupConsistencyListener
         try
         {
             final Set<Group> groups = storeDataManager.query().getGroupsContaining( key );
+            logger.trace( "For repo: {}, containing groups are: {}", key, groups );
             for ( final Group group : groups )
             {
                 logger.debug( "Removing {} from membership of group: {}", key, group.getKey() );
@@ -71,9 +72,10 @@ public class GroupConsistencyListener
 
     public void storeDeleted( @Observes final ArtifactStoreDeletePostEvent event )
     {
-        //        logger.info( "Processing proxy-manager store deletion: {}", event );
+        logger.trace( "Processing proxy-manager store deletion: {}", event.getStores() );
         for ( final ArtifactStore store : event )
         {
+            logger.trace( "Processing deletion of: {}", store.getKey() );
             processChanged( store );
         }
     }

--- a/core/src/main/java/org/commonjava/indy/core/change/GroupConsistencyListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/GroupConsistencyListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/change/event/DefaultStoreEventDispatcher.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/event/DefaultStoreEventDispatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/change/event/IndyFileEventManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/event/IndyFileEventManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/conf/DefaultIndyConfigFactory.java
+++ b/core/src/main/java/org/commonjava/indy/core/conf/DefaultIndyConfigFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/conf/IndySchedulerConfig.java
+++ b/core/src/main/java/org/commonjava/indy/core/conf/IndySchedulerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/conf/IndyWeftConfig.java
+++ b/core/src/main/java/org/commonjava/indy/core/conf/IndyWeftConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import javax.annotation.PostConstruct;
@@ -110,8 +111,7 @@ public abstract class AbstractMergedContentGenerator
 
     protected abstract String getMergedMetadataName();
 
-    protected void clearAllMerged( final ArtifactStore store, final String path )
-            throws IndyWorkflowException
+    protected void clearAllMerged( final ArtifactStore store, final String... paths )
     {
         final Set<Group> groups = new HashSet<>();
 
@@ -133,12 +133,18 @@ public abstract class AbstractMergedContentGenerator
 
         }
 
-        groups.stream().forEach( group -> clearMergedFile( group, path ) );
+        groups.parallelStream().forEach( group -> Stream.of(paths).forEach( path->{
+            logger.trace( "Clearing: '{}' in: {}", path, group );
+            clearMergedFile( group, path );
+        } ));
 
         if ( mergedContentActions != null )
         {
             StreamSupport.stream( mergedContentActions.spliterator(), true )
-                         .forEach( action -> action.clearMergedPath( store, groups, path ) );
+                         .forEach( action -> Stream.of(paths).forEach( path->{
+                             logger.trace( "Executing clearMergedPath on action: {} for group: {} and path: {}", action, groups, path );
+                             action.clearMergedPath( store, groups, path );
+                         } ) );
         }
     }
 
@@ -174,6 +180,9 @@ public abstract class AbstractMergedContentGenerator
                 ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( group ), path );
                 nfc.clearMissing( resource );
             }
+
+            // make sure we delete these, even if they're left over.
+            helper.deleteChecksumsAndMergeInfo( group, path );
         }
         catch ( final IndyWorkflowException | IOException e )
         {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.core.content;
 
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.WeftManaged;
+import org.commonjava.indy.IndyMetricsNames;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.change.event.ArtifactStorePostRescanEvent;
 import org.commonjava.indy.change.event.ArtifactStorePreRescanEvent;
@@ -25,8 +26,12 @@ import org.commonjava.indy.change.event.IndyStoreErrorEvent;
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.change.event.IndyFileEventManager;
+import org.commonjava.indy.core.metrics.IndyMetricsCoreNames;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.measure.annotation.IndyMetrics;
+import org.commonjava.indy.measure.annotation.Measure;
+import org.commonjava.indy.measure.annotation.MetricNamed;
 import org.commonjava.indy.model.core.AbstractRepository;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -154,6 +159,8 @@ public class DefaultDownloadManager
     }
 
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_LIST + IndyMetricsNames.TIMER ),
+                  meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_LIST + IndyMetricsNames.METER ) ) )
     public List<StoreResource> list( final ArtifactStore store, final String path, final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {
@@ -283,6 +290,8 @@ public class DefaultDownloadManager
     }
 
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_LIST + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_LIST + IndyMetricsNames.METER ) ) )
     public List<StoreResource> list( final List<? extends ArtifactStore> stores, final String path, final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {
@@ -338,6 +347,8 @@ public class DefaultDownloadManager
     }
 
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_RETRIEVE_FIRST + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_RETRIEVE_FIRST + IndyMetricsNames.METER ) ) )
     public Transfer retrieveFirst( final List<? extends ArtifactStore> stores, final String path,
                                    final EventMetadata eventMetadata )
             throws IndyWorkflowException
@@ -389,6 +400,8 @@ public class DefaultDownloadManager
      * @see org.commonjava.indy.core.rest.util.FileManager#downloadAll(java.util.List, java.lang.String)
      */
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_RETRIEVE_ALL + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_RETRIEVE_ALL + IndyMetricsNames.METER ) ) )
     public List<Transfer> retrieveAll( final List<? extends ArtifactStore> stores, final String path,
                                        final EventMetadata eventMetadata )
             throws IndyWorkflowException
@@ -437,6 +450,8 @@ public class DefaultDownloadManager
      * java.lang.String)
      */
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_RETRIEVE + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_RETRIEVE + IndyMetricsNames.METER ) ) )
     public Transfer retrieve( final ArtifactStore store, final String path, final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {
@@ -514,6 +529,8 @@ public class DefaultDownloadManager
     }
 
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_EXISTS + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_EXISTS + IndyMetricsNames.METER ) ) )
     public boolean exists(final ArtifactStore store, String path)
             throws IndyWorkflowException
     {
@@ -562,6 +579,8 @@ public class DefaultDownloadManager
      * java.lang.String, java.io.InputStream)
      */
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_STORE + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_STORE + IndyMetricsNames.METER ) ) )
     public Transfer store( final ArtifactStore store, final String path, final InputStream stream,
                            final TransferOperation op, final EventMetadata eventMetadata )
             throws IndyWorkflowException
@@ -855,6 +874,8 @@ public class DefaultDownloadManager
     }
 
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_GET_TRANSFER + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_GET_TRANSFER + IndyMetricsNames.METER ) ) )
     public Transfer getStorageReference( final ArtifactStore store, final String... path )
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
@@ -864,6 +885,8 @@ public class DefaultDownloadManager
     }
 
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_GET_TRANSFER + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_GET_TRANSFER + IndyMetricsNames.METER ) ) )
     public Transfer getStorageReference( final StoreKey key, final String... path )
             throws IndyWorkflowException
     {
@@ -1120,6 +1143,8 @@ public class DefaultDownloadManager
     }
 
     @Override
+    @IndyMetrics( measure = @Measure( timers = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_LIST_RECURSIVE + IndyMetricsNames.TIMER ),
+                                      meters = @MetricNamed( name = IndyMetricsCoreNames.DOWNLOADMGR_LIST_RECURSIVE + IndyMetricsNames.METER ) ) )
     public List<Transfer> listRecursively( final StoreKey src, final String startPath )
             throws IndyWorkflowException
     {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/content/HttpMetadataCleanupGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/HttpMetadataCleanupGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/content/group/GroupMergeHelper.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/group/GroupMergeHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/content/group/GroupMergeHelper.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/group/GroupMergeHelper.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.slf4j.Logger;
@@ -71,17 +72,29 @@ public class GroupMergeHelper
             logger.debug( "Deleting: {}", targetSha );
             targetSha.delete();
         }
+        else
+        {
+            logger.trace( "{} does not exist. Not deleting.", targetSha );
+        }
 
         if ( targetMd5 != null )
         {
             logger.debug( "Deleting: {}", targetMd5 );
             targetMd5.delete();
         }
+        else
+        {
+            logger.trace( "{} does not exist. Not deleting.", targetMd5 );
+        }
 
         if ( targetInfo != null )
         {
             logger.debug( "Deleting: {}", targetInfo );
             targetInfo.delete();
+        }
+        else
+        {
+            logger.trace( "{} does not exist. Not deleting.", targetInfo );
         }
     }
 
@@ -103,10 +116,19 @@ public class GroupMergeHelper
         return mergeInfoBuilder.toString();
     }
 
+    public final String generateMergeInfoFromKeys( final List<StoreKey> sources )
+    {
+        final StringBuilder mergeInfoBuilder = new StringBuilder();
+        sources.forEach( src->mergeInfoBuilder.append(src).append('\n') );
+        return mergeInfoBuilder.toString();
+    }
+
     public final void writeMergeInfo( final String mergeInfo, final Group group, final String path )
     {
         final String infoPath = path+MERGEINFO_SUFFIX;
-        logger.trace( ".info file path is {} for group {}, content is {}", infoPath, group.getKey(), mergeInfo );
+        logger.trace( ".info file path is {} for group {} (members: {}), content is {}", infoPath, group.getKey(),
+                      group.getConstituents(), mergeInfo );
+
         final Transfer targetInfo = downloadManager.getStorageReference( group, infoPath );
         Writer fw = null;
         try

--- a/core/src/main/java/org/commonjava/indy/core/content/group/MetadataMerger.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/group/MetadataMerger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/ctl/AdminController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/AdminController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/ctl/NfcController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/NfcController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ReplicationController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ReplicationController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ReplicationRepositoryCreator.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ReplicationRepositoryCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/ctl/StatsController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/StatsController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/data/StoreDataSetupAction.java
+++ b/core/src/main/java/org/commonjava/indy/core/data/StoreDataSetupAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/ContentExpiration.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ContentExpiration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/EventTypeMatcher.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/EventTypeMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/IndySchedulerException.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/IndySchedulerException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/LegacyQuartzDBMigrationAction.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/LegacyQuartzDBMigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleKey.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/SchedulerCancelEvent.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/SchedulerCancelEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/SchedulerEvent.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/SchedulerEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/SchedulerScheduleEvent.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/SchedulerScheduleEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/SchedulerTriggerEvent.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/SchedulerTriggerEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/StoreKeyMatcher.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/StoreKeyMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/inject/ContentMetadataCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/ContentMetadataCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreCacheProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreLockerProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreLockerProducer.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.commonjava.indy.core.inject;
 
 import org.commonjava.cdi.util.weft.Locker;

--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreLockerProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreLockerProducer.java
@@ -1,0 +1,40 @@
+package org.commonjava.indy.core.inject;
+
+import org.commonjava.cdi.util.weft.Locker;
+import org.commonjava.indy.model.core.StoreKey;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+public class CoreLockerProducer
+{
+
+    private Locker<StoreKey> groupMembershipLocker;
+
+    private Locker<StoreKey> storeContentLocker;
+
+    @PostConstruct
+    public void init()
+    {
+        groupMembershipLocker = new Locker<>();
+        storeContentLocker = new Locker<>();
+    }
+
+    @GroupMembershipLocks
+    @Produces
+    @ApplicationScoped
+    public Locker<StoreKey> getGroupMembershipLocker()
+    {
+        return groupMembershipLocker;
+    }
+
+    @StoreContentLocks
+    @Produces
+    @ApplicationScoped
+    public Locker<StoreKey> getStoreContentLocker()
+    {
+        return storeContentLocker;
+    }
+
+}

--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreProvider.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/inject/ExpiringMemoryNotFoundCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/ExpiringMemoryNotFoundCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/inject/GroupMembershipLocks.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/GroupMembershipLocks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/inject/GroupMembershipLocks.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/GroupMembershipLocks.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.inject;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply "content-metadata" cache in infinispan.xml.
+ */
+@Qualifier
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface GroupMembershipLocks
+{
+}

--- a/core/src/main/java/org/commonjava/indy/core/inject/StoreContentLocks.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/StoreContentLocks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/inject/StoreContentLocks.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/StoreContentLocks.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.inject;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply "content-metadata" cache in infinispan.xml.
+ */
+@Qualifier
+@Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface StoreContentLocks
+{
+}

--- a/core/src/main/java/org/commonjava/indy/core/lifecycle/IndyUserLifecycleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/lifecycle/IndyUserLifecycleManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/metrics/IndyMetricsCoreNames.java
+++ b/core/src/main/java/org/commonjava/indy/core/metrics/IndyMetricsCoreNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/commonjava/indy/core/metrics/IndyMetricsCoreNames.java
+++ b/core/src/main/java/org/commonjava/indy/core/metrics/IndyMetricsCoreNames.java
@@ -22,6 +22,24 @@ import org.commonjava.indy.IndyMetricsNames;
  */
 public class IndyMetricsCoreNames extends IndyMetricsNames
 {
+    private static final String DOWNLOAD_MANAGER_PREFIX = "org.commonjava.indy.core.download-manager.";
+
+    public static final String DOWNLOADMGR_LIST = DOWNLOAD_MANAGER_PREFIX + "list";
+
+    public static final String DOWNLOADMGR_LIST_RECURSIVE = "list-recursive";
+
+    public static final String DOWNLOADMGR_RETRIEVE = DOWNLOAD_MANAGER_PREFIX + "retrieve";
+
+    public static final String DOWNLOADMGR_RETRIEVE_ALL = DOWNLOAD_MANAGER_PREFIX + "retrieve-all";
+
+    public static final String DOWNLOADMGR_RETRIEVE_FIRST = DOWNLOAD_MANAGER_PREFIX + "retrieve-first";
+
+    public static final String DOWNLOADMGR_STORE = DOWNLOAD_MANAGER_PREFIX + "store";
+
+    public static final String DOWNLOADMGR_EXISTS = DOWNLOAD_MANAGER_PREFIX + "exists";
+
+    public static final String DOWNLOADMGR_GET_TRANSFER = DOWNLOAD_MANAGER_PREFIX + "get-transfer";
+
     private static final String MODULE_PREFIX_NAME = "org.commonjava.indy.core";
 
     private static final String MODULE_DEFAULTCONTENTMANAGER_PREFIX_NAME = ".defaultContentManager.";

--- a/core/src/main/java/org/commonjava/indy/core/model/StoreHttpExchangeMetadata.java
+++ b/core/src/main/java/org/commonjava/indy/core/model/StoreHttpExchangeMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/core/conf/DefaultIndyConfigFactoryTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/conf/DefaultIndyConfigFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/core/content/DefaultContentManagerTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/content/DefaultContentManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/core/content/DefaultDownloadManagerTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/content/DefaultDownloadManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/core/ctl/ContentControllerTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/ctl/ContentControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/core/expire/ContentExpirationTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/expire/ContentExpirationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/core/expire/LegacyQuartzDBMigrationActionTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/expire/LegacyQuartzDBMigrationActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/core/expire/ScheduleManagerTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/expire/ScheduleManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/core/inject/ExpiringMemoryNotFoundCacheTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/inject/ExpiringMemoryNotFoundCacheTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/fixture/GalleyFixture.java
+++ b/core/src/test/java/org/commonjava/indy/fixture/GalleyFixture.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/fixture/MockContentAdvisor.java
+++ b/core/src/test/java/org/commonjava/indy/fixture/MockContentAdvisor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/fixture/MockGalleyProvider.java
+++ b/core/src/test/java/org/commonjava/indy/fixture/MockGalleyProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/fixture/ProxyConfigProvider.java
+++ b/core/src/test/java/org/commonjava/indy/fixture/ProxyConfigProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/commonjava/indy/rest/util/DownloadManagerTest.java
+++ b/core/src/test/java/org/commonjava/indy/rest/util/DownloadManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/flat/pom.xml
+++ b/db/flat/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/db/flat/src/main/java/org/commonjava/indy/flat/data/DataFileStoreDataManager.java
+++ b/db/flat/src/main/java/org/commonjava/indy/flat/data/DataFileStoreDataManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/flat/src/main/java/org/commonjava/indy/flat/data/LegacyDataMigrationAction.java
+++ b/db/flat/src/main/java/org/commonjava/indy/flat/data/LegacyDataMigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/flat/src/test/java/org/commonjava/indy/flat/data/DataFileStoreDataManagerTest.java
+++ b/db/flat/src/test/java/org/commonjava/indy/flat/data/DataFileStoreDataManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/flat/src/test/java/org/commonjava/indy/flat/data/DataFileTCKFixtureProvider.java
+++ b/db/flat/src/test/java/org/commonjava/indy/flat/data/DataFileTCKFixtureProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/flat/src/test/java/org/commonjava/indy/flat/data/GroupManagementTest.java
+++ b/db/flat/src/test/java/org/commonjava/indy/flat/data/GroupManagementTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/flat/src/test/java/org/commonjava/indy/flat/data/LegacyDataMigrationActionTest.java
+++ b/db/flat/src/test/java/org/commonjava/indy/flat/data/LegacyDataMigrationActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/flat/src/test/java/org/commonjava/indy/flat/data/RepositoryManagementTest.java
+++ b/db/flat/src/test/java/org/commonjava/indy/flat/data/RepositoryManagementTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/memory/pom.xml
+++ b/db/memory/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryArtifactStoreQuery.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryArtifactStoreQuery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -15,14 +15,15 @@
  */
 package org.commonjava.indy.mem.data;
 
+import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
 import org.commonjava.indy.conf.DefaultIndyConfiguration;
 import org.commonjava.indy.conf.IndyConfiguration;
+import org.commonjava.indy.data.ArtifactStoreQuery;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
 import org.commonjava.indy.data.StoreDataManager;
-import org.commonjava.indy.data.ArtifactStoreQuery;
 import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -41,10 +42,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
-import static org.commonjava.cdi.util.weft.ContextSensitiveWeakHashMap.newSynchronizedContextSensitiveWeakHashMap;
 import static org.commonjava.indy.model.core.StoreType.hosted;
 
 @ApplicationScoped
@@ -52,11 +52,14 @@ import static org.commonjava.indy.model.core.StoreType.hosted;
 public class MemoryStoreDataManager
         implements StoreDataManager
 {
+    private static final long LOCK_TIMEOUT_SECONDS = 10;
+
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     private final Map<StoreKey, ArtifactStore> stores = new ConcurrentHashMap<>();
 
-    private final Map<StoreKey, ReentrantLock> opLocks = newSynchronizedContextSensitiveWeakHashMap();
+    // no need to inject since this is only used internally.
+    private final Locker<StoreKey> opLocks = new Locker<>();
 
     @Inject
     private StoreEventDispatcher dispatcher;
@@ -177,37 +180,47 @@ public class MemoryStoreDataManager
             throws IndyDataException
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
-        ReentrantLock opLock = opLocks.computeIfAbsent( key, k -> new ReentrantLock() );
-        try
-        {
-            logger.info( "DELETE operation starting for store: {}", key );
-            opLock.lock();
-
-            final ArtifactStore store = stores.get( key );
-            if ( store == null )
+        AtomicReference<IndyDataException> error = new AtomicReference<>();
+        opLocks.lockAnd( key, LOCK_TIMEOUT_SECONDS, k->{
+            try
             {
-                logger.warn( "No store found for: {}", key );
-                return;
+                final ArtifactStore store = stores.get( key );
+                if ( store == null )
+                {
+                    logger.warn( "No store found for: {}", key );
+                    return null;
+                }
+
+                if ( isReadonly( store ) )
+                {
+                    throw new IndyDataException( ApplicationStatus.METHOD_NOT_ALLOWED.code(),
+                                                 "The store {} is readonly. If you want to delete this store, please modify it to non-readonly",
+                                                 store.getKey() );
+                }
+
+                preDelete( store, summary, true, eventMetadata );
+
+                ArtifactStore removed = stores.remove( key );
+                logger.info( "REMOVED store: {}", removed );
+
+                postDelete( store, summary, true, eventMetadata );
+            }
+            catch ( IndyDataException e )
+            {
+                error.set( e );
             }
 
-            if ( isReadonly( store ) )
-            {
-                throw new IndyDataException( ApplicationStatus.METHOD_NOT_ALLOWED.code(),
-                                             "The store {} is readonly. If you want to delete this store, please modify it to non-readonly",
-                                             store.getKey() );
-            }
+            return null;
+        }, (k,lock)->{
+            error.set( new IndyDataException( "Failed to lock: %s for DELETE after %d seconds.", key,
+                                              LOCK_TIMEOUT_SECONDS ) );
+            return false;
+        } );
 
-            preDelete( store, summary, true, eventMetadata );
-
-            ArtifactStore removed = stores.remove( key );
-            logger.info( "REMOVED store: {}", removed );
-
-            postDelete( store, summary, true, eventMetadata );
-        }
-        finally
+        IndyDataException ex = error.get();
+        if ( ex != null )
         {
-            opLock.unlock();
-            logger.trace( "Delete operation complete: {}", key );
+            throw ex;
         }
     }
 
@@ -289,11 +302,8 @@ public class MemoryStoreDataManager
                            final boolean fireEvents, final EventMetadata eventMetadata )
             throws IndyDataException
     {
-        ReentrantLock opLock = opLocks.computeIfAbsent( store.getKey(), k -> new ReentrantLock() );
-        try
-        {
-            opLock.lock();
-
+        AtomicReference<IndyDataException> error = new AtomicReference<>();
+        boolean result = opLocks.lockAnd( store.getKey(), LOCK_TIMEOUT_SECONDS, k-> {
             ArtifactStore original = stores.get( store.getKey() );
             if ( original == store )
             {
@@ -305,7 +315,16 @@ public class MemoryStoreDataManager
 
             if ( !skipIfExists || original == null )
             {
-                preStore( store, original, summary, original != null, fireEvents, eventMetadata );
+                try
+                {
+                    preStore( store, original, summary, original != null, fireEvents, eventMetadata );
+                }
+                catch ( IndyDataException e )
+                {
+                    error.set( e );
+                    return false;
+                }
+
                 final ArtifactStore old = stores.put( store.getKey(), store );
                 try
                 {
@@ -320,11 +339,19 @@ public class MemoryStoreDataManager
             }
 
             return false;
-        }
-        finally
+        }, (k,lock)->{
+            error.set( new IndyDataException( "Failed to lock: %s for STORE after %d seconds.", k,
+                                              LOCK_TIMEOUT_SECONDS ) );
+            return false;
+        });
+
+        IndyDataException ex = error.get();
+        if ( ex != null )
         {
-            opLock.unlock();
+            throw ex;
         }
+
+        return result;
     }
 
 }

--- a/db/memory/src/test/java/org/commonjava/indy/mem/data/ConcurrencyTest.java
+++ b/db/memory/src/test/java/org/commonjava/indy/mem/data/ConcurrencyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/memory/src/test/java/org/commonjava/indy/mem/data/MemoryGroupManagementTest.java
+++ b/db/memory/src/test/java/org/commonjava/indy/mem/data/MemoryGroupManagementTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/memory/src/test/java/org/commonjava/indy/mem/data/MemoryRepositoryManagementTest.java
+++ b/db/memory/src/test/java/org/commonjava/indy/mem/data/MemoryRepositoryManagementTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/memory/src/test/java/org/commonjava/indy/mem/data/MemoryTCKFixtureProvider.java
+++ b/db/memory/src/test/java/org/commonjava/indy/mem/data/MemoryTCKFixtureProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/memory/src/test/java/org/commonjava/indy/mem/data/fixture/ThreadDumper.java
+++ b/db/memory/src/test/java/org/commonjava/indy/mem/data/fixture/ThreadDumper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployments/docker/pom.xml
+++ b/deployments/docker/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/deployments/launcher/pom.xml
+++ b/deployments/launcher/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/deployments/launcher/src/main/bin/indy.sh
+++ b/deployments/launcher/src/main/bin/indy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deployments/launcher/src/main/data/templates/README.txt
+++ b/deployments/launcher/src/main/data/templates/README.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/deployments/launcher/src/main/etc/indy/conf.d/README.txt
+++ b/deployments/launcher/src/main/etc/indy/conf.d/README.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/deployments/launcher/src/main/etc/indy/logging/logback.xml
+++ b/deployments/launcher/src/main/etc/indy/logging/logback.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder-tests/pom.xml
+++ b/embedder-tests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder-tests/rest-min/pom.xml
+++ b/embedder-tests/rest-min/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder-tests/rest-min/src/main/resources/META-INF/beans.xml
+++ b/embedder-tests/rest-min/src/main/resources/META-INF/beans.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2014 Red Hat, Inc..
-  All rights reserved. This program and the accompanying materials
-  are made available under the terms of the GNU Public License v3.0
-  which accompanies this distribution, and is available at
-  http://www.gnu.org/licenses/gpl.html
-  
-  Contributors:
-      Red Hat, Inc. - initial API and implementation
+
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 -->
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/embedder-tests/rest-min/src/main/resources/etc/aprox/conf.d/README.txt
+++ b/embedder-tests/rest-min/src/main/resources/etc/aprox/conf.d/README.txt
@@ -1,3 +1,19 @@
+====
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+====
+
 You can place individual *.conf files here and have them picked up in the Indy configuration, since the /etc/main.conf file uses:
 
 Include conf.d/*.conf

--- a/embedder-tests/rest-min/src/test/resources/logback-test.xml
+++ b/embedder-tests/rest-min/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder-tests/savant-report/pom.xml
+++ b/embedder-tests/savant-report/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder-tests/savant/pom.xml
+++ b/embedder-tests/savant/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder-tests/savant/src/main/resources/etc/aprox/conf.d/README.txt
+++ b/embedder-tests/savant/src/main/resources/etc/aprox/conf.d/README.txt
@@ -1,3 +1,19 @@
+====
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+====
+
 You can place individual *.conf files here and have them picked up in the Indy configuration, since the /etc/main.conf file uses:
 
 Include conf.d/*.conf

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder/src/it/resources/META-INF/beans.xml
+++ b/embedder/src/it/resources/META-INF/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder/src/it/resources/logback.xml
+++ b/embedder/src/it/resources/logback.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/embedder/src/main/resources/META-INF/beans.xml
+++ b/embedder/src/main/resources/META-INF/beans.xml
@@ -1,13 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2014 Red Hat, Inc..
-  All rights reserved. This program and the accompanying materials
-  are made available under the terms of the GNU Public License v3.0
-  which accompanies this distribution, and is available at
-  http://www.gnu.org/licenses/gpl.html
-  
-  Contributors:
-      Red Hat, Inc. - initial API and implementation
+
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
 -->
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/embedder/src/test/resources/logback-test.xml
+++ b/embedder/src/test/resources/logback-test.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/filers/default/pom.xml
+++ b/filers/default/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/CacheInstanceAdapter.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/CacheInstanceAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/FastLocalCacheProducer.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/FastLocalCacheProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/NFSOwnerCache.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/NFSOwnerCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/migrate/PackageTypedStorageMigrationAction.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/migrate/PackageTypedStorageMigrationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/default/src/test/java/org/commonjava/indy/filer/def/perf/RouteSelectorPerfTest.java
+++ b/filers/default/src/test/java/org/commonjava/indy/filer/def/perf/RouteSelectorPerfTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/infinispan/pom.xml
+++ b/filers/infinispan/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/InfinispanGalleyStorageProvider.java
+++ b/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/InfinispanGalleyStorageProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/conf/InfinispanStorageProviderConfiguration.java
+++ b/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/conf/InfinispanStorageProviderConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/fileio/StorageFileEntry.java
+++ b/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/fileio/StorageFileEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/fileio/StorageFileIO.java
+++ b/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/fileio/StorageFileIO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/fileio/StorageFileMetadata.java
+++ b/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/fileio/StorageFileMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/fileio/StorageFileTaskContext.java
+++ b/filers/infinispan/src/main/java/org/commonjava/indy/filer/ispn/fileio/StorageFileTaskContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/infinispan/src/main/resources/META-INF/beans.xml
+++ b/filers/infinispan/src/main/resources/META-INF/beans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/filers/infinispan/src/test/java/org/commonjava/indy/filer/ispn/fileio/StorageFileIOTest.java
+++ b/filers/infinispan/src/test/java/org/commonjava/indy/filer/ispn/fileio/StorageFileIOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/filers/infinispan/test.txt
+++ b/filers/infinispan/test.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/filers/pom.xml
+++ b/filers/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ftests/common/pom.xml
+++ b/ftests/common/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/category/BytemanTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/category/BytemanTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/category/EventDependent.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/category/EventDependent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/category/TimingDependent.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/category/TimingDependent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/fixture/IDETestProvider.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/fixture/IDETestProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/fixture/ThreadDumper.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/fixture/ThreadDumper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/pom.xml
+++ b/ftests/core/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ftests/core/pom.xml
+++ b/ftests/core/pom.xml
@@ -72,6 +72,11 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-pkg-maven-common</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
       <scope>compile</scope>

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractContentTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractContentTimeoutWorkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractMetadataTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractMetadataTimeoutWorkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractRemoteRepoTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractRemoteRepoTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInHostedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInHostedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInRemoteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AuthoritativeIndexedContentInRemoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/CacheFirstTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/CacheFirstTimeoutWorkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ConcurrentMissingMetadataChecksumAndFileDownloadTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ConcurrentMissingMetadataChecksumAndFileDownloadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentNotAvailableInGroupWithDisabledRemoteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentNotAvailableInGroupWithDisabledRemoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentPassthroughTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentPassthroughTimeoutWorkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentRescheduleTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentTimeoutWorkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadContentHasLengthHeaderHostedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadContentHasLengthHeaderHostedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadContentHasLengthHeaderTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadContentHasLengthHeaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadFromSecondRemoteAfterFirstHostedRepoTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadFromSecondRemoteAfterFirstHostedRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadWhileProxyingInProgressTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/DownloadWhileProxyingInProgressTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/EmptyDisabledTimeoutsMapRetrievalTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/EmptyDisabledTimeoutsMapRetrievalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupContentCopiedEarlierInMembershipIsReturnedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupContentCopiedEarlierInMembershipIsReturnedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupDownloadWithFirstRepoTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupDownloadWithFirstRepoTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoAsPomTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoAsPomTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoWhenNotInPathMaskTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoWhenNotInPathMaskTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupIgnoresDisabledRemoteRepositoryTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupIgnoresDisabledRemoteRepositoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeInfoGenTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeInfoGenTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWhenConstituentDisabledTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWhenConstituentDisabledTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWhenGroupWithGroupMemberChangesTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWhenGroupWithGroupMemberChangesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWhenNewHostedAddedInMultiHostedGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWhenNewHostedAddedInMultiHostedGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWhenSeqNewHostedAddedInMultiHostedGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWhenSeqNewHostedAddedInMultiHostedGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWithRepoErrorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWithRepoErrorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWithRepoTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeWithRepoTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataRemergeWhenConstituentDisabledTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataRemergeWhenConstituentDisabledTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupPreferContentFromFirstMemberTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupPreferContentFromFirstMemberTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMissingAddToNFCTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMissingAddToNFCTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedRepositoryDeleteNotAllowedWhenReadonly.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedRepositoryDeleteNotAllowedWhenReadonly.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.commonjava.indy.ftest.core.content;
 
 import org.commonjava.indy.audit.ChangeSummary;

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/LateJoinDownloadWhileProxyingInProgressTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/LateJoinDownloadWhileProxyingInProgressTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetaListingRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetaListingRescheduleTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataFirstTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataFirstTimeoutWorkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataMergeRepoNoMetaListingTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataMergeRepoNoMetaListingTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataPassthroughTimeoutWorkingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataPassthroughTimeoutWorkingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRescheduleTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MixContentRescheduleTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NFCForGroupsWithGroupsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NFCForGroupsWithGroupsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NFCForTwoGroupsWithSameHostedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NFCForTwoGroupsWithSameHostedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NestedStoreInGroupWithErrorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/NestedStoreInGroupWithErrorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ProxyRemoteContentTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ProxyRemoteContentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ReDownloadOnContentTransferExceptionTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ReDownloadOnContentTransferExceptionTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.commonjava.indy.ftest.core.content;
 
 import org.apache.commons.io.IOUtils;

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ReaonlyHostedDeleteFileTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ReaonlyHostedDeleteFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ReaonlyHostedStoreFileTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ReaonlyHostedStoreFileTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoGetErrorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoGetErrorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoGetTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoGetTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoHeadErrorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoHeadErrorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoHeadExistenceCheckTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoHeadExistenceCheckTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoHeadTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoHeadTimeoutTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreAndRetreiveTimeoutScheduleTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreAndRetreiveTimeoutScheduleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreAndShowsInDisabledTimeoutsMapTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreAndShowsInDisabledTimeoutsMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesThenReEnabledTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesThenReEnabledTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutNeverDisableTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutNeverDisableTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutReenableWithTimeoutSetTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutReenableWithTimeoutSetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskExistsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskExistsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskExtTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskExtTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataExcludeTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataExcludeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/Return404DisableTimeoutForEnabledRepoTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/Return404DisableTimeoutForEnabledRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForHostedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForHostedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForHostedWithNoNFSTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForHostedWithNoNFSTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForRemoteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForRemoteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForRemoteWithNoNFSTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RoutedCacheProviderForRemoteWithNoNFSTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreAndConsistentlyVerifyPathInfoExistenceTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreAndConsistentlyVerifyPathInfoExistenceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreAndVerifyJarViaDirectDownloadTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreAndVerifyJarViaDirectDownloadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreAndVerifyViaClientContentDownloadTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreAndVerifyViaClientContentDownloadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreAndVerifyViaDirectDownloadTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreAndVerifyViaDirectDownloadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreFileAndVerifyExistenceInGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreFileAndVerifyExistenceInGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreFileAndVerifyPathInfoResultExistsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreFileAndVerifyPathInfoResultExistsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreFileAndVerifyViaExistsMethodTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreFileAndVerifyViaExistsMethodTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreThenGetUnSuffixedDirAndDownloadTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreThenGetUnSuffixedDirAndDownloadTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreThenGetUnSuffixedDirAndDownloadViaGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreThenGetUnSuffixedDirAndDownloadViaGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreTwoFilesAndVerifyPresenceInGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreTwoFilesAndVerifyPresenceInGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/fixture/DelayedDownload.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/fixture/DelayedDownload.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/fixture/InputTimer.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/fixture/InputTimer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/fixture/ReluctantInputStream.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/fixture/ReluctantInputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/lifecycle/HttpSiteConfigTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/lifecycle/HttpSiteConfigTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/lifecycle/UserIndyLifecycleManagerTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/lifecycle/UserIndyLifecycleManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AbstractStoreManagementTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AbstractStoreManagementTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndDeleteGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndDeleteGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndDeleteHostedRepoTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndDeleteHostedRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndDeleteRemoteRepoTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndDeleteRemoteRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndRetrieveGroupTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndRetrieveGroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndRetrieveHostedRepoTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndRetrieveHostedRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndRetrieveRemoteRepoTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddAndRetrieveRemoteRepoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddHostedRepoThenModifyAndVerifyTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddHostedRepoThenModifyAndVerifyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddRemoteRepoThenModifyAndVerifyTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/AddRemoteRepoThenModifyAndVerifyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/CreateGroupThenModifyAndVerifyChangesTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/CreateGroupThenModifyAndVerifyChangesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/GroupAdjustmentToMemberDeletionTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/GroupAdjustmentToMemberDeletionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/HostedAuthIndexWithReadonly.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/HostedAuthIndexWithReadonly.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/ListStoresByTypeTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/ListStoresByTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/ReadonlyHostedRepoDeleteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/ReadonlyHostedRepoDeleteTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoInValidUrlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoInValidUrlTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoValidUrlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/RemoteRepoValidUrlTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/urls/AbstractCoreUrlsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/urls/AbstractCoreUrlsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/urls/CreateHostedStoreAndVerifyUrlInAllEndpointsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/urls/CreateHostedStoreAndVerifyUrlInAllEndpointsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/urls/StoreOneAndSourceStoreUrlInHtmlListingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/urls/StoreOneAndSourceStoreUrlInHtmlListingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/urls/StoreOneAndVerifyInHtmlListingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/urls/StoreOneAndVerifyInHtmlListingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/core/src/test/java/org/commonjava/indy/ftest/core/fixture/TestProvider.java
+++ b/ftests/core/src/test/java/org/commonjava/indy/ftest/core/fixture/TestProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/metrics/pom.xml
+++ b/ftests/metrics/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/IndyMetricsTest.java
+++ b/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/IndyMetricsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/ZabbixCacheStorageTest.java
+++ b/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/ZabbixCacheStorageTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/client/IndyMetricsFtestClientModule.java
+++ b/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/client/IndyMetricsFtestClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/client/ZabbixCacheStorageTestClientModule.java
+++ b/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/client/ZabbixCacheStorageTestClientModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/jaxrs/MetricsTestResource.java
+++ b/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/jaxrs/MetricsTestResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/jaxrs/ZabbixCacheStorageResource.java
+++ b/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/jaxrs/ZabbixCacheStorageResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ftests/pom.xml
+++ b/ftests/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/models/core-java/pom.xml
+++ b/models/core-java/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/IndyContentConstants.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/IndyContentConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/IndyException.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/IndyException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/core/expire/Expiration.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/core/expire/Expiration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/core/expire/ExpirationSet.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/core/expire/ExpirationSet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/inject/Production.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/inject/Production.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/inject/TestData.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/inject/TestData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AccessChannel.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AccessChannel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -113,14 +113,16 @@ public abstract class ArtifactStore
     public abstract ArtifactStore copyOf( String packageType, String name );
 
     @Override
-    public int hashCode()
+    public final int hashCode()
     {
         final int prime = 31;
-        return prime + ( ( key == null ) ? 0 : key.hashCode() );
+        int result = super.hashCode();
+        result = prime * result + ( ( key == null ) ? 19 : key.hashCode() );
+        return result;
     }
 
     @Override
-    public boolean equals( final Object obj )
+    public final boolean equals( final Object obj )
     {
         if ( this == obj )
         {

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/GenericPackageTypeDescriptor.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/GenericPackageTypeDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/PackageTypeDescriptor.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/PackageTypeDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/PackageTypes.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/PackageTypes.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/PathStyle.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/PathStyle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
@@ -79,18 +79,18 @@ public final class StoreKey
     }
 
     @Override
-    public int hashCode()
+    public final int hashCode()
     {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ( ( packageType == null ) ? 0 : packageType.hashCode() );
-        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
-        result = prime * result + ( ( type == null ) ? 0 : type.hashCode() );
+        result = prime * result + ( ( packageType == null ) ? 7 : packageType.hashCode() );
+        result = prime * result + ( ( name == null ) ? 13 : name.hashCode() );
+        result = prime * result + ( ( type == null ) ? 17 : type.hashCode() );
         return result;
     }
 
     @Override
-    public boolean equals( final Object obj )
+    public final boolean equals( final Object obj )
     {
         if ( this == obj )
         {

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreType.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/CreationDTO.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/CreationDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/DirectoryListingDTO.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/DirectoryListingDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/DirectoryListingEntryDTO.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/DirectoryListingEntryDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/EndpointView.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/EndpointView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/EndpointViewListing.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/EndpointViewListing.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/NotFoundCacheDTO.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/NotFoundCacheDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/NotFoundCacheSectionDTO.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/NotFoundCacheSectionDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/ReplicationAction.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/ReplicationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/ReplicationDTO.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/ReplicationDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/StoreListingDTO.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/StoreListingDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/ApiSerializerModule.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/ApiSerializerModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/IndyObjectMapper.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/IndyObjectMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/IndySerializationException.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/IndySerializationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/IndySerializerModule.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/IndySerializerModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/ModuleSet.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/ModuleSet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/SimpleModuleSet.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/SimpleModuleSet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/StoreKeyDeserializer.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/StoreKeyDeserializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/StoreKeySerializer.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/StoreKeySerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/spi/AddOnListing.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/spi/AddOnListing.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/spi/IndyAddOnID.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/spi/IndyAddOnID.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/spi/UIRoute.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/spi/UIRoute.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/spi/UISection.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/spi/UISection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/model/util/HttpUtils.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/util/HttpUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/pkg/maven/model/MavenPackageTypeDescriptor.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/pkg/maven/model/MavenPackageTypeDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/NPMPackageTypeDescriptor.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/NPMPackageTypeDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/main/java/org/commonjava/indy/stats/IndyVersioning.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/stats/IndyVersioning.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/PackageTypesTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/PackageTypesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/DirectoryListingDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/DirectoryListingDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/DirectoryListingEntryDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/DirectoryListingEntryDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/EndpointViewListingTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/EndpointViewListingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/NotFoundCacheDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/NotFoundCacheDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/NotFoundCacheSectionDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/NotFoundCacheSectionDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/ReplicationDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/ReplicationDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/StoreListingDTOTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/dto/StoreListingDTOTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/io/ModelJSONTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/io/ModelJSONTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/model/GroupTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/model/GroupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/model/HostedRepositoryTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/model/HostedRepositoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/model/RemoteRepositoryTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/model/RemoteRepositoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/model/StoreKeyTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/model/StoreKeyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/core-java/src/test/java/org/commonjava/indy/model/stats/IndyVersioningTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/stats/IndyVersioningTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/pom.xml
+++ b/models/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/planning/activity-tracking-no-external-id.sequence.txt
+++ b/planning/activity-tracking-no-external-id.sequence.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   <packaging>pom</packaging>
   
   <name>Indy :: Project Root</name>
-  <inceptionYear>2011-2017</inceptionYear>
+  <inceptionYear>2011-2018</inceptionYear>
   
   <scm>
     <connection>scm:git:https://github.com/Commonjava/indy.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <kojijiVersion>2.3-SNAPSHOT</kojijiVersion>
     <rwxVersion>2.0</rwxVersion>
     <jhttpcVersion>1.7</jhttpcVersion>
-    <weftVersion>1.6</weftVersion>
+    <weftVersion>1.7</weftVersion>
     <httpTestserverVersion>1.3</httpTestserverVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1429,7 +1429,7 @@
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
-            <arguments>-Prelease,run-its</arguments>
+            <arguments>-Prelease,run-its -DskipTests=true</arguments>
           </configuration>
         </plugin>
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1429,7 +1429,7 @@
             <autoVersionSubmodules>true</autoVersionSubmodules>
             <mavenExecutorId>forked-path</mavenExecutorId>
             <useReleaseProfile>false</useReleaseProfile>
-            <arguments>-Prelease,run-its -DskipTests=true</arguments>
+            <arguments>-Prelease,run-its -T8 -DskipTests=true</arguments>
           </configuration>
         </plugin>
         <plugin>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/scripts/folo-repair/folofix/__init__.py
+++ b/scripts/folo-repair/folofix/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/folo-repair/folofix/command.py
+++ b/scripts/folo-repair/folofix/command.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/folo-repair/folofix/downloader.py
+++ b/scripts/folo-repair/folofix/downloader.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/folo-repair/folofix/reporter.py
+++ b/scripts/folo-repair/folofix/reporter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/folo-repair/setup.py
+++ b/scripts/folo-repair/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/indy-log-utils/indylog/__init__.py
+++ b/scripts/indy-log-utils/indylog/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/indy-log-utils/indylog/command.py
+++ b/scripts/indy-log-utils/indylog/command.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/indy-log-utils/indylog/counter.py
+++ b/scripts/indy-log-utils/indylog/counter.py
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import sys
 import re

--- a/scripts/indy-log-utils/indylog/timer.py
+++ b/scripts/indy-log-utils/indylog/timer.py
@@ -1,3 +1,19 @@
+#
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import sys
 import re

--- a/scripts/indy-log-utils/setup.py
+++ b/scripts/indy-log-utils/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 #
-# Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/multibuild/mb/__init__.py
+++ b/scripts/multibuild/mb/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/multibuild/mb/builder.py
+++ b/scripts/multibuild/mb/builder.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/multibuild/mb/command.py
+++ b/scripts/multibuild/mb/command.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/multibuild/mb/reporter.py
+++ b/scripts/multibuild/mb/reporter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/multibuild/mb/util.py
+++ b/scripts/multibuild/mb/util.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/multibuild/mb/vagrant.py
+++ b/scripts/multibuild/mb/vagrant.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/multibuild/sample-testfile.yaml
+++ b/scripts/multibuild/sample-testfile.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/multibuild/setup.py
+++ b/scripts/multibuild/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/subsys/flatfile/pom.xml
+++ b/subsys/flatfile/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/DataFile.java
+++ b/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/DataFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/DataFileManager.java
+++ b/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/DataFileManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/change/DataFileEvent.java
+++ b/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/change/DataFileEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/change/DataFileEventManager.java
+++ b/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/change/DataFileEventManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/change/DataFileEventType.java
+++ b/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/change/DataFileEventType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/conf/DataFileConfiguration.java
+++ b/subsys/flatfile/src/main/java/org/commonjava/indy/subsys/datafile/conf/DataFileConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/git/pom.xml
+++ b/subsys/git/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/subsys/git/src/main/java/org/commonjava/indy/subsys/git/ConflictStrategy.java
+++ b/subsys/git/src/main/java/org/commonjava/indy/subsys/git/ConflictStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/git/src/main/java/org/commonjava/indy/subsys/git/GitConfig.java
+++ b/subsys/git/src/main/java/org/commonjava/indy/subsys/git/GitConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/git/src/main/java/org/commonjava/indy/subsys/git/GitManager.java
+++ b/subsys/git/src/main/java/org/commonjava/indy/subsys/git/GitManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/git/src/main/java/org/commonjava/indy/subsys/git/GitSubsystemException.java
+++ b/subsys/git/src/main/java/org/commonjava/indy/subsys/git/GitSubsystemException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/git/src/test/java/org/commonjava/indy/subsys/git/AbstractGitManagerTest.java
+++ b/subsys/git/src/test/java/org/commonjava/indy/subsys/git/AbstractGitManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/git/src/test/java/org/commonjava/indy/subsys/git/GitManagerConcurrentTest.java
+++ b/subsys/git/src/test/java/org/commonjava/indy/subsys/git/GitManagerConcurrentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/git/src/test/java/org/commonjava/indy/subsys/git/GitManagerTest.java
+++ b/subsys/git/src/test/java/org/commonjava/indy/subsys/git/GitManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/groovy/pom.xml
+++ b/subsys/groovy/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/IndyGroovyException.java
+++ b/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/IndyGroovyException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/ScriptEngine.java
+++ b/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/ScriptEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/TemplatingEngine.java
+++ b/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/TemplatingEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/ScriptEngineTest.java
+++ b/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/ScriptEngineTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/MockDownloadManager.java
+++ b/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/MockDownloadManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/ScriptedThing.java
+++ b/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/ScriptedThing.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/ScriptedThingOwner.java
+++ b/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/ScriptedThingOwner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/TestProvider.java
+++ b/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/TestProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/pom.xml
+++ b/subsys/http/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/HttpWrapper.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/HttpWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpConnectionManager.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpConnectionManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpException.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpProvider.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/conf/IndyHttpConfig.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/conf/IndyHttpConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/HttpFactoryPasswordDelegate.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/HttpFactoryPasswordDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/HttpResources.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/HttpResources.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/IndySiteConfigLookup.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/IndySiteConfigLookup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/UserPass.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/UserPass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/http/src/test/java/org/commonjava/indy/subsys/http/util/IndySiteConfigLookupTest.java
+++ b/subsys/http/src/test/java/org/commonjava/indy/subsys/http/util/IndySiteConfigLookupTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/infinispan/pom.xml
+++ b/subsys/infinispan/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheHandle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheKeyMatcher.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheKeyMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/IndyGridFS.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/IndyGridFS.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/qualifer/IndyCache.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/inject/qualifer/IndyCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/pom.xml
+++ b/subsys/jaxrs/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/HeaderDebugger.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/HeaderDebugger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeploymentProvider.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeploymentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyResources.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyResources.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RestProvider.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RestProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SecurityFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SecurityFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SecurityManager.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SecurityManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/UnhandledIOExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/UnhandledIOExceptionHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/UnhandledRuntimeExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/UnhandledRuntimeExceptionHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/jackson/CDIJacksonProvider.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/jackson/CDIJacksonProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/BasicAuthenticationOAuthTranslator.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/BasicAuthenticationOAuthTranslator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/KeycloakDeploymentProvider.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/KeycloakDeploymentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/SecurityResource.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/SecurityResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/metrics/IndyMetricsJaxrsNames.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/metrics/IndyMetricsJaxrsNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ui/UIApp.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ui/UIApp.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ui/UIServlet.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ui/UIServlet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/CdiInjectorFactoryImpl.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/CdiInjectorFactoryImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/DeploymentInfoUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/DeploymentInfoUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JaxRsRequestHelper.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JaxRsRequestHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JaxRsUriFormatter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JaxRsUriFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/RequestScopeListener.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/RequestScopeListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/SecurityParam.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/SecurityParam.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/jaxrs/src/test/java/org/commonjava/indy/bind/jaxrs/util/JaxRsUriFormatterTest.java
+++ b/subsys/jaxrs/src/test/java/org/commonjava/indy/bind/jaxrs/util/JaxRsUriFormatterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/keycloak/pom.xml
+++ b/subsys/keycloak/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/KeycloakAuthenticator.java
+++ b/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/KeycloakAuthenticator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/SecurityConstraintProvider.java
+++ b/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/SecurityConstraintProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/conf/KeycloakConfig.java
+++ b/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/conf/KeycloakConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/conf/KeycloakSecurityBindings.java
+++ b/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/conf/KeycloakSecurityBindings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/conf/KeycloakSecurityConstraint.java
+++ b/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/conf/KeycloakSecurityConstraint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/rest/SecurityController.java
+++ b/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/rest/SecurityController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/util/KeycloakBearerTokenDebug.java
+++ b/subsys/keycloak/src/main/java/org/commonjava/indy/subsys/keycloak/util/KeycloakBearerTokenDebug.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/keycloak/src/test/java/org/commonjava/indy/subsys/keycloak/rest/SecurityControllerTest.java
+++ b/subsys/keycloak/src/test/java/org/commonjava/indy/subsys/keycloak/rest/SecurityControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/pom.xml
+++ b/subsys/metrics/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/conf/conf.d/elasticsearch.properties
+++ b/subsys/metrics/src/main/conf/conf.d/elasticsearch.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsManager.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsManager.java
@@ -89,13 +89,13 @@ public class IndyMetricsManager
 
     public Timer getTimer( MetricNamed named )
     {
-        logger.info( "call in IndyMetricsManager.getTimer from registry: {}", metricRegistry );
+        logger.trace( "call in IndyMetricsManager.getTimer" );
         return this.metricRegistry.timer( named.name() );
     }
 
     public Meter getMeter( MetricNamed named )
     {
-        logger.info( "call in IndyMetricsManager.getMeter from registry: {}", metricRegistry );
+        logger.trace( "call in IndyMetricsManager.getMeter" );
         return metricRegistry.meter( named.name() );
     }
 

--- a/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsManager.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsNames.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsNames.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/IndyMetrics.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/IndyMetrics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/Measure.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/Measure.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/MetricNamed.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/MetricNamed.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/conf/IndyMetricsConfig.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/conf/IndyMetricsConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/conf/annotation/IndyMetricsNamed.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/conf/annotation/IndyMetricsNamed.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/exception/IndyMetricsException.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/exception/IndyMetricsException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/healthcheck/IndyHealthCheck.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/healthcheck/IndyHealthCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/healthcheck/IndyHealthCheckRegistrySet.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/healthcheck/IndyHealthCheckRegistrySet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/healthcheck/impl/ThreadDeadlockHealthCheck.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/healthcheck/impl/ThreadDeadlockHealthCheck.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
@@ -62,7 +62,7 @@ public class MetricsInterceptor
             return context.proceed();
         }
 
-        logger.debug( "Gathering metrics for: {} (metrics annotation: {})", context.getContextData(), metrics );
+        logger.trace( "Gathering metrics for: {}", context.getContextData() );
 
         Measure measures = metrics.measure();
         List<Timer.Context> timers = Stream.of( measures.timers() )

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/producer/IndyProducer.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/producer/IndyProducer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jvm/IndyJVMInstrumentation.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jvm/IndyJVMInstrumentation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/reporter/ReporterIntializer.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/reporter/ReporterIntializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/api/IndyZabbixApi.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/api/IndyZabbixApi.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/api/Request.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/api/Request.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/api/RequestBuilder.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/api/RequestBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/api/ZabbixApi.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/api/ZabbixApi.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/cache/ZabbixCacheStorage.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/cache/ZabbixCacheStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/reporter/HostUtil.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/reporter/HostUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/reporter/IndyZabbixReporter.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/reporter/IndyZabbixReporter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/DataObject.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/DataObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/IndyZabbixSender.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/IndyZabbixSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/SenderRequest.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/SenderRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/SenderResult.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/SenderResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/ZabbixSender.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/zabbix/sender/ZabbixSender.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/test/java/org/commonjava/indy/metrics/socket/Capitalizer.java
+++ b/subsys/metrics/src/test/java/org/commonjava/indy/metrics/socket/Capitalizer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/test/java/org/commonjava/indy/metrics/socket/Expectation.java
+++ b/subsys/metrics/src/test/java/org/commonjava/indy/metrics/socket/Expectation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/test/java/org/commonjava/indy/metrics/socket/ZabbixResult.java
+++ b/subsys/metrics/src/test/java/org/commonjava/indy/metrics/socket/ZabbixResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/test/java/org/commonjava/indy/metrics/socket/ZabbixSocketServer.java
+++ b/subsys/metrics/src/test/java/org/commonjava/indy/metrics/socket/ZabbixSocketServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/test/java/org/commonjava/indy/metrics/zabbix/api/ZabbixAPITest.java
+++ b/subsys/metrics/src/test/java/org/commonjava/indy/metrics/zabbix/api/ZabbixAPITest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/test/java/org/commonjava/indy/metrics/zabbix/api/ZabbxiAPIHandler.java
+++ b/subsys/metrics/src/test/java/org/commonjava/indy/metrics/zabbix/api/ZabbxiAPIHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/metrics/src/test/java/org/commonjava/indy/metrics/zabbix/sender/ZabbixSenderTest.java
+++ b/subsys/metrics/src/test/java/org/commonjava/indy/metrics/zabbix/sender/ZabbixSenderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subsys/pom.xml
+++ b/subsys/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/db/pom.xml
+++ b/test/db/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/db/src/main/java/org/commonjava/indy/core/data/AbstractProxyDataManagerTCK.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/AbstractProxyDataManagerTCK.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/db/src/main/java/org/commonjava/indy/core/data/GroupDataManagerTCK.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/GroupDataManagerTCK.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/db/src/main/java/org/commonjava/indy/core/data/RepositoryDataManagerTCK.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/RepositoryDataManagerTCK.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/db/src/main/java/org/commonjava/indy/core/data/TCKFixtureProvider.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/TCKFixtureProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/db/src/main/java/org/commonjava/indy/core/data/testutil/StoreEventDispatcherStub.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/testutil/StoreEventDispatcherStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/docker/gogs-test-appliance/pom.xml
+++ b/test/docker/gogs-test-appliance/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/docker/gogs-test-appliance/src/main/assembly/image-base.xml
+++ b/test/docker/gogs-test-appliance/src/main/assembly/image-base.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/docker/gogs-test-appliance/src/main/docker/Dockerfile
+++ b/test/docker/gogs-test-appliance/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/docker/keycloak-test-appliance/pom.xml
+++ b/test/docker/keycloak-test-appliance/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/docker/keycloak-test-appliance/src/main/docker/Dockerfile
+++ b/test/docker/keycloak-test-appliance/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/docker/pom.xml
+++ b/test/docker/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/fixtures-core/pom.xml
+++ b/test/fixtures-core/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/CoreServerFixture.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/CoreServerFixture.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/HttpTestFixture.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/HttpTestFixture.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/MockContentAdvisor.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/MockContentAdvisor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/MockGalleyProvider.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/MockGalleyProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/MockInstance.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/MockInstance.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures-core/src/test/java/org/commonjava/indy/test/fixture/core/CoreVertxServerFixtureTest.java
+++ b/test/fixtures-core/src/test/java/org/commonjava/indy/test/fixture/core/CoreVertxServerFixtureTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/providers-core/pom.xml
+++ b/test/providers-core/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/providers-core/src/main/java/org/commonjava/indy/test/fixture/core/CoreServerProvider.java
+++ b/test/providers-core/src/main/java/org/commonjava/indy/test/fixture/core/CoreServerProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/utils/src/main/java/org/commonjava/indy/test/utils/WeldJUnit4Runner.java
+++ b/test/utils/src/main/java/org/commonjava/indy/test/utils/WeldJUnit4Runner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tools/assemblies/pom.xml
+++ b/tools/assemblies/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tools/roader/dumper.rb
+++ b/tools/roader/dumper.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/roader/loader.rb
+++ b/tools/roader/loader.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+# Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/uis/layover/app/css/indy.css
+++ b/uis/layover/app/css/indy.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/uis/layover/app/index.html
+++ b/uis/layover/app/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/js/app.js
+++ b/uis/layover/app/js/app.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/uis/layover/app/js/controllers.js
+++ b/uis/layover/app/js/controllers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/uis/layover/app/js/directives.js
+++ b/uis/layover/app/js/directives.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/uis/layover/app/js/filters.js
+++ b/uis/layover/app/js/filters.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/uis/layover/app/js/services.js
+++ b/uis/layover/app/js/services.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/uis/layover/app/js/utils.js
+++ b/uis/layover/app/js/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/dialogs/changelog-dialog.html
+++ b/uis/layover/app/partials/dialogs/changelog-dialog.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/dialogs/confirm-dialog.html
+++ b/uis/layover/app/partials/dialogs/confirm-dialog.html
@@ -1,6 +1,5 @@
 <!--
-
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/dialogs/save-dialog.html
+++ b/uis/layover/app/partials/dialogs/save-dialog.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/directives/ap-group-available.html
+++ b/uis/layover/app/partials/directives/ap-group-available.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/directives/ap-group-constituent.html
+++ b/uis/layover/app/partials/directives/ap-group-constituent.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/footer.html
+++ b/uis/layover/app/partials/footer.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/group-detail.html
+++ b/uis/layover/app/partials/group-detail.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/group-edit.html
+++ b/uis/layover/app/partials/group-edit.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/group-list.html
+++ b/uis/layover/app/partials/group-list.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/hosted-detail.html
+++ b/uis/layover/app/partials/hosted-detail.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/hosted-edit.html
+++ b/uis/layover/app/partials/hosted-edit.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/hosted-list.html
+++ b/uis/layover/app/partials/hosted-list.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/includes/group-view.html
+++ b/uis/layover/app/partials/includes/group-view.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/includes/hosted-view.html
+++ b/uis/layover/app/partials/includes/hosted-view.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/includes/remote-view.html
+++ b/uis/layover/app/partials/includes/remote-view.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/includes/store-control-panel.html
+++ b/uis/layover/app/partials/includes/store-control-panel.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/nfc.html
+++ b/uis/layover/app/partials/nfc.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/remote-detail.html
+++ b/uis/layover/app/partials/remote-detail.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/remote-edit.html
+++ b/uis/layover/app/partials/remote-edit.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/partials/remote-list.html
+++ b/uis/layover/app/partials/remote-list.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/app/rest-api.html
+++ b/uis/layover/app/rest-api.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/layover/pom.xml
+++ b/uis/layover/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (C) 2011-2017 Red Hat, Inc. (https://github.com/Commonjava/indy)
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Move errors for incorporating individual repos' metadata to logged errors, but stop throwing exceptions.

We need to be more resilient to continuent repos that have bad content. This will allow us to see the
problems in our logs, but not have to be stopped by them.

* Refactor to use Locker in weft to make ReentrantLock handling consistent
* Fix tests after metadata generation patch-up to be resilient to member metadata failures
* Fix NPE in Koji maven metadata provider
* Isolate the missing-metadata sets used for download and generating from dir contents to avoid apparent race condition.

Try to improve object equality for ArtifactStore to deal with apparent duplicates after cache retrieval
of metadata, though I don't think this makes much difference so far.

* Mark out the rest-min embedder/launcher/docker image, since we don't use them, and they just take time to build.