### PR TITLE
Update version to 1.3.2-SNAPSHOT for some poms

### DIFF
--- a/deployments/docker/pom.xml
+++ b/deployments/docker/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-deployments</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.docker</groupId>

--- a/embedder-tests/pom.xml
+++ b/embedder-tests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.embed.test</groupId>

--- a/embedder-tests/savant/pom.xml
+++ b/embedder-tests/savant/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.embed.test</groupId>
     <artifactId>indy-embedder-tests</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-embedder-test-savant</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
         <groupId>org.commonjava.indy.docker</groupId>
         <artifactId>indy-docker-base</artifactId>
         <type>tar.gz</type>
-        <version>1.3.1-SNAPSHOT</version>
+        <version>1.3.2-SNAPSHOT</version>
         <scope>provided</scope>
       </dependency>
 

--- a/test/docker/gogs-test-appliance/pom.xml
+++ b/test/docker/gogs-test-appliance/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.docker</groupId>
     <artifactId>indy-test-docker-appliances</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-docker-gogs-test-appliance</artifactId>

--- a/test/docker/keycloak-test-appliance/pom.xml
+++ b/test/docker/keycloak-test-appliance/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.docker</groupId>
     <artifactId>indy-test-docker-appliances</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>indy-docker-keycloak-test-appliance</artifactId>

--- a/test/docker/pom.xml
+++ b/test/docker/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.docker</groupId>


### PR DESCRIPTION
@jdcasey I don't know how you modify the versions in pom s when doing release. But I found some are not updated to 1.3.2-snapshot.