### PR TITLE
[Master][Performance] change NFC clear sequence in path promotion

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -573,7 +573,7 @@ public class PromotionManager
                              request.getSource(), tgt, request.getTarget() );
 
                 final boolean purgeSource = request.isPurgeSource();
-                contents.parallelStream().forEach( ( transfer ) -> {
+                contents.forEach( ( transfer ) -> {
                     final String path = transfer.getPath();
 
                     if ( !transfer.exists() )
@@ -706,11 +706,11 @@ public class PromotionManager
     private void clearStoreNFC( final Set<String> sourcePaths, ArtifactStore store )
             throws IndyDataException
     {
-        Set<String> paths = sourcePaths.parallelStream()
+        Set<String> paths = sourcePaths.stream()
                                        .map( sp -> sp.startsWith( "/" ) && sp.length() > 1 ? sp.substring( 1 ) : sp )
                                        .collect( Collectors.toSet() );
 
-        paths.parallelStream().forEach( path -> {
+        paths.forEach( path -> {
             ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( store ), path );
 
             logger.debug( "Clearing NFC path: {} from: {}\n\tResource: {}", path, store.getKey(), resource );
@@ -720,7 +720,7 @@ public class PromotionManager
         Set<Group> groups = storeManager.query().getGroupsAffectedBy( store.getKey() );
         if ( groups != null )
         {
-            groups.parallelStream().forEach( group -> paths.forEach(
+            groups.forEach( group -> paths.forEach(
                     path -> {
                         ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( group ), path );
 


### PR DESCRIPTION
  Seems that currently we clear nfc each time for a transfer promote,
but I think we can clear that after all transfer promotion done for once
in a bundle.
  And I changed some of the collection stream to use parallel stream to
see if that helps enhance performance.