### PR TITLE
Add metrics to subdivide content requests and provide cache execution timing/count

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -19,6 +19,7 @@ import org.commonjava.indy.action.BootupAction;
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.indy.action.ShutdownAction;
 import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
@@ -148,6 +149,7 @@ public class DefaultContentIndexManager
     }
 
     @Override
+    @Measure
     public boolean removeIndexedStorePath( String rawPath, StoreKey key, Consumer<IndexedStorePath> pathConsumer )
     {
         String path = getStrategyPath( key, rawPath );
@@ -181,6 +183,7 @@ public class DefaultContentIndexManager
     }
 
     @Override
+    @Measure
     public void deIndexStorePath( final StoreKey key, final String rawPath )
     {
         String path = getStrategyPath( key, rawPath );
@@ -190,6 +193,7 @@ public class DefaultContentIndexManager
     }
 
     @Override
+    @Measure
     public StoreKey getIndexedStoreKey( final StoreKey key, final String rawPath )
     {
         String path = getStrategyPath( key, rawPath );
@@ -200,6 +204,7 @@ public class DefaultContentIndexManager
     }
 
     @Override
+    @Measure
     public void indexTransferIn( Transfer transfer, StoreKey...topKeys )
     {
         if ( transfer != null && transfer.exists() )
@@ -214,6 +219,7 @@ public class DefaultContentIndexManager
      * When we store or retrieve content, index it for faster reference next time.
      */
     @Override
+    @Measure
     public void indexPathInStores( String rawPath, StoreKey originKey, StoreKey... topKeys )
     {
         String path = getStrategyPath( originKey, rawPath );
@@ -231,6 +237,7 @@ public class DefaultContentIndexManager
     }
 
     @Override
+    @Measure
     public void clearAllIndexedPathInStore( ArtifactStore store )
     {
         Set<IndexedStorePath> isps =
@@ -243,6 +250,7 @@ public class DefaultContentIndexManager
     }
 
     @Override
+    @Measure
     public void clearAllIndexedPathWithOriginalStore( ArtifactStore originalStore )
     {
         StoreKey osk = originalStore.getKey();
@@ -262,6 +270,7 @@ public class DefaultContentIndexManager
     }
 
     @Override
+    @Measure
     public void clearAllIndexedPathInStoreWithOriginal( ArtifactStore store, ArtifactStore originalStore )
     {
         Set<IndexedStorePath> isps = contentIndex.cacheKeySetByFilter(
@@ -292,6 +301,7 @@ public class DefaultContentIndexManager
      * the path should be cleared.
      */
     @Override
+    @Measure
     public void clearIndexedPathFrom( String rawPath, Set<Group> groups, Consumer<IndexedStorePath> pathConsumer )
     {
         if ( groups == null || groups.isEmpty() )

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/RemoteCacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/RemoteCacheHandle.java
@@ -36,7 +36,7 @@ public class RemoteCacheHandle<K,V> extends BasicCacheHandle<K, V>
     @Override
     protected String getMetricName( String opName )
     {
-        return name( getMetricPrefix(), "remote", opName );
+        return name( getMetricPrefix(), cache.getName(), "remote", opName );
     }
 
 }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
@@ -58,15 +58,16 @@ public class ResourceManagementFilter
     public static final String ORIGINAL_THREAD_NAME = "original-thread-name";
 
     public static final String METHOD_PATH_TIME = "method-path-time";
-    
 
-    private static final String POM_CONTENT_METRIC = "pom";
+    private static final String BASE_CONTENT_METRIC = "indy.content.";
 
-    private static final String NORMAL_CONTENT_METRIC = "content";
+    private static final String POM_CONTENT_METRIC = BASE_CONTENT_METRIC + "pom";
 
-    private static final String METADATA_CONTENT_METRIC = "metadata";
+    private static final String NORMAL_CONTENT_METRIC = BASE_CONTENT_METRIC + "other";
 
-    private static final String SPECIAL_CONTENT_METRIC = "special";
+    private static final String METADATA_CONTENT_METRIC = BASE_CONTENT_METRIC + "metadata";
+
+    private static final String SPECIAL_CONTENT_METRIC = BASE_CONTENT_METRIC + "special";
 
     @Inject
     private CacheProvider cacheProvider;
@@ -95,7 +96,7 @@ public class ResourceManagementFilter
     }
 
     @Override
-    @Measure( timers = @MetricNamed( DEFAULT ), exceptions = @MetricNamed( DEFAULT ) )
+    @Measure
     public void doFilter( final ServletRequest request, final ServletResponse response, final FilterChain chain )
             throws IOException, ServletException
     {

--- a/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/MetricNamed.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/measure/annotation/MetricNamed.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.indy.measure.annotation;
 
+import org.commonjava.indy.metrics.IndyMetricsConstants;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -26,7 +28,11 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention( RUNTIME )
 public @interface MetricNamed
 {
-    String DEFAULT = "default";
+    /**
+     * Need to migrate to {@link IndyMetricsConstants#DEFAULT}.
+     * @deprecated
+     */
+    String DEFAULT = IndyMetricsConstants.DEFAULT;
 
     String value() default DEFAULT;
 }

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/IndyMetricsConstants.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/IndyMetricsConstants.java
@@ -26,11 +26,15 @@ import static org.commonjava.indy.measure.annotation.MetricNamed.DEFAULT;
 
 public class IndyMetricsConstants
 {
+    public static final String DEFAULT = "default";
+
     public static final String EXCEPTION = "exception";
 
     public static final String METER = "meter";
 
     public static final String TIMER = "timer";
+
+    public static final String SKIP_METRIC = "skip-this-metric";
 
     /**
      * Get default metric name. Use abbreviated package name, e.g., foo.bar.ClassA.methodB -> f.b.ClassA.methodB
@@ -39,6 +43,16 @@ public class IndyMetricsConstants
     {
         // minimum len 1 shortens the package name and keeps class name
         String cls = ClassUtils.getAbbreviatedName( declaringClass.getName(), 1 );
+        return name( cls, method );
+    }
+
+    /**
+     * Get default metric name. Use abbreviated package name, e.g., foo.bar.ClassA.methodB -> f.b.ClassA.methodB
+     */
+    public static String getDefaultName( String declaringClass, String method )
+    {
+        // minimum len 1 shortens the package name and keeps class name
+        String cls = ClassUtils.getAbbreviatedName( declaringClass, 1 );
         return name( cls, method );
     }
 

--- a/subsys/metrics/src/main/java/org/commonjava/indy/metrics/IndyMetricsManager.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/metrics/IndyMetricsManager.java
@@ -35,8 +35,17 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.EXCEPTION;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.METER;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.SKIP_METRIC;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.TIMER;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.getDefaultName;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.getName;
 import static org.commonjava.indy.metrics.jvm.IndyJVMInstrumentation.registerJvmMetric;
 import static org.commonjava.indy.model.core.StoreType.remote;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
@@ -184,6 +193,52 @@ public class  IndyMetricsManager
     public Meter getMeter( String name )
     {
         return metricRegistry.meter( name );
+    }
+
+    public <T> T wrapWithStandardMetrics( final Supplier<T> method, final Supplier<String> classifier )
+    {
+        String suppliedName = classifier.get();
+        if ( SKIP_METRIC.equals( suppliedName ) )
+        {
+            return method.get();
+        }
+
+        String nodePrefix = config.getNodePrefix();
+
+        StackTraceElement traceElement = Thread.currentThread().getStackTrace()[1];
+
+        String defaultName = getDefaultName( traceElement.getClassName(), traceElement.getMethodName() );
+        String metricName = getName( nodePrefix, suppliedName, defaultName, TIMER );
+
+        Timer.Context timer = getTimer( metricName ).time();
+        logger.trace( "START: {} ({})", metricName, timer );
+
+        try
+        {
+            return method.get();
+        }
+        catch ( Throwable e )
+        {
+            getMeter(
+                   getName( nodePrefix, suppliedName, defaultName, EXCEPTION ) )
+                         .mark();
+
+            getMeter(
+                   getName( nodePrefix, suppliedName, defaultName, EXCEPTION,
+                            e.getClass().getSimpleName() ) ).mark();
+
+            throw e;
+        }
+        finally
+        {
+            if ( timer != null )
+            {
+                timer.stop();
+            }
+
+            getMeter( getName( nodePrefix, suppliedName, defaultName, METER ) ).mark();
+            logger.trace( "CALLS++ {}", metricName );
+        }
     }
 
 }


### PR DESCRIPTION
* Also provides a new wrapWithStandardMetrics() method in IndyMetricsManager to allow us to measure specific code blocks with custom names, not just at the method / interceptor level.
* Provides support for empty @Measure annotation, which will use the standard set of timing/counting metrics (as with the new method above)