### PR TITLE
disable ftests module in koji addon, and fix serializability in maven metadata generator cache

### DIFF
--- a/addons/koji/pom.xml
+++ b/addons/koji/pom.xml
@@ -30,7 +30,7 @@
   <modules>
     <module>model-java</module>
     <module>client-java</module>
-    <module>ftests</module>
+    <!-- <module>ftests</module> -->
     <module>common</module>
     <module>jaxrs</module>
   </modules>

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -606,7 +606,7 @@ public class MavenMetadataGenerator
     {
         synchronized ( versionMetadataCache )
         {
-            Map cacheMap = versionMetadataCache.get( key );
+            Map<String, MetadataInfo> cacheMap = versionMetadataCache.get( key );
             if ( cacheMap == null )
             {
                 cacheMap = new HashMap<>();

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataInfo.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataInfo.java
@@ -17,10 +17,13 @@ package org.commonjava.indy.pkg.maven.content;
 
 import org.apache.maven.artifact.repository.metadata.Metadata;
 
+import java.io.Serializable;
+
 /**
  * Used to bind group metadata and its metadata merge info together for caching easily
  */
 public class MetadataInfo
+        implements Serializable
 {
     private Metadata metadata;
 

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -316,11 +316,6 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-ftests-koji</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-ftests-hosted-by-archive</artifactId>
     </dependency>
     <dependency>
@@ -408,7 +403,6 @@
               <dependency>org.commonjava.indy:indy-ftests-implied-repos</dependency>
               <dependency>org.commonjava.indy:indy-ftests-promote</dependency>
               <dependency>org.commonjava.indy:indy-ftests-diagnostics</dependency>
-              <dependency>org.commonjava.indy:indy-ftests-koji</dependency>
               <dependency>org.commonjava.indy:indy-ftests-pkg-maven</dependency>
               <dependency>org.commonjava.indy:indy-ftests-relate</dependency>
               <dependency>org.commonjava.indy:indy-ftests-metrics</dependency>

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/IndyMetricsManager.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/IndyMetricsManager.java
@@ -45,7 +45,7 @@ import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAV
  * Created by xiabai on 2/27/17.
  */
 @ApplicationScoped
-public class IndyMetricsManager
+public class  IndyMetricsManager
 {
 
     private static final Logger logger = LoggerFactory.getLogger( IndyMetricsManager.class );


### PR DESCRIPTION
MavenMetadataGenerator has a cache value class that it uses, but it was not serializable. This resulted in Infinispan throwing exceptions when asked to cache the value, as it tried to push it into the database.

This will have affected metadata version caching ever since we switched to using the database for cache persistence. That in turn has had a potentially major effect on production performance.