### PR TITLE
Add metric to start-up action and adjust some default config

### DIFF
--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCheckRegistrySet.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCheckRegistrySet.java
@@ -19,6 +19,8 @@ public class IspnCheckRegistrySet
 {
     public static final String INDY_METRIC_ISPN = "indy.ispn";
 
+    private static final String SIZE = "size";
+
     private static final String CURRENT_NUMBER_OF_ENTRIES = "CurrentNumberOfEntries";
 
     private static final String CURRENT_NUMBER_OF_ENTRIES_IN_MEMORY = "CurrentNumberOfEntriesInMemory";
@@ -52,6 +54,11 @@ public class IspnCheckRegistrySet
            {
                Cache<Object, Object> cache = cacheManager.getCache( n );
                AdvancedCache<Object, Object> advancedCache = cache.getAdvancedCache();
+
+               gauges.put( name( cache.getName(), SIZE ), (Gauge) () -> advancedCache.size() ); // default
+
+               // TODO: below are advanced gauges via advancedCache.getStats().
+               // Unfortunately all methods return -1 (tested on infinispan 9.1.7). we need to watch it with new releases.
 
                if ( ispnGauges == null || ispnGauges.contains( CURRENT_NUMBER_OF_ENTRIES ) )
                {

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <infinispan
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="urn:infinispan:config:8.2 http://www.infinispan.org/schemas/infinispan-config-8.2.xsd"
-    xmlns="urn:infinispan:config:8.2">
+    xsi:schemaLocation="urn:infinispan:config:9.1 http://www.infinispan.org/schemas/infinispan-config-9.1.xsd"
+    xmlns="urn:infinispan:config:9.1">
 
-  <cache-container default-cache="local" name="IndyCacheManager" shutdown-hook="DEFAULT">
-    <local-cache-configuration name="local-template">
+  <cache-container default-cache="local" name="IndyCacheManager" shutdown-hook="DEFAULT" statistics="true">
+    <local-cache-configuration name="local-template" statistics="true">
       <eviction strategy="LRU" size="200000" type="COUNT"/>
     </local-cache-configuration>
 
     <local-cache name="local" configuration="local-template"/>
 
-    <local-cache name="koji-maven-version-metadata" >
+    <local-cache name="koji-maven-version-metadata" configuration="local-template">
       <eviction strategy="LRU" size="200000" type="COUNT"/>
     </local-cache>
 
-    <local-cache name="folo-in-progress" >
+    <local-cache name="folo-in-progress" configuration="local-template">
       <eviction size="200000" type="COUNT" strategy="LRU"/>
       <indexing index="LOCAL">
         <property name="hibernate.search.model_mapping">org.commonjava.indy.folo.data.FoloCacheProducer</property>
@@ -24,22 +24,22 @@
       </indexing>
     </local-cache>
 
-    <local-cache name="folo-sealed">
+    <local-cache name="folo-sealed" configuration="local-template">
       <eviction size="1000" type="COUNT" strategy="LRU"/>
       <persistence passivation="true">
         <file-store shared="false" preload="false" fetch-state="true" path="${indy.data}/folo"/>
       </persistence>
     </local-cache>
 
-    <local-cache name="content-index">
+    <local-cache name="content-index" configuration="local-template">
       <eviction strategy="LRU" size="200000" type="COUNT"/>
     </local-cache>
 
-    <local-cache name="maven-version-metadata-cache" deadlock-detection-spin="10000">
+    <local-cache name="maven-version-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
       <eviction size="10000000" type="COUNT" strategy="LRU"/>
     </local-cache>
 
-    <local-cache name="indy-nfs-owner-cache" deadlock-detection-spin="10000">
+    <local-cache name="indy-nfs-owner-cache" deadlock-detection-spin="10000" configuration="local-template">
       <eviction size="200000" type="COUNT" strategy="LRU"/>
       <transaction transaction-manager-lookup="org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
                    locking="PESSIMISTIC"/>
@@ -49,12 +49,12 @@
         This cache works for delete the fast local cache of the NFS supported repo cache on local. With the expiration,
         it will make all cache entries expired after 1 day, and trigger the purge of the expired cache every 30 mins
     -->
-    <local-cache name="indy-fastlocal-file-delete-cache">
+    <local-cache name="indy-fastlocal-file-delete-cache" configuration="local-template">
       <eviction size="200000" strategy="LRU"/>
       <expiration lifespan="86400000" max-idle="86400000" interval="1800000"/>
     </local-cache>
 
-    <local-cache name="schedule-expire-cache">
+    <local-cache name="schedule-expire-cache" configuration="local-template">
       <!--
           this expiration interval is used to trigger the purge threads of ISPN to let it purge the cache, which will
           trigger the cache expire event to happen. Did not find a way to let the expire event automatically happen
@@ -63,7 +63,7 @@
       <expiration interval="300" />
     </local-cache>
 
-    <local-cache name="nfc">
+    <local-cache name="nfc" configuration="local-template">
       <!--
           Use both eviction and expiration to guide against OOM, and run expiration thread twice an hour. Refer to
           http://infinispan.org/docs/8.2.x/user_guide/user_guide.html#configuration

--- a/subsys/metrics/src/main/conf/conf.d/metrics.conf
+++ b/subsys/metrics/src/main/conf/conf.d/metrics.conf
@@ -1,11 +1,14 @@
 [metrics]
 enabled = false
 reporter.enabled = true
+
+# Enable kojiji metrics. Default false.
+#
 koji.enabled = true
 
 # Enable Infinispan metrics. Default false.
 #
-#ispn.enabled = true
+ispn.enabled = true
 
 # Specify ISPN cache gauges. This works only if ispn.enabled is true. Default All. Names are case sensitive.
 #
@@ -14,7 +17,7 @@ koji.enabled = true
 
 # Enable Galley to measure artifact downloading time. Default false.
 #
-#measure.transport = true
+measure.transport = true
 
 # Specify a repository list for those to measure artifact downloading time. This works only if
 # measure.transport is true.
@@ -27,13 +30,10 @@ koji.enabled = true
 #
 #measure.transport.repos = central
 
-######################################
-# List of enabled reporters (comma-separated)
-# At present, Indy metrics feature just support three reporters
-# GraPhiteDB,Zabbix,Console,Elasticsearch
-######################################
-
-reporter = graphite;zabbix;elasticsearch
+# List of reporters (comma-separated). At present, Indy supports reporters:
+# reporter = graphite,zabbix,elasticsearch,console
+#
+reporter = console
 
 ############################################
 # Console reporter options

--- a/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsManager.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/IndyMetricsManager.java
@@ -84,12 +84,13 @@ public class IndyMetricsManager
     @PostConstruct
     public void initMetric()
     {
-        logger.warn( "Starting metrics subsystem..." );
-
         if ( !config.isMetricsEnabled() )
         {
+            logger.info( "Indy metrics subsystem not enabled" );
             return;
         }
+
+        logger.info( "Init metrics subsystem..." );
 
         IndyJVMInstrumentation.init( metricRegistry );
         IndyHealthCheckRegistrySet healthCheckRegistrySet = new IndyHealthCheckRegistrySet();
@@ -113,16 +114,16 @@ public class IndyMetricsManager
         {
             setUpTransportMetricConfig();
         }
+    }
 
-        try
+    public void startReporter() throws Exception
+    {
+        if ( !config.isMetricsEnabled() )
         {
-            reporter.initReporter( metricRegistry );
+            return;
         }
-        catch ( Exception e )
-        {
-            logger.error( e.getMessage() );
-            throw new RuntimeException( e );
-        }
+        logger.info( "Start metrics reporters" );
+        reporter.initReporter( metricRegistry );
     }
 
     private void setUpIspnMetrics()

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/producer/IndyMetricProducer.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/producer/IndyMetricProducer.java
@@ -16,7 +16,9 @@
 package org.commonjava.indy.metrics.jaxrs.producer;
 
 import com.codahale.metrics.MetricRegistry;
-import org.commonjava.indy.metrics.conf.IndyMetricsConfig;
+import org.commonjava.indy.IndyMetricsManager;
+import org.commonjava.indy.action.IndyLifecycleException;
+import org.commonjava.indy.action.StartupAction;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
@@ -25,8 +27,10 @@ import javax.inject.Inject;
 /**
  * Created by xiabai on 2/27/17.
  */
-public class IndyProducer
+public class IndyMetricProducer implements StartupAction
 {
+
+    private static final String METRIC_ID = "metric";
 
     @ApplicationScoped
     @Produces
@@ -35,4 +39,31 @@ public class IndyProducer
         return new MetricRegistry();
     }
 
+    @Override
+    public String getId()
+    {
+        return METRIC_ID;
+    }
+
+    @Inject
+    private IndyMetricsManager indyMetricsManager;
+
+    @Override
+    public void start() throws IndyLifecycleException
+    {
+        try
+        {
+            indyMetricsManager.startReporter();
+        }
+        catch ( Exception e )
+        {
+            throw new IndyLifecycleException( "Failed while attempting to start Metric reporters.", e );
+        }
+    }
+
+    @Override
+    public int getStartupPriority()
+    {
+        return 10;
+    }
 }

--- a/subsys/metrics/src/main/resources/default-metrics.conf
+++ b/subsys/metrics/src/main/resources/default-metrics.conf
@@ -1,11 +1,14 @@
 [metrics]
 enabled = false
 reporter.enabled = true
+
+# Enable kojiji metrics. Default false.
+#
 koji.enabled = true
 
 # Enable Infinispan metrics. Default false.
 #
-#ispn.enabled = true
+ispn.enabled = true
 
 # Specify ISPN cache gauges. This works only if ispn.enabled is true. Default All. Names are case sensitive.
 #
@@ -14,7 +17,7 @@ koji.enabled = true
 
 # Enable Galley to measure artifact downloading time. Default false.
 #
-#measure.transport = true
+measure.transport = true
 
 # Specify a repository list for those to measure artifact downloading time. This works only if
 # measure.transport is true.
@@ -27,13 +30,10 @@ koji.enabled = true
 #
 #measure.transport.repos = central
 
-######################################
-# List of enabled reporters (comma-separated)
-# At present, Indy metrics feature just support three reporters
-# GraPhiteDB,Zabbix,Console,Elasticsearch
-######################################
-
-reporter = graphite;zabbix;elasticsearch
+# List of reporters (comma-separated). At present, Indy supports reporters:
+# reporter = graphite,zabbix,elasticsearch,console
+#
+reporter = console
 
 ############################################
 # Console reporter options


### PR DESCRIPTION
I found metric is not started when I wanted to test ispn metric via console reporter. It must have been triggerred by accessing something. I added it to start-up actions. 
And I enabled transport,ispn,koji by default if the overall metric subsys is enabled in default-metric.conf. After the change, I can see ispn garges printed like:
indy.ispn.content-index.CurrentNumberOfEntries
             value = -1
indy.ispn.content-index.CurrentNumberOfEntriesInMemory
             value = -1
I also see,
healthcheck.ThreadDeadlock
             value = 1
This proves that the healthcheck impl is wrong (ref my email yesterday). I will fix it later. 