### PR TITLE
Support remote ISPN caches

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
@@ -16,7 +16,7 @@
 package org.commonjava.indy.content.index;
 
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -77,8 +77,8 @@ public class ContentIndexCacheProducer
     @ContentIndexCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<IndexedStorePath, StoreKey> contentIndexCacheCfg()
+    public BasicCacheHandle<IndexedStorePath, StoreKey> contentIndexCacheCfg()
     {
-        return cacheProducer.getCache( "content-index", IndexedStorePath.class, StoreKey.class );
+        return cacheProducer.getBasicCache( "content-index", IndexedStorePath.class, StoreKey.class );
     }
 }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
@@ -79,6 +79,6 @@ public class ContentIndexCacheProducer
     @ApplicationScoped
     public BasicCacheHandle<IndexedStorePath, StoreKey> contentIndexCacheCfg()
     {
-        return cacheProducer.getBasicCache( "content-index", IndexedStorePath.class, StoreKey.class );
+        return cacheProducer.getBasicCache( "content-index" );
     }
 }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -22,7 +22,7 @@ import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
@@ -44,7 +44,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 /**
  * Created by jdcasey on 5/2/16.
@@ -64,7 +63,7 @@ public class DefaultContentIndexManager
 
     @ContentIndexCache
     @Inject
-    private CacheHandle<IndexedStorePath, StoreKey> contentIndex;
+    private BasicCacheHandle<IndexedStorePath, StoreKey> contentIndex;
 
     @Inject
     private NotFoundCache nfc;
@@ -82,7 +81,7 @@ public class DefaultContentIndexManager
     }
 
     public DefaultContentIndexManager( StoreDataManager storeDataManager, SpecialPathManager specialPathManager,
-                                CacheHandle<IndexedStorePath, StoreKey> contentIndex,
+                                BasicCacheHandle<IndexedStorePath, StoreKey> contentIndex,
                                 Map<String, PackageIndexingStrategy> indexingStrategies,
                                 NotFoundCache nfc )
     {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
@@ -85,7 +85,7 @@ public class FoloCacheProducer
         final CacheHandle<TrackedContentEntry, TrackedContentEntry> handler =
                         cacheProducer.getCache( IN_PROGRESS_NAME, TrackedContentEntry.class, TrackedContentEntry.class );
 
-        handler.execute( cache->{
+        handler.executeCache( cache->{
             SearchManagerImplementor searchManager = (SearchManagerImplementor) Search.getSearchManager( cache );
 
             searchManager.registerKeyTransformer( TrackedContentEntry.class, TrackedContentEntryTransformer.class );

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
@@ -83,7 +83,7 @@ public class FoloCacheProducer
 
     private void registerTransformer(){
         final CacheHandle<TrackedContentEntry, TrackedContentEntry> handler =
-                        cacheProducer.getCache( IN_PROGRESS_NAME, TrackedContentEntry.class, TrackedContentEntry.class );
+                        cacheProducer.getCache( IN_PROGRESS_NAME );
 
         handler.executeCache( cache->{
             SearchManagerImplementor searchManager = (SearchManagerImplementor) Search.getSearchManager( cache );
@@ -99,7 +99,7 @@ public class FoloCacheProducer
     @ApplicationScoped
     public CacheHandle<TrackedContentEntry, TrackedContentEntry> inProgressFoloRecordCacheCfg()
     {
-        return cacheProducer.getCache( IN_PROGRESS_NAME, TrackedContentEntry.class, TrackedContentEntry.class );
+        return cacheProducer.getCache( IN_PROGRESS_NAME );
     }
 
     @FoloSealedCache
@@ -107,6 +107,6 @@ public class FoloCacheProducer
     @ApplicationScoped
     public CacheHandle<TrackingKey, TrackedContent> sealedFoloRecordCacheCfg()
     {
-        return cacheProducer.getCache( SEALED_NAME, TrackingKey.class, TrackedContent.class );
+        return cacheProducer.getCache( SEALED_NAME );
     }
 }

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -140,7 +140,7 @@ public final class ProxyResponseWriter
         this.metricsConfig = metricsConfig;
         this.metricRegistry = metricRegistry;
         this.cls = ClassUtils.getAbbreviatedName( getClass().getName(), 1 ); // e.g., foo.bar.ClassA -> f.b.ClassA
-        this.proxyAuthCache = cacheProducer.getCache( HTTP_PROXY_AUTH_CACHE, String.class, Boolean.class );
+        this.proxyAuthCache = cacheProducer.getCache( HTTP_PROXY_AUTH_CACHE );
     }
 
     @Override

--- a/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
@@ -200,7 +200,7 @@ public class HttpProxyTest
         proxy = new HttpProxy( config, bootOpts,
                                new ProxyAcceptHandler( config, storeManager, contentController, auth, core.getCache(),
                                                        scriptEngine, new MDCManager(), null, null,
-                                                       new CacheProducer( null, cacheManager ) ) );
+                                                       new CacheProducer( null, cacheManager, null ) ) );
         proxy.start();
     }
 

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/CachedKojiContentProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/CachedKojiContentProvider.java
@@ -37,7 +37,7 @@ public class CachedKojiContentProvider
 
     private final String KOJI_BUILD_INFO = "koji-buildInfoByIdOrNvr"; // immutable
 
-    private final String KOJI_BUILD_INFO_CONTAINING_ARTIFACT = "koji_buildInfoContainingArtifact"; // volatile
+    private final String KOJI_BUILD_INFO_CONTAINING_ARTIFACT = "koji-buildInfoContainingArtifact"; // volatile
 
     private final String KOJI_ARCHIVES_FOR_BUILD = "koji-ArchivesForBuild"; // immutable
 

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/CachedKojiContentProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/CachedKojiContentProvider.java
@@ -108,7 +108,7 @@ public class CachedKojiContentProvider
             return kojiClient.listTags( buildIds, session );
         }
 
-        CacheHandle<Integer, List> cache = cacheProducer.getCache( KOJI_TAGS, Integer.class, List.class );
+        CacheHandle<Integer, List> cache = cacheProducer.getCache( KOJI_TAGS );
 
         Map<Integer, List<KojiTagInfo>> map = new HashMap<>();
         List<Integer> missed = new ArrayList<>();
@@ -156,7 +156,7 @@ public class CachedKojiContentProvider
             return kojiClient.multiCall( GET_BUILD, args, KojiBuildInfo.class, session );
         }
 
-        CacheHandle<Object, KojiBuildInfo> cache = cacheProducer.getCache( KOJI_BUILD_INFO, Object.class, KojiBuildInfo.class );
+        CacheHandle<Object, KojiBuildInfo> cache = cacheProducer.getCache( KOJI_BUILD_INFO );
 
         Map<Object, KojiBuildInfo> m = new HashMap<>();
         List<Object> missed = new ArrayList<>();
@@ -231,7 +231,7 @@ public class CachedKojiContentProvider
             return supplier.getKojiContent();
         }
 
-        CacheHandle<K, V> cache = cacheProducer.getCache( name, kType, vType );
+        CacheHandle<K, V> cache = cacheProducer.getCache( name );
         V ret = cache.get( key );
         if ( ret == null )
         {

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
@@ -102,7 +102,7 @@ public class KojiBuildAuthority
     {
         this.config = config;
         this.typeMapper = typeMapper;
-        this.kojiContentProvider = new CachedKojiContentProvider( kojiClient, new CacheProducer( null, cacheManager ) );
+        this.kojiContentProvider = new CachedKojiContentProvider( kojiClient, new CacheProducer( null, cacheManager, null ) );
         this.storeDataManager = storeDataManager;
         this.contentDigester = contentDigester;
         this.directContentAccess = directContentAccess;

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -36,6 +36,7 @@ import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.measure.annotation.MetricNamed;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.pkg.maven.content.group.MavenMetadataProvider;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import org.commonjava.maven.atlas.ident.ref.InvalidRefException;
@@ -84,7 +85,7 @@ public class KojiMavenMetadataProvider
 
     @Inject
     @KojiMavenVersionMetadataCache
-    private CacheHandle<ProjectRef, Metadata> versionMetadata;
+    private BasicCacheHandle<ProjectRef, Metadata> versionMetadata;
 
     @Inject
     private CachedKojiContentProvider kojiContentProvider;
@@ -199,9 +200,7 @@ public class KojiMavenMetadataProvider
                     Metadata md = metadata;
 
                     // FIXME: Need a way to listen for cache expiration and re-request this?
-                    versionMetadata.executeCache( ( cache ) -> cache.getAdvancedCache()
-                                                               .put( ga, md, kojiConfig.getMetadataTimeoutSeconds(),
-                                                                     TimeUnit.SECONDS ) );
+                    versionMetadata.execute( ( cache ) -> cache.put( ga, md, kojiConfig.getMetadataTimeoutSeconds(), TimeUnit.SECONDS ) );
                 }
                 else
                 {

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -110,7 +110,7 @@ public class KojiMavenMetadataProvider
                                       KojiBuildAuthority buildAuthority, IndyKojiConfig kojiConfig, ExecutorService executorService, DefaultCacheManager cacheManager )
     {
         this.versionMetadata = versionMetadata;
-        this.kojiContentProvider = new CachedKojiContentProvider( kojiClient, new CacheProducer( null, cacheManager ) );
+        this.kojiContentProvider = new CachedKojiContentProvider( kojiClient, new CacheProducer( null, cacheManager, null ) );
         this.buildAuthority = buildAuthority;
         this.kojiConfig = kojiConfig;
         this.executorService = executorService;
@@ -199,7 +199,7 @@ public class KojiMavenMetadataProvider
                     Metadata md = metadata;
 
                     // FIXME: Need a way to listen for cache expiration and re-request this?
-                    versionMetadata.execute( ( cache ) -> cache.getAdvancedCache()
+                    versionMetadata.executeCache( ( cache ) -> cache.getAdvancedCache()
                                                                .put( ga, md, kojiConfig.getMetadataTimeoutSeconds(),
                                                                      TimeUnit.SECONDS ) );
                 }

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiCacheProducer.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiCacheProducer.java
@@ -40,6 +40,6 @@ public class KojiCacheProducer
     @ApplicationScoped
     public BasicCacheHandle<ProjectRef, Metadata> versionMetadataCache()
     {
-        return cacheProducer.getBasicCache( "koji-maven-version-metadata", ProjectRef.class, Metadata.class );
+        return cacheProducer.getBasicCache( "koji-maven-version-metadata" );
     }
 }

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiCacheProducer.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiCacheProducer.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.koji.inject;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import org.commonjava.maven.atlas.ident.ref.ProjectRef;
@@ -37,8 +38,8 @@ public class KojiCacheProducer
     @KojiMavenVersionMetadataCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<ProjectRef, Metadata> versionMetadataCache()
+    public BasicCacheHandle<ProjectRef, Metadata> versionMetadataCache()
     {
-        return cacheProducer.getCache( "koji-maven-version-metadata", ProjectRef.class, Metadata.class );
+        return cacheProducer.getBasicCache( "koji-maven-version-metadata", ProjectRef.class, Metadata.class );
     }
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -39,6 +39,6 @@ public class MetadataCacheProducer
     @ApplicationScoped
     public CacheHandle<StoreKey, Map> mavenVersionMetaCacheCfg()
     {
-        return cacheProducer.getCache( "maven-version-metadata-cache", StoreKey.class, Map.class );
+        return cacheProducer.getCache( "maven-version-metadata-cache" );
     }
 }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
@@ -22,7 +22,7 @@ import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.core.inject.ContentMetadataCache;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.galley.KeyedLocation;
-import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.io.ChecksummingTransferDecorator;
 import org.commonjava.maven.galley.io.checksum.ContentDigest;
@@ -60,7 +60,7 @@ public class DefaultContentDigester
 
     @Inject
     @ContentMetadataCache
-    private CacheHandle<String, TransferMetadata> metadataCache;
+    private BasicCacheHandle<String, TransferMetadata> metadataCache;
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -69,7 +69,7 @@ public class DefaultContentDigester
     }
 
     public DefaultContentDigester( DirectContentAccess directContentAccess,
-                                   CacheHandle<String, TransferMetadata> metadataCache )
+                                   BasicCacheHandle<String, TransferMetadata> metadataCache )
     {
         this.directContentAccess = directContentAccess;
         this.metadataCache = metadataCache;

--- a/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
@@ -25,7 +25,7 @@ import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
-import org.infinispan.Cache;
+import org.infinispan.commons.api.BasicCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,7 +85,7 @@ public class SchedulerController
 
             // This key matcher will compare with the cache key group to see if the group ends with the "Disable-Timeout"(jobtype)
             ExpirationSet expirations = scheduleManager.findMatchingExpirations(
-                    cacheHandle -> cacheHandle.execute( Cache::keySet )
+                    cacheHandle -> cacheHandle.execute( BasicCache::keySet )
                                               .stream()
                                               .filter( key -> key.getType()
                                                                  .equals( StoreEnablementManager.DISABLE_TIMEOUT ) )

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -138,7 +138,7 @@ public class ScheduleManager
         }
 
         // register this producer as schedule cache listener
-        scheduleCache.execute( cache -> {
+        scheduleCache.executeCache( cache -> {
             cache.addListener( ScheduleManager.this );
             return null;
         } );
@@ -567,7 +567,7 @@ public class ScheduleManager
     private Date getNextExpireTime( final ScheduleKey cacheKey )
     {
 
-        return scheduleCache.execute( cache -> {
+        return scheduleCache.executeCache( cache -> {
             final CacheEntry entry = cache.getAdvancedCache().getCacheEntry( cacheKey );
             if ( entry != null )
             {

--- a/core/src/main/java/org/commonjava/indy/core/expire/StoreKeyMatcher.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/StoreKeyMatcher.java
@@ -18,7 +18,7 @@ package org.commonjava.indy.core.expire;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheKeyMatcher;
-import org.infinispan.Cache;
+import org.infinispan.commons.api.BasicCache;
 
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,7 +46,7 @@ public class StoreKeyMatcher
     @Override
     public Set<ScheduleKey> matches( CacheHandle<ScheduleKey, ?> cacheHandle )
     {
-        return cacheHandle.execute( Cache::keySet )
+        return cacheHandle.execute( BasicCache::keySet )
                           .stream()
                           .filter( key -> key != null && key.exists() && key.groupName().equals( ScheduleManager.groupName( storeKey, eventType ) ) )
                           .collect( Collectors.toSet() );

--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
@@ -44,7 +44,7 @@ public class ScheduleCacheProducer
     @ApplicationScoped
     public CacheHandle<ScheduleKey, Map> versionMetadataCache()
     {
-        return cacheProducer.getCache( SCHEDULE_EXPIRE, ScheduleKey.class, Map.class );
+        return cacheProducer.getCache( SCHEDULE_EXPIRE );
     }
 
 }

--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreCacheProducer.java
@@ -15,7 +15,7 @@
  */
 package org.commonjava.indy.core.inject;
 
-import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import org.commonjava.maven.galley.io.checksum.TransferMetadata;
 
@@ -24,7 +24,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 /**
- * Produces ISPN Cache instances (wrapped in {@link CacheHandle} to help with shutdown blocking) for use in core class
+ * Produces ISPN Cache instances (wrapped in {@link BasicCacheHandle} to help with shutdown blocking) for use in core class
  * implementations.
  */
 public class CoreCacheProducer
@@ -38,8 +38,8 @@ public class CoreCacheProducer
     @ContentMetadataCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<String, TransferMetadata> contentMetadataCache()
+    public BasicCacheHandle<String, TransferMetadata> contentMetadataCache()
     {
-        return cacheProducer.getCache( CONTENT_METADATA_NAME, String.class, TransferMetadata.class );
+        return cacheProducer.getBasicCache( CONTENT_METADATA_NAME, String.class, TransferMetadata.class );
     }
 }

--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreCacheProducer.java
@@ -40,6 +40,6 @@ public class CoreCacheProducer
     @ApplicationScoped
     public BasicCacheHandle<String, TransferMetadata> contentMetadataCache()
     {
-        return cacheProducer.getBasicCache( CONTENT_METADATA_NAME, String.class, TransferMetadata.class );
+        return cacheProducer.getBasicCache( CONTENT_METADATA_NAME );
     }
 }

--- a/core/src/main/java/org/commonjava/indy/core/inject/IspnNotFoundCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/IspnNotFoundCache.java
@@ -82,8 +82,11 @@ public class IspnNotFoundCache
     @PostConstruct
     private void start()
     {
-        queryFactory = Search.getQueryFactory( nfcCache.getCache() ); // Obtain a query factory for the cache
-        maxResultSetSize = config.getNfcMaxResultSetSize();
+        nfcCache.executeCache( (cache) -> {
+            queryFactory = Search.getQueryFactory( cache ); // Obtain a query factory for the cache
+            maxResultSetSize = config.getNfcMaxResultSetSize();
+            return null;
+        } );
     }
 
     private int getTimeoutInSeconds( ConcreteResource resource )
@@ -152,9 +155,11 @@ public class IspnNotFoundCache
     @Override
     public void clearMissing( final Location location )
     {
-        Cache<String, NfcConcreteResourceWrapper> cache = nfcCache.getCache();
-        Set<String> paths = getMissing( location );
-        paths.forEach( path -> cache.remove( getResourceKey( new ConcreteResource( location, path ) ) ) );
+        nfcCache.execute( (cache) -> {
+            Set<String> paths = getMissing( location );
+            paths.forEach( path -> cache.remove( getResourceKey( new ConcreteResource( location, path ) ) ) );
+            return null;
+        } );
     }
 
     @Override
@@ -167,7 +172,7 @@ public class IspnNotFoundCache
     @Override
     public void clearAllMissing()
     {
-        nfcCache.getCache().clear();
+        nfcCache.execute( (cache) -> { cache.clear(); return null; } );
     }
 
     @Override
@@ -292,7 +297,7 @@ public class IspnNotFoundCache
     @Override
     public long getSize()
     {
-        return nfcCache.getCache().size();
+        return nfcCache.execute( (cache) -> new Long( cache.size() ) );
     }
 
     private int getProperPageSize( int pageSize )

--- a/core/src/main/java/org/commonjava/indy/core/inject/NfcCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/NfcCacheProducer.java
@@ -39,6 +39,6 @@ public class NfcCacheProducer
     @ApplicationScoped
     public CacheHandle<String, NfcConcreteResourceWrapper> nfcCache()
     {
-        return cacheProducer.getCache( NFC, String.class, NfcConcreteResourceWrapper.class );
+        return cacheProducer.getCache( NFC );
     }
 }

--- a/deployments/launcher/pom.xml
+++ b/deployments/launcher/pom.xml
@@ -195,6 +195,12 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-infinispan</artifactId>
+      <type>tar.gz</type>
+      <classifier>confset</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-prefetch</artifactId>
       <type>tar.gz</type>
       <classifier>confset</classifier>

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/CacheInstanceAdapter.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/CacheInstanceAdapter.java
@@ -48,7 +48,7 @@ public class CacheInstanceAdapter<K, V>
     @Override
     public <R> R execute( Function<Cache<K, V>, R> operation )
     {
-        return cacheHandle.execute( operation );
+        return cacheHandle.executeCache( operation );
     }
 
     @Override

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/FastLocalCacheProducer.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/FastLocalCacheProducer.java
@@ -33,7 +33,7 @@ public class FastLocalCacheProducer
     @ApplicationScoped
     public CacheHandle<String, String> nfsOwnerCacheCfg()
     {
-        return cacheProducer.getCache( "indy-nfs-owner-cache", String.class, String.class );
+        return cacheProducer.getCache( "indy-nfs-owner-cache" );
     }
 
     @FastLocalFileRemoveCache
@@ -41,6 +41,6 @@ public class FastLocalCacheProducer
     @ApplicationScoped
     public CacheHandle<String, ConcreteResource> fastLocalFileRemoveCfg()
     {
-        return cacheProducer.getCache( "indy-fastlocal-file-delete-cache", String.class, ConcreteResource.class );
+        return cacheProducer.getCache( "indy-fastlocal-file-delete-cache" );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithArtifactsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithArtifactsTest.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.infinispan.AdvancedCache;
@@ -98,7 +99,7 @@ public class ContentIndexDirLvWithArtifactsTest
     @Rule
     public ExpectationServer server = new ExpectationServer();
 
-    private CacheHandle<IndexedStorePath, StoreKey> contentIndex;
+    private BasicCacheHandle<IndexedStorePath, StoreKey> contentIndex;
 
     @Before
     public void getIndexManager()

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithMetadataTest.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.infinispan.AdvancedCache;
@@ -82,7 +83,7 @@ public class ContentIndexDirLvWithMetadataTest
     @Rule
     public ExpectationServer server = new ExpectationServer();
 
-    private CacheHandle<IndexedStorePath, StoreKey> contentIndex;
+    private BasicCacheHandle<IndexedStorePath, StoreKey> contentIndex;
 
     @Before
     public void getIndexManager()

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexRemoteRepoUsageTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexRemoteRepoUsageTest.java
@@ -78,7 +78,7 @@ public class ContentIndexRemoteRepoUsageTest
     public void getIndexManager()
     {
         indexManager = CDI.current().select( ContentIndexManager.class ).get();
-        cacheHandle = CDI.current().select( ContentIndexCacheProducer.class ).get().contentIndexCacheCfg();
+        cacheHandle = (CacheHandle) CDI.current().select( ContentIndexCacheProducer.class ).get().contentIndexCacheCfg();
     }
 
     @Test

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexRemoteRepoUsageTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexRemoteRepoUsageTest.java
@@ -95,7 +95,7 @@ public class ContentIndexRemoteRepoUsageTest
         logger.info( "\n\n\nBEFORE: Indexed path entry: " + indexedStoreKey + "\n\n\n\n");
         assertThat( indexedStoreKey, nullValue() );
 
-        Long hits = cacheHandle.execute( (cache) -> cache.getAdvancedCache().getStats().getHits() );
+        Long hits = cacheHandle.executeCache( (cache) -> cache.getAdvancedCache().getStats().getHits() );
         assertThat( hits == 0, equalTo( true ) );
 
         try (InputStream first = client.content().get( repo.getKey(), FIRST_PATH ))
@@ -107,7 +107,7 @@ public class ContentIndexRemoteRepoUsageTest
         logger.info( "\n\n\nAFTER 1: Indexed path entry: " + indexedStoreKey + "\n\n\n\n");
         assertThat( indexedStoreKey, notNullValue() );
 
-        hits = cacheHandle.execute( (cache) -> cache.getAdvancedCache().getStats().getHits() );
+        hits = cacheHandle.executeCache( (cache) -> cache.getAdvancedCache().getStats().getHits() );
         assertThat( hits >= 1, equalTo( true ) );
 
         try (InputStream first = client.content().get( repo.getKey(), FIRST_PATH ))
@@ -118,7 +118,7 @@ public class ContentIndexRemoteRepoUsageTest
         StoreKey indexedStoreKey2 = indexManager.getIndexedStoreKey( repo.getKey(), FIRST_PATH );
         logger.info( "\n\n\nAFTER 2: Indexed path entry: " + indexedStoreKey2 + "\n\n\n\n");
 
-        hits = cacheHandle.execute( (cache) -> cache.getAdvancedCache().getStats().getHits() );
+        hits = cacheHandle.executeCache( (cache) -> cache.getAdvancedCache().getStats().getHits() );
         assertThat( hits >= 2, equalTo( true ) );
 
         // object equality should work since we haven't persisted this anywhere yet.

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/infinispan/CacheProducerMergeXmlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/infinispan/CacheProducerMergeXmlTest.java
@@ -55,7 +55,7 @@ public class CacheProducerMergeXmlTest
     {
         manager = new DefaultCacheManager(
                 new GlobalConfigurationBuilder().globalJmxStatistics().allowDuplicateDomains( true ).build() );
-        producer = new CacheProducer( new DefaultIndyConfiguration(), manager );
+        producer = new CacheProducer( new DefaultIndyConfiguration(), manager, null );
         producer.start();
         manager = producer.getCacheManager();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -843,6 +843,11 @@
         <version>${infinispanVersion}</version>
       </dependency>
       <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-client-hotrod</artifactId>
+        <version>${infinispanVersion}</version>
+      </dependency>
+      <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
         <version>3.3.0.Final</version>

--- a/pom.xml
+++ b/pom.xml
@@ -641,6 +641,14 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-subsys-infinispan</artifactId>
+        <version>1.3.2-SNAPSHOT</version>
+        <type>tar.gz</type>
+        <classifier>confset</classifier>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-prefetch</artifactId>
         <version>1.3.2-SNAPSHOT</version>
         <type>tar.gz</type>

--- a/subsys/infinispan/pom.xml
+++ b/subsys/infinispan/pom.xml
@@ -90,4 +90,26 @@
       <artifactId>postgresql</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>confset</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>confset</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/subsys/infinispan/pom.xml
+++ b/subsys/infinispan/pom.xml
@@ -66,6 +66,10 @@
       <artifactId>infinispan-cachestore-jdbc</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-client-hotrod</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/subsys/infinispan/src/main/conf/conf.d/infinispan-remote.conf
+++ b/subsys/infinispan/src/main/conf/conf.d/infinispan-remote.conf
@@ -1,0 +1,16 @@
+[infinispan-remote]
+
+# By default, the remote cache is disabled. An alternative embedded cache will be returned when this is disabled.
+#
+#enabled=true
+
+# Remote Infinispan server. Default localhost.
+#remote.server=localhost
+
+# By default, hotrod endpoint on port 11222.
+#
+#hotrod.port=11222
+
+# Caches matching below patterns are remote caches. Patterns split by comma.
+#
+#remote.patterns=remote.+

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/BasicCacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/BasicCacheHandle.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.infinispan;
+
+import com.codahale.metrics.Timer;
+import org.commonjava.indy.metrics.IndyMetricsManager;
+import org.infinispan.commons.api.BasicCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.METER;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.TIMER;
+
+public class BasicCacheHandle<K,V>
+{
+    Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private String name;
+
+    protected BasicCache<K,V> cache;
+
+    private IndyMetricsManager metricsManager;
+
+    private String metricPrefix;
+
+    private boolean stopped;
+
+    public boolean isStopped()
+    {
+        return stopped;
+    }
+
+    protected BasicCacheHandle()
+    {
+    }
+
+    protected BasicCacheHandle( String named, BasicCache<K, V> cache, IndyMetricsManager metricsManager, String metricPrefix )
+    {
+        this.name = named;
+        this.cache = cache;
+        this.metricsManager = metricsManager;
+        this.metricPrefix = metricPrefix;
+    }
+
+    public BasicCacheHandle( String named, BasicCache<K, V> cache )
+    {
+        this( named, cache, null, null );
+    }
+
+    public BasicCache<K,V> getCache(){
+        return cache;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public <R> R execute( Function<BasicCache<K, V>, R> operation )
+    {
+        if ( !stopped )
+        {
+            Timer.Context context = startMetrics( "execute" );
+
+            try
+            {
+                return operation.apply( cache );
+            }
+            catch ( RuntimeException e )
+            {
+                logger.error( "Failed to complete operation: " + e.getMessage(), e );
+            }
+            finally
+            {
+                if ( context != null )
+                {
+                    context.stop();
+                }
+            }
+        }
+        else
+        {
+            logger.error( "Cannot complete operation. Cache {} is shutting down.", name );
+        }
+
+        return null;
+    }
+
+    public void stop()
+    {
+        logger.info( "Cache {} is shutting down!", name );
+        this.stopped = true;
+    }
+
+    public boolean containsKey( K key )
+    {
+        return execute( cache -> cache.containsKey( key ) );
+    }
+
+    public V put( K key, V value )
+    {
+        return execute( cache -> cache.put( key, value ) );
+    }
+
+    public V put( K key, V value, int expiration, TimeUnit timeUnit )
+    {
+        return execute( cache -> cache.put( key, value, expiration, timeUnit ) );
+    }
+
+    public V putIfAbsent( K key, V value )
+    {
+        return execute( ( c ) -> c.putIfAbsent( key, value ) );
+    }
+
+    public V computeIfAbsent( K key, Function<? super K, ? extends V> mappingFunction )
+    {
+        return execute( c -> c.computeIfAbsent( key, mappingFunction ) );
+    }
+
+    public V remove( K key )
+    {
+        return execute( cache -> cache.remove( key ) );
+    }
+
+    public V get( K key )
+    {
+        return execute( cache -> cache.get( key ) );
+    }
+
+    protected Timer.Context startMetrics( String name )
+    {
+        if ( metricsManager != null )
+        {
+            metricsManager.getMeter( name( metricPrefix, name, METER ) ).mark();
+            return metricsManager.getTimer( name( metricPrefix, name, TIMER ) ).time();
+        }
+
+        return null;
+    }
+
+    public Set<K> cacheKeySetByFilter( Predicate<K> filter )
+    {
+        return this.cache.keySet().stream().filter( filter ).collect( Collectors.toSet() );
+    }
+
+    public boolean isEmpty(){
+        return execute( c->c.isEmpty() );
+    }
+
+}

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheHandle.java
@@ -34,8 +34,6 @@ import java.util.function.Function;
  */
 public class CacheHandle<K,V> extends BasicCacheHandle<K,V>
 {
-    Logger logger = LoggerFactory.getLogger( getClass() );
-
     protected CacheHandle(){}
 
     public CacheHandle( String named, Cache<K, V> cache, IndyMetricsManager metricsManager, String metricPrefix )
@@ -48,13 +46,9 @@ public class CacheHandle<K,V> extends BasicCacheHandle<K,V>
         this( named, cache, null, null );
     }
 
-    @Deprecated
-    public Cache<K,V> getCache(){
-        return (Cache) cache;
-    }
-
     public <R> R executeCache( Function<Cache<K, V>, R> operation )
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
         if ( !isStopped() )
         {
             Timer.Context context = startMetrics( "execute" );

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -29,7 +29,6 @@ import org.commonjava.indy.subsys.infinispan.config.ISPNRemoteConfiguration;
 import org.infinispan.Cache;
 import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
-import org.infinispan.commons.api.BasicCache;
 import org.infinispan.commons.marshall.MarshallableTypeHints;
 import org.infinispan.configuration.ConfigurationManager;
 import org.infinispan.configuration.cache.Configuration;
@@ -166,6 +165,10 @@ public class CacheProducer
         }
     }
 
+    /**
+     * Get a BasicCache instance. If the remote cache is enabled, it will match the named with remote.patterns.
+     * If matched, it will create/return a RemoteCache. If not matched, an embedded cache will be created/returned to the caller.
+     */
     public synchronized <K, V> BasicCacheHandle<K, V> getBasicCache( String named, Class<K> keyClass, Class<V> valueClass )
     {
         BasicCacheHandle<K, V> handle = caches.get( named );

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -91,10 +91,6 @@ public class CacheProducer
         this.indyConfiguration = indyConfiguration;
         this.cacheManager = cacheManager;
         this.remoteConfiguration = remoteConfiguration;
-        if ( remoteConfiguration != null )
-        {
-            startRemoteManager();
-        }
     }
 
     @PostConstruct
@@ -108,7 +104,7 @@ public class CacheProducer
 
     private void startRemoteManager()
     {
-        if ( !remoteConfiguration.isEnabled() )
+        if ( remoteConfiguration == null || !remoteConfiguration.isEnabled() )
         {
             logger.info( "Infinispan remote configuration not enabled. Skip." );
             return;
@@ -180,13 +176,23 @@ public class CacheProducer
 
         if ( remoteConfiguration.isEnabled() && remoteConfiguration.isRemoteCache( named ) )
         {
-            RemoteCache<K, V> cache = remoteCacheManager.getCache( named );
+            RemoteCache<K, V> cache = null;
+            try
+            {
+                cache = remoteCacheManager.getCache( named );
+            }
+            catch ( Exception e )
+            {
+                logger.warn( "Get remote cache failed", e );
+            }
+
             if ( cache == null )
             {
-                logger.warn( "Remote cache not found, name: {}", named );
+                logger.warn( "Can not get remote cache, name: {}", named );
             }
             else
             {
+                logger.info( "Get remote cache, name: {}", named );
                 handle = new RemoteCacheHandle( named, cache, metricsManager, getCacheMetricPrefix( named ) );
             }
         }

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -117,6 +117,7 @@ public class CacheProducer
         ConfigurationBuilder builder = new ConfigurationBuilder();
         builder.addServer().host( remoteConfiguration.getRemoteServer() ).port( remoteConfiguration.getHotrodPort() );
         remoteCacheManager = new RemoteCacheManager( builder.build() );
+        logger.info( "Infinispan remote cache manager started." );
     }
 
     private void startEmbeddedManager()
@@ -182,13 +183,16 @@ public class CacheProducer
             RemoteCache<K, V> cache = remoteCacheManager.getCache( named );
             if ( cache == null )
             {
-                logger.debug( "Remote cache not found, name: {}", named );
-                return null;
+                logger.warn( "Remote cache not found, name: {}", named );
             }
-            handle = new RemoteCacheHandle( named, cache, metricsManager, getCacheMetricPrefix( named ) );
+            else
+            {
+                handle = new RemoteCacheHandle( named, cache, metricsManager, getCacheMetricPrefix( named ) );
+            }
         }
-        else
+        if ( handle == null )
         {
+            logger.debug( "Get embedded cache, name: {}", named );
             handle = getCache( named, keyClass, valueClass );
         }
         caches.put( named, handle );

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/RemoteCacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/RemoteCacheHandle.java
@@ -18,6 +18,8 @@ package org.commonjava.indy.subsys.infinispan;
 import org.commonjava.indy.metrics.IndyMetricsManager;
 import org.infinispan.client.hotrod.RemoteCache;
 
+import static com.codahale.metrics.MetricRegistry.name;
+
 public class RemoteCacheHandle<K,V> extends BasicCacheHandle<K, V>
 {
 
@@ -29,6 +31,12 @@ public class RemoteCacheHandle<K,V> extends BasicCacheHandle<K, V>
     public RemoteCacheHandle( String named, RemoteCache<K, V> cache )
     {
         this( named, cache, null, null );
+    }
+
+    @Override
+    protected String getMetricName( String opName )
+    {
+        return name( getMetricPrefix(), "remote", opName );
     }
 
 }

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/RemoteCacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/RemoteCacheHandle.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.infinispan;
+
+import org.commonjava.indy.metrics.IndyMetricsManager;
+import org.infinispan.client.hotrod.RemoteCache;
+
+public class RemoteCacheHandle<K,V> extends BasicCacheHandle<K, V>
+{
+
+    public RemoteCacheHandle( String named, RemoteCache<K, V> cache, IndyMetricsManager metricsManager, String metricPrefix )
+    {
+        super( named, cache, metricsManager, metricPrefix );
+    }
+
+    public RemoteCacheHandle( String named, RemoteCache<K, V> cache )
+    {
+        this( named, cache, null, null );
+    }
+
+}

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/config/ISPNRemoteConfiguration.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/config/ISPNRemoteConfiguration.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.infinispan.config;
+
+import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.web.config.annotation.ConfigName;
+import org.commonjava.web.config.annotation.SectionName;
+import org.infinispan.client.hotrod.impl.ConfigurationProperties;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+@SectionName( "infinispan-remote" )
+@ApplicationScoped
+public class ISPNRemoteConfiguration
+        implements IndyConfigInfo
+{
+    private static final String DEFAULT_REMOTE_SERVER = "localhost";
+
+    private static final Boolean DEFAULT_ENABLED = Boolean.FALSE;
+
+    private Boolean enabled;
+
+    private String remoteServer;
+
+    private Integer hotrodPort;
+
+    private String remotePatterns;
+
+    public ISPNRemoteConfiguration()
+    {
+    }
+
+    private List<String> remotePatternsList;
+
+    @PostConstruct
+    private void init()
+    {
+        if ( isNotBlank( remotePatterns ) )
+        {
+            remotePatternsList = new ArrayList<>();
+            String[] patterns = remotePatterns.split( "," );
+            for ( String pattern : patterns )
+            {
+                remotePatternsList.add( pattern );
+            }
+        }
+    }
+
+    public Boolean isEnabled()
+    {
+        return enabled == null ? DEFAULT_ENABLED : enabled;
+    }
+
+    @ConfigName( "enabled" )
+    public void setEnabled( Boolean enabled )
+    {
+        this.enabled = enabled;
+    }
+
+    public String getRemoteServer()
+    {
+        return remoteServer == null ? DEFAULT_REMOTE_SERVER : remoteServer;
+    }
+
+    @ConfigName( "remote.server" )
+    public void setRemoteServer( String remoteServer )
+    {
+        this.remoteServer = remoteServer;
+    }
+
+    public Integer getHotrodPort()
+    {
+        return hotrodPort == null ? ConfigurationProperties.DEFAULT_HOTROD_PORT : hotrodPort;
+    }
+
+    @ConfigName( "hotrod.port" )
+    public void setHotrodPort( Integer hotrodPort )
+    {
+        this.hotrodPort = hotrodPort;
+    }
+
+    public String getRemotePatterns()
+    {
+        return remotePatterns;
+    }
+
+    @ConfigName( "remote.patterns" )
+    public void setRemotePatterns( String remotePatterns )
+    {
+        this.remotePatterns = remotePatterns;
+    }
+
+    // utils
+
+    public boolean isRemoteCache( String cacheName )
+    {
+        if ( remotePatternsList == null )
+        {
+            return false;
+        }
+        for ( String pattern : remotePatternsList )
+        {
+            if ( cacheName.matches( pattern ) || cacheName.equals( pattern ) )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return new File( IndyConfigInfo.CONF_INCLUDES_DIR, "infinispan-remote.conf" ).getPath();
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return Thread.currentThread()
+                     .getContextClassLoader()
+                     .getResourceAsStream( "default-infinispan-remote.conf" );
+    }
+}

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/config/ISPNRemoteConfiguration.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/config/ISPNRemoteConfiguration.java
@@ -20,12 +20,9 @@ import org.commonjava.web.config.annotation.ConfigName;
 import org.commonjava.web.config.annotation.SectionName;
 import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -48,22 +45,6 @@ public class ISPNRemoteConfiguration
 
     public ISPNRemoteConfiguration()
     {
-    }
-
-    private List<String> remotePatternsList;
-
-    @PostConstruct
-    private void init()
-    {
-        if ( isNotBlank( remotePatterns ) )
-        {
-            remotePatternsList = new ArrayList<>();
-            String[] patterns = remotePatterns.split( "," );
-            for ( String pattern : patterns )
-            {
-                remotePatternsList.add( pattern );
-            }
-        }
     }
 
     public Boolean isEnabled()
@@ -114,17 +95,23 @@ public class ISPNRemoteConfiguration
 
     public boolean isRemoteCache( String cacheName )
     {
-        if ( remotePatternsList == null )
+        if ( remotePatterns == null )
         {
             return false;
         }
-        for ( String pattern : remotePatternsList )
+
+        String[] patterns = remotePatterns.split( "," );
+        for ( String pattern : patterns )
         {
-            if ( cacheName.matches( pattern ) || cacheName.equals( pattern ) )
+            if ( isNotBlank( pattern ) )
             {
-                return true;
+                if ( cacheName.matches( pattern ) || cacheName.equals( pattern ) )
+                {
+                    return true;
+                }
             }
         }
+
         return false;
     }
 

--- a/subsys/infinispan/src/main/resources/default-infinispan-remote.conf
+++ b/subsys/infinispan/src/main/resources/default-infinispan-remote.conf
@@ -1,0 +1,16 @@
+[infinispan-remote]
+
+# By default, the remote cache is disabled. An alternative embedded cache will be returned when this is disabled.
+#
+#enabled=true
+
+# Remote Infinispan server. Default localhost.
+#remote.server=localhost
+
+# By default, hotrod endpoint on port 11222.
+#
+#hotrod.port=11222
+
+# Caches matching below patterns are remote caches. Patterns split by comma.
+#
+#remote.patterns=remote.+

--- a/subsys/prefetch/src/main/java/org/commonjava/indy/subsys/prefetch/PrefetchCacheProducer.java
+++ b/subsys/prefetch/src/main/java/org/commonjava/indy/subsys/prefetch/PrefetchCacheProducer.java
@@ -34,6 +34,6 @@ public class PrefetchCacheProducer
     @ApplicationScoped
     public CacheHandle<RemoteRepository, List> contentIndexCacheCfg()
     {
-        return cacheProducer.getCache( "prefetch-cache", RemoteRepository.class, List.class );
+        return cacheProducer.getCache( "prefetch-cache" );
     }
 }


### PR DESCRIPTION
This is a big PR. I tried to break it to some commits, but still big.
I have done some tests on my local, i.e., start a docker for infinispan-server, config/enable remote cache for content-index, maven-metadata, etc, then run some requests, and watch the status on remote cache admin console. 
The point to highlight is that this PR support remote cache in a flexible way, i.e., if remote cache is not enabled, it just works as usual embedded caches.
Please review. 