### PR TITLE
Set the content-type from upstream

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
@@ -144,7 +144,9 @@ public class HttpConduitWrapper
                 writeStatus( metadata.getResponseStatusCode(), metadata.getResponseStatusMessage() );
             }
 
-            writeHeader( ApplicationHeader.content_type, contentController.getContentType( path ) );
+            String contentType = metadata.getContentType();
+            writeHeader( ApplicationHeader.content_type,
+                         contentType != null ? contentType : contentController.getContentType( path ) );
             for ( final Map.Entry<String, List<String>> headerSet : metadata.getResponseHeaders().entrySet() )
             {
                 final String key = headerSet.getKey();
@@ -199,7 +201,9 @@ public class HttpConduitWrapper
                 writeHeader( ApplicationHeader.last_modified, lastMod );
             }
 
-            writeHeader( ApplicationHeader.content_type, contentController.getContentType( path ) );
+            String contentType = metadata.getContentType();
+            writeHeader( ApplicationHeader.content_type,
+                         contentType != null ? contentType : contentController.getContentType( path ) );
 
             logger.trace( "Write body, {}", writeBody );
             if ( writeBody )

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/SetContentTypeFromUpstreamIfExistsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/SetContentTypeFromUpstreamIfExistsTest.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.http.HttpResponse;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.client.core.helper.HttpResources;
+import org.commonjava.indy.client.core.module.IndyRawHttpModule;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Test;
+
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies that the content type header from upstream will be used.
+ * <br/>
+ * Given:
+ * <ul>
+ *     <li>Content is stored in a remote repository</li>
+ * </ul>
+ * <br/>
+ * When:
+ * <ul>
+ *     <li>Request the remote content and the response contains the header Content-Type.</li>
+ * </ul>
+ * <br/>
+ * Then:
+ * <ul>
+ *     <li>The Content-Type from upstream will be used and return to user.</li>
+ * </ul>
+ */
+public class SetContentTypeFromUpstreamIfExistsTest
+                extends AbstractContentManagementTest
+{
+
+    @Test
+    public void run() throws Exception
+    {
+        final String content = "This is some content " + System.currentTimeMillis() + "." + System.nanoTime();
+        final String path = "org/foo/foo-project/1/foo-1.jar";
+
+        server.expect( "GET", server.formatUrl( STORE, path ), ( request, response ) -> {
+            response.setStatus( 200 );
+            response.setHeader( "Content-Length", Integer.toString( content.length() ) );
+            response.setHeader( "Content-Type", "application/java-archive; charset=UTF-8" );
+            PrintWriter writer = response.getWriter();
+
+            writer.write( content );
+        } );
+
+        client.stores()
+              .create( new RemoteRepository( STORE, server.formatUrl( STORE ) ), "adding remote",
+                       RemoteRepository.class );
+
+        try (HttpResources httpResources = client.module( IndyRawHttpModule.class )
+                                                 .getHttp()
+                                                 .getRaw( client.content().contentPath( remote, STORE, path ) ))
+        {
+            HttpResponse response = httpResources.getResponse();
+            String contentType = response.getFirstHeader( "Content-Type" ).getValue();
+            assertThat( contentType, equalTo( "application/java-archive;charset=UTF-8" ) );
+        }
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        List<IndyClientModule> mods = new ArrayList<>();
+        Collection<IndyClientModule> fromParent = super.getAdditionalClientModules();
+
+        if ( fromParent != null )
+        {
+            mods.addAll( fromParent );
+        }
+
+        mods.add( new IndyRawHttpModule() );
+
+        return mods;
+    }
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/SetContentTypeNotExistsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/SetContentTypeNotExistsTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.http.HttpResponse;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.client.core.helper.HttpResources;
+import org.commonjava.indy.client.core.module.IndyRawHttpModule;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Test;
+
+import javax.activation.MimetypesFileTypeMap;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Verifies that the content type header will be set via JDK's mime-typing classes if there is no one from upstream.
+ * <br/>
+ * Given:
+ * <ul>
+ *     <li>Content is stored in a remote repository</li>
+ * </ul>
+ * <br/>
+ * When:
+ * <ul>
+ *     <li>Request the remote content and the response doesn't contain the header Content-Type.</li>
+ * </ul>
+ * <br/>
+ * Then:
+ * <ul>
+ *     <li>The Content-Type will be set via JDK's mime-typing classes and return to user.</li>
+ * </ul>
+ */
+public class SetContentTypeNotExistsTest
+                extends AbstractContentManagementTest
+{
+
+    @Test
+    public void run() throws Exception
+    {
+        final String content = "This is some content " + System.currentTimeMillis() + "." + System.nanoTime();
+        final String path = "org/foo/foo-project/1/foo-1.jar";
+
+        server.expect( "GET", server.formatUrl( STORE, path ), ( request, response ) -> {
+            response.setStatus( 200 );
+            response.setHeader( "Content-Length", Integer.toString( content.length() ) );
+            PrintWriter writer = response.getWriter();
+
+            writer.write( content );
+        } );
+
+        client.stores()
+              .create( new RemoteRepository( STORE, server.formatUrl( STORE ) ), "adding remote",
+                       RemoteRepository.class );
+
+        try (HttpResources httpResources = client.module( IndyRawHttpModule.class )
+                                                 .getHttp()
+                                                 .getRaw( client.content().contentPath( remote, STORE, path ) ))
+        {
+            HttpResponse response = httpResources.getResponse();
+
+            String contentType = response.getFirstHeader( "Content-Type" ).getValue();
+            assertThat( contentType, equalTo( new MimetypesFileTypeMap().getContentType( path ) ) );
+        }
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        List<IndyClientModule> mods = new ArrayList<>();
+        Collection<IndyClientModule> fromParent = super.getAdditionalClientModules();
+
+        if ( fromParent != null )
+        {
+            mods.addAll( fromParent );
+        }
+
+        mods.add( new IndyRawHttpModule() );
+
+        return mods;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>0.17.2</atlasVersion>
-    <galleyVersion>0.16.5</galleyVersion>
+    <galleyVersion>0.16.6-SNAPSHOT</galleyVersion>
     <bomVersion>24</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.14</partylineVersion>

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
@@ -194,11 +194,9 @@ public final class ResponseUtils
     {
         Logger logger = LoggerFactory.getLogger( ResponseUtils.class );
 
-        // I don't think we want to use the result from upstream; it's often junk...we should retain control of this.
-        builder.header( ApplicationHeader.content_type.key(), contentType );
-
         boolean lastModSet = false;
         boolean lenSet = false;
+        boolean conTypeSet = false;
 
         if ( exchangeMetadata != null )
         {
@@ -207,8 +205,8 @@ public final class ResponseUtils
                 final String key = headerSet.getKey();
                 if ( ApplicationHeader.content_type.upperKey().equals( key ) )
                 {
-                    logger.debug( "Skipping set for header: {}", ApplicationHeader.content_type.upperKey() );
-                    continue;
+                    logger.debug( "Marking {} as already set.", ApplicationHeader.content_type.upperKey() );
+                    conTypeSet = true;
                 }
                 else if ( ApplicationHeader.last_modified.upperKey().equals( key ) )
                 {
@@ -246,6 +244,13 @@ public final class ResponseUtils
                 logger.debug( "Adding Content-Length header: {}", item.length() );
 
                 builder.header( ApplicationHeader.content_length.key(), item.length() );
+            }
+
+            if ( !conTypeSet )
+            {
+                logger.debug( "Adding Content-Type header: {}", contentType );
+
+                builder.header( ApplicationHeader.content_type.key(), contentType );
             }
 
             // Indy origin contains the storeKey of the repository where the content came from


### PR DESCRIPTION
Let's use the content-type from upstream instead of ignoring it,
and use the JDK's mime-typing classes for that has no such field
in upstream server.