### PR TITLE
Fix for Indy client core 1.3 cannot authenticate

### DIFF
--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.client.core.helper.HttpResources.cleanupResources;
 import static org.commonjava.indy.client.core.helper.HttpResources.entityToString;
@@ -81,9 +82,7 @@ public class IndyClientHttp
 
     private final String baseUrl;
 
-    private final String apiVersion;
-
-    private List<Header> defaultHeaders = new ArrayList();
+    private List<Header> defaultHeaders;
 
     public IndyClientHttp( final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper,
                            SiteConfig location, String apiVersion )
@@ -91,10 +90,9 @@ public class IndyClientHttp
     {
         this.objectMapper = mapper;
         this.location = location;
-        this.apiVersion = apiVersion;
         baseUrl = location.getUri();
         checkBaseUrl( baseUrl );
-        setDefaultHeaders();
+        addApiVersionHeader( apiVersion );
 
         factory = new HttpFactory( authenticator );
     }
@@ -105,20 +103,18 @@ public class IndyClientHttp
     {
         this.objectMapper = mapper;
         this.location = location;
-        this.apiVersion = apiVersion;
         baseUrl = location.getUri();
         checkBaseUrl( baseUrl );
-        setDefaultHeaders();
+        addApiVersionHeader( apiVersion );
 
         factory = new HttpFactory( passwordManager );
     }
 
-    private void setDefaultHeaders()
+    private void addApiVersionHeader( String apiVersion )
     {
-        if ( apiVersion != null )
+        if ( isNotBlank( apiVersion ) )
         {
-            Header header = new BasicHeader( HEADER_INDY_API_VERSION, apiVersion );
-            defaultHeaders.add( header );
+            addDefaultHeader( HEADER_INDY_API_VERSION, apiVersion );
         }
     }
 
@@ -891,6 +887,10 @@ public class IndyClientHttp
 
     public void addDefaultHeader( String key, String value )
     {
+        if ( defaultHeaders == null )
+        {
+            defaultHeaders = new ArrayList<>();
+        }
         defaultHeaders.add( new BasicHeader( key, value ) );
     }
 }

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/auth/OAuth20BearerTokenAuthenticator.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/auth/OAuth20BearerTokenAuthenticator.java
@@ -15,12 +15,16 @@
  */
 package org.commonjava.indy.client.core.auth;
 
+import java.io.IOException;
 import java.net.URL;
-import java.util.Collections;
 
 import org.apache.http.Header;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.util.jhttpc.JHttpCException;
 
@@ -52,11 +56,19 @@ public class OAuth20BearerTokenAuthenticator
     }
 
     @Override
-    public HttpClientBuilder decorateClientBuilder(HttpClientBuilder builder)
-            throws JHttpCException
+    public HttpClientBuilder decorateClientBuilder( HttpClientBuilder builder ) throws JHttpCException
     {
-        final Header header = new BasicHeader( AUTHORIZATION_HEADER, String.format( BEARER_FORMAT, token ) );
-        return builder.setDefaultHeaders( Collections.<Header> singleton( header ) );
+        builder.addInterceptorFirst( new HttpRequestInterceptor()
+        {
+            @Override
+            public void process( HttpRequest httpRequest, HttpContext httpContext ) throws HttpException, IOException
+            {
+                final Header header = new BasicHeader( AUTHORIZATION_HEADER, String.format( BEARER_FORMAT, token ) );
+                httpRequest.addHeader( header );
+            }
+        } );
+
+        return builder;
     }
 
 }


### PR DESCRIPTION
OAuth uses defaultHeaders to add the Bearer header. However, this will be overridden if the user set other default headers. The fix is in OAuth20BearerTokenAuthenticator where I use a single request interceptor.