### PR TITLE
Fix metrics reporter filters to align with metric name change

### DIFF
--- a/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/jaxrs/MetricsTestResource.java
+++ b/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/jaxrs/MetricsTestResource.java
@@ -52,7 +52,7 @@ public class MetricsTestResource
     @Path( "/metricRegistry/timer" )
     public Response getTimerCount()
     {
-        Timer timer = metricRegistry.timer( "testTimerRequest" );
+        Timer timer = metricRegistry.timer( "testTimerRequest.timer" );
         return Response.ok( timer.getCount(), MediaType.APPLICATION_JSON ).build();
     }
 
@@ -76,7 +76,7 @@ public class MetricsTestResource
     @Path( "/metricRegistry/meter" )
     public Response getMeterCount()
     {
-        Meter meter = metricRegistry.meter( "testMeterRequest" );
+        Meter meter = metricRegistry.meter( "testMeterRequest.meter" );
         return Response.ok( meter.getCount(), MediaType.APPLICATION_JSON ).build();
     }
 

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
@@ -75,7 +75,7 @@ public class MetricsInterceptor
 
         List<Timer.Context> timers = Stream.of( measure.timers() ).map( named ->
                                         {
-                                            String name = getName( nodePrefix, named, defaultName );
+                                            String name = getName( nodePrefix, named, defaultName, TIMER );
                                             Timer.Context tc = metricsManager.getTimer( name ).time();
                                             logger.trace( "START: {} ({})", name, tc );
                                             return tc;
@@ -110,7 +110,7 @@ public class MetricsInterceptor
             }
             Stream.of( measure.meters() ).forEach( ( named ) ->
                                         {
-                                            String name = getName( nodePrefix, named, defaultName );
+                                            String name = getName( nodePrefix, named, defaultName, METER );
                                             Meter meter = metricsManager.getMeter( name );
                                             logger.trace( "CALLS++ {}", name );
                                             meter.mark();
@@ -134,19 +134,14 @@ public class MetricsInterceptor
      * @param named user specified name
      * @param defaultName 'class name + method name', not null.
      */
-    private String getName( String nodePrefix, MetricNamed named, String defaultName )
+    private String getName( String nodePrefix, MetricNamed named, String defaultName, String suffix )
     {
         String name = named.value();
         if ( isBlank( name ) || name.equals( DEFAULT ) )
         {
             name = defaultName;
         }
-        return name( nodePrefix, name );
-    }
-
-    private String getName( String nodePrefix, MetricNamed named, String defaultName, String suffix )
-    {
-        return name( getName( nodePrefix, named, defaultName ), suffix );
+        return name( nodePrefix, name, suffix );
     }
 
 }


### PR DESCRIPTION
The old reporter assumes names begin with "org.commonjava.indy". But 1.3 changed to short names. This causes "no point" error in Grafana.