### PR TITLE
Refactor Git audit log for data files

### DIFF
--- a/addons/revisions/common/src/test/java/org/commonjava/indy/revisions/RevisionsManagerTest.java
+++ b/addons/revisions/common/src/test/java/org/commonjava/indy/revisions/RevisionsManagerTest.java
@@ -16,6 +16,8 @@
 package org.commonjava.indy.revisions;
 
 import static org.apache.commons.lang.StringUtils.join;
+import static org.commonjava.indy.audit.ChangeSummary.SYSTEM_USER;
+import static org.commonjava.indy.subsys.git.GitManager.COMMIT_CHANGELOG_ENTRIES;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -99,11 +101,15 @@ public class RevisionsManagerTest
 
         final DataFile f2 = dfManager.getDataFile( "test/bar.txt" );
         f2.writeString( "this is a test", "UTF-8", new ChangeSummary( "test-user", "test for second file." ) );
+
+        revManager.commitDataUpdates();
+
         f2.writeString( "this is another test", "UTF-8", new ChangeSummary( "test-user", "test (2) for second file." ) );
 
         final List<DataFileEvent> events = listener.waitForEvents( 3 );
         System.out.println( "Got events:\n  " + join( events, "\n  " ) );
 
+        revManager.commitDataUpdates();
         final List<ChangeSummary> changeLog = revManager.getDataChangeLog( f2.getPath(), 0, -1 );
         assertThat( changeLog, notNullValue() );
         assertThat( changeLog.size(), equalTo( 2 ) );
@@ -127,6 +133,7 @@ public class RevisionsManagerTest
         events = listener.waitForEvents( 1 );
         System.out.println( "Got events:\n  " + join( events, "\n  " ) );
 
+        revManager.commitDataUpdates();
         final List<ChangeSummary> changeLog = revManager.getDataChangeLog( f1.getPath(), 0, -1 );
         assertThat( changeLog, notNullValue() );
         assertThat( changeLog.size(), equalTo( 1 ) );
@@ -155,19 +162,21 @@ public class RevisionsManagerTest
 
         System.out.println( "Got events:\n  " + join( events, "\n  " ) );
 
+        revManager.commitDataUpdates();
         List<ChangeSummary> changeLog = revManager.getDataChangeLog( f1.getPath(), 0, -1 );
         assertThat( changeLog, notNullValue() );
         assertThat( changeLog.size(), equalTo( 0 ) );
 
         lcEvents.fireStarted();
 
+        revManager.commitDataUpdates();
         changeLog = revManager.getDataChangeLog( f1.getPath(), 0, -1 );
         assertThat( changeLog, notNullValue() );
         assertThat( changeLog.size(), equalTo( 1 ) );
 
         assertThat( changeLog.get( 0 )
                              .getSummary()
-                             .contains( RevisionsManager.CATCHUP_CHANGELOG ), equalTo( true ) );
+                             .contains( RevisionsManager.CATCHUP_CHANGELOG_MODIFIED ), equalTo( true ) );
     }
 
     @Test
@@ -185,13 +194,14 @@ public class RevisionsManagerTest
 
         listener.waitForEvents( 3 );
 
-        final List<ChangeSummary> changeLog = revManager.getDataChangeLog( f2.getPath(), 1, 1 );
+        revManager.commitDataUpdates();
+        final List<ChangeSummary> changeLog = revManager.getDataChangeLog( f2.getPath(), 0, 1 );
         assertThat( changeLog, notNullValue() );
         assertThat( changeLog.size(), equalTo( 1 ) );
 
         final ChangeSummary summary = changeLog.get( 0 );
         assertThat( summary.getSummary()
-                           .startsWith( testSummary ), equalTo( true ) );
+                           .contains( testSummary ), equalTo( true ) );
     }
 
     @ApplicationScoped

--- a/subsys/git/src/main/java/org/commonjava/indy/subsys/git/ChangelogEntry.java
+++ b/subsys/git/src/main/java/org/commonjava/indy/subsys/git/ChangelogEntry.java
@@ -1,0 +1,46 @@
+package org.commonjava.indy.subsys.git;
+
+import java.util.Collection;
+import java.util.Date;
+
+/**
+ * Created by ruhan on 5/7/18.
+ */
+public class ChangelogEntry
+{
+    private String username;
+
+    private String message;
+
+    private Collection<String> paths; // file(s) affected
+
+    private Date timestamp;
+
+    public ChangelogEntry( String user, String message, Collection<String> paths )
+    {
+        this.username = user;
+        this.message = message;
+        this.paths = paths;
+        this.timestamp = new Date();
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public String getMessage()
+    {
+        return message;
+    }
+
+    public Collection<String> getPaths()
+    {
+        return paths;
+    }
+
+    public Date getTimestamp()
+    {
+        return timestamp;
+    }
+}

--- a/subsys/git/src/test/java/org/commonjava/indy/subsys/git/GitManagerConcurrentTest.java
+++ b/subsys/git/src/test/java/org/commonjava/indy/subsys/git/GitManagerConcurrentTest.java
@@ -88,7 +88,8 @@ public class GitManagerConcurrentTest
         FileUtils.write( f, "This is a test" );
 
         final String user = "testAddAndCommit";
-        git.addAndCommitFiles( new ChangeSummary( user, "first commit"), f );
+        git.addFiles( new ChangeSummary( user, "first commit"), f );
+        git.commit();
 
         pool.execute( () -> {
             try
@@ -110,7 +111,8 @@ public class GitManagerConcurrentTest
             try
             {
                 FileUtils.write( f, "This is another test" );
-                git.addAndCommitFiles( new ChangeSummary( user, "second commit"), f );
+                git.addFiles( new ChangeSummary( user, "second commit"), f );
+                git.commit();
             }
             catch ( Exception e )
             {
@@ -159,7 +161,8 @@ public class GitManagerConcurrentTest
 
                     final String user = "test" + j;
                     final String log = "test commit " + j;
-                    git.addAndCommitFiles( new ChangeSummary( user, log ), f );
+                    git.addFiles( new ChangeSummary( user, log ), f );
+                    git.commit();
                 }
                 catch ( Exception e )
                 {
@@ -203,7 +206,8 @@ public class GitManagerConcurrentTest
 
                 final String user = "test" + i;
                 final String log = "test commit " + i;
-                git.addAndCommitFiles( new ChangeSummary( user, log ), f );
+                git.addFiles( new ChangeSummary( user, log ), f );
+                git.commit();
             }
             catch ( Exception e )
             {
@@ -225,7 +229,8 @@ public class GitManagerConcurrentTest
 
                     final String user = "test" + j;
                     final String log = "delete test" + j + ".txt";
-                    git.deleteAndCommit( new ChangeSummary( user, log ), f );
+                    git.delete( new ChangeSummary( user, log ), f );
+                    git.commit();
                 }
                 catch ( Exception e )
                 {

--- a/subsys/git/src/test/java/org/commonjava/indy/subsys/git/GitManagerTest.java
+++ b/subsys/git/src/test/java/org/commonjava/indy/subsys/git/GitManagerTest.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.subsys.git;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.apache.commons.io.IOUtils.copy;
+import static org.commonjava.indy.audit.ChangeSummary.SYSTEM_USER;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -76,16 +77,17 @@ public class GitManagerTest extends AbstractGitManagerTest
 
         final String user = "test";
         final String log = "test commit";
-        git.addAndCommitFiles( new ChangeSummary( user, log ), f );
+        git.addFiles( new ChangeSummary( user, log ), f );
+        git.commit();
 
         final List<ChangeSummary> changelog = git.getChangelog( f, 0, 1 );
 
         assertThat( changelog, notNullValue() );
         assertThat( changelog.size(), equalTo( 1 ) );
         assertThat( changelog.get( 0 )
-                             .getUser(), equalTo( user ) );
+                             .getUser(), equalTo( SYSTEM_USER ) );
         assertThat( changelog.get( 0 )
-                             .getSummary(), equalTo( log ) );
+                             .getSummary().contains( log ), equalTo( true ) );
     }
 
 


### PR DESCRIPTION
One question is: when deleting files the old code use commit.setOnly(path) following rm.addFilepattern(). I don't know why and removed it. If this is necessary, please let me know. 