### PR TITLE
 [Prefetch] Use path mask firstly if repo has path mask patterns

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/prefetch/KojiContentListBuilder.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/prefetch/KojiContentListBuilder.java
@@ -57,9 +57,17 @@ public class KojiContentListBuilder
             return Collections.emptyList();
         }
         Set<String> paths = repository.getPathMaskPatterns();
-        return paths.stream()
-                    .map( p -> new StoreResource( LocationUtils.toLocation( repository ), p ) )
-                    .collect( Collectors.toList() );
+        // Koji list builder only cares paths in the path masks
+        if ( paths != null && !paths.isEmpty() )
+        {
+            return paths.stream()
+                        .map( p -> new StoreResource( LocationUtils.toLocation( repository ), p ) )
+                        .collect( Collectors.toList() );
+        }
+        else
+        {
+            return Collections.emptyList();
+        }
     }
 
     @Override

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -29,7 +29,6 @@ import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.measure.annotation.MetricNamed;
-import org.commonjava.indy.model.core.AbstractRepository;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
@@ -71,7 +70,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.ConcurrentHashMap;
@@ -207,7 +205,7 @@ public class DefaultDownloadManager
         }
         else
         {
-            if ( ! checkListingMask( store, path ) )
+            if ( ! PathMaskChecker.checkListingMask( store, path ) )
             {
                 return result; // if list not permitted for the path, return empty list
             }
@@ -460,7 +458,7 @@ public class DefaultDownloadManager
             return null;
         }
 
-        if ( !checkMask(store, path))
+        if ( !PathMaskChecker.checkMask( store, path))
         {
             return null;
         }
@@ -526,7 +524,7 @@ public class DefaultDownloadManager
     public boolean exists(final ArtifactStore store, String path)
             throws IndyWorkflowException
     {
-        if ( !checkMask( store, path ) )
+        if ( !PathMaskChecker.checkMask( store, path ) )
         {
             return false;
         }
@@ -1184,91 +1182,6 @@ public class DefaultDownloadManager
         return null;
     }
 
-    // path mask checking
-    private boolean checkListingMask( final ArtifactStore store, final String path )
-    {
-        if ( !( store instanceof AbstractRepository ) )
-        {
-            return true;
-        }
-
-        AbstractRepository repo = (AbstractRepository) store;
-        Set<String> maskPatterns = repo.getPathMaskPatterns();
-
-        logger.trace( "Checking mask in: {}, type: {}", repo.getName(), repo.getKey().getType() );
-        logger.trace( "Mask patterns in {}: {}", repo.getName(), maskPatterns );
-
-        if (maskPatterns == null || maskPatterns.isEmpty())
-        {
-            logger.trace( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
-            return true;
-        }
-
-        for ( String pattern : maskPatterns )
-        {
-            if ( isRegexPattern( pattern ) )
-            {
-                // if there is a regexp pattern we cannot check presence of directory listing, because we would have to
-                // check only the beginning of the regexp and that's impossible, so we have to assume that the path is
-                // present
-                return true;
-            }
-        }
-
-        for ( String pattern : maskPatterns )
-        {
-            if ( path.startsWith( pattern ) || pattern.startsWith( path ) )
-            {
-                logger.trace( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
-                return true;
-            }
-        }
-        return false;
-    }
-
-    // slightly different from checkListingMask in that for regex pattern the pattern.match() is called
-    private boolean checkMask( final ArtifactStore store, final String path )
-    {
-        if ( !( store instanceof AbstractRepository ) )
-        {
-            return true;
-        }
-
-        AbstractRepository repo = (AbstractRepository) store;
-        Set<String> maskPatterns = repo.getPathMaskPatterns();
-
-        logger.trace( "Checking mask in: {}, type: {}", repo.getName(), repo.getKey().getType() );
-        logger.trace( "Mask patterns in {}: {}", repo.getName(), maskPatterns );
-
-        if (maskPatterns == null || maskPatterns.isEmpty())
-        {
-            logger.trace( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
-            return true;
-        }
-
-        for ( String pattern : maskPatterns )
-        {
-            // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
-            if ( isRegexPattern( pattern ) )
-            {
-                if ( path.matches( pattern.substring( 2, pattern.length() - 1 ) ) )
-                {
-                    return true;
-                }
-            }
-            else if ( path.startsWith( pattern ) )
-            {
-                logger.trace( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean isRegexPattern( String pattern )
-    {
-        return pattern != null && pattern.startsWith( "r|" ) && pattern.endsWith( "|" );
-    }
 
     private void fireIndyStoreErrorEvent( TransferLocationException e )
     {

--- a/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.content;
+
+import org.commonjava.indy.model.core.AbstractRepository;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+public class PathMaskChecker
+{
+    private static final Logger logger = LoggerFactory.getLogger( PathMaskChecker.class );
+
+    // slightly different from checkListingMask in that for regex pattern the pattern.match() is called
+    public static boolean checkMask( final ArtifactStore store, final String path )
+    {
+        if ( !( store instanceof AbstractRepository ) )
+        {
+            return true;
+        }
+
+        AbstractRepository repo = (AbstractRepository) store;
+
+        return checkMask( repo, path );
+    }
+
+    public static boolean checkMask(final AbstractRepository repo, final String path){
+        Set<String> maskPatterns = repo.getPathMaskPatterns();
+
+        logger.trace( "Checking mask in: {}, type: {}", repo.getName(), repo.getKey().getType() );
+        logger.trace( "Mask patterns in {}: {}", repo.getName(), maskPatterns );
+
+        if (maskPatterns == null || maskPatterns.isEmpty())
+        {
+            logger.trace( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
+            return true;
+        }
+
+        for ( String pattern : maskPatterns )
+        {
+            // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
+            if ( isRegexPattern( pattern ) )
+            {
+                if ( path.matches( pattern.substring( 2, pattern.length() - 1 ) ) )
+                {
+                    return true;
+                }
+            }
+            else if ( path.startsWith( pattern ) )
+            {
+                logger.trace( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
+                return true;
+            }
+        }
+
+        logger.debug( "Path {} not available in path mask {} of repo {}", path, maskPatterns, repo );
+
+        return false;
+    }
+
+    // path mask checking
+    public static boolean checkListingMask( final ArtifactStore store, final String path )
+    {
+        if ( !( store instanceof AbstractRepository ) )
+        {
+            return true;
+        }
+
+        AbstractRepository repo = (AbstractRepository) store;
+        Set<String> maskPatterns = repo.getPathMaskPatterns();
+
+        logger.trace( "Checking mask in: {}, type: {}", repo.getName(), repo.getKey().getType() );
+        logger.trace( "Mask patterns in {}: {}", repo.getName(), maskPatterns );
+
+        if (maskPatterns == null || maskPatterns.isEmpty())
+        {
+            logger.trace( "Checking mask in: {}, - NO PATTERNS", repo.getName() );
+            return true;
+        }
+
+        for ( String pattern : maskPatterns )
+        {
+            if ( isRegexPattern( pattern ) )
+            {
+                // if there is a regexp pattern we cannot check presence of directory listing, because we would have to
+                // check only the beginning of the regexp and that's impossible, so we have to assume that the path is
+                // present
+                return true;
+            }
+        }
+
+        for ( String pattern : maskPatterns )
+        {
+            if ( path.startsWith( pattern ) || pattern.startsWith( path ) )
+            {
+                logger.trace( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
+                return true;
+            }
+        }
+
+        logger.debug( "Listing for path {} not enabled by path mask {} of repo {}", path, maskPatterns, repo );
+
+        return false;
+    }
+
+    public static boolean isRegexPattern( String pattern )
+    {
+        return pattern != null && pattern.startsWith( "r|" ) && pattern.endsWith( "|" );
+    }
+}

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -144,7 +144,12 @@ public abstract class AbstractIndyFunctionalTest
 
     protected void waitForEventPropagation()
     {
-        long ms = 1000 * getTestTimeoutMultiplier();
+        waitForEventPropagationWithMultiplier( getTestTimeoutMultiplier() );
+    }
+
+    protected void waitForEventPropagationWithMultiplier( int multiplier )
+    {
+        long ms = 1000 * multiplier;
 
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.info( "Waiting {}ms for Indy server events to clear.", ms );
@@ -156,7 +161,7 @@ public abstract class AbstractIndyFunctionalTest
         catch ( InterruptedException e )
         {
             e.printStackTrace();
-            fail( "Thread interrupted while waiting for server events to propagate.");
+            fail( "Thread interrupted while waiting for server events to propagate." );
         }
 
         logger.info( "Resuming test" );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/prefetch/AbstractRemotePrefetchTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/prefetch/AbstractRemotePrefetchTest.java
@@ -52,4 +52,10 @@ public abstract class AbstractRemotePrefetchTest
         super.initTestConfig( fixture );
         writeConfigFile( "conf.d/threadpools.conf", "[threadpools]\nenabled=true" );
     }
+
+    @Override
+    protected int getTestTimeoutMultiplier()
+    {
+        return 2;
+    }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/prefetch/RemotePrefetchDisableTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/prefetch/RemotePrefetchDisableTest.java
@@ -136,9 +136,7 @@ public class RemotePrefetchDisableTest
         remote1.setPrefetchListingType( RemoteRepository.PREFETCH_LISTING_TYPE_HTML );
         remote1.setPrefetchPriority( 1 );
         client.stores().update( remote1, "change prefetch priority" );
-
-        Thread.sleep( 2000 );
-
+        waitForEventPropagationWithMultiplier( 2 );
         assertThat( fileMeta.exists(), equalTo( false ) );
         assertThat( fileJar.exists(), equalTo( false ) );
         assertThat( fileSrc.exists(), equalTo( false ) );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/prefetch/RemotePrefetchDownloadWithPathMaskPlaintextTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/prefetch/RemotePrefetchDownloadWithPathMaskPlaintextTest.java
@@ -23,6 +23,8 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.commonjava.indy.model.core.StoreType.remote;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
@@ -36,29 +38,24 @@ import static org.junit.Assert.assertThat;
  *     <li>The external repo has hierarchy dirs with each html page listing</li>
  *     <li>The external repo has 3 files in different dirs</li>
  *     <li>The indy remote is not set with prefetch enabled</li>
- *     <li>The indy prefetch rescan interval set to 5s</li>
  * </ul>
  *
  * <br/>
  * <b>WHEN:</b>
  * <ul>
- *     <li>1. The indy remote repo is updated with prefetch enabled</li>
- *     <li>2. The indy remote repo is updated with prefetch rescan enabled</li>
- *     <li>3. The external repo added new files after a while(4~5s)</li>
+ *     <li>The indy remote repo is updated with plaintext path masks</li>
+ *     <li>The indy remote repo is updated with prefetch enabled (prefetch priority changed to positive number)</li>
  * </ul>
  *
  * <br/>
  * <b>THEN:</b>
  * <ul>
- *     <li>The old remote files will be downloaded automatically after a while without an explicit retrieve through API.(Means by background prefetch)</li>
- *     <li>The new added files will not be downloaded before interval(5s)</li>
- *     <li>After 10s the new added files will be downloaded</li>
+ *     <li>Only the files match the path mask will be downloaded automatically after a while without an explicit retrieve through API.</li>
  * </ul>
  */
-public class RemotePrefetchRescanTest
+public class RemotePrefetchDownloadWithPathMaskPlaintextTest
         extends AbstractRemotePrefetchTest
 {
-
     @Test
     public void run()
             throws Exception
@@ -67,13 +64,10 @@ public class RemotePrefetchRescanTest
         final String pathOrg = "org/";
         final String pathFoo = pathOrg + "foo/";
         final String pathBar = pathFoo + "bar/";
+        final String pathVer = pathBar + "1.0/";
         final String pathMeta = pathBar + "maven-metadata.xml";
-        final String pathVer1 = pathBar + "1.0/";
-        final String pathJar1 = pathVer1 + "foo-bar-1.0.jar";
-        final String pathSrc1 = pathVer1 + "foo-bar-1.0-sources.jar";
-        final String pathVer2 = pathBar + "2.0/";
-        final String pathJar2 = pathVer2 + "foo-bar-2.0.jar";
-        final String pathSrc2 = pathVer2 + "foo-bar-2.0-sources.jar";
+        final String pathJar = pathVer + "foo-bar-1.0.jar";
+        final String pathSrc = pathVer + "foo-bar-1.0-sources.jar";
 
         // @formatter:off
         final String rootHtml = "<!DOCTYPE html><html><body>"
@@ -98,7 +92,7 @@ public class RemotePrefetchRescanTest
                 + "<a href=\"foo-bar-1.0.jar\" title=\"foo-bar-1.0.jar\">foo-bar-1.0.jar</a>"
                 + "<a href=\"foo-bar-1.0-sources.jar\" title=\"foo-bar-1.0-sources.jar\">foo-bar-1.0-sources.jar</a>"
                 + "</body></html>";
-        final String contentMeta1 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        final String contentMeta = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
                                     + "<metadata>"
                                     + "<groupId>org.foo</groupId>"
                                     + "<artifactId>bar</artifactId>"
@@ -111,23 +105,25 @@ public class RemotePrefetchRescanTest
                                     + "<lastUpdated>20150722164334</lastUpdated>"
                                     + "</versioning>"
                                     + "</metadata>";
-        final String contentJar1 = "This is content for jar1";
-        final String contentSrc1 = "This is content for src1";
-        final String contentJar2 = "This is content for jar2";
-        final String contentSrc2 = "This is content for src2";
+        final String contentJar = "This is content for jar";
+        final String contentSrc = "This is content for src";
         // @formatter:on
 
         server.expect( server.formatUrl( repo1, "/" ), 200, rootHtml );
         server.expect( server.formatUrl( repo1, pathOrg ), 200, orgHtml );
         server.expect( server.formatUrl( repo1, pathFoo ), 200, fooHtml );
         server.expect( server.formatUrl( repo1, pathBar ), 200, barHtml );
-        server.expect( server.formatUrl( repo1, pathVer1 ), 200, verHtml );
-        server.expect( server.formatUrl( repo1, pathMeta ), 200, contentMeta1 );
-        server.expect( server.formatUrl( repo1, pathJar1 ), 200, contentJar1 );
-        server.expect( server.formatUrl( repo1, pathSrc1 ), 200, contentSrc1 );
+        server.expect( server.formatUrl( repo1, pathVer ), 200, verHtml );
+        server.expect( server.formatUrl( repo1, pathMeta ), 200, contentMeta );
+        server.expect( server.formatUrl( repo1, pathJar ), 200, contentJar );
+        server.expect( server.formatUrl( repo1, pathSrc ), 200, contentSrc );
 
         RemoteRepository remote1 =
                 new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, repo1, server.formatUrl( repo1 ) );
+        Set<String> pathMasks = new HashSet<>( 1 );
+        pathMasks.add( "org/foo/bar/1.0/foo-bar-1.0.jar" );
+        pathMasks.add( "org/foo/bar/1.0/foo-bar-1.0-sources.jar" );
+        remote1.setPathMaskPatterns( pathMasks );
         client.stores().create( remote1, "adding remote", RemoteRepository.class );
 
         System.out.println( String.format( "Indy HOME:%s", fixture.getBootOptions().getIndyHome() ) );
@@ -135,91 +131,33 @@ public class RemotePrefetchRescanTest
         File fileMeta = Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage", MAVEN_PKG_KEY,
                                    remote.singularEndpointName() + "-" + repo1, pathMeta ).toFile();
         File fileJar = Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage", MAVEN_PKG_KEY,
-                                  remote.singularEndpointName() + "-" + repo1, pathJar1 ).toFile();
+                                  remote.singularEndpointName() + "-" + repo1, pathJar ).toFile();
         File fileSrc = Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage", MAVEN_PKG_KEY,
-                                  remote.singularEndpointName() + "-" + repo1, pathSrc1 ).toFile();
-        File fileJar2 = Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage", MAVEN_PKG_KEY,
-                                  remote.singularEndpointName() + "-" + repo1, pathJar2 ).toFile();
-        File fileSrc2 = Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage", MAVEN_PKG_KEY,
-                                  remote.singularEndpointName() + "-" + repo1, pathSrc2 ).toFile();
-
+                                  remote.singularEndpointName() + "-" + repo1, pathSrc ).toFile();
 
         assertThat( fileMeta.exists(), equalTo( false ) );
         assertThat( fileJar.exists(), equalTo( false ) );
         assertThat( fileSrc.exists(), equalTo( false ) );
-        assertThat( fileJar2.exists(), equalTo( false ) );
-        assertThat( fileSrc2.exists(), equalTo( false ) );
-
 
         remote1.setPrefetchListingType( RemoteRepository.PREFETCH_LISTING_TYPE_HTML );
         remote1.setPrefetchPriority( 1 );
-        remote1.setPrefetchRescan( true );
         client.stores().update( remote1, "change prefetch priority" );
-        waitForEventPropagationWithMultiplier( 2 );
-        assertThat( fileMeta.exists(), equalTo( true ) );
+        waitForEventPropagation();
         assertThat( fileJar.exists(), equalTo( true ) );
         assertThat( fileSrc.exists(), equalTo( true ) );
-        assertContent( fileMeta, contentMeta1 );
-        assertContent( fileJar, contentJar1 );
-        assertContent( fileSrc, contentSrc1 );
-        assertThat( fileJar2.exists(), equalTo( false ) );
-        assertThat( fileSrc2.exists(), equalTo( false ) );
-
-        waitForEventPropagationWithMultiplier( 2 );
-
-        // @formatter:off
-        final String bar2Html="<!DOCTYPE html><html><body>"
-                + "<a href=\"../\">../</a>"
-                + "<a href=\"1.0/\" title=\"1.0/\">1.0/</a>"
-                + "<a href=\"2.0/\" title=\"2.0/\">2.0/</a>"
-                + "<a href=\"maven-metadata.xml\" title=\"maven-metadata.xml\">maven-metadata.xml</a>"
-                + "</body></html>";
-        final String ver2Html="<!DOCTYPE html><html><body>"
-                + "<a href=\"../\">../</a>"
-                + "<a href=\"foo-bar-2.0.jar\" title=\"foo-bar-2.0.jar\">foo-bar-2.0.jar</a>"
-                + "<a href=\"foo-bar-2.0-sources.jar\" title=\"foo-bar-2.0-sources.jar\">foo-bar-2.0-sources.jar</a>"
-                + "</body></html>";
-        final String contentMeta2 = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<metadata>"
-                + "<groupId>org.foo</groupId>"
-                + "<artifactId>bar</artifactId>"
-                + "<versioning>"
-                + "<latest>2.0</latest>"
-                + "<release>2.0</release>"
-                + "<versions>"
-                + "<version>1.0</version>"
-                + "<version>2.0</version>"
-                + "</versions>"
-                + "<lastUpdated>20160921184754</lastUpdated>"
-                + "</versioning>"
-                + "</metadata>";
-        // @formatter:on
-
-        server.expect( server.formatUrl( repo1, pathBar ), 200, bar2Html );
-        server.expect( server.formatUrl( repo1, pathVer2 ), 200, ver2Html );
-        server.expect( server.formatUrl( repo1, pathMeta ), 200, contentMeta2 );
-        server.expect( server.formatUrl( repo1, pathJar2 ), 200, contentJar2 );
-        server.expect( server.formatUrl( repo1, pathSrc2 ), 200, contentSrc2 );
-
-        waitForEventPropagationWithMultiplier( 6 );
-
-        assertThat( fileJar.exists(), equalTo( true ) );
-        assertThat( fileSrc.exists(), equalTo( true ) );
-        assertContent( fileJar, contentJar1 );
-        assertContent( fileSrc, contentSrc1 );
-        assertThat( fileJar2.exists(), equalTo( true ) );
-        assertThat( fileSrc2.exists(), equalTo( true ) );
-        assertThat( fileMeta.exists(), equalTo( true ) );
-        assertContent( fileJar2, contentJar2 );
-        assertContent( fileSrc2, contentSrc2 );
-        assertContent( fileMeta, contentMeta2 );
+        assertContent( fileJar, contentJar );
+        assertContent( fileSrc, contentSrc );
+        assertThat( fileMeta.exists(), equalTo( false ) );
     }
+
+
 
     @Override
     protected void initTestConfig( CoreServerFixture fixture )
             throws IOException
     {
         super.initTestConfig( fixture );
-        writeConfigFile( "conf.d/prefetch.conf", "[prefetch]\nenabled=true\nprefetch.batchsize=3\nprefetch.rescan.interval.seconds=5" );
+        writeConfigFile( "conf.d/prefetch.conf", "[prefetch]\nenabled=true\nprefetch.batchsize=3" );
     }
+
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/prefetch/RemotePrefetchDownloadingTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/prefetch/RemotePrefetchDownloadingTest.java
@@ -59,8 +59,6 @@ public class RemotePrefetchDownloadingTest
     public void run()
             throws Exception
     {
-        final int THREAD_SLEEP_INTERVAL = 1000;
-
         final String repo1 = "repo1";
         final String pathOrg = "org/";
         final String pathFoo = pathOrg + "foo/";
@@ -139,7 +137,7 @@ public class RemotePrefetchDownloadingTest
         // Only when prefetch priority change to positive number will trigger prefetch
         remote1.setNfcTimeoutSeconds( 120 );
         client.stores().update( remote1, "change nfc timeout" );
-        Thread.sleep( THREAD_SLEEP_INTERVAL );
+        waitForEventPropagation();
         assertThat( fileMeta.exists(), equalTo( false ) );
         assertThat( fileJar.exists(), equalTo( false ) );
         assertThat( fileSrc.exists(), equalTo( false ) );
@@ -147,7 +145,7 @@ public class RemotePrefetchDownloadingTest
         remote1.setPrefetchListingType( RemoteRepository.PREFETCH_LISTING_TYPE_HTML );
         remote1.setPrefetchPriority( 1 );
         client.stores().update( remote1, "change prefetch priority" );
-        Thread.sleep( THREAD_SLEEP_INTERVAL );
+        waitForEventPropagation();
         assertThat( fileMeta.exists(), equalTo( true ) );
         assertThat( fileJar.exists(), equalTo( true ) );
         assertThat( fileSrc.exists(), equalTo( true ) );
@@ -155,8 +153,6 @@ public class RemotePrefetchDownloadingTest
         assertContent( fileJar, contentJar );
         assertContent( fileSrc, contentSrc );
     }
-
-
 
     @Override
     protected void initTestConfig( CoreServerFixture fixture )

--- a/subsys/prefetch/pom.xml
+++ b/subsys/prefetch/pom.xml
@@ -18,6 +18,10 @@
       <artifactId>indy-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.maven.galley</groupId>
       <artifactId>galley-api</artifactId>
     </dependency>


### PR DESCRIPTION
We should care about path mask cases for prefetch. This PR will give this:
* If a remote repo contains some regex styled path masks, it will still use the root path as the initial start point of downloading
* If a remote repo only contains plaintext styled path masks, will directly use the path masks as the downloading list.
* Whatever path masks the repo has, if it has, the prefetcher will only download the path mask permitted artifacts.