### PR TITLE
Add git hooks folder to store git hooks for indy

### DIFF
--- a/scripts/git-hooks/README.md
+++ b/scripts/git-hooks/README.md
@@ -1,0 +1,12 @@
+# Useful git-hooks for project
+
+This setup intends to keep git hooks for indy project
+
+## Installing
+
+Copy all files in "hooks" folder to your local .git/hooks
+
+## Hooks functions:
+
+* pre-push: Added some script to forbid direct push to upstream indy repo. We need to ensure this to avoid misoperations 
+

--- a/scripts/git-hooks/hooks/pre-push
+++ b/scripts/git-hooks/hooks/pre-push
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# An example hook script to verify what is about to be pushed.  Called by "git
+# push" after it has checked the remote status, but before anything has been
+# pushed.  If this script exits with a non-zero status nothing will be pushed.
+#
+# This hook is called with the following parameters:
+#
+# $1 -- Name of the remote to which the push is being done
+# $2 -- URL to which the push is being done
+#
+# If pushing without using a named remote those arguments will be equal.
+#
+# Information about the commits which are being pushed is supplied as lines to
+# the standard input in the form:
+#
+#   <local ref> <local sha1> <remote ref> <remote sha1>
+#
+# This script prevented to push of commits directly to upstream indy remote repo(git@github.com:commonjava/indy.git),
+# which will be done sometimes as misoperations
+
+remote="$1"
+url="$2"
+
+z40=0000000000000000000000000000000000000000
+
+while read local_ref local_sha remote_ref remote_sha
+do
+	if [ "$local_sha" = $z40 ]
+	then
+		# Handle delete
+		:
+	else
+		if [ "$remote_sha" = $z40 ]
+		then
+			# New branch, examine all commits
+			range="$local_sha"
+		else
+			# Update to existing branch, examine new commits
+			range="$remote_sha..$local_sha"
+		fi
+		# Check for WIP commit
+		if [[ $remote = *'upstream'* ]] || [[ $remote =~ ^git@github.com:[c|C]ommonjava/[i|I]ndy.git$ ]] || [[ $url =~ ^git@github.com:[c|C]ommonjava/[i|I]ndy.git$ ]]
+		then
+			echo >&2 "Direct push to $remote is forbidden, not pushing"
+			exit 1
+		fi
+	fi
+done
+
+exit 0


### PR DESCRIPTION
Want to share some git hooks, so we can use it to do some git control actions, like misoperation to push directly to upstream indy repo.
If we have some other useful git hooks files, we can also keep it in scripts/git-hooks/hooks folder which I added in this PR