### PR TITLE
Fix implied detector problem when adding implied to groups

### DIFF
--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
@@ -179,11 +179,10 @@ public class ImpliedRepositoryDetector
             finally
             {
                 logger.debug( "FINISHED Processing: {}", event );
-            }
-
-            synchronized ( ImpliedRepositoryDetector.this )
-            {
-                ImpliedRepositoryDetector.this.notifyAll();
+                synchronized ( ImpliedRepositoryDetector.this )
+                {
+                    ImpliedRepositoryDetector.this.notifyAll();
+                }
             }
         } );
     }

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
@@ -269,27 +269,30 @@ public class ImpliedRepositoryDetector
                 final ChangeSummary summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, message );
                 for ( final Group g : groups )
                 {
-                    Group group = g.copyOf();
-
-                    boolean changed = false;
-                    for ( final ArtifactStore implied : job.implied )
+                    if ( config.isEnabledForGroup( g.getName() ) )
                     {
-                        boolean groupChanged = group.addConstituent( implied );
-                        changed = groupChanged || changed;
+                        Group group = g.copyOf();
 
-                        logger.debug( "After attempting to add: {} to group: {}, changed status is: {}", implied, group,
-                                      changed );
+                        boolean changed = false;
+                        for ( final ArtifactStore implied : job.implied )
+                        {
+                            boolean groupChanged = group.addConstituent( implied );
+                            changed = groupChanged || changed;
+
+                            logger.debug( "After attempting to add: {} to group: {}, changed status is: {}", implied,
+                                          group, changed );
+                        }
+
+                        if ( changed )
+                        {
+                            storeManager.storeArtifactStore( group, summary, false, false,
+                                                             new EventMetadata().set( StoreDataManager.EVENT_ORIGIN,
+                                                                                      IMPLIED_REPOS_DETECTION )
+                                                                                .set( IMPLIED_REPOS, job.implied ) );
+                        }
+
+                        anyChanged = changed || anyChanged;
                     }
-
-                    if ( changed )
-                    {
-                        storeManager.storeArtifactStore( group, summary, false, false,
-                                                         new EventMetadata().set( StoreDataManager.EVENT_ORIGIN,
-                                                                                  IMPLIED_REPOS_DETECTION )
-                                                                            .set( IMPLIED_REPOS, job.implied ) );
-                    }
-
-                    anyChanged = changed || anyChanged;
                 }
             }
         }

--- a/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetectorTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetectorTest.java
@@ -116,6 +116,7 @@ public class ImpliedRepositoryDetectorTest
 
         final ImpliedRepoConfig config = new ImpliedRepoConfig();
         config.setEnabled( true );
+        config.addEnabledGroupNamePattern( ".*" );
 
         File rootDir = temp.newFolder( "indy.root" );
         final DataFileManager dataFiles = new DataFileManager( rootDir, new DataFileEventManager() );
@@ -180,7 +181,7 @@ public class ImpliedRepositoryDetectorTest
 
         assertThat( storeManager.query().packageType( MAVEN_PKG_KEY ).getRemoteRepository( "i-repo-one" ), notNullValue() );
 
-        assertThat( getGroup().getConstituents().contains( new StoreKey( StoreType.remote, "i-repo-one" ) ),
+        assertThat( getGroup().getConstituents().contains( new StoreKey( MAVEN_PKG_KEY, StoreType.remote, "i-repo-one" ) ),
                     equalTo( true ) );
     }
 

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/maint/AbstractMaintFunctionalTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/maint/AbstractMaintFunctionalTest.java
@@ -28,6 +28,8 @@ import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.implrepo.client.ImpliedRepoClientModule;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -55,18 +57,20 @@ public class AbstractMaintFunctionalTest
     {
         setupChangelog = "Create test structures";
 
+        final StoreKey groupKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, group, PUBLIC );
         if ( client.stores()
-                   .exists( group, PUBLIC ) )
+                   .exists( groupKey ) )
         {
             System.out.println( "Loading pre-existing public group." );
             pubGroup = client.stores()
-                      .load( group, PUBLIC, Group.class );
+                      .load( groupKey, Group.class );
         }
         else
         {
             System.out.println( "Creating new group 'public'" );
             pubGroup = client.stores()
-                             .create( new Group( PUBLIC ), setupChangelog, Group.class );
+                             .create( new Group( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, PUBLIC ), setupChangelog,
+                                      Group.class );
         }
     }
 
@@ -80,6 +84,6 @@ public class AbstractMaintFunctionalTest
     @Override
     protected Collection<IndyClientModule> getAdditionalClientModules()
     {
-        return Collections.<IndyClientModule> singleton( new ImpliedRepoClientModule() );
+        return Collections.singleton( new ImpliedRepoClientModule() );
     }
 }

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/maint/CreateGroupWithMemberImplicationsTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/maint/CreateGroupWithMemberImplicationsTest.java
@@ -20,6 +20,7 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -27,6 +28,26 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>RemoteRepositories test and implied</li>
+ *     <li>Group pubGroup</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Make remote implied as implied repo for remote test through implied addon client</li>
+ *     <li>Add test to pubGroup</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>implied will be added to pubGroup automatically</li>
+ * </ul>
+ */
 public class CreateGroupWithMemberImplicationsTest
     extends AbstractMaintFunctionalTest
 {
@@ -39,34 +60,33 @@ public class CreateGroupWithMemberImplicationsTest
         throws Exception
     {
         System.out.println( "\n\n\n\n\nSTARTING: " + name.getMethodName() + "\n\n\n\n\n" );
-        final StoreKey impliedKey = new StoreKey( StoreType.remote, IMPLIED );
-        final StoreKey testKey = new StoreKey( StoreType.remote, TEST_REPO );
+        final StoreKey impliedKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, IMPLIED );
+        final StoreKey testKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, TEST_REPO );
 
-        testRepo =
-            client.stores()
-                  .create( new RemoteRepository( TEST_REPO, "http://www.bar.com/repo" ), setupChangelog,
-                           RemoteRepository.class );
+        testRepo = client.stores()
+                         .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, TEST_REPO,
+                                                        "http://www.bar.com/repo" ), setupChangelog,
+                                  RemoteRepository.class );
 
         client.stores()
-              .create( new RemoteRepository( IMPLIED, "http://www.foo.com/repo" ), setupChangelog,
-                       RemoteRepository.class );
+              .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, IMPLIED,
+                                             "http://www.foo.com/repo" ), setupChangelog, RemoteRepository.class );
 
         client.module( ImpliedRepoClientModule.class )
               .setStoresImpliedBy( testRepo, Collections.singletonList( impliedKey ), "setting store implications" );
 
         pubGroup.addConstituent( testKey );
 
-        client.stores()
-              .update( pubGroup, "Add test repo that has implied repos" );
+        client.stores().update( pubGroup, "Add test repo that has implied repos" );
 
         // wait for events...
         Thread.sleep( 2000 );
 
         pubGroup = client.stores()
-                         .load( StoreType.group, PUBLIC, Group.class );
+                         .load( new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.group, PUBLIC ),
+                                Group.class );
 
-        assertThat( pubGroup.getConstituents()
-                            .contains( impliedKey ), equalTo( true ) );
+        assertThat( pubGroup.getConstituents().contains( impliedKey ), equalTo( true ) );
         System.out.println( "\n\n\n\n\nENDED: " + name.getMethodName() + "\n\n\n\n\n" );
     }
 

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/AbstractSkimFunctionalTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/AbstractSkimFunctionalTest.java
@@ -29,6 +29,8 @@ import org.commonjava.indy.ftest.core.category.EventDependent;
 import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.commonjava.maven.atlas.ident.ref.ProjectVersionRef;
 import org.commonjava.maven.galley.maven.parse.PomPeek;
@@ -60,23 +62,24 @@ public class AbstractSkimFunctionalTest
         final String changelog = "Create test structures";
 
         final String url = server.formatUrl( TEST_REPO );
-        final RemoteRepository testRepo =
-            client.stores()
-                  .create( new RemoteRepository( TEST_REPO, url ), changelog, RemoteRepository.class );
+        final RemoteRepository testRepo = client.stores()
+                                                .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY,
+                                                                               TEST_REPO, url ), changelog,
+                                                         RemoteRepository.class );
 
         Group g;
-        if ( client.stores()
-                   .exists( group, PUBLIC ) )
+        final StoreKey groupKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, group, PUBLIC );
+        if ( client.stores().exists( groupKey ) )
         {
             System.out.println( "Loading pre-existing public group." );
             g = client.stores()
-                      .load( group, PUBLIC, Group.class );
+                      .load( groupKey, Group.class );
         }
         else
         {
             System.out.println( "Creating new group 'public'" );
             g = client.stores()
-                      .create( new Group( PUBLIC ), changelog, Group.class );
+                      .create( new Group( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, PUBLIC ), changelog, Group.class );
         }
 
         g.setConstituents( Collections.singletonList( testRepo.getKey() ) );

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/DisabledGroupNotAddingImpliedTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/DisabledGroupNotAddingImpliedTest.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.implrepo.skim;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Implied config enabled group public but not enabled build_disabled</li>
+ *     <li>Both group contains remote repo test, which contains a pom with path p and refer a implied repo i</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Access pom through path p in group pub</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>A new implied remote repo point to i will be added to group public</li>
+ *     <li>This new implied repo will NOT be added to group build_enabled</li>
+ * </ul>
+ */
+public class DisabledGroupNotAddingImpliedTest
+        extends AbstractSkimFunctionalTest
+{
+    private static final String REPO = "i-repo-one";
+
+    private static final String DISABLED_GROUP = "builds-disabled";
+
+    @Test
+    public void skimPomForRepoAndAddItInGroup()
+            throws Exception
+    {
+        logger.debug( "Start testing!" );
+        final PomRef ref = loadPom( "one-repo", Collections.singletonMap( "one-repo.url", server.formatUrl( REPO ) ) );
+
+        server.expect( server.formatUrl( TEST_REPO, ref.path ), 200, ref.pom );
+
+        final StoreKey testRepoKey =
+                new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, TEST_REPO );
+
+        final StoreKey impliedRepoKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, REPO );
+
+        Group disabledGroup = new Group( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, DISABLED_GROUP );
+        disabledGroup.addConstituent( testRepoKey );
+        disabledGroup = client.stores()
+                              .create( disabledGroup, String.format( "Create group %s", DISABLED_GROUP ),
+                                       Group.class );
+
+        assertThat( "Disabled repo should not contain implied before getting pom",
+                    disabledGroup.getConstituents().contains( impliedRepoKey ), equalTo( false ) );
+
+        logger.debug( "Start fetching pom!" );
+        final StoreKey pubGroupKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.group,
+                                                   PUBLIC );
+        final InputStream stream = client.content().get( pubGroupKey, ref.path );
+        final String downloaded = IOUtils.toString( stream );
+        IOUtils.closeQuietly( stream );
+
+        assertThat( "SANITY: downloaded POM is wrong!", downloaded, equalTo( ref.pom ) );
+
+        // sleep while event observer runs...
+        System.out.println( "Waiting 5s for events to run." );
+        Thread.sleep( 5000 );
+
+        final Group pub = client.stores().load( pubGroupKey, Group.class );
+        assertThat( "Group public does not contain implied repository",
+                    pub.getConstituents().contains( impliedRepoKey ), equalTo( true ) );
+
+        disabledGroup = client.stores().load( disabledGroup.getKey(), Group.class );
+        assertThat( "Disabled group contains implied repository, but it is disabled in implied config",
+                    disabledGroup.getConstituents().contains( impliedRepoKey ), equalTo( false ) );
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/implied-repos.conf",
+                         String.format( "[implied-repos]\nenabled=true\nenabled.group=%s\nenabled.group=build_.+",
+                                        PUBLIC ) );
+    }
+
+}

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/EnabledGroupAddingImpliedTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/EnabledGroupAddingImpliedTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.implrepo.skim;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>Implied config enabled both group public and build_enabled</li>
+ *     <li>Both group contains remote repo test, which contains a pom with path p and refer a implied repo i</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Access pom through path p in group pub</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>A new implied remote repo point to i will be added to both groups public and build_enabled</li>
+ * </ul>
+ */
+public class EnabledGroupAddingImpliedTest
+        extends AbstractSkimFunctionalTest
+{
+    private static final String REPO = "i-repo-one";
+
+    private static final String ENABLED_GROUP = "build_enabled";
+
+    @Test
+    public void skimPomForRepoAndAddItInGroup()
+            throws Exception
+    {
+        logger.debug( "Start testing!" );
+        final PomRef ref = loadPom( "one-repo", Collections.singletonMap( "one-repo.url", server.formatUrl( REPO ) ) );
+
+        server.expect( server.formatUrl( TEST_REPO, ref.path ), 200, ref.pom );
+
+        final StoreKey testRepoKey =
+                new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, TEST_REPO );
+
+        final StoreKey impliedRepoKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, REPO );
+
+        Group disabledGroup = new Group( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, ENABLED_GROUP );
+        disabledGroup.addConstituent( testRepoKey );
+        disabledGroup = client.stores()
+                              .create( disabledGroup, String.format( "Create group %s", ENABLED_GROUP ),
+                                       Group.class );
+
+        assertThat( "Enabled repo should not contain implied before getting pom",
+                    disabledGroup.getConstituents().contains( impliedRepoKey ), equalTo( false ) );
+
+        logger.debug( "Start fetching pom!" );
+        final StoreKey pubGroupKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.group,
+                                                   PUBLIC );
+        final InputStream stream = client.content().get( pubGroupKey, ref.path );
+        final String downloaded = IOUtils.toString( stream );
+        IOUtils.closeQuietly( stream );
+
+        assertThat( "SANITY: downloaded POM is wrong!", downloaded, equalTo( ref.pom ) );
+
+        // sleep while event observer runs...
+        System.out.println( "Waiting 5s for events to run." );
+        Thread.sleep( 5000 );
+
+        final Group pub = client.stores().load( pubGroupKey, Group.class );
+        assertThat( "Group public does not contain implied repository",
+                    pub.getConstituents().contains( impliedRepoKey ), equalTo( true ) );
+
+        disabledGroup = client.stores().load( disabledGroup.getKey(), Group.class );
+        assertThat( "Enabled group does not contain implied repository",
+                    disabledGroup.getConstituents().contains( impliedRepoKey ), equalTo( true ) );
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/implied-repos.conf",
+                         String.format( "[implied-repos]\nenabled=true\nenabled.group=%s\nenabled.group=build_.+",
+                                        PUBLIC ) );
+    }
+
+}

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/PomWithPluginRepoAddsRepoToGroupTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/PomWithPluginRepoAddsRepoToGroupTest.java
@@ -21,6 +21,7 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.junit.Test;
 
 import java.io.InputStream;
@@ -29,6 +30,29 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>A pom in remote repo test with path p</li>
+ *     <li>The pom contains declaration of a plugin repo r</li>
+ *     <li>Group pub contains remote repo test</li>
+ *     <li>No remote repo point to plugin repo r contained in group pub at first</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Access pom through path p in group pub</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>A new remote i point to plugin repo r will be added into group pub</li>
+ *     <li>Remote test will have metatada "implied_stores" point to "remote:i"</li>
+ *     <li>This remote i will have metatada "implied_by_stores" point to "remote:test"</li>
+ * </ul>
+ */
 public class PomWithPluginRepoAddsRepoToGroupTest
     extends AbstractSkimFunctionalTest
 {
@@ -43,8 +67,10 @@ public class PomWithPluginRepoAddsRepoToGroupTest
         
         server.expect( server.formatUrl( TEST_REPO, ref.path ), 200, ref.pom );
 
-        final InputStream stream = client.content()
-                                         .get( StoreType.group, PUBLIC, ref.path );
+        final StoreKey pubGroupKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.group,
+                                                   PUBLIC );
+
+        final InputStream stream = client.content().get( pubGroupKey, ref.path );
         final String downloaded = IOUtils.toString( stream );
         IOUtils.closeQuietly( stream );
         
@@ -54,21 +80,21 @@ public class PomWithPluginRepoAddsRepoToGroupTest
         System.out.println( "Waiting 5s for events to run." );
         Thread.sleep( 5000 );
 
-        final Group g = client.stores().load( StoreType.group, PUBLIC, Group.class );
+        final Group g = client.stores().load( pubGroupKey, Group.class );
+        final StoreKey remoteRepoKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, REPO );
         assertThat( "Group membership does not contain implied repository",
-                    g.getConstituents()
-                     .contains( new StoreKey( StoreType.remote, REPO ) ), equalTo( true ) );
+                    g.getConstituents().contains( remoteRepoKey ), equalTo( true ) );
 
         RemoteRepository r = client.stores()
-                                         .load( StoreType.remote, TEST_REPO, RemoteRepository.class );
+                                   .load( new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote,
+                                                        TEST_REPO ), RemoteRepository.class );
 
         String metadata = r.getMetadata( ImpliedRepoMetadataManager.IMPLIED_STORES );
 
         assertThat( "Reference to repositories implied by POMs in this repo is missing from metadata.",
                     metadata.contains( "remote:" + REPO ), equalTo( true ) );
 
-        r = client.stores()
-                  .load( StoreType.remote, REPO, RemoteRepository.class );
+        r = client.stores().load( remoteRepoKey, RemoteRepository.class );
 
         metadata = r.getMetadata( ImpliedRepoMetadataManager.IMPLIED_BY_STORES );
 

--- a/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/PomWithRepoAddsRepoToGroupTest.java
+++ b/addons/implied-repos/ftests/src/main/java/org/commonjava/indy/implrepo/skim/PomWithRepoAddsRepoToGroupTest.java
@@ -16,15 +16,13 @@
 package org.commonjava.indy.implrepo.skim;
 
 import org.apache.commons.io.IOUtils;
-import org.commonjava.indy.ftest.core.category.EventDependent;
-import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.implrepo.data.ImpliedRepoMetadataManager;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import java.io.InputStream;
 import java.util.Collections;
@@ -32,6 +30,29 @@ import java.util.Collections;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>A pom in remote repo test with path p</li>
+ *     <li>The pom contains declaration of a repo r</li>
+ *     <li>Group pub contains remote repo test</li>
+ *     <li>No remote repo point to repo r contained in group pub at first</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Access pom through path p in group pub</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>A new remote i point to repo r will be added into group pub</li>
+ *     <li>Remote test will have metatada "implied_stores" point to "remote:i"</li>
+ *     <li>This remote i will have metatada "implied_by_stores" point to "remote:test"</li>
+ * </ul>
+ */
 public class PomWithRepoAddsRepoToGroupTest
     extends AbstractSkimFunctionalTest
 {
@@ -45,8 +66,10 @@ public class PomWithRepoAddsRepoToGroupTest
         
         server.expect( server.formatUrl( TEST_REPO, ref.path ), 200, ref.pom );
 
+        final StoreKey pubGroupKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.group,
+                                                   PUBLIC );
         final InputStream stream = client.content()
-                                         .get( StoreType.group, PUBLIC, ref.path );
+                                         .get( pubGroupKey, ref.path );
         final String downloaded = IOUtils.toString( stream );
         IOUtils.closeQuietly( stream );
         
@@ -56,13 +79,14 @@ public class PomWithRepoAddsRepoToGroupTest
         System.out.println( "Waiting 5s for events to run." );
         Thread.sleep( 5000 );
 
-        final Group g = client.stores().load( StoreType.group, PUBLIC, Group.class );
+        final Group g = client.stores().load( pubGroupKey, Group.class );
+        final StoreKey remoteRepoKey = new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, REPO );
         assertThat( "Group membership does not contain implied repository",
-                    g.getConstituents()
-                     .contains( new StoreKey( StoreType.remote, REPO ) ), equalTo( true ) );
+                    g.getConstituents().contains( remoteRepoKey ), equalTo( true ) );
 
         RemoteRepository r = client.stores()
-                                         .load( StoreType.remote, TEST_REPO, RemoteRepository.class );
+                                   .load( new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote,
+                                                        TEST_REPO ), RemoteRepository.class );
 
         String metadata = r.getMetadata( ImpliedRepoMetadataManager.IMPLIED_STORES );
 
@@ -70,7 +94,7 @@ public class PomWithRepoAddsRepoToGroupTest
                     metadata.contains( "remote:" + REPO ), equalTo( true ) );
 
         r = client.stores()
-                  .load( StoreType.remote, REPO, RemoteRepository.class );
+                  .load( remoteRepoKey, RemoteRepository.class );
 
         metadata = r.getMetadata( ImpliedRepoMetadataManager.IMPLIED_BY_STORES );
 

--- a/embedder/src/test/resources/logback-test.xml
+++ b/embedder/src/test/resources/logback-test.xml
@@ -43,8 +43,9 @@
     </appender>
 
   <logger name="org.commonjava.indy" level="TRACE"/>
+  <logger name="org.commonjava.maven.galley" level="DEBUG"/>
 
-  <root level="DEBUG">
+  <root level="INFO">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
   </root>


### PR DESCRIPTION
When adding implied to group, the implied detector does not check implied configuration "enabled.group". So even we disabled groups in  implied config, these disabled groups will also contain the implied repos, which is obviously not reasonable.

