### PR TITLE
Use origin store information when accessing group index entries

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexedStorePath.java
@@ -81,7 +81,7 @@ public class IndexedStorePath
     @JsonIgnore
     public StoreKey getOriginStoreKey()
     {
-        return new StoreKey( packageType, originStoreType, originStoreName );
+        return originStoreName == null ? null : new StoreKey( packageType, originStoreType, originStoreName );
     }
 
     public StoreType getStoreType()

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -371,7 +371,13 @@ public abstract class IndexingContentManagerDecorator
 
         if ( storePath != null )
         {
-            Transfer transfer = delegate.getTransfer( storePath.getStoreKey(), path, op );
+            StoreKey actualStorageKey = storePath.getOriginStoreKey();
+            if ( actualStorageKey == null )
+            {
+                actualStorageKey = storePath.getStoreKey();
+            }
+
+            Transfer transfer = delegate.getTransfer( actualStorageKey, path, op );
             if ( transfer == null || !transfer.exists() )
             {
                 logger.trace( "Found obsolete index entry: {}. De-indexing from: {} and {}", storePath, storeKey,


### PR DESCRIPTION
If not available, revert to using the main entry key