### PR TITLE
Reduce httproxy awaitReadable time from 1 sec to 100 mill

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyRequestReader.java
@@ -49,6 +49,8 @@ import java.util.concurrent.TimeUnit;
 public final class ProxyRequestReader
         implements ChannelListener<ConduitStreamSourceChannel>
 {
+    private static final int AWAIT_READABLE_IN_MILLISECONDS = 100;
+
     private static final List<Character> HEAD_END = Collections.unmodifiableList(
             Arrays.asList( Character.valueOf( '\r' ), Character.valueOf( '\n' ), Character.valueOf( '\r' ),
                            Character.valueOf( '\n' ) ) );
@@ -178,15 +180,7 @@ public final class ProxyRequestReader
         while ( true )
         {
             ByteBuffer buf = ByteBuffer.allocate( 1024 );
-            try
-            {
-                channel.awaitReadable( 1, TimeUnit.SECONDS );
-            }
-            catch ( InterruptedIOException e )
-            {
-                logger.debug( "proxy request read channel timed out while waiting for input. Considering this request failed." );
-                return -1;
-            }
+            channel.awaitReadable( AWAIT_READABLE_IN_MILLISECONDS, TimeUnit.MILLISECONDS );
 
             int read = channel.read( buf ); // return the number of bytes read, possibly zero, or -1
 

--- a/addons/httprox/ftests/src/main/resources/logback-test.xml
+++ b/addons/httprox/ftests/src/main/resources/logback-test.xml
@@ -21,12 +21,12 @@
     <!-- encoders are assigned the type
          ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
     <encoder>
-      <pattern>[%thread] %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
     </encoder>
   </appender>
 
   <logger name="org.commonjava.indy.httprox" level="TRACE"/>
-  <logger name="org.apache.http" level="TRACE"/>
+  <logger name="org.apache.http" level="INFO"/>
 
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
When I looked deep into the httproxy MITM performance, I found it spends a few seconds to do the SSL handshakes. This should not be that long. I found the doRead() always wait for one second before it read 0 bytes (the EOF, indicating the reading is done). I set channel.awaitReadable to 100 mill and the handshakes are finished much faster (within one second). I believe this will boost MITM (and HTTP download) performance quite a bit. I guess it can reduce 1/3 of total downloading time for NPM/yarn builds.  