### PR TITLE
Remove not used ISPN @Listener

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
@@ -18,7 +18,6 @@ package org.commonjava.indy.core.expire.cache;
 import org.commonjava.indy.core.expire.ScheduleKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
-import org.infinispan.notifications.Listener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +30,6 @@ import java.util.Map;
  * This ISPN cache producer is used to generate {@link ScheduleCache}. This type of cache is used as a job control center
  * to control the content expiration scheduling.
  */
-@Listener
 public class ScheduleCacheProducer
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );


### PR DESCRIPTION
I found this listener is not used (when I go through ISPN code to support remote cache). 