### PR TITLE
Bugfixes, and parallelize Koji archive scanning for metadata generation

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -224,13 +225,14 @@ public class KojiMavenMetadataProvider
         return kojiClient.withKojiSession( ( session ) -> {
 
             // short-term caches to help improve performance a bit by avoiding xml-rpc calls.
-            Map<Integer, KojiBuildArchiveCollection> seenBuildArchives = new HashMap<>();
-            Set<Integer> seenBuilds = new HashSet<>();
-
             List<KojiArchiveInfo> archives = kojiClient.listArchivesMatching( ga, session );
 
-            CountDownLatch latch = new CountDownLatch( archives.size() );
+            Map<Integer, KojiBuildArchiveCollection> seenBuildArchives = new ConcurrentHashMap<>();
+            Set<Integer> seenBuilds = new ConcurrentHashSet<>();
             Set<SingleVersion> versions = new ConcurrentHashSet<>();
+
+            CountDownLatch latch = new CountDownLatch( archives.size() );
+
             for ( KojiArchiveInfo archive : archives )
             {
                 executorService.submit( ()->{

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -99,7 +99,7 @@ public class KojiMavenMetadataProvider
     private Locker<ProjectRef> versionMetadataLocks;
 
     @WeftManaged
-    @ExecutorConfig( threads=8, priority=3, named="koji-metadata" )
+    @ExecutorConfig( threads=8, priority=8, named="koji-metadata" )
     @Inject
     private ExecutorService executorService;
 

--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
@@ -348,7 +348,7 @@ public class KojiMavenMetadataProviderTest
                 new KojiBuildAuthority( kojiConfig, new StandardTypeMapper(), kojiClient, storeDataManager,
                                         contentDigester, directContentAccess );
 
-        provider = new KojiMavenMetadataProvider( this.cache, kojiClient, buildAuthority, kojiConfig );
+        provider = new KojiMavenMetadataProvider( this.cache, kojiClient, buildAuthority, kojiConfig, Executors.newCachedThreadPool() );
     }
 
     private static DefaultCacheManager cacheManager;

--- a/rest/api/pom.xml
+++ b/rest/api/pom.xml
@@ -27,6 +27,11 @@
     <artifactId>indy-rest-api</artifactId>
     <name>Indy :: REST :: API</name>
 
+    <properties>
+      <skipTests>false</skipTests>
+      <skipSurefire>false</skipSurefire>
+    </properties>
+
     <dependencies>
       <dependency>
         <groupId>org.commonjava.indy.embed</groupId>
@@ -75,6 +80,12 @@
 
     <build>
       <plugins>
+        <plugin>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <skip>false</skip>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>


### PR DESCRIPTION
* Fix NPE introduced by changes for group-level indexing fix
* Refactored KojiMavenMetadataProducer to use a thread pool for scanning archives matching a certain GA when trying to formulate entries to augment aggregated maven-metadata.xml files
* Try to prevent `-DskipTests=true` or `-DskipSurefire=true` from turning off the JUnit test code that is used to generate the Swagger API documentation JSON/YAML. This should allow us to turn off other tests when they're redundant without losing the ability to publish swagger docs.