### PR TITLE
Add a log for proxy authentication failure case

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -176,6 +176,7 @@ public final class ProxyResponseWriter
                                         "Passing BASIC authentication credentials to Keycloak bearer-token translation authenticator" );
                                 if ( !proxyAuthenticator.authenticate( proxyUserPass, http ) )
                                 {
+                                    logger.warn("Proxy authentication failed for this request: {}", requestLine.toString());
                                     break;
                                 }
                             }


### PR DESCRIPTION
Indy met some weird proxy access problem in hawtio npm build problem, I suspects that it is related to proxy authentication but no evidence, so added this log for a tracking.