### PR TITLE
Stop tracking NFC for ALL hosted repos, add NFC timing metrics

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -278,7 +278,7 @@ public abstract class IndexingContentManagerDecorator
                     {
                         ; // metadata generated/exists but missing due to membership change, not add to nfc so next req can retry
                     }
-                    else
+                    else if ( StoreType.hosted != type ) // don't track NFC for hosted repos
                     {
                         nfc.addMissing( resource );
                     }
@@ -597,7 +597,7 @@ public abstract class IndexingContentManagerDecorator
 
     private void nfcForGroup( final ArtifactStore store, final Transfer transfer, final ConcreteResource resource )
     {
-        if ( store.getKey().getType() == StoreType.group )
+        if ( StoreType.group == store.getType() )
         {
             if ( exists( transfer ) )
             {

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
@@ -107,7 +107,10 @@ class NFCContentListener
                     final ArtifactStore store = storeDataManager.getArtifactStore( key );
                     final ConcreteResource r = new ConcreteResource( LocationUtils.toLocation( store ), isp.getPath() );
                     logger.debug( "Add NFC of resource {} in store {}", r, store );
-                    nfc.addMissing( r );
+                    if ( StoreType.hosted != key.getType() )
+                    {
+                        nfc.addMissing( r );
+                    }
                 }
                 catch ( IndyDataException ex )
                 {

--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -30,9 +30,11 @@ fi
 
 pushd $DIR
 
-pushd $DIR/deployments/launcher/target/
-rm -rf indy
-tar -zxvf indy-launcher-*-complete.tar.gz
+if [ "x${TEST_NOCLEAN}" == "x" ]; then
+  pushd $DIR/deployments/launcher/target/
+  rm -rf indy
+  tar -zxvf indy-launcher-*-complete.tar.gz
+fi
 
 if [ "x${TEST_REPOS}" != "x" ]; then
   echo "Copying repository/group definitions from: ${TEST_REPOS}"

--- a/core/src/main/java/org/commonjava/indy/core/inject/NFCMetricsDecorator.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/NFCMetricsDecorator.java
@@ -1,0 +1,73 @@
+package org.commonjava.indy.core.inject;
+
+import org.commonjava.indy.measure.annotation.Measure;
+import org.commonjava.indy.measure.annotation.MetricNamed;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
+
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.enterprise.inject.Any;
+import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
+
+@Decorator
+public abstract class NFCMetricsDecorator
+        implements NotFoundCache
+{
+    @Delegate
+    @Any
+    @Inject
+    private NotFoundCache delegate;
+
+    @Measure( timers = @MetricNamed( "indy.nfc.addMissing" ) )
+    @Override
+    public void addMissing( final ConcreteResource resource )
+    {
+        delegate.addMissing( resource );
+    }
+
+    @Measure( timers = @MetricNamed( "indy.nfc.isMissing" ) )
+    @Override
+    public boolean isMissing( final ConcreteResource resource )
+    {
+        return delegate.isMissing( resource );
+    }
+
+    @Measure( timers = @MetricNamed( "indy.nfc.clearMissing.location" ) )
+    @Override
+    public void clearMissing( final Location location )
+    {
+        delegate.clearMissing( location );
+    }
+
+    @Measure( timers = @MetricNamed( "indy.nfc.clearMissing.resource" ) )
+    @Override
+    public void clearMissing( final ConcreteResource resource )
+    {
+        delegate.clearMissing( resource );
+    }
+
+    @Measure( timers = @MetricNamed( "indy.nfc.clearAllMissing" ) )
+    @Override
+    public void clearAllMissing()
+    {
+        delegate.clearAllMissing();
+    }
+
+    @Measure( timers = @MetricNamed( "indy.nfc.getAllMissing" ) )
+    @Override
+    public Map<Location, Set<String>> getAllMissing()
+    {
+        return delegate.getAllMissing();
+    }
+
+    @Measure( timers = @MetricNamed( "indy.nfc.getMissing.location" ) )
+    @Override
+    public Set<String> getMissing( final Location location )
+    {
+        return delegate.getMissing( location );
+    }
+}

--- a/deployments/launcher/src/main/resources/META-INF/beans.xml
+++ b/deployments/launcher/src/main/resources/META-INF/beans.xml
@@ -32,6 +32,7 @@
     <class>org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator</class>
 
     <class>org.commonjava.indy.content.index.IndexingDirectContentAccessDecorator</class>
+    <class>org.commonjava.indy.core.inject.NFCMetricsDecorator</class>
   </decorators>
       
 </beans>

--- a/embedder/src/main/resources/META-INF/beans.xml
+++ b/embedder/src/main/resources/META-INF/beans.xml
@@ -44,6 +44,8 @@
     <class>org.commonjava.indy.autoprox.data.AutoProxDataManagerDecorator</class>
     <class>org.commonjava.indy.implrepo.data.ImpliedReposStoreDataManagerDecorator</class>
     <!--<class>org.commonjava.indy.implrepo.data.ValidRemoteStoreDataManagerDecorator</class>-->
+    
+    <class>org.commonjava.indy.core.inject.NFCMetricsDecorator</class>
   </decorators>
       
 </beans>


### PR DESCRIPTION
* Decorator to track call timings to NFC
* Changes to stop using NFC for hosted repos, since filesystem isn't markedly slower than NFC itself
* Add option to test script to leave pre-existing expanded tarball in place