### PR TITLE
Revert ISPN to 8.2 due to persistence incompatibility

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -28,7 +28,6 @@ import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
-import org.infinispan.cdi.embedded.ConfigureCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +54,6 @@ public class ContentIndexManager
     @Inject
     private SpecialPathManager specialPathManager;
 
-    @ConfigureCache( "content-index" )
     @ContentIndexCache
     @Inject
     private CacheHandle<IndexedStorePath, IndexedStorePath> contentIndex;

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
@@ -28,7 +28,6 @@ import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.measure.annotation.MetricNamed;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.infinispan.Cache;
-import org.infinispan.cdi.embedded.ConfigureCache;
 import org.infinispan.query.Search;
 import org.infinispan.query.dsl.Query;
 import org.infinispan.query.dsl.QueryBuilder;
@@ -54,7 +53,6 @@ public class FoloRecordCache
     @Inject
     private CacheHandle<TrackedContentEntry, TrackedContentEntry> inProgressRecordCache;
 
-    @ConfigureCache("folo-sealed")
     @FoloSealedCache
     @Inject
     private CacheHandle<TrackingKey, TrackedContent> sealedRecordCache;

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -32,7 +32,6 @@ import org.commonjava.maven.galley.event.FileDeletionEvent;
 import org.commonjava.maven.galley.event.FileEvent;
 import org.commonjava.maven.galley.event.FileStorageEvent;
 import org.commonjava.maven.galley.model.Transfer;
-import org.infinispan.cdi.embedded.ConfigureCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +61,6 @@ public class MetadataMergePomChangeListener
     @Inject
     private IndyFileEventManager fileEvent;
 
-    @ConfigureCache( "maven-version-metadata-cache" )
     @Inject
     @MavenVersionMetadataCache
     private CacheHandle<StoreKey, Map> versionMetadataCache;

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -58,7 +58,6 @@ import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.model.TypeMapping;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
-import org.infinispan.cdi.embedded.ConfigureCache;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -125,7 +124,6 @@ public class MavenMetadataGenerator
 
     private static final String CLASSIFIER = "classifier";
 
-    @ConfigureCache( "maven-version-metadata-cache" )
     @Inject
     @MavenVersionMetadataCache
     private CacheHandle<StoreKey, Map> versionMetadataCache;

--- a/core/src/main/java/org/commonjava/indy/core/inject/GroupMembershipLocks.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/GroupMembershipLocks.java
@@ -22,9 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Qualifier used to supply "content-metadata" cache in infinispan.xml.
- */
 @Qualifier
 @Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
 @Retention( RetentionPolicy.RUNTIME)

--- a/core/src/main/java/org/commonjava/indy/core/inject/StoreContentLocks.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/StoreContentLocks.java
@@ -22,9 +22,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Qualifier used to supply "content-metadata" cache in infinispan.xml.
- */
 @Qualifier
 @Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
 @Retention( RetentionPolicy.RUNTIME)

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/infinispan/CacheProducerMergeXmlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/infinispan/CacheProducerMergeXmlTest.java
@@ -64,13 +64,13 @@ public class CacheProducerMergeXmlTest
     public void testMerge()
             throws Exception
     {
-        assertThat( manager.getCacheConfiguration( "local" ).memory().size(), equalTo( 10000000L ) );
-        assertThat( manager.getCacheConfiguration( "koji-maven-version-metadata" ).memory().size(),
+        assertThat( manager.getCacheConfiguration( "local" ).eviction().size(), equalTo( 10000000L ) );
+        assertThat( manager.getCacheConfiguration( "koji-maven-version-metadata" ).eviction().size(),
                     equalTo( 10000000L ) );
-        assertThat( manager.getCacheConfiguration( "folo-in-progress" ).memory().size(), equalTo( 10000000L ) );
+        assertThat( manager.getCacheConfiguration( "folo-in-progress" ).eviction().size(), equalTo( 10000000L ) );
         assertThat( manager.getCacheConfiguration( "folo-sealed" ).persistence().passivation(), equalTo( false ) );
-        assertThat( manager.getCacheConfiguration( "content-index" ).memory().size(), equalTo( 10000000L ) );
-        assertThat( manager.getCacheConfiguration( "indy-nfs-owner-cache" ).memory().size(), equalTo( 10000000L ) );
+        assertThat( manager.getCacheConfiguration( "content-index" ).eviction().size(), equalTo( 10000000L ) );
+        assertThat( manager.getCacheConfiguration( "indy-nfs-owner-cache" ).eviction().size(), equalTo( 10000000L ) );
         assertThat( manager.getCacheConfiguration( "nfc" ), notNullValue() );
         assertThat( manager.getCacheConfiguration( "schedule-expire-cache" ), notNullValue() );
         assertThat( manager.getCacheConfiguration( "maven-version-metadata-cache" ), notNullValue() );

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <!-- thirdparty projects -->
     <javaVersion>1.8</javaVersion>
     <slf4j-version>1.6.1</slf4j-version>
-    <infinispanVersion>9.1.7.Final</infinispanVersion>
+    <infinispanVersion>8.2.4.Final</infinispanVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <hibernateVersion>5.8.1.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCheckRegistrySet.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCheckRegistrySet.java
@@ -65,11 +65,6 @@ public class IspnCheckRegistrySet
                    gauges.put( name( cache.getName(), CURRENT_NUMBER_OF_ENTRIES ),
                                (Gauge) () -> advancedCache.getStats().getCurrentNumberOfEntries() );
                }
-               if ( ispnGauges == null || ispnGauges.contains( CURRENT_NUMBER_OF_ENTRIES_IN_MEMORY ) )
-               {
-                   gauges.put( name( cache.getName(), CURRENT_NUMBER_OF_ENTRIES_IN_MEMORY ),
-                               (Gauge) () -> advancedCache.getStats().getCurrentNumberOfEntriesInMemory() );
-               }
                if ( ispnGauges == null || ispnGauges.contains( TOTAL_NUMBER_OF_ENTRIES ) )
                {
                    gauges.put( name( cache.getName(), TOTAL_NUMBER_OF_ENTRIES ),

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <infinispan
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="urn:infinispan:config:9.1 http://www.infinispan.org/schemas/infinispan-config-9.1.xsd"
-    xmlns="urn:infinispan:config:9.1">
+    xsi:schemaLocation="urn:infinispan:config:8.2 http://www.infinispan.org/schemas/infinispan-config-8.2.xsd"
+    xmlns="urn:infinispan:config:8.2">
 
   <cache-container default-cache="local" name="IndyCacheManager" shutdown-hook="DEFAULT" statistics="true">
     <local-cache-configuration name="local-template" statistics="true">
@@ -34,6 +34,8 @@
     <local-cache name="content-index" configuration="local-template">
       <eviction strategy="LRU" size="200000" type="COUNT"/>
     </local-cache>
+
+    <local-cache name="content-metadata" configuration="local-template"/>
 
     <local-cache name="maven-version-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
       <eviction size="10000000" type="COUNT" strategy="LRU"/>


### PR DESCRIPTION
I revert to ISPN 8.x based on the latest code, so we don't lose @ligangty 's fix for log conflict, etc. 
I also add a missing config "content-metadata" to infinispan.xml, and remove 3 "ConfigureCache" annotations (I think they are misused because we use CacheProducer to produce all ISPN caches). 