### PR TITLE
Change to use !isMergable for GAV content index strategy

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/index/MavenIndexingStrategy.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/index/MavenIndexingStrategy.java
@@ -51,7 +51,7 @@ public class MavenIndexingStrategy
     public String getIndexPath( final String rawPath )
     {
         final SpecialPathInfo info = specialPathManager.getSpecialPathInfo( rawPath );
-        if ( info == null || !info.isMetadata() )
+        if ( info == null || !info.isMergable() )
         {
             return PathUtils.getCurrentDirPath( rawPath );
         }


### PR DESCRIPTION
   I saw that most metadata which should be fetched from group level
when accessing group is mergable, so I think we should just avoid
mergable metadata files in this strategy