### PR TITLE
Add API to clean infinispan cache

### DIFF
--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
@@ -22,6 +22,7 @@ import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAV
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
+import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
@@ -34,6 +35,7 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.core.ctl.ContentController;
+import org.commonjava.indy.core.ctl.IspnCacheController;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.slf4j.Logger;
@@ -167,6 +169,30 @@ public class MaintenanceHandler
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to delete: %s in: ALL. Reason: %s", e.getMessage() ), e );
+            response = formatResponse( e );
+        }
+        return response;
+    }
+
+    @Inject
+    private IspnCacheController ispnCacheController;
+
+    @ApiOperation( "Clean the specified Infinispan cache." )
+    @ApiResponse( code = 200, message = "Clean complete." )
+    @Path( "/infinispan/cache/{name}" )
+    @DELETE
+    public Response cleanInfinispanCache(
+                    @ApiParam( "The name of cache to clean, 'all' for all caches" ) @PathParam( "name" ) final String name )
+    {
+        Response response;
+        try
+        {
+            ispnCacheController.clean( name );
+            response = Response.ok().build();
+        }
+        catch ( final IndyWorkflowException e )
+        {
+            logger.error( String.format( "Failed to clean: %s. Reason: %s", name, e.getMessage() ), e );
             response = formatResponse( e );
         }
         return response;

--- a/core/src/main/java/org/commonjava/indy/core/ctl/IspnCacheController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/IspnCacheController.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.ctl;
+
+import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.subsys.infinispan.CacheProducer;
+import org.infinispan.Cache;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Set;
+
+@ApplicationScoped
+public class IspnCacheController
+{
+    public static final String ALL_CACHES = "all";
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private CacheProducer cacheProducer;
+
+    private EmbeddedCacheManager cacheManager;
+
+    @PostConstruct
+    private void setUp()
+    {
+        cacheManager = cacheProducer.getCacheManager();
+    }
+
+    public void clean( String name ) throws IndyWorkflowException
+    {
+        if ( ALL_CACHES.equals( name ) ) // clean all caches
+        {
+            Set<String> names = cacheManager.getCacheNames();
+            names.forEach( ( n ) -> cacheManager.getCache( n ).clear() );
+            return;
+        }
+
+        // clean named cache
+        Cache<Object, Object> cache = cacheManager.getCache( name );
+        if ( cache == null )
+        {
+            throw new IndyWorkflowException( "Cache not found, name: " + name );
+        }
+        cache.clear();
+    }
+}


### PR DESCRIPTION
I tested it manually. First I use curl to produce an NFC entry, then use the new API "curl -X DELETE http://localhost:8080/api/admin/maint/infinispan/cache/nfc" to clean it. At last, go look from UI and the entry is removed. 