### PR TITLE
reimplement more comprehensive cache warming

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -164,7 +164,7 @@ public class ContentIndexManager
             keySet.forEach( (key)->{
                 IndexedStorePath isp = new IndexedStorePath( key, originKey, path );
                 logger.trace( "Indexing path: {} in: {} via member: {}", path, key, originKey );
-                contentIndex.put( isp, isp );
+                contentIndex.put( isp, origin );
             } );
     }
 

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -164,7 +164,7 @@ public class ContentIndexManager
             keySet.forEach( (key)->{
                 IndexedStorePath isp = new IndexedStorePath( key, originKey, path );
                 logger.trace( "Indexing path: {} in: {} via member: {}", path, key, originKey );
-                contentIndex.put( isp, origin );
+                contentIndex.put( isp, isp );
             } );
     }
 
@@ -190,7 +190,7 @@ public class ContentIndexManager
 
     /**
      * <b>NOT Recursive</b>. This assumes you've recursed the group membership structure beforehand, using
-     * {@link StoreDataManager#getGroupsAffectedBy(Collection)} to find the set of {@link Group} instances for which
+     * {@link StoreDataManager#query()#getGroupsAffectedBy(Collection)} to find the set of {@link Group} instances for which
      * the path should be cleared.
      */
     public void clearIndexedPathFrom( String path, Set<Group> groups, Consumer<IndexedStorePath> pathConsumer )

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
@@ -48,11 +48,17 @@ public class IndexedStorePath
 
     private String packageType;
 
+    private transient StoreKey storeKey;
+
+    private transient StoreKey originKey;
+
     // this needs to be public for Infinispan to not throw InvalidClassException with the first httprox request
     public IndexedStorePath(){}
 
     public IndexedStorePath( StoreKey storeKey, String path )
     {
+        this.storeKey = storeKey;
+
         this.packageType = storeKey.getPackageType();
         if ( this.packageType == null )
         {
@@ -68,6 +74,8 @@ public class IndexedStorePath
     public IndexedStorePath( StoreKey storeKey, StoreKey origin, String path )
     {
         this( storeKey, path );
+        this.originKey = origin;
+
         this.originStoreType = origin.getType();
         this.originStoreName = origin.getName();
     }
@@ -75,13 +83,13 @@ public class IndexedStorePath
     @JsonIgnore
     public StoreKey getStoreKey()
     {
-        return new StoreKey( packageType, storeType, storeName );
+        return storeKey != null ? storeKey : new StoreKey( packageType, storeType, storeName );
     }
 
     @JsonIgnore
     public StoreKey getOriginStoreKey()
     {
-        return new StoreKey( packageType, originStoreType, originStoreName );
+        return originKey != null ? originKey : new StoreKey( packageType, originStoreType, originStoreName );
     }
 
     public StoreType getStoreType()
@@ -119,13 +127,15 @@ public class IndexedStorePath
     {
         /* @formatter:off */
         return "IndexedStorePath{" +
-                "packageType=" + packageType +
-                ", storeType=" + storeType  +
-                ", storeName='" + storeName + '\'' +
-                ", originStoreType=" + originStoreType +
-                ", originStoreName='" + originStoreName + '\'' +
-                ", path='" + path + '\'' +
-                '}';
+                "\n  object ref: " + super.hashCode() +
+                "\n  hashcode: " + hashCode() +
+                "\n  packageType=" + packageType +
+                "\n  storeType=" + storeType  +
+                "\n  storeName=" + storeName +
+                "\n  originStoreType=" + originStoreType +
+                "\n  originStoreName=" + originStoreName +
+                "\n  path='" + path + '\'' +
+                "\n}";
         /* @formatter:on */
     }
 

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -346,7 +346,7 @@ public abstract class IndexingContentManagerDecorator
     public Transfer getIndexedTransfer( final StoreKey storeKey, final StoreKey topKey, final String path, final TransferOperation op )
             throws IndyWorkflowException
     {
-        logger.trace( "Looking for indexed path: {} in: {} (entry point: {})", path, storeKey, topKey );
+        logger.debug( "Looking for indexed path: {} in: {} (entry point: {})", path, storeKey, topKey );
 
         try
         {
@@ -371,21 +371,22 @@ public abstract class IndexingContentManagerDecorator
 
         if ( storePath != null )
         {
-            Transfer transfer = delegate.getTransfer( storePath.getStoreKey(), path, op );
+            Transfer transfer = delegate.getTransfer( storeKey, path, op );
             if ( transfer == null || !transfer.exists() )
             {
-                logger.trace( "Found obsolete index entry: {}. De-indexing from: {} and {}", storePath, storeKey,
+                logger.debug( "Found obsolete index entry: {}. De-indexing from: {} and {}", storePath, storeKey,
                               topKey );
                 // something happened to the underlying Transfer...de-index it, and don't return it.
                 indexManager.deIndexStorePath( storeKey, path );
                 if ( topKey != null )
                 {
+                    logger.debug( "{} Not found in: {}. De-indexing from: {} (topKey)", path, storeKey, topKey );
                     indexManager.deIndexStorePath( topKey, path );
                 }
             }
             else
             {
-                logger.trace( "Found it!" );
+                logger.debug( "Found it: {}", transfer );
                 return transfer;
             }
         }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/warmer/ContentIndexWarmer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/warmer/ContentIndexWarmer.java
@@ -5,6 +5,7 @@ import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.index.ContentIndexManager;
+import org.commonjava.indy.content.index.conf.ContentIndexConfig;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
@@ -31,6 +32,9 @@ public class ContentIndexWarmer
     private ContentIndexManager indexManager;
 
     @Inject
+    private ContentIndexConfig indexConfig;
+
+    @Inject
     private StoreDataManager storeDataManager;
 
     @Inject
@@ -46,72 +50,101 @@ public class ContentIndexWarmer
     public void warmCaches()
     {
         executor.submit( ()->{
-            Map<StoreKey, List<Transfer>> transferMap = new ConcurrentHashMap<>();
-
+            boolean oldAuthIdx = indexConfig.isAuthoritativeIndex();
+            indexConfig.setAuthoritativeIndex( false );
             try
             {
-                List<ArtifactStore> concreteStores = storeDataManager.query().storeTypes( StoreType.hosted, StoreType.remote ).getAll();
-
-                CountDownLatch latch = new CountDownLatch( concreteStores.size() );
-
-                concreteStores.forEach( store -> executor.submit( () -> {
-                    try
-                    {
-                        List<Transfer> transfers = downloadManager.listRecursively( store.getKey(), DownloadManager.ROOT_PATH );
-                        transferMap.put( store.getKey(), transfers );
-                        transfers.forEach( t->indexManager.indexTransferIn( t, store.getKey() ) );
-                    }
-                    catch ( IndyWorkflowException e )
-                    {
-                        logger.warn( "Failed to retrieve root directory of storage for: " + store.getKey(),
-                                     e );
-                    }
-                    finally
-                    {
-                        latch.countDown();
-                    }
-                } ) );
+                Map<StoreKey, List<Transfer>> transferMap = new ConcurrentHashMap<>();
 
                 try
                 {
-                    latch.await();
-                }
-                catch ( InterruptedException e )
-                {
-                    logger.info("Manager thread interrupted while waiting for concrete store indexing to complete.");
-                    return;
-                }
+                    List<ArtifactStore> concreteStores =
+                            storeDataManager.query().storeTypes( StoreType.hosted, StoreType.remote ).getAll();
 
-                storeDataManager.query().storeType( Group.class ).stream().forEach( g-> executor.submit(() -> {
-                    StoreKey gkey = g.getKey();
+                    CountDownLatch latch = new CountDownLatch( concreteStores.size() );
+
+                    concreteStores.forEach( store -> executor.submit( () -> {
+                        try
+                        {
+                            List<Transfer> transfers = downloadManager.listRecursively( store.getKey(), DownloadManager.ROOT_PATH );
+                            transferMap.put( store.getKey(), transfers );
+                            transfers.forEach( t -> indexManager.indexTransferIn( t, store.getKey() ) );
+                        }
+                        catch ( IndyWorkflowException e )
+                        {
+                            logger.warn( "Failed to retrieve root directory of storage for: " + store.getKey(), e );
+                        }
+                        finally
+                        {
+                            latch.countDown();
+                        }
+                    } ) );
 
                     try
                     {
-                        List<ArtifactStore> stores =
-                                storeDataManager.query().getOrderedConcreteStoresInGroup( g.getName() );
-
-                        stores.forEach( s -> {
-                             List<Transfer> txfrs = transferMap.get( s.getKey() );
-                             txfrs.forEach( t -> {
-                                 if ( indexManager.getIndexedStorePath( gkey, t.getPath() ) == null )
-                                 {
-                                     indexManager.indexTransferIn( t, gkey );
-                                 }
-                             } );
-                         } );
+                        latch.await();
                     }
-                    catch ( IndyDataException e )
+                    catch ( InterruptedException e )
                     {
-                        logger.warn( "Failed to get ordered concrete stores for group: " + g.getName(), e );
+                        logger.info(
+                                "Manager thread interrupted while waiting for concrete store indexing to complete." );
+                        return;
                     }
-                } ) );
-            }
-            catch ( IndyDataException e )
-            {
-                logger.warn( "Content index warm-up failed: %s", e, e.getMessage() );
-            }
 
-            logger.info( "Content index cache has been re-established." );
+                    List<Group> groups = storeDataManager.query().storeType( Group.class ).getAll();
+                    CountDownLatch groupLatch = new CountDownLatch( groups.size() );
+
+                    groups.forEach( g -> executor.submit( () -> {
+                        StoreKey gkey = g.getKey();
+
+                        try
+                        {
+                            List<ArtifactStore> stores =
+                                    storeDataManager.query().getOrderedConcreteStoresInGroup( g.getName() );
+
+                            stores.forEach( s -> {
+                                List<Transfer> txfrs = transferMap.get( s.getKey() );
+                                txfrs.forEach( t -> {
+                                    if ( indexManager.getIndexedStorePath( gkey, t.getPath() ) == null )
+                                    {
+                                        indexManager.indexTransferIn( t, gkey );
+                                    }
+                                } );
+                            } );
+                        }
+                        catch ( IndyDataException e )
+                        {
+                            logger.warn( "Failed to get ordered concrete stores for group: " + g.getName(), e );
+                        }
+                        finally
+                        {
+                            groupLatch.countDown();
+                        }
+                    } ) );
+
+                    try
+                    {
+                        groupLatch.await();
+                    }
+                    catch ( InterruptedException e )
+                    {
+                        logger.info(
+                                "Manager thread interrupted while waiting for group indexing to complete." );
+                        return;
+                    }
+
+                }
+                catch ( IndyDataException e )
+                {
+                    logger.warn( "Content index warm-up failed: %s", e, e.getMessage() );
+                }
+
+                logger.info( "Content index cache has been re-established." );
+            }
+            finally
+            {
+                indexConfig.setAuthoritativeIndex( oldAuthIdx );
+            }
 
         } );
     }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
@@ -43,7 +43,7 @@ public class TransferStreamingOutput
     implements StreamingOutput
 {
 
-    private static final String TRANSFER_METRIC_NAME = "transferred";
+    private static final String TRANSFER_METRIC_NAME = "indy.transferred";
 
     private InputStream stream;
 

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentIndexRemoteRepoUsageTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentIndexRemoteRepoUsageTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.content.index.ContentIndexManager;
+import org.commonjava.indy.content.index.IndexedStorePath;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.enterprise.inject.spi.CDI;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Remote repository A</li>
+ *     <li>Path P in repository A that has not yet been downloaded</li>
+ *     <li>ContentIndexManager does NOT contain entry for path P in repo A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Fetch path P from repository A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>After first retrieval of Path P, ContentIndexManager should contain entry for path P in repo A</li>
+ * </ul>
+ */
+public class ContentIndexRemoteRepoUsageTest
+        extends AbstractIndyFunctionalTest
+{
+
+    private static final String FIRST_PATH = "org/foo/bar/1/first.txt";
+
+    private static final String FIRST_PATH_CONTENT = "first content";
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    private ContentIndexManager indexManager;
+
+    @Before
+    public void getIndexManager()
+    {
+        indexManager = CDI.current().select( ContentIndexManager.class ).get();
+    }
+
+    @Test
+    public void bypassNotIndexedContentWithAuthoritativeIndex()
+            throws Exception
+    {
+        final String repoName = newName();
+        RemoteRepository repo = new RemoteRepository( MAVEN_PKG_KEY, repoName, server.formatUrl( repoName ) );
+        repo = client.stores().create( repo, name.getMethodName(), RemoteRepository.class );
+
+        server.expect( server.formatUrl( repoName, FIRST_PATH ), 200, FIRST_PATH_CONTENT );
+
+        assertThat( indexManager.getIndexedStorePath( repo.getKey(), FIRST_PATH ), nullValue() );
+
+        try (InputStream first = client.content().get( repo.getKey(), FIRST_PATH ))
+        {
+            assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
+        }
+
+        assertThat( indexManager.getIndexedStorePath( repo.getKey(), FIRST_PATH ), notNullValue() );
+    }
+}


### PR DESCRIPTION
But this time, background the whole operation and wait until all concrete stores are processed before processing group content-index references.