### PR TITLE
[POC] Add kafka log appeneder

### DIFF
--- a/deployments/launcher/src/main/etc/indy/logging/logback.xml
+++ b/deployments/launcher/src/main/etc/indy/logging/logback.xml
@@ -121,6 +121,7 @@
 
   <!-- This example configuration is probably most unreliable under
     failure conditions but wont block your application at all -->
+  <!-- The encoder part is using JsonLayout format encoder to generate structured logs using json format -->
   <!-- use async delivery. the application threads are not blocked by logging -->
   <!--
     ProducerConfigs as below:
@@ -132,9 +133,13 @@
   <!-- there is no fallback <appender-ref>. If this appender cannot deliver, it will drop its messages. -->
   <!--
   <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
-    <encoder>
-      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+      <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+        <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter"/>
+        <appendLineSeparator>true</appendLineSeparator>
+      </layout>
     </encoder>
+
     <topic>indy-logs</topic>
     <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.HostNameKeyingStrategy" />
     <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy" />

--- a/deployments/launcher/src/main/etc/indy/logging/logback.xml
+++ b/deployments/launcher/src/main/etc/indy/logging/logback.xml
@@ -119,6 +119,42 @@
     </headers>
   </appender -->
 
+  <!-- This example configuration is probably most unreliable under
+    failure conditions but wont block your application at all -->
+  <!-- use async delivery. the application threads are not blocked by logging -->
+  <!--
+    ProducerConfigs as below:
+     * acks=0: don't wait for a broker to ack the reception of a batch.
+     * linger.ms=1000: wait up to 1000ms and collect log messages before sending them as a batch
+     * max.block.ms=0: even if the producer buffer runs full, do not block the application but start to drop messages
+     * client.id=client.id=${HOSTNAME}-${CONTEXT_NAME}-logback-relaxed: define a client-id that you use to identify yourself against the kafka broker
+  -->
+  <!-- there is no fallback <appender-ref>. If this appender cannot deliver, it will drop its messages. -->
+  <!--
+  <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <topic>indy-logs</topic>
+    <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.HostNameKeyingStrategy" />
+    <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy" />
+
+    <producerConfig>bootstrap.servers=localhost:9092</producerConfig>
+    <producerConfig>acks=0</producerConfig>
+    <producerConfig>linger.ms=1000</producerConfig>
+    <producerConfig>max.block.ms=0</producerConfig>
+    <producerConfig>client.id=${HOSTNAME}-${CONTEXT_NAME}-logback-relaxed</producerConfig>
+  </appender>
+  -->
+
+  <!-- Followed with kafka appender, to prevent a metadata blocking problem -->
+  <!--
+  <logger name="org.apache.kafka" additivity="false" level="INFO">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="FILE" />
+  </logger>
+  -->
+
   <logger name="org.jboss" level="ERROR"/>
   <!-- <logger name="org.jboss.resteasy" level="DEBUG"/> -->
 
@@ -148,6 +184,10 @@
   <root level="INFO">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
+    <!-- if kafka function is on, include KAFKA appender -->
+    <!--
+    <appender-ref ref="KAFKA" />
+    -->
 
     <!-- if elasticsearch function is on, include ELASTIC appender-->
     <!-- if condition='property("elasticsearch.enable").equalsIgnoreCase("true")'>

--- a/pom.xml
+++ b/pom.xml
@@ -1438,6 +1438,16 @@
         <artifactId>logback-kafka-appender</artifactId>
         <version>0.2.0-RC2</version>
       </dependency>
+      <dependency>
+        <groupId>ch.qos.logback.contrib</groupId>
+        <artifactId>logback-json-classic</artifactId>
+        <version>0.1.5</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback.contrib</groupId>
+        <artifactId>logback-jackson</artifactId>
+        <version>0.1.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   
@@ -1449,6 +1459,14 @@
     <dependency>
       <groupId>com.github.danielwegener</groupId>
       <artifactId>logback-kafka-appender</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback.contrib</groupId>
+      <artifactId>logback-json-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback.contrib</groupId>
+      <artifactId>logback-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,8 @@
 
     <!-- thirdparty projects -->
     <javaVersion>1.8</javaVersion>
-    <slf4j-version>1.6.1</slf4j-version>
+    <slf4j-version>1.7.16</slf4j-version>
+    <logback-version>1.2.3</logback-version>
     <infinispanVersion>8.2.4.Final</infinispanVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <hibernateVersion>5.8.1.Final</hibernateVersion>
@@ -1422,6 +1423,21 @@
         <artifactId>metrics-elasticsearch-reporter</artifactId>
         <version>2.2.0</version>
       </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${logback-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.danielwegener</groupId>
+        <artifactId>logback-kafka-appender</artifactId>
+        <version>0.2.0-RC2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   
@@ -1429,6 +1445,10 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.danielwegener</groupId>
+      <artifactId>logback-kafka-appender</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>


### PR DESCRIPTION
  Some notes:
   * AsynchronousDeliveryStrategy can not guarantee if the logs missing will happen as it does not check failures. If want to do the checking, BlockingDeliveryStrategy should be used, but as its name showed, it will block the logging thread if the log action and kafka producing action takes long time.
   * In log config, logger for "org.apache.kafka" should be raised to "INFO" upper level, as it will cause some Kafka Timeout error with "DEBUG" and below.
   * Should upgrade logback version to 1.2.3+