### PR TITLE
Turn off use of Koji sessions

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -311,7 +311,9 @@ public abstract class KojiContentManagerDecorator
         Logger logger = LoggerFactory.getLogger( getClass() );
         try
         {
-            return kojiClient.withKojiSession( ( session ) -> {
+//            return kojiClient.withKojiSession( ( session ) -> {
+            KojiSessionInfo session = null;
+
                 List<KojiBuildInfo> builds = kojiClient.listBuildsContaining( artifactRef, session ); // use multicall
 
                 Collections.sort( builds, ( build1, build2 ) -> build2.getCreationTime()
@@ -387,7 +389,7 @@ public abstract class KojiContentManagerDecorator
                 logger.trace( "No builds were found that matched the restrictions." );
 
                 return defValue;
-            } );
+//            } );
         }
         catch ( KojiClientException e )
         {

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -222,7 +222,8 @@ public class KojiMavenMetadataProvider
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
 
-        return kojiClient.withKojiSession( ( session ) -> {
+//        return kojiClient.withKojiSession( ( session ) -> {
+        KojiSessionInfo session = null;
 
             // short-term caches to help improve performance a bit by avoiding xml-rpc calls.
             List<KojiArchiveInfo> archives = kojiClient.listArchivesMatching( ga, session );
@@ -339,7 +340,7 @@ public class KojiMavenMetadataProvider
             md.setVersioning( versioning );
 
             return md;
-        } );
+//        } );
     }
 
     private ArchiveScan scanArchive( final KojiArchiveInfo archive, final KojiSessionInfo session,


### PR DESCRIPTION
We should not need to login in order to query Koji about archives, builds, and tags. This is all we need in order to proxy Koji content and formulate metadata for content Koji can offer. The login/logout process takes hundreds of milliseconds in both systems I've tested, and seems to roughly double the times for the calls themselves somehow (maybe owing to session tracking).

I've turned session usage off and tried the new code in our staging environment, and it seems to function much faster. This is a particular problem when we use something like PME to align dependencies, and the call is made to Indy to find out what versions are available.