### PR TITLE
Fixing path masks in koji remotes and improve repair endpoints

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
@@ -233,6 +233,8 @@ public final class ProxyRequestReader
                                 {
                                     logger.debug( "Detected end of request headers." );
                                     headDone = true;
+
+                                    logger.trace( "Proxy request header:\n{}\n", new String( bReq.toByteArray() ) );
                                 }
                             }
                             finally

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiBuildAuthority.java
@@ -83,7 +83,7 @@ public class KojiBuildAuthority
     private TypeMapper typeMapper;
 
     @Inject
-    private CachedKojiContentProvider kojiContentProvider;
+    private IndyKojiContentProvider kojiContentProvider;
 
     @Inject
     private StoreDataManager storeDataManager;
@@ -102,7 +102,7 @@ public class KojiBuildAuthority
     {
         this.config = config;
         this.typeMapper = typeMapper;
-        this.kojiContentProvider = new CachedKojiContentProvider( kojiClient, new CacheProducer( null, cacheManager, null ) );
+        this.kojiContentProvider = new IndyKojiContentProvider( kojiClient, new CacheProducer( null, cacheManager, null ) );
         this.storeDataManager = storeDataManager;
         this.contentDigester = contentDigester;
         this.directContentAccess = directContentAccess;

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -40,7 +40,6 @@ import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
-import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.atlas.ident.util.ArtifactPathInfo;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.ConcreteResource;
@@ -61,7 +60,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.regex.Pattern;
 
 import static org.commonjava.indy.koji.model.IndyKojiConstants.KOJI_ORIGIN;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.KOJI_ORIGIN_BINARY;
@@ -113,7 +111,7 @@ public abstract class KojiContentManagerDecorator
     private StoreDataManager storeDataManager;
 
     @Inject
-    private CachedKojiContentProvider kojiContentProvider;
+    private IndyKojiContentProvider kojiContentProvider;
 
     @Inject
     private KojiUtils kojiUtils;

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -88,7 +88,7 @@ public class KojiMavenMetadataProvider
     private BasicCacheHandle<ProjectRef, Metadata> versionMetadata;
 
     @Inject
-    private CachedKojiContentProvider kojiContentProvider;
+    private IndyKojiContentProvider kojiContentProvider;
 
     @Inject
     private IndyKojiConfig kojiConfig;
@@ -111,7 +111,7 @@ public class KojiMavenMetadataProvider
                                       KojiBuildAuthority buildAuthority, IndyKojiConfig kojiConfig, ExecutorService executorService, DefaultCacheManager cacheManager )
     {
         this.versionMetadata = versionMetadata;
-        this.kojiContentProvider = new CachedKojiContentProvider( kojiClient, new CacheProducer( null, cacheManager, null ) );
+        this.kojiContentProvider = new IndyKojiContentProvider( kojiClient, new CacheProducer( null, cacheManager, null ) );
         this.buildAuthority = buildAuthority;
         this.kojiConfig = kojiConfig;
         this.executorService = executorService;

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiPathPatternFormatter.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiPathPatternFormatter.java
@@ -32,16 +32,21 @@ public class KojiPathPatternFormatter
         Set<String> patterns = new HashSet<>();
         for ( KojiArchiveInfo a : archives )
         {
-            if ( !kojiUtils.isVersionSignatureAllowedWithVersion( artifactRef.getVersionStringRaw() ) )
+            ArtifactRef ar = a.asArtifact();
+            if ( !kojiUtils.isVersionSignatureAllowedWithVersion( a.getVersion() ) )
             {
+                logger.warn(
+                        "Cannot use Koji archive for path_mask_patterns: {}. Version '{}' is not allowed from Koji.", a,
+                        a.getVersion() );
                 continue;
             }
-            String pattern = getPatternString( artifactRef, a );
+            String pattern = getPatternString( ar, a );
             if ( pattern != null )
             {
                 patterns.add( pattern );
             }
         }
+
         if ( !patterns.isEmpty() )
         {
             String meta = getMetaString( artifactRef ); // Add metadata.xml to path mask patterns

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiPathPatternFormatter.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiPathPatternFormatter.java
@@ -1,6 +1,7 @@
 package org.commonjava.indy.koji.content;
 
 import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
+import org.apache.commons.lang.StringUtils;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
 import org.commonjava.indy.koji.util.KojiUtils;
 import org.commonjava.maven.atlas.ident.ref.ArtifactRef;
@@ -14,6 +15,7 @@ import javax.inject.Inject;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
 import static org.commonjava.maven.galley.maven.util.ArtifactPathUtils.formatMetadataPath;
@@ -69,7 +71,9 @@ public class KojiPathPatternFormatter
             logger.trace( "Pattern ignored, gId: {}, artiId: {}, ver: {}", gId, artiId, ver );
             return null;
         }
-        String pattern = gId.replace( '.', '/' ) + "/" + artiId + "/" + ver + "/" + a.getFilename();
+
+        // NOTE: This is not completely precise, but the trade-off in speed should make it worthwhile.
+        String pattern = "r|" + StringUtils.replace( gId, ".", "\\/" ) + "\\/.+\\/" + ver + "\\/.+|";
         logger.trace( "Pattern: {}", pattern );
 
         return pattern;

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/metrics/KojiIspnCacheRegistry.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/metrics/KojiIspnCacheRegistry.java
@@ -15,7 +15,7 @@
  */
 package org.commonjava.indy.koji.metrics;
 
-import org.commonjava.indy.koji.content.CachedKojiContentProvider;
+import org.commonjava.indy.koji.content.IndyKojiContentProvider;
 import org.commonjava.indy.subsys.infinispan.metrics.IspnCacheRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,7 +30,7 @@ public class KojiIspnCacheRegistry implements IspnCacheRegistry
     private Logger logger = LoggerFactory.getLogger( getClass() );
 
     @Inject
-    private CachedKojiContentProvider kojiContentProvider;
+    private IndyKojiContentProvider kojiContentProvider;
 
     @Override
     public Set<String> getCacheNames()

--- a/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
+++ b/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
@@ -24,6 +24,7 @@ import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
 import org.commonjava.indy.koji.data.KojiRepairException;
 import org.commonjava.indy.koji.data.KojiRepairManager;
+import org.commonjava.indy.koji.model.KojiMultiRepairResult;
 import org.commonjava.indy.koji.model.KojiRepairRequest;
 import org.commonjava.indy.koji.model.KojiRepairResult;
 import org.commonjava.indy.model.core.PackageTypeDescriptor;
@@ -43,6 +44,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
+import static org.commonjava.indy.koji.model.IndyKojiConstants.ALL_MASKS;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.MASK;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.REPAIR_KOJI;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.VOL;
@@ -115,6 +117,29 @@ public class KojiRepairResource
         {
             String user = securityManager.getUser( securityContext, servletRequest );
             return repairManager.repairPathMask( request, user );
+        }
+        catch ( KojiRepairException e )
+        {
+            logger.error( e.getMessage(), e );
+            throwError( e );
+        }
+
+        return null;
+    }
+
+    @ApiOperation( "Repair koji repository path masks for ALL koji remote repositories." )
+    @ApiResponse( code = 200, message = "Operation finished (consult response content for success/failure).",
+                  response = KojiMultiRepairResult.class )
+    @POST
+    @Path( "/" + ALL_MASKS )
+    @Consumes( ApplicationContent.application_json )
+    public KojiMultiRepairResult repairAllPathMasks( final @Context HttpServletRequest servletRequest,
+                                             final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
+    {
+        try
+        {
+            String user = securityManager.getUser( securityContext, servletRequest );
+            return repairManager.repairAllPathMasks( user );
         }
         catch ( KojiRepairException e )
         {

--- a/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
+++ b/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
@@ -43,6 +43,7 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
+import static org.commonjava.indy.koji.model.IndyKojiConstants.MASK;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.REPAIR_KOJI;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.VOL;
 import static org.commonjava.indy.util.ApplicationContent.application_json;
@@ -105,7 +106,7 @@ public class KojiRepairResource
                        value = "JSON request specifying source and other configuration options",
                        required = true, dataType = "org.commonjava.indy.koji.model.KojiRepairRequest" )
     @POST
-    @Path( "/" + VOL )
+    @Path( "/" + MASK )
     @Consumes( ApplicationContent.application_json )
     public KojiRepairResult repairPathMasks( final KojiRepairRequest request, final @Context HttpServletRequest servletRequest,
                                     final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )

--- a/addons/koji/model-java/src/main/java/org/commonjava/indy/koji/model/IndyKojiConstants.java
+++ b/addons/koji/model-java/src/main/java/org/commonjava/indy/koji/model/IndyKojiConstants.java
@@ -34,6 +34,5 @@ public class IndyKojiConstants
 
     public static final String MASK = "mask";
 
-    public static final String REPAIR_KOJI_MASK = REPAIR_KOJI + "/" + MASK;
-
+    public static final String ALL_MASKS = "mask/all";
 }

--- a/addons/koji/model-java/src/main/java/org/commonjava/indy/koji/model/KojiMultiRepairResult.java
+++ b/addons/koji/model-java/src/main/java/org/commonjava/indy/koji/model/KojiMultiRepairResult.java
@@ -1,0 +1,21 @@
+package org.commonjava.indy.koji.model;
+
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.List;
+
+public class KojiMultiRepairResult
+{
+    @ApiModelProperty( "Results for all stores where repair was attempted, including failures" )
+    private List<KojiRepairResult> results;
+
+    public List<KojiRepairResult> getResults()
+    {
+        return results;
+    }
+
+    public void setResults( final List<KojiRepairResult> results )
+    {
+        this.results = results;
+    }
+}

--- a/addons/koji/model-java/src/main/java/org/commonjava/indy/koji/model/KojiRepairResult.java
+++ b/addons/koji/model-java/src/main/java/org/commonjava/indy/koji/model/KojiRepairResult.java
@@ -206,7 +206,7 @@ public class KojiRepairResult
 
         public boolean isChanged()
         {
-            return !originalValue.equals( value );
+            return (originalValue == null && value != null) || !originalValue.equals( value );
         }
 
         public Object getOriginalValue()

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreEnablementManager.java
@@ -135,6 +135,14 @@ public class StoreEnablementManager
         try
         {
             ArtifactStore store = storeDataManager.getArtifactStore( key );
+            if ( store == null )
+            {
+                logger.warn( "Attempt to disable missing repo! Skipping." );
+                return;
+            }
+
+            store = store.copyOf();
+
             int disableTimeout = store.getDisableTimeout();
             if ( disableTimeout <= TIMEOUT_NEVER_DISABLE )
             {
@@ -193,6 +201,14 @@ public class StoreEnablementManager
                 try
                 {
                     ArtifactStore store = storeDataManager.getArtifactStore( key );
+                    if ( store == null )
+                    {
+                        logger.warn( "Attempt to re-enable missing repository! Skipping." );
+                        cancelReEnablementTimeout( key );
+                        return;
+                    }
+
+                    store = store.copyOf();
                     if ( store.isDisabled() )
                     {
                         store.setDisabled( false );

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -303,6 +303,13 @@ public class MemoryStoreDataManager
             throws IndyDataException
     {
         AtomicReference<IndyDataException> error = new AtomicReference<>();
+        logger.trace( "Storing {} using operation lock: {}", store, opLocks );
+        if ( store == null )
+        {
+            logger.warn( "Tried to store null ArtifactStore!" );
+            return false;
+        }
+
         boolean result = opLocks.lockAnd( store.getKey(), LOCK_TIMEOUT_SECONDS, k-> {
             ArtifactStore original = stores.get( store.getKey() );
             if ( original == store )

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -233,6 +233,7 @@ public abstract class ArtifactStore
 
     protected void copyBase( ArtifactStore store )
     {
+        store.setRescanInProgress( store.isRescanInProgress() );
         store.setDescription( getDescription() );
         store.setDisabled( isDisabled() );
         store.setMetadata( getMetadata() );
@@ -240,6 +241,7 @@ public abstract class ArtifactStore
         store.setPathStyle( getPathStyle() );
         store.setDisableTimeout( getDisableTimeout() );
         store.setPathMaskPatterns( getPathMaskPatterns() );
+        store.setAuthoritativeIndex( isAuthoritativeIndex() );
     }
 
     protected void setTransientMetadata( Map<String, Object> transientMetadata )

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
@@ -159,6 +159,7 @@ public class Group
     public Group copyOf( final String packageType, final String name )
     {
         Group g = new Group( packageType, name, new ArrayList<>( getConstituents() ) );
+        g.setPrependConstituent( isPrependConstituent() );
         copyBase( g );
 
         return g;


### PR DESCRIPTION
* koji path-mask calculation didn't work after changes in Kojiji to separate listArchives from retrieval of type-specific info (https://github.com/release-engineering/kojiji/pull/95)
* implement /api/repair/koji/mask/all REST endpoint to avoid need to identify broken repos
* improve path masking efficiency (at cost of lost precision) to use regex and improve time to disqualify a repo
* add in missing field copy operations from ArtifactStore.copyOf() implementations
* add trace logging of generic-proxy request headers once parsed

This PR is mainly to address path-masking problems in the Koji integration that were introduced with Kojiji v2.3. It also introduces a repair-all-masks REST endpoint to complement the repair-repo-masks endpoint added recently. This eliminates the need to identify broken Koji proxy repos up front, and feed them in individually.

While I was fixing the path-masking logic, I also refactored it to use regex patterns. This will reduce precision, though the content index and NFC should compensate for the speed reduction here. At the same time, the regex should provide a faster response to disqualify that repo from a content search (even if it provides false positive matches occasionally), owing to fewer comparisons per repository.

Finally, I noticed some problems where ArtifactStore.copyOf() wasn't being used when updating a repository definition. I fixed these in StoreEnablementManager and KojiRepairManager, but also had to improve the copyOf() implementations to account for fields that had been missed in previous work. 