### PR TITLE
Add config to disable remote content listing download

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -291,7 +291,7 @@ public class MavenMetadataGenerator
         if ( pathElementsCount >= 2 )
         {
             // regardless, we will need this first level of listings. What we do with it will depend on the logic below...
-            final List<StoreResource> firstLevelFiles = fileManager.listRaw( store, path );
+            final List<StoreResource> firstLevelFiles = fileManager.listRaw( store, path, eventMetadata );
 
             ArtifactPathInfo samplePomInfo = null;
             for ( final StoreResource topResource : firstLevelFiles )
@@ -311,7 +311,7 @@ public class MavenMetadataGenerator
                                                              .map( (res) -> res.getPath() )
                                                              .filter( (subpath) -> subpath.endsWith( "/" ) )
                                                              .collect( Collectors.toList() );
-                final Map<String, List<StoreResource>> secondLevelMap = fileManager.listRaw( store, firstLevelDirs );
+                final Map<String, List<StoreResource>> secondLevelMap = fileManager.listRaw( store, firstLevelDirs, eventMetadata );
                 nextTopResource: for ( final String topPath : firstLevelDirs )
                 {
                     final List<StoreResource> secondLevelListing = secondLevelMap.get( topPath );

--- a/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
@@ -43,6 +43,8 @@ public class DefaultIndyConfiguration
 
     public static final int DEFAULT_NFC_MAX_RESULT_SET_SIZE = 10000; // 10,000
 
+    public static final Boolean DEFAULT_ALLOW_REMOTE_LIST_DOWNLOAD = true;
+
     private Integer passthroughTimeoutSeconds;
 
     private Integer notFoundCacheTimeoutSeconds;
@@ -56,6 +58,8 @@ public class DefaultIndyConfiguration
     private Integer nfcMaxResultSetSize;
 
     private String mdcHeaders;
+
+    private Boolean allowRemoteListDownload;
 
     public DefaultIndyConfiguration()
     {
@@ -149,6 +153,18 @@ public class DefaultIndyConfiguration
     public File getIndyConfDir()
     {
         return getSyspropDir( IndyConfigFactory.CONFIG_DIR_PROP );
+    }
+
+    @Override
+    public Boolean isAllowRemoteListDownload()
+    {
+        return allowRemoteListDownload == null ? DEFAULT_ALLOW_REMOTE_LIST_DOWNLOAD : allowRemoteListDownload;
+    }
+
+    @ConfigName( "remote.list.download.enabled" )
+    public void setAllowRemoteListDownload( Boolean allowRemoteListDownload )
+    {
+        this.allowRemoteListDownload = allowRemoteListDownload;
     }
 
     private File getSyspropDir( final String property )

--- a/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
@@ -43,7 +43,7 @@ public class DefaultIndyConfiguration
 
     public static final int DEFAULT_NFC_MAX_RESULT_SET_SIZE = 10000; // 10,000
 
-    public static final Boolean DEFAULT_ALLOW_REMOTE_LIST_DOWNLOAD = true;
+    public static final Boolean DEFAULT_ALLOW_REMOTE_LIST_DOWNLOAD = false;
 
     private Integer passthroughTimeoutSeconds;
 

--- a/api/src/main/java/org/commonjava/indy/conf/IndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/IndyConfiguration.java
@@ -66,4 +66,6 @@ public interface IndyConfiguration
 
     File getIndyConfDir();
 
+    Boolean isAllowRemoteListDownload();
+
 }

--- a/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
+++ b/api/src/main/java/org/commonjava/indy/content/DirectContentAccess.java
@@ -80,7 +80,13 @@ public interface DirectContentAccess
     List<StoreResource> listRaw( ArtifactStore store, String parentPath )
             throws IndyWorkflowException;
 
+    List<StoreResource> listRaw( ArtifactStore store, String parentPath, EventMetadata eventMetadata )
+            throws IndyWorkflowException;
+
     Map<String, List<StoreResource>> listRaw( ArtifactStore store, List<String> parentPathList )
+            throws IndyWorkflowException;
+
+    Map<String, List<StoreResource>> listRaw( ArtifactStore store, List<String> parentPathList, EventMetadata eventMetadata )
             throws IndyWorkflowException;
 
 }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
@@ -177,8 +177,22 @@ public class DefaultDirectContentAccess
     }
 
     @Override
+    public List<StoreResource> listRaw( ArtifactStore store, String path, EventMetadata eventMetadata )
+            throws IndyWorkflowException
+    {
+        return downloadManager.list( store, path, eventMetadata );
+    }
+
+    @Override
+    public Map<String, List<StoreResource>> listRaw( ArtifactStore store, List<String> parentPathList )
+            throws IndyWorkflowException
+    {
+        return listRaw( store, parentPathList, new EventMetadata() );
+    }
+
+    @Override
     public Map<String, List<StoreResource>> listRaw( ArtifactStore store,
-                                                     List<String> parentPathList ) throws IndyWorkflowException
+                                                     List<String> parentPathList, EventMetadata eventMetadata ) throws IndyWorkflowException
     {
         CompletionService<List<StoreResource>> executor = new ExecutorCompletionService<>( executorService );
         Map<String, Future<List<StoreResource>>> futures = new HashMap<>();
@@ -188,7 +202,7 @@ public class DefaultDirectContentAccess
             logger.trace( "Requesting listing of {} in {}", path, store );
             Future<List<StoreResource>> future = executor.submit( ()->{
                 logger.trace( "Starting listing of {} in {}", path, store );
-                List<StoreResource> listRaw = listRaw( store, path );
+                List<StoreResource> listRaw = listRaw( store, path, eventMetadata );
                 logger.trace( "Listing of {} in {} finished", path, store );
                 return listRaw;
             });

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.change.event.ArtifactStorePostRescanEvent;
 import org.commonjava.indy.change.event.ArtifactStorePreRescanEvent;
 import org.commonjava.indy.change.event.ArtifactStoreRescanEvent;
 import org.commonjava.indy.change.event.IndyStoreErrorEvent;
+import org.commonjava.indy.conf.IndyConfiguration;
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.change.event.IndyFileEventManager;
@@ -122,6 +123,9 @@ public class DefaultDownloadManager
     @Any
     private Instance<ContentAdvisor> contentAdvisors;
 
+    @Inject
+    private IndyConfiguration indyConfig;
+
     protected DefaultDownloadManager()
     {
     }
@@ -165,12 +169,18 @@ public class DefaultDownloadManager
 
         //        final String dir = PathUtils.dirname( path );
 
+        final EventMetadata metadata = eventMetadata == null ?
+                new EventMetadata().set( TransferManager.ALLOW_REMOTE_LISTING_DOWNLOAD,
+                                         indyConfig.isAllowRemoteListDownload() ) :
+                eventMetadata.set( TransferManager.ALLOW_REMOTE_LISTING_DOWNLOAD,
+                                   indyConfig.isAllowRemoteListDownload() );
+
         if ( store.getKey().getType() == StoreType.group )
         {
             try
             {
                 final List<ListingResult> results = transfers.listAll(
-                        locationExpander.expand( new VirtualResource( LocationUtils.toLocations( store ), path ) ), eventMetadata );
+                        locationExpander.expand( new VirtualResource( LocationUtils.toLocations( store ), path ) ), metadata );
 
                 for ( final ListingResult lr : results )
                 {
@@ -218,7 +228,7 @@ public class DefaultDownloadManager
             {
                 try
                 {
-                    final ListingResult lr = transfers.list( res, eventMetadata );
+                    final ListingResult lr = transfers.list( res, metadata );
                     if ( lr != null && lr.getListing() != null )
                     {
                         for ( final String file : lr.getListing() )
@@ -294,10 +304,15 @@ public class DefaultDownloadManager
         final String dir = PathUtils.dirname( path );
 
         final List<StoreResource> result = new ArrayList<>();
+        final EventMetadata metadata = eventMetadata == null ?
+                new EventMetadata().set( TransferManager.ALLOW_REMOTE_LISTING_DOWNLOAD,
+                                         indyConfig.isAllowRemoteListDownload() ) :
+                eventMetadata.set( TransferManager.ALLOW_REMOTE_LISTING_DOWNLOAD,
+                                   indyConfig.isAllowRemoteListDownload() );
         try
         {
             final List<ListingResult> results = transfers.listAll(
-                    locationExpander.expand( new VirtualResource( LocationUtils.toLocations( stores ), path ) ), eventMetadata );
+                    locationExpander.expand( new VirtualResource( LocationUtils.toLocations( stores ), path ) ), metadata );
 
             for ( final ListingResult lr : results )
             {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -22,7 +22,6 @@ import org.commonjava.indy.change.event.ArtifactStorePostRescanEvent;
 import org.commonjava.indy.change.event.ArtifactStorePreRescanEvent;
 import org.commonjava.indy.change.event.ArtifactStoreRescanEvent;
 import org.commonjava.indy.change.event.IndyStoreErrorEvent;
-import org.commonjava.indy.conf.IndyConfiguration;
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.change.event.IndyFileEventManager;
@@ -123,9 +122,6 @@ public class DefaultDownloadManager
     @Any
     private Instance<ContentAdvisor> contentAdvisors;
 
-    @Inject
-    private IndyConfiguration indyConfig;
-
     protected DefaultDownloadManager()
     {
     }
@@ -169,18 +165,12 @@ public class DefaultDownloadManager
 
         //        final String dir = PathUtils.dirname( path );
 
-        final EventMetadata metadata = eventMetadata == null ?
-                new EventMetadata().set( TransferManager.ALLOW_REMOTE_LISTING_DOWNLOAD,
-                                         indyConfig.isAllowRemoteListDownload() ) :
-                eventMetadata.set( TransferManager.ALLOW_REMOTE_LISTING_DOWNLOAD,
-                                   indyConfig.isAllowRemoteListDownload() );
-
         if ( store.getKey().getType() == StoreType.group )
         {
             try
             {
                 final List<ListingResult> results = transfers.listAll(
-                        locationExpander.expand( new VirtualResource( LocationUtils.toLocations( store ), path ) ), metadata );
+                        locationExpander.expand( new VirtualResource( LocationUtils.toLocations( store ), path ) ), eventMetadata );
 
                 for ( final ListingResult lr : results )
                 {
@@ -228,7 +218,7 @@ public class DefaultDownloadManager
             {
                 try
                 {
-                    final ListingResult lr = transfers.list( res, metadata );
+                    final ListingResult lr = transfers.list( res, eventMetadata );
                     if ( lr != null && lr.getListing() != null )
                     {
                         for ( final String file : lr.getListing() )
@@ -304,15 +294,10 @@ public class DefaultDownloadManager
         final String dir = PathUtils.dirname( path );
 
         final List<StoreResource> result = new ArrayList<>();
-        final EventMetadata metadata = eventMetadata == null ?
-                new EventMetadata().set( TransferManager.ALLOW_REMOTE_LISTING_DOWNLOAD,
-                                         indyConfig.isAllowRemoteListDownload() ) :
-                eventMetadata.set( TransferManager.ALLOW_REMOTE_LISTING_DOWNLOAD,
-                                   indyConfig.isAllowRemoteListDownload() );
         try
         {
             final List<ListingResult> results = transfers.listAll(
-                    locationExpander.expand( new VirtualResource( LocationUtils.toLocations( stores ), path ) ), metadata );
+                    locationExpander.expand( new VirtualResource( LocationUtils.toLocations( stores ), path ) ), eventMetadata );
 
             for ( final ListingResult lr : results )
             {

--- a/deployments/launcher/src/main/etc/indy/main.conf
+++ b/deployments/launcher/src/main/etc/indy/main.conf
@@ -2,6 +2,11 @@
 # nfc.timeout=300
 # nfc.sweep.minutes=30
 
+# This controls if indy will do downloading when listing a directory content for a remote repo.
+# If it is disabled, indy will only list the content that has been cache in local for remote repo.
+# Default is not enabled.
+# remote.list.download.enabled = false
+
 # This is a list of http request headers to add to MDC (default: component-id)
 #mdc.headers =
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>0.17.2</atlasVersion>
-    <galleyVersion>0.16.4</galleyVersion>
+    <galleyVersion>0.16.5-SNAPSHOT</galleyVersion>
     <bomVersion>23</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.14</partylineVersion>


### PR DESCRIPTION
  This commit add config to be able to disable remote content listing
download. That means when this is disabled, only the content that's
stored/cached in the system can be viewed on the UI of directory content
listing for remote repository.(or groups with remote repo)

P.S: this PR depends on galley PR: https://github.com/Commonjava/galley/pull/252