### PR TITLE
Add c.o.i.content.index.change.StoreChangeListener to clean up indices when store is deleted

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/change/StoreChangeListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/change/StoreChangeListener.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.content.index.change;
+
+import org.commonjava.indy.change.event.ArtifactStoreDeletePostEvent;
+import org.commonjava.indy.content.index.ContentIndexManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class StoreChangeListener
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private ContentIndexManager contentIndexManager;
+
+    public void storeDeleted( @Observes final ArtifactStoreDeletePostEvent event )
+    {
+        for ( final ArtifactStore store : event )
+        {
+            processChanged( store );
+        }
+    }
+
+    private void processChanged( final ArtifactStore store )
+    {
+        final StoreKey key = store.getKey();
+
+        logger.trace( "Clean index for: {}", key );
+        contentIndexManager.clearAllIndexedPathInStore( store );
+
+        logger.trace( "Clean index with origin: {}", key );
+        contentIndexManager.clearAllIndexedPathWithOriginalStore( store );
+    }
+
+}

--- a/embedder-tests/savant/src/test/resources/logback-test.xml
+++ b/embedder-tests/savant/src/test/resources/logback-test.xml
@@ -42,6 +42,8 @@
       </encoder>
     </appender>
 
+  <logger name="org.commonjava.indy.content.index" level="TRACE"/>
+
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentIndexNestedGroupAndStoreDeletionTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentIndexNestedGroupAndStoreDeletionTest.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.content.index.ContentIndexManager;
+import org.commonjava.indy.content.index.IndexedStorePath;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import javax.enterprise.inject.spi.CDI;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Remote repository A</li>
+ *     <li>Group TG and G, TG contains G, G contains repository A</li>
+ *     <li>Path P in repository A that has not been downloaded</li>
+ *     <li>ContentIndexManager does NOT contain entry for path P in TG, G, and A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Fetch path P from TG</li>
+ *     <li>Delete TG</li>
+ *     <li>Delete A</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>After retrieval of Path P, ContentIndexManager should contain entries for path P in TG, G, and A</li>
+ *     <li>After delete TG, ContentIndexManager should not contain entry for path P in TG, still contain entries in G and A</li>
+ *     <li>After delete A, ContentIndexManager should not contain entries for path P in G and A</li>
+ * </ul>
+ */
+public class ContentIndexNestedGroupAndStoreDeletionTest
+        extends AbstractIndyFunctionalTest
+{
+
+    private static final String PATH = "org/foo/bar/1/test.txt";
+
+    private static final String CONTENT = "This is a test";
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    private ContentIndexManager indexManager;
+
+    private RemoteRepository repositoryA;
+
+    private Group group, topGroup; // topGroup contains group, group contains repositoryA
+
+    @Before
+    public void setUp() throws Exception
+    {
+        final String repoA = "A";
+
+        final String gNameG = "G";
+
+        final String gNameTG = "TG";
+
+        indexManager = CDI.current().select( ContentIndexManager.class ).get();
+
+        repositoryA = new RemoteRepository( MAVEN_PKG_KEY, repoA, server.formatUrl( repoA ) );
+        repositoryA = client.stores().create( repositoryA, name.getMethodName(), RemoteRepository.class );
+
+        server.expect( server.formatUrl( repoA, PATH ), 200, CONTENT );
+
+        group = new Group( MAVEN_PKG_KEY, gNameG, repositoryA.getKey() );
+        group = client.stores().create( group, name.getMethodName(), Group.class );
+
+        topGroup = new Group( MAVEN_PKG_KEY, gNameTG, group.getKey() );
+        topGroup = client.stores().create( topGroup, name.getMethodName(), Group.class );
+    }
+
+    @Test
+    public void bypassNotIndexedContentWithAuthoritativeIndex()
+            throws Exception
+    {
+        // Fetch path P from TG
+        try (InputStream first = client.content().get( topGroup.getKey(), PATH ))
+        {
+            assertThat( IOUtils.toString( first ), equalTo( CONTENT ) );
+        }
+
+        indexExist( topGroup, group, repositoryA );
+
+        client.stores().delete( topGroup.getKey(), name.getMethodName() ); // delete TG
+
+        indexNotExist( topGroup );
+
+        indexExist( group, repositoryA );
+
+        client.stores().delete( repositoryA.getKey(), name.getMethodName() ); // delete A
+
+        indexNotExist( group, repositoryA );
+
+    }
+
+    private void indexNotExist( ArtifactStore... stores )
+    {
+        for ( ArtifactStore store : stores )
+        {
+            IndexedStorePath indexedPath = indexManager.getIndexedStorePath( store.getKey(), PATH );
+            assertThat( indexedPath, nullValue() );
+        }
+    }
+
+    private void indexExist( ArtifactStore... stores )
+    {
+        for ( ArtifactStore store : stores )
+        {
+            IndexedStorePath indexedPath = indexManager.getIndexedStorePath( store.getKey(), PATH );
+            logger.debug( "\n\n\nGot indexedPath: " + indexedPath + "\n\n\n" );
+            assertThat( indexedPath, notNullValue() );
+        }
+    }
+}


### PR DESCRIPTION
I found the indices were really not cleaned when a repo/group were deleted. This could cause a lot of useless entries left in the cache. Fix it by listening to the store post deletion event. 