### PR TITLE
Cache Koji content aggressively

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
@@ -492,7 +492,7 @@ public class IndyKojiConfig
                 this.queryCacheEnabled = Boolean.valueOf( value.trim() );
                 break;
             }
-            case "query.cache.timeout.seconds":
+            case "query.cache.timeout.hours":
             {
                 this.queryCacheTimeoutHours = Integer.valueOf( value );
                 break;

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/conf/IndyKojiConfig.java
@@ -73,6 +73,10 @@ public class IndyKojiConfig
 
     private static final boolean DEFAULT_PROXY_BINARY_BUILDS = false;
 
+    private static final Boolean DEFAULT_QUERY_CACHE_ENABLED = true;
+
+    private static final int DEFAULT_QUERY_CACHE_EXPIRATION_HOURS = 3; // 3 hours for volatile caches
+
     private Boolean enabled;
 
     private String url;
@@ -101,6 +105,8 @@ public class IndyKojiConfig
 
     private Boolean tagPatternsEnabled;
 
+    private Boolean queryCacheEnabled;
+
     private Boolean proxyBinaryBuilds;
 
     private List<String> tagPatterns;
@@ -114,6 +120,8 @@ public class IndyKojiConfig
     private String binayNamingFormat = "koji-binary-${name}-${version}"; // default
 
     private Integer downloadTimeoutSeconds;
+
+    private Integer queryCacheTimeoutHours;
 
     private Long lockTimeoutSeconds;
 
@@ -389,6 +397,26 @@ public class IndyKojiConfig
         return getEnabled();
     }
 
+    public Boolean isQueryCacheEnabled()
+    {
+        return queryCacheEnabled == null ? DEFAULT_QUERY_CACHE_ENABLED : queryCacheEnabled;
+    }
+
+    public void setQueryCacheEnabled( Boolean queryCacheEnabled )
+    {
+        this.queryCacheEnabled = queryCacheEnabled;
+    }
+
+    public Integer getQueryCacheTimeoutHours()
+    {
+        return queryCacheTimeoutHours == null ? DEFAULT_QUERY_CACHE_EXPIRATION_HOURS : queryCacheTimeoutHours;
+    }
+
+    public void setQueryCacheTimeoutHours( Integer queryCacheTimeoutHours )
+    {
+        this.queryCacheTimeoutHours = queryCacheTimeoutHours;
+    }
+
     public Boolean getTagPatternsEnabled()
     {
         return tagPatternsEnabled == null ? DEFAULT_TAG_PATTERNS_ENABLED : tagPatternsEnabled;
@@ -457,6 +485,16 @@ public class IndyKojiConfig
             case "tag.patterns.enabled":
             {
                 this.tagPatternsEnabled = Boolean.valueOf( value.trim() );
+                break;
+            }
+            case "query.cache.enabled":
+            {
+                this.queryCacheEnabled = Boolean.valueOf( value.trim() );
+                break;
+            }
+            case "query.cache.timeout.seconds":
+            {
+                this.queryCacheTimeoutHours = Integer.valueOf( value );
                 break;
             }
             case "proxy.binary.builds":

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/CachedKojiContentProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/CachedKojiContentProvider.java
@@ -1,0 +1,241 @@
+package org.commonjava.indy.koji.content;
+
+import com.redhat.red.build.koji.KojiClient;
+import com.redhat.red.build.koji.KojiClientException;
+import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveQuery;
+import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiSessionInfo;
+import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
+import org.commonjava.indy.koji.conf.IndyKojiConfig;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.CacheProducer;
+import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
+import org.commonjava.maven.atlas.ident.ref.ProjectRef;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.redhat.red.build.koji.model.xmlrpc.messages.Constants.GET_BUILD;
+
+@ApplicationScoped
+public class CachedKojiContentProvider
+{
+    private Logger logger = LoggerFactory.getLogger( getClass() );
+
+
+    private final String KOJI_TAGS = "koji-tags"; // 99% immutable
+
+    private final String KOJI_BUILD_INFO = "koji-buildInfoByIdOrNvr"; // immutable
+
+    private final String KOJI_BUILD_INFO_CONTAINING_ARTIFACT = "koji_buildInfoContainingArtifact"; // volatile
+
+    private final String KOJI_ARCHIVES_FOR_BUILD = "koji-ArchivesForBuild"; // immutable
+
+    private final String KOJI_ARCHIVES_MATCHING_GA = "koji-ArchivesMatchingGA"; // volatile
+
+
+    @Inject
+    private CacheProducer cacheProducer;
+
+    @Inject
+    private KojiClient kojiClient;
+
+    @Inject
+    private IndyKojiConfig kojiConfig;
+
+    public CachedKojiContentProvider()
+    {
+    }
+
+    public CachedKojiContentProvider( KojiClient kojiClient, CacheProducer cacheProducer )
+    {
+        this.kojiClient = kojiClient;
+        this.cacheProducer = cacheProducer;
+    }
+
+    /**
+     * The caller actually passes SimpleArtifactRef which has right hashcode/equals so we can use it as cache key.
+     */
+    public List<KojiBuildInfo> listBuildsContaining( ArtifactRef artifactRef, KojiSessionInfo session )
+                    throws KojiClientException
+    {
+        return computeIfAbsent( KOJI_BUILD_INFO_CONTAINING_ARTIFACT, ArtifactRef.class, List.class, artifactRef,
+                                () -> kojiClient.listBuildsContaining( artifactRef, session ),
+                                kojiConfig.getQueryCacheTimeoutHours() );
+    }
+
+
+    public List<KojiTagInfo> listTags( Integer buildId, KojiSessionInfo session ) throws KojiClientException
+    {
+        return computeIfAbsent( KOJI_TAGS, Integer.class, List.class, buildId,
+                                () -> kojiClient.listTags( buildId, session ) );
+    }
+
+    public Map<Integer, List<KojiTagInfo>> listTags( List<Integer> buildIds, KojiSessionInfo session )
+                    throws KojiClientException
+    {
+        logger.debug( "listTags, buildIds: {}", buildIds );
+
+        if ( !kojiConfig.isQueryCacheEnabled() )
+        {
+            logger.trace( "Cache not enabled, run direct kojiClient.listTags" );
+            return kojiClient.listTags( buildIds, session );
+        }
+
+        CacheHandle<Integer, List> cache = cacheProducer.getCache( KOJI_TAGS, Integer.class, List.class );
+
+        Map<Integer, List<KojiTagInfo>> map = new HashMap<>();
+        List<Integer> missed = new ArrayList<>();
+        for ( Integer buildId : buildIds )
+        {
+            List ret = cache.get( buildId );
+            if ( ret != null )
+            {
+                map.put( buildId, ret );
+            }
+            else
+            {
+                missed.add( buildId );
+            }
+        }
+        if ( !missed.isEmpty() )
+        {
+            Map<Integer, List<KojiTagInfo>> retrieved = kojiClient.listTags( missed, session );
+            map.putAll( retrieved );
+            retrieved.forEach( ( k, v ) -> cache.put( k, v ) );
+        }
+        return map;
+    }
+
+
+    public KojiBuildInfo getBuildInfo( Integer buildId, KojiSessionInfo session ) throws KojiClientException
+    {
+        return computeIfAbsent( KOJI_BUILD_INFO, Object.class, KojiBuildInfo.class, buildId,
+                                () -> kojiClient.getBuildInfo( buildId, session ) );
+    }
+
+    public KojiBuildInfo getBuildInfo( String nvr, KojiSessionInfo session ) throws KojiClientException
+    {
+        return computeIfAbsent( KOJI_BUILD_INFO, Object.class, KojiBuildInfo.class, nvr,
+                                () -> kojiClient.getBuildInfo( nvr, session ) );
+    }
+
+    public List<KojiBuildInfo> getBuildInfo( List<Object> args, KojiSessionInfo session )
+    {
+        logger.debug( "getBuildInfo, args: {}", args );
+
+        if ( !kojiConfig.isQueryCacheEnabled() )
+        {
+            logger.trace( "Cache not enabled, run direct kojiClient.multiCall" );
+            return kojiClient.multiCall( GET_BUILD, args, KojiBuildInfo.class, session );
+        }
+
+        CacheHandle<Object, KojiBuildInfo> cache = cacheProducer.getCache( KOJI_BUILD_INFO, Object.class, KojiBuildInfo.class );
+
+        Map<Object, KojiBuildInfo> m = new HashMap<>();
+        List<Object> missed = new ArrayList<>();
+        for ( Object obj : args )
+        {
+            KojiBuildInfo kojiBuildInfo = cache.get( obj );
+            if ( kojiBuildInfo != null )
+            {
+                m.put( obj, kojiBuildInfo );
+            }
+            else
+            {
+                missed.add( obj );
+            }
+        }
+        if ( !missed.isEmpty() )
+        {
+            List<KojiBuildInfo> retrieved = kojiClient.multiCall( GET_BUILD, missed, KojiBuildInfo.class, session );
+            for ( int i = 0; i < missed.size(); i++ )
+            {
+                Object obj = missed.get( i );
+                KojiBuildInfo kojiBuildInfo = retrieved.get( i );
+                m.put( obj, kojiBuildInfo );
+                cache.put( obj, kojiBuildInfo );
+            }
+        }
+
+        List<KojiBuildInfo> ret = new ArrayList<>();
+        args.forEach( (a) -> ret.add( m.get( a ) ) ); // keep the order of results equal to args
+        return ret;
+    }
+
+
+    public List<KojiArchiveInfo> listArchivesMatching( ProjectRef ga, KojiSessionInfo session )
+                    throws KojiClientException
+    {
+        KojiArchiveQuery query = new KojiArchiveQuery( ga );
+        return computeIfAbsent( KOJI_ARCHIVES_MATCHING_GA, ProjectRef.class, List.class, ga,
+                                () -> kojiClient.listArchives( query, session ),
+                                kojiConfig.getQueryCacheTimeoutHours() );
+    }
+
+    public List<KojiArchiveInfo> listArchivesForBuild( Integer buildId, KojiSessionInfo session )
+                    throws KojiClientException
+    {
+        KojiArchiveQuery query = new KojiArchiveQuery().withBuildId( buildId );
+        return computeIfAbsent( KOJI_ARCHIVES_FOR_BUILD, Integer.class, List.class, buildId,
+                                () -> kojiClient.listArchives( query, session ) );
+    }
+
+
+    @FunctionalInterface
+    private interface KojiContentSupplier<T>
+    {
+        T getKojiContent() throws KojiClientException;
+    }
+
+    private <K, V> V computeIfAbsent( String name, Class<K> kType, Class<V> vType, K key,
+                                      KojiContentSupplier<V> supplier ) throws KojiClientException
+    {
+        return computeIfAbsent( name, kType, vType, key, supplier, 0 );
+    }
+
+    private <K, V> V computeIfAbsent( String name, Class<K> kType, Class<V> vType, K key,
+                                      KojiContentSupplier<V> supplier, int expirationHours )
+                    throws KojiClientException
+    {
+        logger.debug( "computeIfAbsent, cache: {}, key: {}", name, key );
+
+        if ( !kojiConfig.isQueryCacheEnabled() )
+        {
+            logger.trace( "Cache not enabled, run direct supplier.getKojiContent" );
+            return supplier.getKojiContent();
+        }
+
+        CacheHandle<K, V> cache = cacheProducer.getCache( name, kType, vType );
+        V ret = cache.get( key );
+        if ( ret == null )
+        {
+            logger.trace( "Entry not found, run supplier and put, expirationHours: {}", expirationHours );
+            ret = supplier.getKojiContent();
+            if ( expirationHours > 0 )
+            {
+                cache.put( key, ret, expirationHours, TimeUnit.HOURS );
+            }
+            else
+            {
+                cache.put( key, ret );
+            }
+        }
+
+        if ( ret instanceof List )
+        {
+            ret = (V) new ArrayList( (List) ret ); // protective copy
+        }
+        logger.trace( "Return value, cache: {}, key: {}, ret: {}", name, key, ret );
+        return ret;
+    }
+
+}

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/CachedKojiContentProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/CachedKojiContentProvider.java
@@ -19,8 +19,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static com.redhat.red.build.koji.model.xmlrpc.messages.Constants.GET_BUILD;
@@ -41,6 +43,22 @@ public class CachedKojiContentProvider
 
     private final String KOJI_ARCHIVES_MATCHING_GA = "koji-ArchivesMatchingGA"; // volatile
 
+    /**
+     * This is to register ISPN caches produced by this provider so that the Metrics knows them.
+     */
+    public Set<String> getCacheNames()
+    {
+        Set<String> ret = new HashSet<>();
+        if ( kojiConfig.isEnabled() && kojiConfig.isQueryCacheEnabled() )
+        {
+            ret.add( KOJI_TAGS );
+            ret.add( KOJI_BUILD_INFO );
+            ret.add( KOJI_BUILD_INFO_CONTAINING_ARTIFACT );
+            ret.add( KOJI_ARCHIVES_FOR_BUILD );
+            ret.add( KOJI_ARCHIVES_MATCHING_GA );
+        }
+        return ret;
+    }
 
     @Inject
     private CacheProducer cacheProducer;
@@ -188,7 +206,6 @@ public class CachedKojiContentProvider
         return computeIfAbsent( KOJI_ARCHIVES_FOR_BUILD, Integer.class, List.class, buildId,
                                 () -> kojiClient.listArchives( query, session ) );
     }
-
 
     @FunctionalInterface
     private interface KojiContentSupplier<T>

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
@@ -31,6 +31,7 @@ import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordType;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -80,8 +81,12 @@ public class KojijiProvider
     }
 
     @Override
-    public void start()
-            throws IndyLifecycleException
+    public void start() throws IndyLifecycleException
+    {
+    }
+
+    @PostConstruct
+    private void setUp() throws KojiClientException
     {
         if ( !config.isEnabled() )
         {
@@ -99,20 +104,13 @@ public class KojijiProvider
             kojiPasswordManager.bind( config.getKeyPassword(), config.getKojiSiteId(), PasswordType.KEY );
         }
 
-        try
+        if ( indyMetricsConfig.isKojiMetricEnabled() )
         {
-            if ( indyMetricsConfig.isKojiMetricEnabled() )
-            {
-                kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor, metricRegistry );
-            }
-            else
-            {
-                kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor );
-            }
+            kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor, metricRegistry );
         }
-        catch ( KojiClientException e )
+        else
         {
-            throw new IndyLifecycleException( "Init KojiClient failed", e );
+            kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor );
         }
 
         versionMetadataLocks = new Locker<>();

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/metrics/KojiIspnCacheRegistry.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/metrics/KojiIspnCacheRegistry.java
@@ -1,0 +1,27 @@
+package org.commonjava.indy.koji.metrics;
+
+import org.commonjava.indy.koji.content.CachedKojiContentProvider;
+import org.commonjava.indy.subsys.infinispan.metrics.IspnCacheRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Set;
+
+@ApplicationScoped
+public class KojiIspnCacheRegistry implements IspnCacheRegistry
+{
+    private Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private CachedKojiContentProvider kojiContentProvider;
+
+    @Override
+    public Set<String> getCacheNames()
+    {
+        Set<String> ret = kojiContentProvider.getCacheNames();
+        logger.info( "[Metrics] Register Koji query cache, names: {}", ret );
+        return ret;
+    }
+}

--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiMavenMetadataProviderTest.java
@@ -346,9 +346,9 @@ public class KojiMavenMetadataProviderTest
 
         KojiBuildAuthority buildAuthority =
                 new KojiBuildAuthority( kojiConfig, new StandardTypeMapper(), kojiClient, storeDataManager,
-                                        contentDigester, directContentAccess );
+                                        contentDigester, directContentAccess, cacheManager );
 
-        provider = new KojiMavenMetadataProvider( this.cache, kojiClient, buildAuthority, kojiConfig, Executors.newCachedThreadPool() );
+        provider = new KojiMavenMetadataProvider( this.cache, kojiClient, buildAuthority, kojiConfig, Executors.newCachedThreadPool(), cacheManager );
     }
 
     private static DefaultCacheManager cacheManager;

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheHandle.java
@@ -28,6 +28,7 @@ import javax.transaction.NotSupportedException;
 import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -129,6 +130,11 @@ public class CacheHandle<K,V>
     public V put( K key, V value )
     {
         return execute( cache -> cache.put( key, value ) );
+    }
+
+    public V put( K key, V value, int expiration, TimeUnit timeUnit )
+    {
+        return execute( cache -> cache.put( key, value, expiration, timeUnit ) );
     }
 
     public V putIfAbsent( K key, V value )

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCacheRegistry.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCacheRegistry.java
@@ -1,0 +1,11 @@
+package org.commonjava.indy.subsys.infinispan.metrics;
+
+import java.util.Set;
+
+/**
+ * This is for other components to register ISPN caches so that they can be monitored by Metircs.
+ */
+public interface IspnCacheRegistry
+{
+    Set<String> getCacheNames();
+}

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnRegistrySetProvider.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnRegistrySetProvider.java
@@ -8,9 +8,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.commonjava.indy.subsys.infinispan.metrics.IspnCheckRegistrySet.INDY_METRIC_ISPN;
@@ -24,6 +26,9 @@ public class IspnRegistrySetProvider
 
     @Inject
     private CacheProducer cacheProducer;
+
+    @Inject
+    private Instance<IspnCacheRegistry> cacheRegistrySet;
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -41,6 +46,15 @@ public class IspnRegistrySetProvider
         if ( gauges != null )
         {
             list = Arrays.asList( gauges.trim().split( "\\s*,\\s*" ) );
+        }
+
+        for ( IspnCacheRegistry cacheRegistry : cacheRegistrySet )
+        {
+            Set<String> caches = cacheRegistry.getCacheNames();
+            if ( caches != null )
+            {
+                caches.forEach( ( n ) -> cacheProducer.getCacheManager().getCache( n ) );
+            }
         }
 
         registry.register( name( metricsConfig.getNodePrefix(), INDY_METRIC_ISPN ),


### PR DESCRIPTION
1. Mode all direct kojiClient calls to CachedKojiContentProvider to cache the content. 
2. Add koji config to enable/disable query caches. Add config to expire volatile cache entries. 

I tested it via external Koji test and the caches are working. 

TODO: the caches are acquired via cache manager API. So by default, we don't need to define them in infinispan.xml. However, the current ISPN metrics won't include these because metric registers before these caches are created (they are created the first time being used). I need to figure out a way to include them in ISPN metrics. 
