### PR TITLE
Support default name for Indy metric annotation

### DIFF
--- a/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsManager.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsManager.java
@@ -87,16 +87,16 @@ public class IndyMetricsManager
         }
     }
 
-    public Timer getTimer( MetricNamed named )
+    public Timer getTimer( String name )
     {
         logger.trace( "call in IndyMetricsManager.getTimer" );
-        return this.metricRegistry.timer( named.name() );
+        return this.metricRegistry.timer( name );
     }
 
-    public Meter getMeter( MetricNamed named )
+    public Meter getMeter( String name )
     {
         logger.trace( "call in IndyMetricsManager.getMeter" );
-        return metricRegistry.meter( named.name() );
+        return metricRegistry.meter( name );
     }
 
 }

--- a/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/MetricNamed.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/MetricNamed.java
@@ -30,5 +30,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention( RUNTIME )
 public @interface MetricNamed
 {
-    String name();
+    String name() default "";
 }


### PR DESCRIPTION
This can simplify the usage of metric anno without defining the names beforehand. E.g., new anno looks like:
@IndyMetrics( measure = @Measure( timers = @MetricNamed(), meters = @MetricNamed(), ... ))