### PR TITLE
[Hold] Redirect old directory listing request to new entry point

### DIFF
--- a/addons/content-browse/client-java/pom.xml
+++ b/addons/content-browse/client-java/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>indy-content-browse</artifactId>
+    <groupId>org.commonjava.indy</groupId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>indy-content-browse-client-java</artifactId>
+  <name>Indy :: Add-Ons :: Directory Content Browse :: Java Client</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-client-core-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-browse-model-java</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/addons/content-browse/client-java/src/main/java/org/commonjava/indy/content/browse/client/IndyContentBrowseClientModule.java
+++ b/addons/content-browse/client-java/src/main/java/org/commonjava/indy/content/browse/client/IndyContentBrowseClientModule.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.content.browse.client;
+
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.client.core.util.UrlUtils;
+import org.commonjava.indy.content.browse.model.ContentBrowseResult;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+
+public class IndyContentBrowseClientModule
+        extends IndyClientModule
+{
+    public ContentBrowseResult getContentList( final StoreKey key, final String path )
+            throws IndyClientException
+    {
+        return http.get(
+                UrlUtils.buildUrl( "browse", key.getPackageType(), key.getType().singularEndpointName(), key.getName(),
+                                   path ), ContentBrowseResult.class );
+    }
+
+    public ContentBrowseResult getContentList( final String packageType, final StoreType type, final String name,
+                                               final String path )
+            throws IndyClientException
+    {
+        return http.get( UrlUtils.buildUrl( "browse", packageType, type.singularEndpointName(), name, path ),
+                         ContentBrowseResult.class );
+    }
+}

--- a/addons/content-browse/ftests/pom.xml
+++ b/addons/content-browse/ftests/pom.xml
@@ -40,6 +40,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-browse-client-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-client-core-java</artifactId>
     </dependency>
     <dependency>
@@ -50,6 +54,21 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-test-fixtures-core</artifactId>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>http-testserver</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>

--- a/addons/content-browse/ftests/src/main/java/org/commonjava/indy/content/browse/ftest/MetaListingRescheduleTimeoutTest.java
+++ b/addons/content-browse/ftests/src/main/java/org/commonjava/indy/content/browse/ftest/MetaListingRescheduleTimeoutTest.java
@@ -13,9 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.commonjava.indy.ftest.core.content;
+package org.commonjava.indy.content.browse.ftest;
 
-import org.apache.commons.io.IOUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.content.browse.client.IndyContentBrowseClientModule;
+import org.commonjava.indy.content.browse.model.ContentBrowseResult;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.model.core.RemoteRepository;
@@ -30,6 +33,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 
 import static org.commonjava.indy.model.core.StoreType.remote;
@@ -57,7 +62,7 @@ public class MetaListingRescheduleTimeoutTest
 {
 
     @Rule
-    public ExpectationServer server = new ExpectationServer( "repos" );
+    public ExpectationServer server = new ExpectationServer(  );
 
     //    @Ignore // content listing is disabled for now, 2018/4/3
     @Test
@@ -69,11 +74,9 @@ public class MetaListingRescheduleTimeoutTest
         final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 3000;
 
         final String repoId = "test-repo";
-        // path without trailing slash for ExpectationServer...
-        String repoRootPath = "org/foo/bar";
+        String repoRootPath = "org/foo/bar/";
         final String repoRootUrl = server.formatUrl( repoId, repoRootPath );
         // now append the trailing '/' so Indy knows to try a directory listing...
-        repoRootPath += "/";
         final String repoSubPath1 = "org/foo/bar/1.0/pom.xml";
         final String repoSubPath2 = "org/foo/bar/1.1/pom.xml";
 
@@ -97,32 +100,34 @@ public class MetaListingRescheduleTimeoutTest
         repository.setMetadataTimeoutSeconds( METADATA_TIMEOUT_SECONDS );
         client.stores().create( repository, changelog, RemoteRepository.class );
 
-        try (InputStream is = client.content().get( remote, repoId, repoSubPath1 ))
+
+        try (InputStream is = client.content().get( repository.getKey(), repoSubPath1 ))
         {
         }
-        try (InputStream is = client.content().get( remote, repoId, repoSubPath2 ))
+        try (InputStream is = client.content().get( repository.getKey(), repoSubPath2 ))
         {
         }
+
+        IndyContentBrowseClientModule browseClientModule = client.module( IndyContentBrowseClientModule.class );
 
         // first time trigger normal content storage with timeout, should be 4s
-        InputStream content = client.content().get( remote, repoId, repoRootPath );
+        logger.debug("Start to request listing of {}", repoRootPath);
+        final ContentBrowseResult content = browseClientModule.getContentList( repository.getKey(), repoRootPath );
         assertThat( "no metadata result", content, notNullValue() );
         logger.debug( "### will begin to get content" );
-        IOUtils.readLines( content ).forEach( logger::info );
-        content.close();
 
-        final String listingMetaPath = "org/foo/bar/.listing.txt";
+        final String listingMetaPath = repoRootPath + ".listing.txt";
 
         File listingMetaFile = Paths.get( fixture.getBootOptions().getIndyHome(), "var/lib/indy/storage", MAVEN_PKG_KEY,
                                           remote.singularEndpointName() + "-" + repoId, listingMetaPath ).toFile();
 
-        assertThat( "metadata doesn't exist: " + listingMetaFile, listingMetaFile.exists(), equalTo( true ) );
+        assertThat( ".listing doesn't exist: " + listingMetaFile, listingMetaFile.exists(), equalTo( true ) );
 
         // wait for first time
         Thread.sleep( METADATA_TIMEOUT_WAITING_MILLISECONDS );
 
         // as the metadata content re-request, the metadata timeout interval should NOT be re-scheduled
-        client.content().get( remote, repoId, repoRootPath ).close();
+        browseClientModule.getContentList( repository.getKey(), repoRootPath );
 
         // will wait second time for a longer period
         Thread.sleep( METADATA_TIMEOUT_WAITING_MILLISECONDS * getTestTimeoutMultiplier() );
@@ -134,15 +139,15 @@ public class MetaListingRescheduleTimeoutTest
     }
 
     @Override
-    protected boolean createStandardTestStructures()
-    {
-        return false;
-    }
-
-    @Override
     protected int getTestTimeoutMultiplier()
     {
         return super.getTestTimeoutMultiplier() * 2;
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
     }
 
     @Override
@@ -151,5 +156,11 @@ public class MetaListingRescheduleTimeoutTest
     {
         writeConfigFile( "main.conf", "remote.list.download.enabled=true\n"
                 + "[storage-default]\nstorage.dir=${indy.home}/var/lib/indy/storage" );
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Collections.singletonList( new IndyContentBrowseClientModule() );
     }
 }

--- a/addons/content-browse/ftests/src/main/java/org/commonjava/indy/content/browse/ftest/StoreThenGetUnSuffixedDirAndDownloadViaGroupTest.java
+++ b/addons/content-browse/ftests/src/main/java/org/commonjava/indy/content/browse/ftest/StoreThenGetUnSuffixedDirAndDownloadViaGroupTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.commonjava.indy.ftest.core.content;
+package org.commonjava.indy.content.browse.ftest;
 
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URL;
 
+import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.model.core.StoreType.hosted;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -35,6 +36,7 @@ import static org.junit.Assert.assertThat;
  * Given:
  * <ul>
  *     <li>Content is stored in a hosted repository</li>
+ *     <li>Hosted repository is a member of a group</li>
  * </ul>
  * <br/>
  * When:
@@ -42,7 +44,7 @@ import static org.junit.Assert.assertThat;
  *     <li>A directory on the stored content's path is requested via GET.
  *        <br/>
  *        <ul>
- *          <li>directly from the hosted repository</li>
+ *          <li>from the group</li>
  *          <li>without a trailing '/' or a '/index.html' in the requested path</li>
  *          <li>without using Accept: application/json</li>
  *        </ul>
@@ -55,7 +57,7 @@ import static org.junit.Assert.assertThat;
  *     <li>The stored content should be unaffected</li>
  * </ul>
  */
-public class StoreThenGetUnSuffixedDirAndDownloadTest
+public class StoreThenGetUnSuffixedDirAndDownloadViaGroupTest
         extends AbstractContentManagementTest
 {
 
@@ -76,18 +78,18 @@ public class StoreThenGetUnSuffixedDirAndDownloadTest
               .store( hosted, STORE, path, stream );
 
         assertThat( client.content()
-                          .exists( hosted, STORE, path ), equalTo( true ) );
+                          .exists( group, PUBLIC, path ), equalTo( true ) );
 
-        try(InputStream htmlIn = client.content().get( new StoreKey( hosted, STORE ), dirPath ))
+        try(InputStream jsonIn = client.content().get( new StoreKey( group, PUBLIC ), dirPath ))
         {
-            assertThat( htmlIn, notNullValue() );
-            String html = IOUtils.toString( htmlIn );
-            assertThat( html.contains( "<html>" ), equalTo( true ) );
-            assertThat( html.contains( "bar-1.pom" ), equalTo( true ) );
+            assertThat( jsonIn, notNullValue() );
+            String json = IOUtils.toString( jsonIn );
+            assertThat( json.startsWith( "{" ), equalTo( true ) );
+            assertThat( json.contains( "bar-1.pom" ), equalTo( true ) );
         }
 
         assertThat( client.content()
-                          .exists( hosted, STORE, path ), equalTo( true ) );
+                          .exists( group, PUBLIC, path ), equalTo( true ) );
 
         final URL url = new URL( client.content()
                                        .contentUrl( hosted, STORE, path ) );

--- a/addons/content-browse/jaxrs/src/main/java/org/commonjava/indy/content/browse/bind/jaxrs/ContentBrowseResource.java
+++ b/addons/content-browse/jaxrs/src/main/java/org/commonjava/indy/content/browse/bind/jaxrs/ContentBrowseResource.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.content.browse.bind.jaxrs;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -24,13 +25,17 @@ import io.swagger.annotations.ApiResponses;
 import org.apache.commons.lang.StringUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.JaxRsRequestHelper;
 import org.commonjava.indy.bind.jaxrs.util.ResponseUtils;
 import org.commonjava.indy.content.browse.ContentBrowseController;
 import org.commonjava.indy.content.browse.model.ContentBrowseResult;
 import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.util.HttpUtils;
+import org.commonjava.indy.util.AcceptInfo;
 import org.commonjava.indy.util.ApplicationContent;
+import org.commonjava.indy.util.ApplicationHeader;
 import org.commonjava.indy.util.UriFormatter;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
@@ -38,7 +43,9 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -46,7 +53,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
-import java.net.URI;
+import java.util.Date;
 
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
 
@@ -70,6 +77,81 @@ public class ContentBrowseResource
 
     @Inject
     private UriFormatter uriFormatter;
+
+    @Inject
+    protected JaxRsRequestHelper jaxRsRequestHelper;
+
+    @ApiOperation( "Retrieve directory content under the given artifact store (type/name) and directory path." )
+    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
+                           @ApiResponse( code = 200, response = String.class, message = "Rendered content listing" ) } )
+    @HEAD
+    @Path( "/{path: (.*)}" )
+    public Response headForDirectory(
+            final @ApiParam( allowableValues = "maven,npm", required = true ) @PathParam( "packageType" )
+                    String packageType,
+            final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
+                    String type, final @ApiParam( required = true ) @PathParam( "name" ) String name,
+            final @PathParam( "path" ) String path, @Context final UriInfo uriInfo,
+            @Context final HttpServletRequest request )
+    {
+        return processHead( packageType, type, name, path, uriInfo, request );
+    }
+
+    @ApiOperation( "Retrieve directory content under the given artifact store (type/name) and directory path." )
+    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
+                           @ApiResponse( code = 200, response = String.class, message = "Rendered content listing" ) } )
+    @HEAD
+    @Path( "/" )
+    public Response headForRoot(
+            final @ApiParam( allowableValues = "maven,npm", required = true ) @PathParam( "packageType" )
+                    String packageType,
+            final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
+                    String type, final @ApiParam( required = true ) @PathParam( "name" ) String name,
+            final @PathParam( "path" ) String path, @Context final UriInfo uriInfo,
+            @Context final HttpServletRequest request )
+    {
+        return processHead( packageType, type, name, "", uriInfo, request );
+    }
+
+    private Response processHead( final String packageType, final String type, final String name, final String path,
+                                  final UriInfo uriInfo, final HttpServletRequest request )
+    {
+        if ( !PackageTypes.contains( packageType ) )
+        {
+            return Response.status( 400 ).build();
+        }
+
+        Response response;
+        ContentBrowseResult result = null;
+        try
+        {
+            result = getBrowseResult( packageType, type, name, path, uriInfo );
+
+            final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.application_json );
+            final String content = mapper.writeValueAsString( result );
+            Response.ResponseBuilder builder = Response.ok()
+                                                       .header( ApplicationHeader.content_type.key(),
+                                                                acceptInfo.getRawAccept() )
+                                                       .header( ApplicationHeader.content_length.key(),
+                                                                Long.toString( content.length() ) )
+                                                       .header( ApplicationHeader.last_modified.key(),
+                                                                HttpUtils.formatDateHeader( new Date() ) );
+            response = builder.build();
+
+        }
+        catch ( IndyWorkflowException e )
+        {
+            logger.error( String.format( "Failed to list content: %s from: %s. Reason: %s",
+                                         StringUtils.isBlank( path ) ? "/" : path, name, e.getMessage() ), e );
+            response = ResponseUtils.formatResponse( e );
+        }
+        catch ( JsonProcessingException e )
+        {
+            response = ResponseUtils.formatResponse( e, "Failed to serialize DTO to JSON: " + result );
+        }
+
+        return response;
+    }
 
     @ApiOperation( "Retrieve directory content under the given artifact store (type/name) and directory path." )
     @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
@@ -112,21 +194,11 @@ public class ContentBrowseResource
             return Response.status( 400 ).build();
         }
 
-        final StoreKey sk = new StoreKey( packageType, StoreType.get( type ), name );
-
-
-        final String browseBaseUri =
-                uriInfo.getBaseUriBuilder().path( BROWSE_REST_BASE_PATH + "/" + packageType ).build().toString();
-
-        final String contentBaseUri =
-                uriInfo.getBaseUriBuilder().path( CONTENT_REST_BASE_PATH + "/" + packageType ).build().toString();
-
         Response response;
         ContentBrowseResult result;
         try
         {
-            result = controller.browseContent( sk, path, browseBaseUri, contentBaseUri, uriFormatter,
-                                               new EventMetadata() );
+            result = getBrowseResult( packageType, type, name, path, uriInfo );
 
             response = formatOkResponseWithJsonEntity( result, mapper );
         }
@@ -138,5 +210,20 @@ public class ContentBrowseResource
         }
 
         return response;
+    }
+
+    private ContentBrowseResult getBrowseResult( final String packageType, final String type, final String name,
+                                                 final String path, final UriInfo uriInfo )
+            throws IndyWorkflowException
+    {
+        final StoreKey sk = new StoreKey( packageType, StoreType.get( type ), name );
+
+        final String browseBaseUri =
+                uriInfo.getBaseUriBuilder().path( BROWSE_REST_BASE_PATH + "/" + packageType ).build().toString();
+
+        final String contentBaseUri =
+                uriInfo.getBaseUriBuilder().path( CONTENT_REST_BASE_PATH + "/" + packageType ).build().toString();
+
+        return controller.browseContent( sk, path, browseBaseUri, contentBaseUri, uriFormatter, new EventMetadata() );
     }
 }

--- a/addons/content-browse/model-java/src/main/java/org/commonjava/indy/content/browse/model/ContentBrowseResult.java
+++ b/addons/content-browse/model-java/src/main/java/org/commonjava/indy/content/browse/model/ContentBrowseResult.java
@@ -151,6 +151,8 @@ public class ContentBrowseResult
 
         private Set<String> sources;
 
+        public ListingURLResult(){}
+
         public ListingURLResult( String path, String listingUrl, Set<String> sources )
         {
             this.path = path;
@@ -173,5 +175,19 @@ public class ContentBrowseResult
             return sources;
         }
 
+        public void setPath( String path )
+        {
+            this.path = path;
+        }
+
+        public void setListingUrl( String listingUrl )
+        {
+            this.listingUrl = listingUrl;
+        }
+
+        public void setSources( Set<String> sources )
+        {
+            this.sources = sources;
+        }
     }
 }

--- a/addons/content-browse/pom.xml
+++ b/addons/content-browse/pom.xml
@@ -33,6 +33,7 @@
     <module>ftests</module>
     <module>model-java</module>
     <module>ui</module>
+    <module>client-java</module>
   </modules>
 
 </project>

--- a/addons/content-browse/ui/package.json
+++ b/addons/content-browse/ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "The ui part of the indy content directory browsing function",
   "main": "src/main/js/index.js",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "private": true,
   "dependencies": {
     "jquery": "3.3.1",

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -26,7 +26,6 @@ import org.commonjava.indy.core.model.StoreHttpExchangeMetadata;
 import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
-import org.commonjava.indy.model.util.HttpUtils;
 import org.commonjava.indy.pkg.npm.content.group.PackageMetadataMerger;
 import org.commonjava.indy.pkg.npm.inject.NPMContentHandler;
 import org.commonjava.indy.util.AcceptInfo;
@@ -46,6 +45,7 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
@@ -62,11 +62,11 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithEntity;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponseFromMetadata;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.setInfoHeaders;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
+import static org.commonjava.indy.core.ctl.ContentController.*;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 
 @ApplicationScoped
@@ -188,38 +188,12 @@ public class NPMContentAccessHandler
 
         eventMetadata = eventMetadata.set( ContentManager.ENTRY_POINT_STORE, sk );
 
-        final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.text_html );
-
         Response response = null;
 
         if ( path == null || path.equals( "" ) )
         {
-            try
-            {
-                logger.info( "Getting listing at: {}", path );
-                final String content =
-                        contentController.renderListing( acceptInfo.getBaseAccept(), sk, path, baseUri, uriFormatter );
-
-                Response.ResponseBuilder builder = Response.ok()
-                                                           .header( ApplicationHeader.content_type.key(),
-                                                                    acceptInfo.getRawAccept() )
-                                                           .header( ApplicationHeader.content_length.key(),
-                                                                    Long.toString( content.length() ) )
-                                                           .header( ApplicationHeader.last_modified.key(),
-                                                                    HttpUtils.formatDateHeader( new Date() ) );
-                if ( builderModifier != null )
-                {
-                    builderModifier.accept( builder );
-                }
-                response = builder.build();
-            }
-            catch ( final IndyWorkflowException e )
-            {
-                logger.error(
-                        String.format( "Failed to list content: %s from: %s. Reason: %s", path, name, e.getMessage() ),
-                        e );
-                response = formatResponse( e, builderModifier );
-            }
+            logger.info( "Getting listing at: {}", path );
+            response = redirectContentListing( packageType, type, name, path, request, builderModifier );
         }
         else
         {
@@ -342,20 +316,8 @@ public class NPMContentAccessHandler
 
         if ( path == null || path.equals( "" ) )
         {
-            try
-            {
-                logger.info( "Getting listing at: {}", path );
-                final String content =
-                        contentController.renderListing( standardAccept, sk, path, baseUri, uriFormatter, eventMetadata );
-
-                response = formatOkResponseWithEntity( content, acceptInfo.getRawAccept(), builderModifier );
-            }
-            catch ( final IndyWorkflowException e )
-            {
-                logger.error( String.format( "Failed to render content listing: %s from: %s. Reason: %s", path, name,
-                                             e.getMessage() ), e );
-                response = formatResponse( e, builderModifier );
-            }
+            logger.info( "Getting listing at: {}", path );
+            response = redirectContentListing( packageType, type, name, path, request, builderModifier );
         }
         else
         {
@@ -391,23 +353,8 @@ public class NPMContentAccessHandler
                     }
                     else if ( item.isDirectory() && StoreType.remote != st )
                     {
-                        try
-                        {
-                            logger.info( "Getting listing at: {}", path + "/" );
-                            final String content =
-                                    contentController.renderListing( standardAccept, sk, path + "/", baseUri,
-                                                                     uriFormatter, eventMetadata );
-
-                            response =
-                                    formatOkResponseWithEntity( content, acceptInfo.getRawAccept(), builderModifier );
-                        }
-                        catch ( final IndyWorkflowException e )
-                        {
-                            logger.error(
-                                    String.format( "Failed to render content listing: %s from: %s. Reason: %s", path,
-                                                   name, e.getMessage() ), e );
-                            response = formatResponse( e, builderModifier );
-                        }
+                        logger.info( "Getting listing at: {}", path + "/" );
+                        response = redirectContentListing( packageType, type, name, path, request, builderModifier );
                     }
                     else
                     {
@@ -552,7 +499,7 @@ public class NPMContentAccessHandler
         }
         catch ( final IOException e )
         {
-            logger.error( String.format( "[NPM] Failed to store the generated targets: s% and s%. Reason: s%",
+            logger.error( String.format( "[NPM] Failed to store the generated targets: %s and %s. Reason: %s",
                                          versionTarget.getResource(), tarballTarget.getResource(), e.getMessage() ), e );
         }
         return null;
@@ -645,5 +592,40 @@ public class NPMContentAccessHandler
             type = MediaType.APPLICATION_OCTET_STREAM;
         }
         return type;
+    }
+
+    private Response redirectContentListing( final String packageType, final String type, final String name,
+                                             final String originPath, final HttpServletRequest request,
+                                             final Consumer<Response.ResponseBuilder> builderModifier )
+    {
+        // final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.text_html );
+        String path = originPath;
+        if ( path != null && path.endsWith( LISTING_HTML_FILE ) )
+        {
+            path = path.replaceAll( String.format( "(%s)$", LISTING_HTML_FILE ), "" );
+        }
+
+        // A problem here is that if client is not browser(like curl or a program http call), the redirect response will
+        // just return a 303 location /browse/*, which is just a single html page with no actual content(because page is rendering
+        // by javascript). So I think we should consider to judge by the User-Agent to decide the real action, and if its not a browser
+        // action, we should redirect it to a REST call of /api/browse which will return the content result in JSON.
+        boolean isBrowser = false;
+        for ( String userAgent : BROWSER_USER_AGENT )
+        {
+            if ( request.getHeader( "User-Agent" ).contains( userAgent ) && HttpMethod.GET.equalsIgnoreCase(
+                request.getMethod() ) )
+            {
+                isBrowser = true;
+                break;
+            }
+        }
+        final String root = isBrowser ? CONTENT_BROWSE_ROOT : CONTENT_BROWSE_API_ROOT;
+        final String browseUri = PathUtils.normalize(root, packageType, type, name, path);
+        logger.debug("Directory listing request will redirect to entry point: {} ", browseUri);
+        Response.ResponseBuilder builder = Response.seeOther(URI.create(browseUri));
+        if (builderModifier != null) {
+            builderModifier.accept(builder);
+        }
+        return builder.build();
     }
 }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -460,11 +460,10 @@ public class ContentAccessHandler
                                              final String originPath, final HttpServletRequest request,
                                              final Consumer<ResponseBuilder> builderModifier )
     {
-        final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.text_html );
+        // final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.text_html );
         String path = originPath;
-        if ( path != null && path.endsWith( LISTING_HTML_FILE ) )
-        {
-            path = path.replaceAll( String.format( "(%s)$", LISTING_HTML_FILE ), "" );
+        if (path != null && path.endsWith(LISTING_HTML_FILE)) {
+            path = path.replaceAll(String.format("(%s)$", LISTING_HTML_FILE), "");
         }
 
         // A problem here is that if client is not browser(like curl or a program http call), the redirect response will
@@ -472,22 +471,18 @@ public class ContentAccessHandler
         // by javascript). So I think we should consider to judge by the User-Agent to decide the real action, and if its not a browser
         // action, we should redirect it to a REST call of /api/browse which will return the content result in JSON.
         boolean isBrowser = false;
-        for ( String userAgent : BROWSER_USER_AGENT )
-        {
-            if ( request.getHeader( "User-Agent" ).contains( userAgent ) && HttpMethod.GET.equalsIgnoreCase(
-                    request.getMethod() ) )
-            {
+        for (String userAgent : BROWSER_USER_AGENT) {
+            if (request.getHeader("User-Agent").contains(userAgent) && HttpMethod.GET.equalsIgnoreCase(request.getMethod())) {
                 isBrowser = true;
                 break;
             }
         }
         final String root = isBrowser ? CONTENT_BROWSE_ROOT : CONTENT_BROWSE_API_ROOT;
-        final String browseUri = PathUtils.normalize( root, packageType, type, name, path );
-        logger.debug( "Directory listing request will redirect to entry point: {} ", browseUri );
-        ResponseBuilder builder = Response.seeOther( URI.create( browseUri ) ).type( acceptInfo.getRawAccept() );
-        if ( builderModifier != null )
-        {
-            builderModifier.accept( builder );
+        final String browseUri = PathUtils.normalize(root, packageType, type, name, path);
+        logger.debug("Directory listing request will redirect to entry point: {} ", browseUri);
+        ResponseBuilder builder = Response.seeOther(URI.create(browseUri));
+        if (builderModifier != null) {
+            builderModifier.accept(builder);
         }
         return builder.build();
     }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/RequestUtils.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/RequestUtils.java
@@ -15,15 +15,25 @@
  */
 package org.commonjava.indy.core.bind.jaxrs.util;
 
+import org.commonjava.maven.galley.util.PathUtils;
 import org.slf4j.Logger;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.Response;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.commonjava.indy.core.ctl.ContentController.BROWSER_USER_AGENT;
+import static org.commonjava.indy.core.ctl.ContentController.CONTENT_BROWSE_API_ROOT;
+import static org.commonjava.indy.core.ctl.ContentController.CONTENT_BROWSE_ROOT;
+import static org.commonjava.indy.core.ctl.ContentController.LISTING_HTML_FILE;
 
 public final class RequestUtils
 {
@@ -44,5 +54,35 @@ public final class RequestUtils
 
         }
         return Collections.unmodifiableMap( headersMap );
+    }
+
+    public static  Response redirectContentListing( final String packageType, final String type, final String name,
+                                             final String originPath, final HttpServletRequest request,
+                                             final Consumer<Response.ResponseBuilder> builderModifier )
+    {
+        // final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.text_html );
+        String path = originPath;
+        if (path != null && path.endsWith(LISTING_HTML_FILE)) {
+            path = path.replaceAll(String.format("(%s)$", LISTING_HTML_FILE), "");
+        }
+
+        // A problem here is that if client is not browser(like curl or a program http call), the redirect response will
+        // just return a 303 location /browse/*, which is just a single html page with no actual content(because page is rendering
+        // by javascript). So I think we should consider to judge by the User-Agent to decide the real action, and if its not a browser
+        // action, we should redirect it to a REST call of /api/browse which will return the content result in JSON.
+        boolean isBrowser = false;
+        for (String userAgent : BROWSER_USER_AGENT) {
+            if (request.getHeader("User-Agent").contains(userAgent) && HttpMethod.GET.equalsIgnoreCase( request.getMethod())) {
+                isBrowser = true;
+                break;
+            }
+        }
+        final String root = isBrowser ? CONTENT_BROWSE_ROOT : CONTENT_BROWSE_API_ROOT;
+        final String browseUri = PathUtils.normalize( root, packageType, type, name, path);
+        Response.ResponseBuilder builder = Response.seeOther( URI.create( browseUri));
+        if (builderModifier != null) {
+            builderModifier.accept(builder);
+        }
+        return builder.build();
     }
 }

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -273,6 +273,10 @@ public class ContentController
         return store;
     }
 
+    /**
+     * @deprecated directory listing has been moved to addons/content-browse
+     */
+    @Deprecated
     public String renderListing( final String acceptHeader, final StoreType type, final String name, final String path,
                                  final String serviceUrl, final UriFormatter uriFormatter )
         throws IndyWorkflowException
@@ -281,6 +285,10 @@ public class ContentController
         return renderListing( acceptHeader, key, path, serviceUrl, uriFormatter );
     }
 
+    /**
+     * @deprecated directory listing has been moved to addons/content-browse
+     */
+    @Deprecated
     public String renderListing( final String acceptHeader, final StoreKey key, final String requestPath,
                                  final String serviceUrl, final UriFormatter uriFormatter )
             throws IndyWorkflowException
@@ -288,6 +296,10 @@ public class ContentController
         return renderListing( acceptHeader, key, requestPath, serviceUrl, uriFormatter, new EventMetadata() );
     }
 
+    /**
+     * @deprecated directory listing has been moved to addons/content-browse
+     */
+    @Deprecated
     public String renderListing( final String acceptHeader, final StoreKey key, final String requestPath,
                                  final String serviceUrl, final UriFormatter uriFormatter, final EventMetadata eventMetadata )
         throws IndyWorkflowException

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -70,6 +70,13 @@ public class ContentController
 
     public static final String LISTING_HTML_FILE = "index.html";
 
+    public static final String CONTENT_BROWSE_ROOT = "/browse";
+
+    public static final String CONTENT_BROWSE_API_ROOT = "/api/browse";
+
+    public static final String[] BROWSER_USER_AGENT =
+            new String[] { "Mozilla/", "Chrome/", "Safari/", "OPR/", "Trident/", "Gecko/", "AppleWebKit/" };
+
     private static final int MAX_PEEK_COUNT = 100;
 
     public static final String HTML_TAG_PATTERN = ".*\\<(!DOCTYPE|[-_.a-zA-Z0-9]+).*";

--- a/pom.xml
+++ b/pom.xml
@@ -868,6 +868,11 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-content-browse-client-java</artifactId>
+        <version>1.6.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-common</artifactId>
         <version>1.7.4-SNAPSHOT</version>
         <classifier>confset</classifier>


### PR DESCRIPTION
This PR will make all directory content listing request redirect from old /api/content to new /browse (or /api/browse if it is not from a browser).
@jdcasey please don't merge this if you don't want this one involved in recent build for fixing perf problems.