### PR TITLE
Add ssl protocols in system properties to avoid ssl handshake problem

### DIFF
--- a/deployments/launcher/src/main/bin/indy.sh
+++ b/deployments/launcher/src/main/bin/indy.sh
@@ -67,4 +67,4 @@ JAVA_OPTS="$JAVA_OPTS $JAVA_DEBUG_OPTS"
 
 MAIN_CLASS=org.commonjava.indy.boot.jaxrs.JaxRsBooter
 
-exec "$JAVA" ${JAVA_OPTS} -cp "${CP}" -Dindy.home="${BASEDIR}" -Dindy.boot.defaults=${BASEDIR}/bin/boot.properties -Dorg.jboss.logging.provider=slf4j ${MAIN_CLASS}  "$@"
+exec "$JAVA" ${JAVA_OPTS} -cp "${CP}" -Dindy.home="${BASEDIR}" -Dindy.boot.defaults=${BASEDIR}/bin/boot.properties -Dorg.jboss.logging.provider=slf4j -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 ${MAIN_CLASS}  "$@"


### PR DESCRIPTION
In recent indy prod logs, I found that indy met some "ssl handshake peer shutdown" problem. After google & SO searching, seems this can solve the problem: System.setProperty("https.protocols", "TLSv1,TLSv1.1,TLSv1.2"); 
So added this property to indy startup script.

P.S: SO discussion here: https://stackoverflow.com/questions/28908835/ssl-peer-shut-down-incorrectly-in-java?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa