### PR TITLE
UI checkbox to setup prepend of new members to group

### DIFF
--- a/uis/layover/app/partials/group-edit.html
+++ b/uis/layover/app/partials/group-edit.html
@@ -41,6 +41,11 @@
         <label>Enabled?</label>
         <span class="hint" ng-if="!raw.enabled && raw.disableExpiration">Set to automatically re-enable at {{raw.disableExpiration | dateFormat}}</span>
       </div>
+      <div class="detail-field">
+        <input type="checkbox" ng-model="store.prepend_constituent" />
+        <label>Prepend Constituents?</label>
+        <span class="hint">If enabled, all new constituents which are added not manually(like promotion) will be at the top of constituents list</span>
+      </div>
 
       <div class="sub-fields">
         <div class="detail-field">

--- a/uis/layover/app/partials/includes/group-view.html
+++ b/uis/layover/app/partials/includes/group-view.html
@@ -30,6 +30,11 @@
 		<label>Enabled?</label>
 		<span class="hint" ng-if="!raw.enabled && raw.disableExpiration">Set to automatically re-enable at {{raw.disableExpiration | dateFormat}}</span>
 	</div>
+	<div class="detail-field">
+		<span>{{store.prepend_constituent | checkmark}}</span>
+		<label>Prepend Constituents?</label>
+		<span class="hint">If enabled, all new constituents which are added not manually(like promotion) will be at the top of constituents list</span>
+	</div>
 	<div class="sub-fields">
 		<div class="detail-field">
 			<label>Disable Timeout:</label>


### PR DESCRIPTION
I think this group prepend config can only control member adding through "addConstituent" method, like promotion to group. Other way like directly store change from json(like ui page changes) will not be influenced by this config.