### PR TITLE
Fix NFC timeout bug which caused entry to be removed incorrectly

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/inject/IspnNotFoundCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/IspnNotFoundCache.java
@@ -106,7 +106,7 @@ public class IspnNotFoundCache
         {
             timeout = System.currentTimeMillis() + ( timeoutInSeconds * 1000 );
         }
-        logger.debug( "[NFC] '{}' will not be checked again until {}", resource,
+        logger.debug( "[NFC] {} will not be checked again until {}", resource,
                       new SimpleDateFormat( TIMEOUT_FORMAT ).format( new Date( timeout ) ) );
 
         final String key = getResourceKey( resource );
@@ -120,12 +120,13 @@ public class IspnNotFoundCache
     {
         String key = getResourceKey( resource );
         NfcConcreteResourceWrapper obj = nfcCache.get( key );
-        boolean missing = ( obj != null && obj.getTimeout() > System.currentTimeMillis() );
-        if ( obj != null && missing )
+        boolean timeout = ( obj != null && obj.getTimeout() < System.currentTimeMillis() );
+        boolean missing = ( obj != null && !timeout );
+        if ( timeout )
         {
             nfcCache.remove( key );
         }
-        logger.debug( "NFC check: {} result is: {}", resource, missing );
+        logger.trace( "NFC check: {}, obj: {}, timeout: {}, missing: {}", resource, obj, timeout, missing );
         return missing;
     }
 


### PR DESCRIPTION
This is my bug. :( The old code removed NFC entry when it is "missing" (It should not. It should only remove it when "timeout"). This bug caused NFC malfunction and made the retrievals very slow. 