### PR TITLE
Remove some parallelStream() that were risky to blow up

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexActions.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexActions.java
@@ -80,7 +80,7 @@ public class ContentIndexActions
     public void clearStoreContent( Set<String> paths, StoreKey originKey, Set<Group> affectedGroups,
                                    boolean clearOriginPath )
     {
-        paths.parallelStream().forEach( path->{
+        paths.forEach( path->{
             if ( clearOriginPath )
             {
                 indexManager.deIndexStorePath( originKey, path );

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
@@ -236,7 +236,7 @@ public class StoreContentListener
 
                 logger.debug( "Got affected groups: {}", groups );
 
-                affectedMembers.parallelStream().forEach( ( memberKey ) -> {
+                affectedMembers.forEach( ( memberKey ) -> {
                     logger.debug( "Listing all {}paths in: {}", ( removeMergableOnly ? "mergeable " : "" ), memberKey );
                     Set<String> paths = listPaths( memberKey, removeMergableOnly ? mergablePathStrings() : ( p ) -> true );
 
@@ -253,8 +253,7 @@ public class StoreContentListener
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
         final boolean isReadonlyHosted = storeDataManager.isReadonly( originKey );
-        paths.parallelStream()
-                 .forEach( p -> {
+        paths.forEach( p -> {
                      if ( deleteOriginPath && !isReadonlyHosted )
                      {
                          try
@@ -267,7 +266,7 @@ public class StoreContentListener
                          }
                      }
 
-                     affectedGroups.parallelStream().forEach( g->{
+                     affectedGroups.forEach( g->{
                          try
                          {
                              Transfer gt = directContentAccess.getTransfer( g, p );
@@ -435,7 +434,7 @@ public class StoreContentListener
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
 
-        groups.parallelStream().forEach( g->{
+        groups.forEach( g->{
             Set<String> paths = listPaths( g.getKey(), pathFilter );
             logger.trace( "Clear mergable files for group: {}, paths: {}", g.getKey(), paths );
             paths.forEach( p->{

--- a/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
@@ -133,7 +133,7 @@ public abstract class AbstractMergedContentGenerator
 
         }
 
-        groups.parallelStream().forEach( group -> Stream.of(paths).forEach( path->{
+        groups.forEach( group -> Stream.of(paths).forEach( path->{
             logger.trace( "Clearing: '{}' in: {}", path, group );
             clearMergedFile( group, path );
         } ));

--- a/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
@@ -285,7 +285,7 @@ public class TimeoutEventListener
     public void clearStoreContent( Set<String> paths, StoreKey originKey, Set<Group> affectedGroups,
                                    boolean clearOriginPath )
     {
-        paths.parallelStream().forEach( p->{
+        paths.forEach( p->{
             if ( clearOriginPath )
             {
                 deleteExpiration( originKey, p );


### PR DESCRIPTION
Some parallel stream might not help the performance but blow up Indy, e.g, when paths are many or affected groups are many. I would rather let one thread to iterate over 600 groups to remove a path than use 80 threads to do it. Because the effort to delete a path is minor but the thread-scheduling may take much more. 