### PR TITLE
Revert "Completely disconnect support for CONNECT when MITM mode is disabled."

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -305,13 +305,6 @@ public final class ProxyResponseWriter
                             }
                             case CONNECT_METHOD:
                             {
-                                if ( !config.isMITMEnabled() )
-                                {
-                                    logger.debug( "CONNECT method not supported unless MITM-proxying is enabled." );
-                                    http.writeStatus( ApplicationStatus.BAD_REQUEST );
-                                    break;
-                                }
-
                                 String uri = requestLine.getUri(); // e.g, github.com:443
                                 logger.debug( "Get CONNECT request, uri: {}", uri );
 
@@ -329,19 +322,27 @@ public final class ProxyResponseWriter
 
                                 SocketChannel socketChannel;
 
-                                ProxyMITMSSLServer svr =
-                                                new ProxyMITMSSLServer( host, port, trackingId, proxyUserPass,
-                                                                        proxyResponseHelper, contentController,
-                                                                        cacheProvider, config );
-                                tunnelAndMITMExecutor.submit( svr );
-                                socketChannel = svr.getSocketChannel();
-
-                                if ( socketChannel == null )
+                                if ( !config.isMITMEnabled() )
                                 {
-                                    logger.debug( "Failed to get MITM socket channel" );
-                                    http.writeStatus( ApplicationStatus.SERVER_ERROR );
-                                    svr.stop();
-                                    break;
+                                    InetSocketAddress target = new InetSocketAddress( host, port );
+                                    socketChannel = SocketChannel.open( target );
+                                }
+                                else
+                                {
+                                    ProxyMITMSSLServer svr =
+                                                    new ProxyMITMSSLServer( host, port, trackingId, proxyUserPass,
+                                                                            proxyResponseHelper, contentController,
+                                                                            cacheProvider, config );
+                                    tunnelAndMITMExecutor.submit( svr );
+                                    socketChannel = svr.getSocketChannel();
+
+                                    if ( socketChannel == null )
+                                    {
+                                        logger.debug( "Failed to get MITM socket channel" );
+                                        http.writeStatus( ApplicationStatus.SERVER_ERROR );
+                                        svr.stop();
+                                        break;
+                                    }
                                 }
 
                                 sslTunnel = new ProxySSLTunnel( sinkChannel, socketChannel );


### PR DESCRIPTION
Reverts Commonjava/indy#1085

We have evidence that this isn't the cause of the freeze we're seeing, so I'm pushing this change to a branch on my fork and will roll it back here until we determine that we really need it.