### PR TITLE
Code change for schedule manager cluster support

### DIFF
--- a/api/src/main/java/org/commonjava/indy/cluster/IndyNode.java
+++ b/api/src/main/java/org/commonjava/indy/cluster/IndyNode.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.cluster;
+
+import java.io.Serializable;
+
+/**
+ * A data model to describe a clustered indy node.
+ */
+public class IndyNode
+        implements Serializable
+{
+    private final String nodeId;
+
+    IndyNode( final String nodeId )
+    {
+        this.nodeId = nodeId;
+    }
+}

--- a/api/src/main/java/org/commonjava/indy/cluster/IndyNodeHolder.java
+++ b/api/src/main/java/org/commonjava/indy/cluster/IndyNodeHolder.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.cluster;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+@ApplicationScoped
+public class IndyNodeHolder
+{
+    public static final Logger logger = LoggerFactory.getLogger( IndyNodeHolder.class );
+
+    public IndyNode getIndyNode()
+    {
+        //TODO: here is just a temporary solution to get a local indy node indicator. Will think more about this way future
+        try
+        {
+            return new IndyNode( InetAddress.getLocalHost().getHostName() );
+        }
+        catch ( UnknownHostException e )
+        {
+            logger.error( "Unable to get " );
+        }
+        return null;
+    }
+}

--- a/core/src/main/conf/conf.d/scheduler.conf
+++ b/core/src/main/conf/conf.d/scheduler.conf
@@ -1,2 +1,3 @@
 [scheduler]
 #enabled=true
+#schedule.cluster.lock.expiration.sec = 3600

--- a/core/src/main/java/org/commonjava/indy/core/conf/IndySchedulerConfig.java
+++ b/core/src/main/java/org/commonjava/indy/core/conf/IndySchedulerConfig.java
@@ -28,44 +28,59 @@ import java.util.Properties;
 
 @ApplicationScoped
 @SectionName( IndySchedulerConfig.SECTION_NAME )
-@Deprecated
 public class IndySchedulerConfig
     extends MapSectionListener
         implements IndyConfigInfo
 {
 
-    //TODO: this class is quartz related function for content expiration, which has been
+    //TODO: All quartz related function for content expiration has been
     //      replaced by ISPN cache timeout way. Will be removed in future
 
     public static final String SECTION_NAME = "scheduler";
 
-    private static final String QUARTZ_DATASOURCE_PREFIX = "org.quartz.dataSource.ds.";
-
-    private static final String DS_DRIVER = "driver";
-
-    private static final String DS_URL = "URL";
-
-    private static final String DDL_PROP = "ddl";
-
     private static final String ENABLED_PROP = "enabled";
 
-    private static final String DEFAULT_DB_URL =
-        String.format( "jdbc:derby:%s/var/lib/indy/data/scheduler",
-                       System.getProperty( "indy.home", System.getProperty( "java.io.tmpdir" ) ) );
+    private static final String CLUSTER_LOCK_EXPIRATION = "schedule.cluster.lock.expiration.sec";
 
-    private static final String DEFAULT_DB_DRIVER = "org.apache.derby.jdbc.EmbeddedDriver";
+//    @Deprecated
+//    private static final String QUARTZ_DATASOURCE_PREFIX = "org.quartz.dataSource.ds.";
+//
+//    @Deprecated
+//    private static final String DS_DRIVER = "driver";
+//
+//    @Deprecated
+//    private static final String DS_URL = "URL";
+//
+//    @Deprecated
+//    private static final String DDL_PROP = "ddl";
+//
+//    @Deprecated
+//    private static final String DEFAULT_DB_URL =
+//        String.format( "jdbc:derby:%s/var/lib/indy/data/scheduler",
+//                       System.getProperty( "indy.home", System.getProperty( "java.io.tmpdir" ) ) );
+//
+//    @Deprecated
+//    private static final String DEFAULT_DB_DRIVER = "org.apache.derby.jdbc.EmbeddedDriver";
 
     private static final boolean DEFAULT_ENABLED = true;
 
+    private static final int DEFAULT_CLUSTER_LOCK_EXPIRATION = 3600;
+
     private Boolean enabled;
 
-    private transient boolean dbDetailsParsed;
+    private Integer clusterLockExpiration;
 
-    private transient String ddlFile;
-
-    private transient String dbUrl;
-
-    private transient String dbDriver;
+//    @Deprecated
+//    private transient boolean dbDetailsParsed;
+//
+//    @Deprecated
+//    private transient String ddlFile;
+//
+//    @Deprecated
+//    private transient String dbUrl;
+//
+//    @Deprecated
+//    private transient String dbDriver;
 
     public IndySchedulerConfig()
     {
@@ -81,103 +96,111 @@ public class IndySchedulerConfig
         }
     }
 
-    private synchronized void parseDatabaseDetails()
-    {
-        if ( !dbDetailsParsed )
-        {
-            dbDetailsParsed = true;
-
-            final Map<String, String> configMap = getConfiguration();
-            if ( configMap == null )
-            {
-                return;
-            }
-
-            for ( final Map.Entry<String, String> entry : configMap.entrySet() )
-            {
-                final String key = entry.getKey();
-                if ( ENABLED_PROP.equalsIgnoreCase( key ) )
-                {
-                    enabled = Boolean.parseBoolean( entry.getValue().toLowerCase() );
-                }
-                else if ( DDL_PROP.equalsIgnoreCase( key ) )
-                {
-                    ddlFile = entry.getValue();
-                }
-                else if ( key.startsWith( QUARTZ_DATASOURCE_PREFIX ) )
-                {
-                    if ( key.endsWith( DS_DRIVER ) )
-                    {
-                        this.dbDriver = entry.getValue();
-                    }
-                    else if ( key.endsWith( DS_URL ) )
-                    {
-                        this.dbUrl = entry.getValue();
-                    }
-                }
-            }
-        }
-    }
+//    @Deprecated
+//    private synchronized void parseDatabaseDetails()
+//    {
+//        if ( !dbDetailsParsed )
+//        {
+//            dbDetailsParsed = true;
+//
+//            final Map<String, String> configMap = getConfiguration();
+//            if ( configMap == null )
+//            {
+//                return;
+//            }
+//
+//            for ( final Map.Entry<String, String> entry : configMap.entrySet() )
+//            {
+//                final String key = entry.getKey();
+//                if ( ENABLED_PROP.equalsIgnoreCase( key ) )
+//                {
+//                    enabled = Boolean.parseBoolean( entry.getValue().toLowerCase() );
+//                }
+//                else if ( DDL_PROP.equalsIgnoreCase( key ) )
+//                {
+//                    ddlFile = entry.getValue();
+//                }
+//                else if ( key.startsWith( QUARTZ_DATASOURCE_PREFIX ) )
+//                {
+//                    if ( key.endsWith( DS_DRIVER ) )
+//                    {
+//                        this.dbDriver = entry.getValue();
+//                    }
+//                    else if ( key.endsWith( DS_URL ) )
+//                    {
+//                        this.dbUrl = entry.getValue();
+//                    }
+//                }
+//            }
+//        }
+//    }
 
     public boolean isEnabled()
     {
-        parseDatabaseDetails();
         return enabled == null ? DEFAULT_ENABLED : enabled;
     }
 
-    public String getDdlFile()
+    public int getClusterLockExpiration()
     {
-        parseDatabaseDetails();
-        return ddlFile;
+        return clusterLockExpiration == null ? DEFAULT_CLUSTER_LOCK_EXPIRATION : clusterLockExpiration;
     }
 
-    public String getDbUrl()
-    {
-        parseDatabaseDetails();
-        return dbUrl == null ? DEFAULT_DB_URL : dbUrl;
-    }
+//    @Deprecated
+//    public String getDdlFile()
+//    {
+//        parseDatabaseDetails();
+//        return ddlFile;
+//    }
+//
+//    @Deprecated
+//    public String getDbUrl()
+//    {
+//        parseDatabaseDetails();
+//        return dbUrl == null ? DEFAULT_DB_URL : dbUrl;
+//    }
+//
+//    @Deprecated
+//    public String getDbDriver()
+//    {
+//        parseDatabaseDetails();
+//        return dbDriver == null ? DEFAULT_DB_DRIVER : dbDriver;
+//    }
 
-    public String getDbDriver()
-    {
-        parseDatabaseDetails();
-        return dbDriver == null ? DEFAULT_DB_DRIVER : dbDriver;
-    }
-
-    public CharSequence validate()
-    {
-        //        parseDatabaseDetails();
-        //        final StringBuilder sb = new StringBuilder();
-        //        if ( dbDriver == null )
-        //        {
-        //            if ( sb.length() > 0 )
-        //            {
-        //                sb.append( "\n" );
-        //            }
-        //            sb.append( "Missing database driver (" )
-        //              .append( QUARTZ_DATASOURCE_PREFIX )
-        //              .append( DS_DRIVER )
-        //              .append( ")" );
-        //        }
-        //
-        //        if ( dbUrl == null )
-        //        {
-        //            if ( sb.length() > 0 )
-        //            {
-        //                sb.append( "\n" );
-        //            }
-        //            sb.append( "Missing database URL (" )
-        //              .append( QUARTZ_DATASOURCE_PREFIX )
-        //              .append( DS_URL )
-        //              .append( ")" );
-        //        }
-        //
-        //        if ( sb.length() > 0 )
-        //        {
-        //            return sb;
-        //        }
-
-        return null;
-    }
+//    public CharSequence validate()
+//    {
+//                parseDatabaseDetails();
+//                final StringBuilder sb = new StringBuilder();
+//                if ( dbDriver == null )
+//                {
+//                    if ( sb.length() > 0 )
+//                    {
+//                        sb.append( "\n" );
+//                    }
+//                    sb.append( "Missing database driver (" )
+//                      .append( QUARTZ_DATASOURCE_PREFIX )
+//                      .append( DS_DRIVER )
+//                      .append( ")" );
+//                }
+//
+//                if ( dbUrl == null )
+//                {
+//                    if ( sb.length() > 0 )
+//                    {
+//                        sb.append( "\n" );
+//                    }
+//                    sb.append( "Missing database URL (" )
+//                      .append( QUARTZ_DATASOURCE_PREFIX )
+//                      .append( DS_URL )
+//                      .append( ")" );
+//                }
+//
+//                if ( sb.length() > 0 )
+//                {
+//                    return sb;
+//                }
+//
+//        return null;
+//    }
 
     @Override
     public Map<String, String> getConfiguration()
@@ -186,11 +209,6 @@ public class IndySchedulerConfig
         if ( configuration == null )
         {
             configuration = new HashMap<>();
-        }
-
-        if ( configuration.isEmpty() )
-        {
-
         }
 
         return configuration;

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -52,6 +52,8 @@ import org.infinispan.notifications.cachelistener.annotation.CacheEntryRemoved;
 import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent;
 import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
+import org.infinispan.notifications.cachemanagerlistener.annotation.ViewChanged;
+import org.infinispan.notifications.cachemanagerlistener.event.ViewChangedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -804,6 +806,14 @@ public class ScheduleManager
             return;
         }
         logger.info( "Cache removed to cancel scheduling, Key is {}, Value is {}", e.getKey(), e.getValue() );
+    }
+
+    // This method is only used to check clustered schedule expire cache nodes topology changing
+    @ViewChanged
+    public void checkClusterChange( ViewChangedEvent event )
+    {
+        logger.debug( "Schedule cache cluster members changed, old members: {}; new members: {}", event.getOldMembers(),
+                      event.getNewMembers() );
     }
 
 }

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -19,9 +19,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.commonjava.indy.action.BootupAction;
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.indy.action.ShutdownAction;
+import org.commonjava.indy.cluster.IndyNode;
+import org.commonjava.indy.cluster.IndyNodeHolder;
 import org.commonjava.indy.conf.IndyConfiguration;
 import org.commonjava.indy.core.conf.IndySchedulerConfig;
 import org.commonjava.indy.core.expire.cache.ScheduleCache;
+import org.commonjava.indy.core.expire.cache.ScheduleEventLockCache;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
@@ -69,6 +72,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.StreamSupport;
 
@@ -84,7 +88,7 @@ import static org.commonjava.indy.core.change.StoreEnablementManager.TIMEOUT_USE
  */
 @SuppressWarnings( "RedundantThrows" )
 @ApplicationScoped
-@Listener
+@Listener(clustered = true)
 public class ScheduleManager
         implements BootupAction, ShutdownAction
 {
@@ -100,6 +104,8 @@ public class ScheduleManager
     public static final String JOB_TYPE = "JOB_TYPE";
 
     public static final String SCHEDULE_TIME = "SCHEDULE_TIME";
+
+    public static final String SCHEDULE_UUID = "SCHEDULE_UUID";
 
     @Inject
     private StoreDataManager dataManager;
@@ -121,11 +127,18 @@ public class ScheduleManager
     private CacheHandle<ScheduleKey, Map> scheduleCache;
 
     @Inject
+    @ScheduleEventLockCache
+    private CacheHandle<UUID, IndyNode> scheduleEventLockCache;
+
+    @Inject
     @Any
     private Instance<ContentAdvisor> contentAdvisor;
 
     @Inject
     private Event<SchedulerEvent> eventDispatcher;
+
+    @Inject
+    private IndyNodeHolder nodeHolder;
 
     @Override
     public void init()
@@ -138,8 +151,13 @@ public class ScheduleManager
         }
 
         // register this producer as schedule cache listener
-        scheduleCache.executeCache( cache -> {
-            cache.addListener( ScheduleManager.this );
+        registerCacheListener( scheduleCache );
+//        registerCacheListener( scheduleEventLockCache );
+    }
+
+    private <K,V> void registerCacheListener(CacheHandle<K, V> cache){
+        cache.executeCache( c->{
+            c.addListener( ScheduleManager.this );
             return null;
         } );
     }
@@ -297,11 +315,17 @@ public class ScheduleManager
 
         dataMap.put( SCHEDULE_TIME, System.currentTimeMillis() );
 
-
         final ScheduleKey cacheKey = new ScheduleKey( key, jobType, jobName );
+        //FIXME: Is this uuid payload needed?
+        dataMap.put( SCHEDULE_UUID, uuidForKey( cacheKey ) );
 
         scheduleCache.execute( cache -> cache.put( cacheKey, dataMap, startSeconds, TimeUnit.SECONDS ) );
         logger.debug( "Scheduled for the key {} with timeout: {} seconds", cacheKey, startSeconds );
+    }
+
+    private UUID uuidForKey( final ScheduleKey key )
+    {
+        return key == null ? null : UUID.nameUUIDFromBytes( key.toStringKey().getBytes() );
     }
 
     public void scheduleContentExpiration( final StoreKey key, final String path,
@@ -759,6 +783,13 @@ public class ScheduleManager
         if ( !e.isPre() )
         {
             final ScheduleKey expiredKey = e.getKey();
+            final UUID uuidOfKey = uuidForKey( expiredKey );
+            if ( uuidOfKey != null && scheduleEventLockCache.containsKey( uuidOfKey ) )
+            {
+                logger.info( "Another instance {} is still handling expiration event for {}", expiredKey,
+                             scheduleEventLockCache.containsKey( uuidOfKey ) );
+                return;
+            }
             final Map expiredContent = e.getValue();
             if ( expiredKey != null && expiredContent != null )
             {
@@ -766,6 +797,9 @@ public class ScheduleManager
                 final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
                 final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
                 fireEvent( eventDispatcher, new SchedulerTriggerEvent( type, data ) );
+                scheduleEventLockCache.executeCache( cache -> cache.put( uuidOfKey, nodeHolder.getIndyNode(),
+                                                                         schedulerConfig.getClusterLockExpiration(),
+                                                                         TimeUnit.SECONDS ) );
             }
         }
     }

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -72,7 +72,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.StreamSupport;
 
@@ -128,7 +127,7 @@ public class ScheduleManager
 
     @Inject
     @ScheduleEventLockCache
-    private CacheHandle<UUID, IndyNode> scheduleEventLockCache;
+    private CacheHandle<ScheduleKey, IndyNode> scheduleEventLockCache;
 
     @Inject
     @Any
@@ -316,16 +315,9 @@ public class ScheduleManager
         dataMap.put( SCHEDULE_TIME, System.currentTimeMillis() );
 
         final ScheduleKey cacheKey = new ScheduleKey( key, jobType, jobName );
-        //FIXME: Is this uuid payload needed?
-        dataMap.put( SCHEDULE_UUID, uuidForKey( cacheKey ) );
 
         scheduleCache.execute( cache -> cache.put( cacheKey, dataMap, startSeconds, TimeUnit.SECONDS ) );
         logger.debug( "Scheduled for the key {} with timeout: {} seconds", cacheKey, startSeconds );
-    }
-
-    private UUID uuidForKey( final ScheduleKey key )
-    {
-        return key == null ? null : UUID.nameUUIDFromBytes( key.toStringKey().getBytes() );
     }
 
     public void scheduleContentExpiration( final StoreKey key, final String path,
@@ -783,11 +775,10 @@ public class ScheduleManager
         if ( !e.isPre() )
         {
             final ScheduleKey expiredKey = e.getKey();
-            final UUID uuidOfKey = uuidForKey( expiredKey );
-            if ( uuidOfKey != null && scheduleEventLockCache.containsKey( uuidOfKey ) )
+            if ( scheduleEventLockCache.containsKey( expiredKey ) )
             {
                 logger.info( "Another instance {} is still handling expiration event for {}", expiredKey,
-                             scheduleEventLockCache.containsKey( uuidOfKey ) );
+                             scheduleEventLockCache.containsKey( expiredKey ) );
                 return;
             }
             final Map expiredContent = e.getValue();
@@ -797,7 +788,7 @@ public class ScheduleManager
                 final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
                 final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
                 fireEvent( eventDispatcher, new SchedulerTriggerEvent( type, data ) );
-                scheduleEventLockCache.executeCache( cache -> cache.put( uuidOfKey, nodeHolder.getIndyNode(),
+                scheduleEventLockCache.executeCache( cache -> cache.put( expiredKey, nodeHolder.getIndyNode(),
                                                                          schedulerConfig.getClusterLockExpiration(),
                                                                          TimeUnit.SECONDS ) );
             }

--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.core.expire.cache;
 
+import org.commonjava.indy.cluster.IndyNode;
 import org.commonjava.indy.core.expire.ScheduleKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
@@ -25,10 +26,14 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.util.Map;
+import java.util.UUID;
 
 /**
- * This ISPN cache producer is used to generate {@link ScheduleCache}. This type of cache is used as a job control center
- * to control the content expiration scheduling.
+ * This ISPN cache producer is used to generate {@link ScheduleCache} and {@link ScheduleEventLockCache}.
+ * <ul>
+ * <li>{@link ScheduleCache} is used as a job control center to control the content expiration scheduling.</li>
+ * <li>{@link ScheduleEventLockCache} is used for control clustered event scheduling synchronization.</li>
+ * </ul>
  */
 public class ScheduleCacheProducer
 {
@@ -39,12 +44,22 @@ public class ScheduleCacheProducer
 
     private static final String SCHEDULE_EXPIRE = "schedule-expire-cache";
 
+    private static final String SCHEDULE_EVENT_LOCK = "schedule-event-lock-cache";
+
     @ScheduleCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<ScheduleKey, Map> versionMetadataCache()
+    public CacheHandle<ScheduleKey, Map> scheduleExpireCache()
     {
         return cacheProducer.getCache( SCHEDULE_EXPIRE );
+    }
+
+    @ScheduleEventLockCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<UUID, IndyNode> scheduleEventLockCache()
+    {
+        return cacheProducer.getCache( SCHEDULE_EVENT_LOCK );
     }
 
 }

--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
@@ -26,7 +26,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.util.Map;
-import java.util.UUID;
 
 /**
  * This ISPN cache producer is used to generate {@link ScheduleCache} and {@link ScheduleEventLockCache}.
@@ -57,7 +56,7 @@ public class ScheduleCacheProducer
     @ScheduleEventLockCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<UUID, IndyNode> scheduleEventLockCache()
+    public CacheHandle<ScheduleKey, IndyNode> scheduleEventLockCache()
     {
         return cacheProducer.getCache( SCHEDULE_EVENT_LOCK );
     }

--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleEventLockCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleEventLockCache.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.expire.cache;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD } )
+@Retention( RetentionPolicy.RUNTIME )
+@Documented
+public @interface ScheduleEventLockCache
+{
+}

--- a/core/src/main/resources/default-scheduler.conf
+++ b/core/src/main/resources/default-scheduler.conf
@@ -1,31 +1,38 @@
 [scheduler]
-ddl=scheduler/quartz-h2.sql
+#enabled=true
+#schedule.cluster.lock.expiration = 1h
 
-org.quartz.dataSource.ds.driver = org.h2.Driver
-org.quartz.dataSource.ds.URL = jdbc:h2:${indy.home}/var/lib/indy/data/scheduler
+############################################################################
+#All quartz based configurations are deprecated, will be removed in future.
+############################################################################
+
+#ddl=scheduler/quartz-h2.sql
+
+#org.quartz.dataSource.ds.driver = org.h2.Driver
+#org.quartz.dataSource.ds.URL = jdbc:h2:${indy.home}/var/lib/indy/data/scheduler
 #org.quartz.dataSource.ds.user = sa
 #org.quartz.dataSource.ds.password =
-org.quartz.dataSource.ds.maxConnections = 9
+#org.quartz.dataSource.ds.maxConnections = 9
 
 ### --------------------------------------------------------------------
 ### DANGER ZONE:
 ### You probably don't need to change anything below this point.
 ### --------------------------------------------------------------------
-org.quartz.scheduler.skipUpdateCheck: true
-org.quartz.scheduler.instanceName = INDY_SCHEDULER
-org.quartz.threadPool.class = org.quartz.simpl.SimpleThreadPool
-org.quartz.threadPool.threadCount = 4
-org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread = true
+#org.quartz.scheduler.skipUpdateCheck: true
+#org.quartz.scheduler.instanceName = INDY_SCHEDULER
+#org.quartz.threadPool.class = org.quartz.simpl.SimpleThreadPool
+#org.quartz.threadPool.threadCount = 4
+#org.quartz.threadPool.threadsInheritContextClassLoaderOfInitializingThread = true
  
 #specify the jobstore used
-org.quartz.jobStore.class = org.quartz.impl.jdbcjobstore.JobStoreTX
-org.quartz.jobStore.driverDelegateClass = org.quartz.impl.jdbcjobstore.StdJDBCDelegate
-org.quartz.jobStore.useProperties = false
+#org.quartz.jobStore.class = org.quartz.impl.jdbcjobstore.JobStoreTX
+#org.quartz.jobStore.driverDelegateClass = org.quartz.impl.jdbcjobstore.StdJDBCDelegate
+#org.quartz.jobStore.useProperties = false
  
 #The datasource for the jobstore that is to be used
-org.quartz.jobStore.dataSource = ds
+#org.quartz.jobStore.dataSource = ds
  
 #quartz table prefixes in the database
-org.quartz.jobStore.tablePrefix = qrtz_
-org.quartz.jobStore.misfireThreshold = 60000
-org.quartz.jobStore.isClustered = false
+#org.quartz.jobStore.tablePrefix = qrtz_
+#org.quartz.jobStore.misfireThreshold = 60000
+#org.quartz.jobStore.isClustered = false

--- a/core/src/main/resources/scheduler/quartz-derby.sql
+++ b/core/src/main/resources/scheduler/quartz-derby.sql
@@ -1,4 +1,8 @@
--- 
+-- ************************************************************************
+-- Deprecated, quartz scheduler has been replaced by ISPN based one,
+-- will be removed in future
+-- ************************************************************************
+--
 -- Apache Derby scripts by Steve Stewart, updated by Ronald Pomeroy
 -- Based on Srinivas Venkatarangaiah's file for Cloudscape
 -- 

--- a/core/src/main/resources/scheduler/quartz-h2.sql
+++ b/core/src/main/resources/scheduler/quartz-h2.sql
@@ -1,3 +1,8 @@
+-- ************************************************************************
+-- Deprecated, quartz scheduler has been replaced by ISPN based one,
+-- will be removed in future
+-- ************************************************************************
+
 -- Thanks to Amir Kibbar and Peter Rietzler for contributing the schema for H2 database,
 -- and verifying that it works with Quartz's StdJDBCDelegate
 --

--- a/deployments/launcher/src/main/bin/indy.sh
+++ b/deployments/launcher/src/main/bin/indy.sh
@@ -95,4 +95,4 @@ JAVA_OPTS="$JAVA_OPTS $JAVA_DEBUG_OPTS"
 
 MAIN_CLASS=org.commonjava.indy.boot.jaxrs.JaxRsBooter
 
-exec "$JAVA" ${JAVA_OPTS} -cp "${CP}" ${SECRETS} -Dindy.home="${BASEDIR}" -Dindy.boot.defaults=${BASEDIR}/bin/boot.properties -Dorg.jboss.logging.provider=slf4j -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 ${MAIN_CLASS}  "$@"
+exec "$JAVA" ${JAVA_OPTS} -cp "${CP}" ${SECRETS} -Dindy.home="${BASEDIR}" -Dindy.boot.defaults=${BASEDIR}/bin/boot.properties -Dorg.jboss.logging.provider=slf4j -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2 -Djava.net.preferIPv4Stack=true ${MAIN_CLASS} "$@"

--- a/subsys/infinispan/src/main/resources/infinispan-cluster.xml
+++ b/subsys/infinispan/src/main/resources/infinispan-cluster.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<infinispan
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="urn:infinispan:config:8.2 http://www.infinispan.org/schemas/infinispan-config-8.2.xsd"
+    xmlns="urn:infinispan:config:8.2">
+
+  <cache-container default-cache="local" name="IndyCacheManager" shutdown-hook="DEFAULT" statistics="true">
+    <transport cluster="indy-cache-cluster"/>
+
+    <!-- distributed caches configuration -->
+    <distributed-cache-configuration name="cluster-template" statistics="true">
+      <eviction strategy="LRU" size="200000" type="COUNT"/>
+    </distributed-cache-configuration>
+
+    <distributed-cache name="cluster" configuration="cluster-template"/>
+
+    <distributed-cache name="schedule-expire-cache" configuration="cluster-template">
+      <expiration interval="300"/>
+      <persistence passivation="true">
+        <file-store shared="true" preload="false" fetch-state="true" path="${indy.data}/scheduler"/>
+      </persistence>
+    </distributed-cache>
+
+    <distributed-cache name="schedule-event-lock-cache" configuration="cluster-template">
+      <expiration interval="300"/>
+      <persistence passivation="true">
+        <file-store shared="true" preload="false" fetch-state="true" path="${indy.data}/scheduler-event-lock"/>
+      </persistence>
+    </distributed-cache>
+    <!-- distributed caches configuration -->
+
+
+    <!-- local caches configuration -->
+    <local-cache-configuration name="local-template" statistics="true">
+      <eviction strategy="LRU" size="200000" type="COUNT"/>
+    </local-cache-configuration>
+
+    <local-cache name="local" configuration="local-template"/>
+
+    <local-cache name="folo-in-progress" configuration="local-template">
+      <eviction size="200000" type="COUNT" strategy="LRU"/>
+      <indexing index="LOCAL">
+        <property name="hibernate.search.model_mapping">org.commonjava.indy.folo.data.FoloCacheProducer</property>
+        <property name="default.directory_provider">ram</property>
+        <!-- <property name="hibernate.search.default.indexBase">${indy.data}/folo/search</property> -->
+      </indexing>
+    </local-cache>
+
+    <local-cache name="folo-sealed" configuration="local-template">
+      <eviction size="1000" type="COUNT" strategy="LRU"/>
+      <persistence passivation="true">
+        <file-store shared="false" preload="false" fetch-state="false" path="${indy.data}/folo"/>
+      </persistence>
+    </local-cache>
+
+    <local-cache name="content-index" configuration="local-template">
+      <eviction strategy="LRU" size="200000" type="COUNT"/>
+    </local-cache>
+
+    <local-cache name="content-metadata" configuration="local-template"/>
+
+    <local-cache name="maven-version-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
+      <eviction size="10000000" type="COUNT" strategy="LRU"/>
+    </local-cache>
+
+    <local-cache name="indy-nfs-owner-cache" deadlock-detection-spin="10000" configuration="local-template">
+      <eviction size="200000" type="COUNT" strategy="LRU"/>
+      <transaction transaction-manager-lookup="org.infinispan.transaction.lookup.DummyTransactionManagerLookup"
+                   locking="PESSIMISTIC"/>
+    </local-cache>
+
+    <!--
+        This cache works for delete the fast local cache of the NFS supported repo cache on local. With the expiration,
+        it will make all cache entries expired after 1 day, and trigger the purge of the expired cache every 30 mins
+    -->
+    <local-cache name="indy-fastlocal-file-delete-cache" configuration="local-template">
+      <eviction size="200000" strategy="LRU"/>
+      <expiration lifespan="86400000" max-idle="86400000" interval="1800000"/>
+    </local-cache>
+
+    <local-cache name="nfc" configuration="local-template">
+      <eviction size="10000000" type="COUNT" strategy="LRU"/>
+      <!--
+        Expires in 72 hours and run expiration every 15 minutes.
+      -->
+      <expiration lifespan="259200000" max-idle="259200000" interval="900000" />
+      <indexing index="LOCAL">
+        <property name="default.directory_provider">ram</property>
+      </indexing>
+    </local-cache>
+
+    <local-cache name="prefetch-cache">
+      <eviction size="20000" type="COUNT" strategy="LRU"/>
+      <persistence passivation="true">
+        <file-store shared="false" preload="true" fetch-state="false" path="${indy.data}/prefetch"/>
+      </persistence>
+    </local-cache>
+    <!-- local caches configuration -->
+
+  </cache-container>
+
+</infinispan>


### PR DESCRIPTION
I've added the code part of the schedule manager cluster support. One thing not sure below:

- In this commit, only when expiration happened we will check & add the schedule-lock cache, which means only lock these actions in cluster: remote re-enablement and metadata deletion. For metadata deletion it is understandable, but for remote disable/enable, I'm not sure if we should also control disable action in cluster level.

I've also added a sample configuration of ispn distributed cache as infinispan-cluster.xml. But one problem of this is that it is not working well with both custom config and classpath config merging, which will cause a ISPN000343 error. I'm suspecting that this may be caused by the xml merging, which caused a wrong set of <transport> in ISPN. I've added a workaround fix for this problem in PR https://github.com/Commonjava/indy/pull/1142

cc @jdcasey 