### PR TITLE
Change content index cache value object type to StoreKey

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.content.index;
 
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 
@@ -70,8 +71,8 @@ public class ContentIndexCacheProducer
     @ContentIndexCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<IndexedStorePath, IndexedStorePath> contentIndexCacheCfg()
+    public CacheHandle<IndexedStorePath, StoreKey> contentIndexCacheCfg()
     {
-        return cacheProducer.getCache( "content-index", IndexedStorePath.class, IndexedStorePath.class );
+        return cacheProducer.getCache( "content-index", IndexedStorePath.class, StoreKey.class );
     }
 }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexManager.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.indy.content.index;
 
-import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
@@ -31,7 +30,7 @@ public interface ContentIndexManager
 
     void deIndexStorePath( final StoreKey key, final String path );
 
-    IndexedStorePath getIndexedStorePath( final StoreKey key, final String path );
+    StoreKey getIndexedStoreKey( final StoreKey key, final String path );
 
     void indexTransferIn( Transfer transfer, StoreKey... topKeys );
 

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -63,7 +63,7 @@ public class DefaultContentIndexManager
 
     @ContentIndexCache
     @Inject
-    private CacheHandle<IndexedStorePath, IndexedStorePath> contentIndex;
+    private CacheHandle<IndexedStorePath, StoreKey> contentIndex;
 
     @Inject
     private NotFoundCache nfc;
@@ -81,7 +81,7 @@ public class DefaultContentIndexManager
     }
 
     public DefaultContentIndexManager( StoreDataManager storeDataManager, SpecialPathManager specialPathManager,
-                                CacheHandle<IndexedStorePath, IndexedStorePath> contentIndex,
+                                CacheHandle<IndexedStorePath, StoreKey> contentIndex,
                                 Map<String, PackageIndexingStrategy> indexingStrategies,
                                 NotFoundCache nfc )
     {
@@ -185,16 +185,16 @@ public class DefaultContentIndexManager
     {
         String path = getStrategyPath( key, rawPath );
         IndexedStorePath toRemove = new IndexedStorePath( key, path );
-        IndexedStorePath val = contentIndex.remove( toRemove );
+        StoreKey val = contentIndex.remove( toRemove );
         logger.trace( "De index{}, key: {}", ( val == null ? " (NOT FOUND)" : "" ), toRemove );
     }
 
     @Override
-    public IndexedStorePath getIndexedStorePath( final StoreKey key, final String rawPath )
+    public StoreKey getIndexedStoreKey( final StoreKey key, final String rawPath )
     {
         String path = getStrategyPath( key, rawPath );
         IndexedStorePath ispKey = new IndexedStorePath( key, path );
-        IndexedStorePath val = contentIndex.get( ispKey );
+        StoreKey val = contentIndex.get( ispKey );
         logger.trace( "Get index{}, key: {}", ( val == null ? " (NOT FOUND)" : "" ), ispKey );
         return val;
     }
@@ -220,13 +220,13 @@ public class DefaultContentIndexManager
 
         IndexedStorePath origin = new IndexedStorePath( originKey, path );
         logger.trace( "Indexing path: {} in: {}", path, originKey );
-        contentIndex.put( origin, origin );
+        contentIndex.put( origin, originKey );
 
         Set<StoreKey> keySet = new HashSet<>( Arrays.asList( topKeys ) );
         keySet.forEach( ( key ) -> {
             IndexedStorePath isp = new IndexedStorePath( key, originKey, path );
             logger.trace( "Indexing path: {} in: {} via member: {}", path, key, originKey );
-            contentIndex.put( isp, origin );
+            contentIndex.put( isp, originKey );
         } );
     }
 

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DirectoryLvContentIndexManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DirectoryLvContentIndexManagerDecorator.java
@@ -76,10 +76,10 @@ public abstract class DirectoryLvContentIndexManagerDecorator
     }
 
     @Override
-    public IndexedStorePath getIndexedStorePath( StoreKey key, String path )
+    public StoreKey getIndexedStoreKey( StoreKey key, String path )
     {
         logger.debug( "DECORATED getIndexedStorePath:(path {}, key {})", path, key );
-        return delegate.getIndexedStorePath( key, getDirPathWithIfMeta( path ) );
+        return delegate.getIndexedStoreKey( key, getDirPathWithIfMeta( path ) );
     }
 
     @Override

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -384,29 +384,23 @@ public abstract class IndexingContentManagerDecorator
             return null;
         }
 
-        IndexedStorePath storePath = indexManager.getIndexedStorePath( storeKey, path );
+        StoreKey indexedStoreKey = indexManager.getIndexedStoreKey( storeKey, path );
 
-        if ( storePath != null )
+        if ( indexedStoreKey != null )
         {
-            StoreKey actualStorageKey = storePath.getOriginStoreKey();
-            if ( actualStorageKey == null )
-            {
-                actualStorageKey = storePath.getStoreKey();
-            }
-
-            Transfer transfer = delegate.getTransfer( actualStorageKey, path, op );
+            Transfer transfer = delegate.getTransfer( indexedStoreKey, path, op );
             if ( transfer == null || !transfer.exists() )
             {
-                if ( storePath.getStoreKey().getType() == StoreType.remote )
+                if ( indexedStoreKey.getType() == StoreType.remote )
                 {
                     // Transfer not existing may be caused by not cached for remote repo, so we should trigger downloading
                     // immediately to check if it really exists.
                     logger.debug( "Will trigger downloading of path {} from store {} from content index level", path,
-                                  storePath.getStoreKey() );
+                                  indexedStoreKey );
                     try
                     {
                         transfer =
-                                delegate.retrieve( storeDataManager.getArtifactStore( storePath.getStoreKey() ), path,
+                                delegate.retrieve( storeDataManager.getArtifactStore( indexedStoreKey ), path,
                                                    metadata );
                         if ( transfer != null && transfer.exists() )
                         {
@@ -416,11 +410,11 @@ public abstract class IndexingContentManagerDecorator
                     }
                     catch ( IndyDataException e )
                     {
-                        logger.warn( "Error to get store {} caused by {}", storePath.getStoreKey(), e.getMessage() );
+                        logger.warn( "Error to get store {} caused by {}", indexedStoreKey, e.getMessage() );
                     }
                 }
 
-                logger.trace( "Found obsolete index entry: {}. De-indexing from: {} and {}", storePath, storeKey,
+                logger.trace( "Found obsolete index entry: {},{}. De-indexing from: {} and {}", indexedStoreKey, path, storeKey,
                               topKey );
                 // something happened to the underlying Transfer...de-index it, and don't return it.
                 indexManager.deIndexStorePath( storeKey, path );

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingDirectContentAccessDecorator.java
@@ -20,6 +20,7 @@ import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.content.index.conf.ContentIndexConfig;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
@@ -115,10 +116,10 @@ public abstract class IndexingDirectContentAccessDecorator
     private Transfer getIndexedTransfer( ArtifactStore store, String path )
             throws IndyWorkflowException
     {
-        IndexedStorePath storePath =
-                indexManager.getIndexedStorePath( store.getKey(), path );
+        StoreKey indexedStoreKey =
+                indexManager.getIndexedStoreKey( store.getKey(), path );
 
-        if ( storePath != null )
+        if ( indexedStoreKey != null )
         {
             Transfer transfer = delegate.getTransfer( store, path );
             if ( transfer == null || !transfer.exists() )
@@ -149,7 +150,7 @@ public abstract class IndexingDirectContentAccessDecorator
         {
             // Here we will filter the resources if authoritative index set on. Only these indexed resources will be return.
             return raws.stream()
-                       .filter( res -> indexManager.getIndexedStorePath( res.getStoreKey(), res.getPath() ) != null )
+                       .filter( res -> indexManager.getIndexedStoreKey( res.getStoreKey(), res.getPath() ) != null )
                        .collect( Collectors.toList() );
         }
         else

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/warmer/ContentIndexWarmer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/warmer/ContentIndexWarmer.java
@@ -107,7 +107,7 @@ public class ContentIndexWarmer
                                 stores.forEach( s -> {
                                     List<Transfer> txfrs = transferMap.get( s.getKey() );
                                     txfrs.forEach( t -> {
-                                        if ( indexManager.getIndexedStorePath( gkey, t.getPath() ) == null )
+                                        if ( indexManager.getIndexedStoreKey( gkey, t.getPath() ) == null )
                                         {
                                             indexManager.indexTransferIn( t, gkey );
                                         }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentIndexNestedGroupAndStoreDeletionTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentIndexNestedGroupAndStoreDeletionTest.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -129,8 +130,8 @@ public class ContentIndexNestedGroupAndStoreDeletionTest
     {
         for ( ArtifactStore store : stores )
         {
-            IndexedStorePath indexedPath = indexManager.getIndexedStorePath( store.getKey(), PATH );
-            assertThat( indexedPath, nullValue() );
+            StoreKey indexedStoreKey = indexManager.getIndexedStoreKey( store.getKey(), PATH );
+            assertThat( indexedStoreKey, nullValue() );
         }
     }
 
@@ -138,9 +139,9 @@ public class ContentIndexNestedGroupAndStoreDeletionTest
     {
         for ( ArtifactStore store : stores )
         {
-            IndexedStorePath indexedPath = indexManager.getIndexedStorePath( store.getKey(), PATH );
-            logger.debug( "\n\n\nGot indexedPath: " + indexedPath + "\n\n\n" );
-            assertThat( indexedPath, notNullValue() );
+            StoreKey indexedStoreKey = indexManager.getIndexedStoreKey( store.getKey(), PATH );
+            logger.debug( "\n\n\nGot indexedStoreKey: " + indexedStoreKey + "\n\n\n" );
+            assertThat( indexedStoreKey, notNullValue() );
         }
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithArtifactsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithArtifactsTest.java
@@ -21,6 +21,7 @@ import org.commonjava.indy.content.index.IndexedStorePath;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.infinispan.AdvancedCache;
@@ -97,7 +98,7 @@ public class ContentIndexDirLvWithArtifactsTest
     @Rule
     public ExpectationServer server = new ExpectationServer();
 
-    private CacheHandle<IndexedStorePath, IndexedStorePath> contentIndex;
+    private CacheHandle<IndexedStorePath, StoreKey> contentIndex;
 
     @Before
     public void getIndexManager()
@@ -149,14 +150,13 @@ public class ContentIndexDirLvWithArtifactsTest
             }
         }
 
-        AdvancedCache<IndexedStorePath, IndexedStorePath> advancedCache =
+        AdvancedCache<IndexedStorePath, StoreKey> advancedCache =
                 (AdvancedCache) contentIndex.execute( c -> c );
         System.out.println( "[Content index DEBUG]: cached isps: " + advancedCache.keySet() );
 
-        for ( IndexedStorePath isp : advancedCache.values() )
+        for ( StoreKey key : advancedCache.values() )
         {
-            assertThat( isp.getStoreKey(), equalTo( remote2.getKey() ) );
-            assertThat( isp.getPath(), equalTo( PATH_DIR ) );
+            assertThat( key, equalTo( remote2.getKey() ) );
         }
 
         System.out.println( "[Content index DEBUG]: cache size:" + advancedCache.size() );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithMetadataTest.java
@@ -21,6 +21,7 @@ import org.commonjava.indy.content.index.IndexedStorePath;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.infinispan.AdvancedCache;
@@ -81,7 +82,7 @@ public class ContentIndexDirLvWithMetadataTest
     @Rule
     public ExpectationServer server = new ExpectationServer();
 
-    private CacheHandle<IndexedStorePath, IndexedStorePath> contentIndex;
+    private CacheHandle<IndexedStorePath, StoreKey> contentIndex;
 
     @Before
     public void getIndexManager()
@@ -116,14 +117,13 @@ public class ContentIndexDirLvWithMetadataTest
         }
 
 
-        AdvancedCache<IndexedStorePath, IndexedStorePath> advancedCache =
+        AdvancedCache<IndexedStorePath, StoreKey> advancedCache =
                 (AdvancedCache) contentIndex.execute( c -> c );
         System.out.println( "[Content index DEBUG]: cached isps: " + advancedCache.keySet() );
 
-        for ( IndexedStorePath isp : advancedCache.values() )
+        for ( StoreKey key : advancedCache.values() )
         {
-            assertThat( isp.getStoreKey(), equalTo( remote2.getKey() ) );
-            assertThat( isp.getPath(), equalTo( PATH_META ) );
+            assertThat( key, equalTo( remote2.getKey() ) );
         }
 
         System.out.println( "[Content index DEBUG]: cache size:" + advancedCache.size() );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexGroupUsageTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexGroupUsageTest.java
@@ -21,6 +21,7 @@ import org.commonjava.indy.content.index.IndexedStorePath;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Before;
 import org.junit.Rule;
@@ -91,30 +92,30 @@ public class ContentIndexGroupUsageTest
         Group group = new Group( MAVEN_PKG_KEY, groupName, repo.getKey() );
         group = client.stores().create( group, name.getMethodName(), Group.class );
 
-        IndexedStorePath indexedPath = indexManager.getIndexedStorePath( repo.getKey(), FIRST_PATH );
-        logger.info( "\n\n\nBEFORE: Indexed path entry: " + indexedPath + "\n\n\n\n");
-        assertThat( indexedPath, nullValue() );
+        StoreKey indexedStoreKey = indexManager.getIndexedStoreKey( repo.getKey(), FIRST_PATH );
+        logger.info( "\n\n\nBEFORE: Indexed path entry: " + indexedStoreKey + "\n\n\n\n");
+        assertThat( indexedStoreKey, nullValue() );
 
         try (InputStream first = client.content().get( repo.getKey(), FIRST_PATH ))
         {
             assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
         }
 
-        indexedPath = indexManager.getIndexedStorePath( repo.getKey(), FIRST_PATH );
-        logger.info( "\n\n\nAFTER remote: Remote-level indexed path entry: " + indexedPath + "\n\n\n\n");
-        assertThat( indexedPath, notNullValue() );
+        indexedStoreKey = indexManager.getIndexedStoreKey( repo.getKey(), FIRST_PATH );
+        logger.info( "\n\n\nAFTER remote: Remote-level indexed path entry: " + indexedStoreKey + "\n\n\n\n");
+        assertThat( indexedStoreKey, notNullValue() );
 
         try (InputStream first = client.content().get( group.getKey(), FIRST_PATH ))
         {
             assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
         }
 
-        IndexedStorePath indexedPath2 = indexManager.getIndexedStorePath( group.getKey(), FIRST_PATH );
-        logger.info( "\n\n\nAFTER group: Group-level indexed path entry: " + indexedPath2 + "\n\n\n\n");
-        assertThat( indexedPath2, notNullValue() );
+        indexedStoreKey = indexManager.getIndexedStoreKey( group.getKey(), FIRST_PATH );
+        logger.info( "\n\n\nAFTER group: Group-level indexed path entry: " + indexedStoreKey + "\n\n\n\n");
+        assertThat( indexedStoreKey, notNullValue() );
 
-        indexedPath = indexManager.getIndexedStorePath( repo.getKey(), FIRST_PATH );
-        logger.info( "\n\n\nAFTER group: Remote-level indexed path entry: " + indexedPath + "\n\n\n\n");
-        assertThat( indexedPath, notNullValue() );
+        indexedStoreKey = indexManager.getIndexedStoreKey( repo.getKey(), FIRST_PATH );
+        logger.info( "\n\n\nAFTER group: Remote-level indexed path entry: " + indexedStoreKey + "\n\n\n\n");
+        assertThat( indexedStoreKey, notNullValue() );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexRemoteRepoUsageTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexRemoteRepoUsageTest.java
@@ -21,6 +21,7 @@ import org.commonjava.indy.content.index.ContentIndexManager;
 import org.commonjava.indy.content.index.IndexedStorePath;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Before;
@@ -71,7 +72,7 @@ public class ContentIndexRemoteRepoUsageTest
 
     private ContentIndexManager indexManager;
 
-    private CacheHandle<IndexedStorePath, IndexedStorePath> cacheHandle;
+    private CacheHandle<IndexedStorePath, StoreKey> cacheHandle;
 
     @Before
     public void getIndexManager()
@@ -90,9 +91,9 @@ public class ContentIndexRemoteRepoUsageTest
 
         server.expect( server.formatUrl( repoName, FIRST_PATH ), 200, FIRST_PATH_CONTENT );
 
-        IndexedStorePath indexedPath = indexManager.getIndexedStorePath( repo.getKey(), FIRST_PATH );
-        logger.info( "\n\n\nBEFORE: Indexed path entry: " + indexedPath + "\n\n\n\n");
-        assertThat( indexedPath, nullValue() );
+        StoreKey indexedStoreKey = indexManager.getIndexedStoreKey( repo.getKey(), FIRST_PATH );
+        logger.info( "\n\n\nBEFORE: Indexed path entry: " + indexedStoreKey + "\n\n\n\n");
+        assertThat( indexedStoreKey, nullValue() );
 
         Long hits = cacheHandle.execute( (cache) -> cache.getAdvancedCache().getStats().getHits() );
         assertThat( hits == 0, equalTo( true ) );
@@ -102,9 +103,9 @@ public class ContentIndexRemoteRepoUsageTest
             assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
         }
 
-        indexedPath = indexManager.getIndexedStorePath( repo.getKey(), FIRST_PATH );
-        logger.info( "\n\n\nAFTER 1: Indexed path entry: " + indexedPath + "\n\n\n\n");
-        assertThat( indexedPath, notNullValue() );
+        indexedStoreKey = indexManager.getIndexedStoreKey( repo.getKey(), FIRST_PATH );
+        logger.info( "\n\n\nAFTER 1: Indexed path entry: " + indexedStoreKey + "\n\n\n\n");
+        assertThat( indexedStoreKey, notNullValue() );
 
         hits = cacheHandle.execute( (cache) -> cache.getAdvancedCache().getStats().getHits() );
         assertThat( hits >= 1, equalTo( true ) );
@@ -114,13 +115,13 @@ public class ContentIndexRemoteRepoUsageTest
             assertThat( IOUtils.toString( first ), equalTo( FIRST_PATH_CONTENT ) );
         }
 
-        IndexedStorePath indexedPath2 = indexManager.getIndexedStorePath( repo.getKey(), FIRST_PATH );
-        logger.info( "\n\n\nAFTER 2: Indexed path entry: " + indexedPath2 + "\n\n\n\n");
+        StoreKey indexedStoreKey2 = indexManager.getIndexedStoreKey( repo.getKey(), FIRST_PATH );
+        logger.info( "\n\n\nAFTER 2: Indexed path entry: " + indexedStoreKey2 + "\n\n\n\n");
 
         hits = cacheHandle.execute( (cache) -> cache.getAdvancedCache().getStats().getHits() );
         assertThat( hits >= 2, equalTo( true ) );
 
         // object equality should work since we haven't persisted this anywhere yet.
-        assertThat( indexedPath == indexedPath2, equalTo( true ) );
+        assertThat( indexedStoreKey == indexedStoreKey2, equalTo( true ) );
     }
 }


### PR DESCRIPTION
This leaves out the complexity/confusion of IndexedStorePath being as the "value" of content-index cache. If the StoreKey to be as the value is conceptually enough? Please review.  