### PR TITLE
Set SO_TIMEOUT for ProxySSLTunnel to 30 min to avoid tunnel write hang

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyMITMSSLServer.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyMITMSSLServer.java
@@ -60,6 +60,7 @@ import static org.commonjava.indy.httprox.util.CertUtils.createSignedCertificate
 import static org.commonjava.indy.httprox.util.CertUtils.getPrivateKey;
 import static org.commonjava.indy.httprox.util.CertUtils.loadX509Certificate;
 import static org.commonjava.indy.httprox.util.HttpProxyConstants.GET_METHOD;
+import static org.commonjava.indy.httprox.util.HttpProxyConstants.MITM_SO_TIMEOUT_MINUTES;
 
 /**
  * We create server crt based on the host name and use a CA crt to sign it. We send the CA crt to client and they use
@@ -183,6 +184,7 @@ public class ProxyMITMSSLServer implements Runnable
         started = true;
 
         socket = sslServerSocket.accept();
+        socket.setSoTimeout( (int) TimeUnit.MINUTES.toMillis( MITM_SO_TIMEOUT_MINUTES ) );
 
         logger.debug( "MITM server accepted" );
         BufferedReader in = new BufferedReader( new InputStreamReader( socket.getInputStream() ) );

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpProxyConstants.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpProxyConstants.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang.StringUtils;
 
 public final class HttpProxyConstants
 {
+    public static final int MITM_SO_TIMEOUT_MINUTES = 30;
 
     public static final String PROXY_REPO_PREFIX = "httprox_";
 

--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -81,6 +81,7 @@ else
   
   <logger name="org.jboss" level="ERROR"/>
   <logger name="org.commonjava" level="DEBUG" />
+  <logger name="org.apache.http.wire" level="DEBUG" />
   <root level="INFO">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />


### PR DESCRIPTION
A very important fix for SSL tunnel. If MITM takes a long time to download a file, the tunnel socket may timeout which cause the MITM write-to-tunnel hang. With this fix, I can successfully run the "npm install phantomjs-prebuilt" which usually takes 10~20 min on my local.  