### PR TITLE
Move away from Streams API, especially parallelized forms

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexActions.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexActions.java
@@ -77,17 +77,15 @@ public class ContentIndexActions
     }
 
     @Override
-    public void clearStoreContent( Set<String> paths, StoreKey originKey, Set<Group> affectedGroups,
+    public void clearStoreContent( String path, ArtifactStore store, Set<Group> affectedGroups,
                                    boolean clearOriginPath )
     {
-        paths.parallelStream().forEach( path->{
-            if ( clearOriginPath )
-            {
-                indexManager.deIndexStorePath( originKey, path );
-            }
+        if ( clearOriginPath )
+        {
+            indexManager.deIndexStorePath( store.getKey(), path );
+        }
 
-            indexManager.clearIndexedPathFrom( path, affectedGroups, null );
-        } );
+        indexManager.clearIndexedPathFrom( path, affectedGroups, null );
     }
 
 }

--- a/addons/diagnostics/jaxrs/src/main/java/org/commonjava/indy/diag/bind/jaxrs/DiagnosticsResource.java
+++ b/addons/diagnostics/jaxrs/src/main/java/org/commonjava/indy/diag/bind/jaxrs/DiagnosticsResource.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.IOException;
 
 import static org.commonjava.indy.util.ApplicationContent.application_zip;
+import static org.commonjava.indy.util.ApplicationContent.text_plain;
 
 /**
  * Created by jdcasey on 1/11/17.
@@ -51,6 +52,21 @@ public class DiagnosticsResource
 {
     @Inject
     private DiagnosticsManager diagnosticsManager;
+
+    @ApiOperation(
+            "Retrieve a thread dump for Indy." )
+    @ApiResponses( { @ApiResponse( code = 200, response = String.class, message = "Thread dump content" ) } )
+    @GET
+    @Path( "/threads" )
+    @Produces(text_plain)
+    public Response getThreadDump()
+    {
+        String threadDump = diagnosticsManager.getThreadDumpString();
+        return Response.ok( threadDump )
+                       .header( ApplicationHeader.content_disposition.key(),
+                                "attachment; filename=indy-threads-" + System.currentTimeMillis() + ".txt" )
+                       .build();
+    }
 
     @ApiOperation(
             "Retrieve a ZIP-compressed file containing log files and a thread dump for Indy." )

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRepairManager.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRepairManager.java
@@ -20,11 +20,18 @@ import com.redhat.red.build.koji.KojiClientException;
 import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiSessionInfo;
+import org.commonjava.atlas.maven.ident.ref.ArtifactRef;
+import org.commonjava.atlas.maven.ident.ref.SimpleArtifactRef;
+import org.commonjava.cdi.util.weft.DrainingExecutorCompletionService;
+import org.commonjava.cdi.util.weft.ExecutorConfig;
+import org.commonjava.cdi.util.weft.SingleThreadedExecutorService;
+import org.commonjava.cdi.util.weft.WeftExecutorService;
+import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
-import org.commonjava.indy.koji.content.IndyKojiContentProvider;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
+import org.commonjava.indy.koji.content.IndyKojiContentProvider;
 import org.commonjava.indy.koji.content.KojiPathPatternFormatter;
 import org.commonjava.indy.koji.model.KojiMultiRepairResult;
 import org.commonjava.indy.koji.model.KojiRepairRequest;
@@ -35,8 +42,6 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
-import org.commonjava.atlas.maven.ident.ref.ArtifactRef;
-import org.commonjava.atlas.maven.ident.ref.SimpleArtifactRef;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +53,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
@@ -84,6 +90,11 @@ public class KojiRepairManager
     @Inject
     private KojiUtils kojiUtils;
 
+    @Inject
+    @WeftManaged
+    @ExecutorConfig( named="koji-repairs", threads=20, priority = 3 )
+    private WeftExecutorService repairExecutor;
+
     private ReentrantLock opLock = new ReentrantLock(); // operations are synchronized
 
     protected KojiRepairManager()
@@ -96,6 +107,7 @@ public class KojiRepairManager
         this.storeManager = storeManager;
         this.config = config;
         this.kojiCachedClient = new IndyKojiContentProvider( kojiClient, null );
+        this.repairExecutor = new SingleThreadedExecutorService( "koji-repairs" );
     }
 
     public KojiMultiRepairResult repairAllPathMasks( final String user )
@@ -109,7 +121,10 @@ public class KojiRepairManager
             {
                 List<RemoteRepository> kojiRemotes = getAllKojiRemotes();
 
-                List<KojiRepairResult> results = kojiRemotes.parallelStream().map( r -> {
+                DrainingExecutorCompletionService<KojiRepairResult> repairService =
+                        new DrainingExecutorCompletionService<>( repairExecutor );
+
+                kojiRemotes.forEach( r -> repairService.submit( ()->{
                     logger.info( "Attempting to repair path masks in Koji remote: {}", r.getKey() );
 
                     KojiRepairRequest request = new KojiRepairRequest( r.getKey(), false );
@@ -123,7 +138,22 @@ public class KojiRepairManager
                     }
 
                     return null;
-                } ).filter( Objects::nonNull ).collect( Collectors.toList() );
+                } ) );
+
+                List<KojiRepairResult> results = new ArrayList<>();
+                try
+                {
+                    repairService.drain( r -> {
+                        if ( r != null )
+                        {
+                            results.add( r );
+                        }
+                    } );
+                }
+                catch ( InterruptedException | ExecutionException e )
+                {
+                    logger.error( "Failed to repair path masks.", e );
+                }
 
                 result.setResults( results );
             }
@@ -470,7 +500,10 @@ public class KojiRepairManager
             {
                 List<RemoteRepository> kojiRemotes = getAllKojiRemotes();
 
-                List<KojiRepairResult> results = kojiRemotes.parallelStream().map( r -> {
+                DrainingExecutorCompletionService<KojiRepairResult> repairService =
+                        new DrainingExecutorCompletionService<>( repairExecutor );
+
+                kojiRemotes.forEach( r -> repairService.submit( () -> {
                     logger.info( "Attempting to repair path masks in Koji remote: {}", r.getKey() );
 
                     KojiRepairRequest request = new KojiRepairRequest( r.getKey(), isDryRun );
@@ -484,7 +517,22 @@ public class KojiRepairManager
                     }
 
                     return null;
-                } ).filter( Objects::nonNull ).collect( Collectors.toList() );
+                } ) );
+
+                List<KojiRepairResult> results = new ArrayList<>();
+                try
+                {
+                    repairService.drain( r -> {
+                        if ( r != null )
+                        {
+                            results.add( r );
+                        }
+                    } );
+                }
+                catch ( InterruptedException | ExecutionException e )
+                {
+                    logger.error( "Failed to repair metadata timeout.", e );
+                }
 
                 result.setResults( results );
             }

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -811,12 +811,10 @@ public class PromotionManager
             Set<PathTransferResult> results = byPathTargetLocks.lockAnd( targetKey, config.getLockTimeoutSeconds(), k -> {
                 logger.info( "Running promotions from: {} (key: {})\n  to: {} (key: {})", src, request.getSource(), tgt,
                              request.getTarget() );
-
                 ExecutorCompletionService<PathTransferResult> svc =
                         new ExecutorCompletionService<>( transferService );
 
                 contents.forEach( ( transfer ) -> svc.submit( newPathsPromoteTransfer( transfer, src, tgt, request ) ) );
-
                 Set<PathTransferResult> pathResults = new HashSet<>();
                 for(int i=0; i<contents.size(); i++)
                 {

--- a/api/src/main/java/org/commonjava/indy/content/StoreContentAction.java
+++ b/api/src/main/java/org/commonjava/indy/content/StoreContentAction.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.content;
 
+import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 
@@ -25,5 +26,5 @@ import java.util.Set;
  */
 public interface StoreContentAction
 {
-    void clearStoreContent( Set<String> paths, StoreKey originKey, Set<Group> affectedGroups, boolean clearOriginPath );
+    void clearStoreContent( String path, ArtifactStore store, Set<Group> affectedGroups, boolean clearOriginPath );
 }

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
@@ -15,11 +15,16 @@
  */
 package org.commonjava.indy.core.change;
 
+import org.commonjava.cdi.util.weft.DrainingExecutorCompletionService;
+import org.commonjava.cdi.util.weft.ExecutorConfig;
+import org.commonjava.cdi.util.weft.WeftExecutorService;
+import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.change.event.ArtifactStoreDeletePreEvent;
 import org.commonjava.indy.change.event.ArtifactStoreEnablementEvent;
 import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
+import org.commonjava.indy.change.event.IndyStoreEvent;
 import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.StoreContentAction;
 import org.commonjava.indy.data.IndyDataException;
@@ -43,12 +48,17 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -62,6 +72,8 @@ import static org.commonjava.maven.galley.util.PathUtils.ROOT;
 @ApplicationScoped
 public class StoreContentListener
 {
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     @Inject
     private Instance<StoreContentAction> storeContentActions;
@@ -78,10 +90,15 @@ public class StoreContentListener
     @Inject
     private NotFoundCache nfc;
 
+    @Inject
+    @WeftManaged
+    @ExecutorConfig( threads=20, priority=7, named="content-cleanup" )
+    private WeftExecutorService cleanupExecutor;
+
     /**
      * Handles store disable/enablement.
      */
-    @Measure( timers = @MetricNamed( DEFAULT ) )
+    @Measure
     public void onStoreEnablement( @Observes final ArtifactStoreEnablementEvent event )
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
@@ -136,8 +153,6 @@ public class StoreContentListener
     private void removeAllSupercededMemberContent( final ArtifactStore store,
                                                    final Map<ArtifactStore, ArtifactStore> changeMap )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-
         StoreKey key = store.getKey();
         // we're only interested in groups, since only adjustments to group memberships can invalidate indexed content.
         if ( group == key.getType() )
@@ -236,58 +251,96 @@ public class StoreContentListener
 
                 logger.debug( "Got affected groups: {}", groups );
 
-                affectedMembers.parallelStream().forEach( ( memberKey ) -> {
+                DrainingExecutorCompletionService<Integer> clearService =
+                        new DrainingExecutorCompletionService<>( cleanupExecutor );
+
+                final Predicate<? super String> mergableFilter = removeMergableOnly ? mergablePathStrings() : ( p ) -> true;
+
+                affectedMembers.forEach( ( memberKey ) -> {
                     logger.debug( "Listing all {}paths in: {}", ( removeMergableOnly ? "mergeable " : "" ), memberKey );
-                    Set<String> paths = listPaths( memberKey, removeMergableOnly ? mergablePathStrings() : ( p ) -> true );
+                    listPathsAnd( memberKey, mergableFilter, p -> clearService.submit(
+                            clearPathProcessor( p, memberKey, groups ) ) );
 
-                    logger.debug( "Got mergable transfers from diverged portion of membership: {}", paths );
-
-                    clearPaths( paths, memberKey, groups, false );
                 } );
 
+                drainAndCount( clearService, "store: " + store.getKey() );
             }
         }
     }
 
-    private void clearPaths( Set<String> paths, StoreKey originKey, Set<Group> affectedGroups, boolean deleteOriginPath )
+    private Callable<Integer> clearPathProcessor( final String path, final StoreKey key, final Set<Group> groups )
+    {
+        try
+        {
+            ArtifactStore store = storeDataManager.getArtifactStore( key );
+            return clearPathProcessor( path, store, groups );
+        }
+        catch ( IndyDataException e )
+        {
+            logger.error( "Cannot clear paths for missing / inaccessible store: " + key, e );
+        }
+
+        return ()->0;
+    }
+
+    private Callable<Integer> clearPathProcessor( final String path, final ArtifactStore store, final Set<Group> groups )
+    {
+        return () -> {
+            logger.debug( "Got mergable transfer from diverged portion of membership: {}", path );
+
+            int cleared = clearPath( path, store, groups, false );
+            return cleared;
+        };
+    }
+
+    private int clearPath( String path, ArtifactStore origin, Set<Group> affectedGroups, boolean deleteOriginPath )
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
-        final boolean isReadonlyHosted = storeDataManager.isReadonly( originKey );
-        paths.parallelStream()
-                 .forEach( p -> {
-                     if ( deleteOriginPath && !isReadonlyHosted )
-                     {
-                         try
-                         {
-                             delete( directContentAccess.getTransfer( originKey, p ) );
-                         }
-                         catch ( IndyWorkflowException e )
-                         {
-                             logger.error( String.format( "Failed to retrieve transfer for: %s in origin store: %s. Reason: %s", p, originKey, e.getMessage() ), e );
-                         }
-                     }
+        final boolean isReadonlyHosted = storeDataManager.isReadonly( origin );
+        AtomicInteger cleared = new AtomicInteger( 0 );
+        if ( deleteOriginPath && !isReadonlyHosted )
+        {
+            try
+            {
+                if ( delete( directContentAccess.getTransfer( origin, path ) ) )
+                {
+                    nfc.clearMissing( LocationUtils.toLocation( origin ) ); // clear NFC for this group
+                    cleared.incrementAndGet();
+                }
+            }
+            catch ( IndyWorkflowException e )
+            {
+                logger.error( String.format( "Failed to retrieve transfer for: %s in origin store: %s. Reason: %s", path,
+                                             origin.getKey(), e.getMessage() ), e );
+            }
+        }
 
-                     affectedGroups.parallelStream().forEach( g->{
-                         try
-                         {
-                             Transfer gt = directContentAccess.getTransfer( g, p );
-                             delete( gt );
-                         }
-                         catch ( IndyWorkflowException e )
-                         {
-                             logger.error( String.format( "Failed to retrieve transfer for: %s in group: %s. Reason: %s", p, g.getName(), e.getMessage() ), e );
-                         }
-                     } );
-                 } );
-
+        affectedGroups.forEach( g -> {
+            try
+            {
+                Transfer gt = directContentAccess.getTransfer( g, path );
+                if ( delete( gt ) )
+                {
+                    cleared.incrementAndGet();
+                }
+            }
+            catch ( IndyWorkflowException e )
+            {
+                logger.error( String.format( "Failed to retrieve transfer for: %s in group: %s. Reason: %s", path,
+                                             g.getName(), e.getMessage() ), e );
+            }
+        } );
 
         logger.debug( "Clearing content via supplemental store-content actions..." );
         StreamSupport.stream( storeContentActions.spliterator(), false )
-                     .forEach( action -> action.clearStoreContent( paths, originKey, affectedGroups, deleteOriginPath ) );
+                     .forEach(
+                             action -> action.clearStoreContent( path, origin, affectedGroups, deleteOriginPath ) );
         logger.debug( "All store-content actions done executing." );
+
+        return cleared.get();
     }
 
-    private void delete( Transfer t )
+    private boolean delete( Transfer t )
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
         if ( t != null && t.exists() )
@@ -295,30 +348,33 @@ public class StoreContentListener
             try
             {
                 logger.debug( "Deleting: {}", t );
-                t.delete( true );
+                boolean deleted = t.delete( true );
                 if ( t.exists() )
                 {
                     logger.error( "{} WAS NOT DELETED!", t );
                 }
+
+                return deleted;
             }
             catch ( IOException e )
             {
                 logger.error( String.format( "Failed to delete: %s. Reason: %s", t, e.getMessage() ), e );
             }
         }
+
+        return false;
     }
 
-    private Set<String> listPaths( StoreKey key, Predicate<? super String> pathFilter )
+    private void listPathsAnd( StoreKey key, Predicate<? super String> pathFilter, Consumer<String> pathAction )
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
 
         Transfer root = null;
         try
         {
-            Set<String> paths = new HashSet<>();
             root = directContentAccess.getTransfer( key, ROOT );
 
-            root.lockWrite();
+//            root.lockWrite();
 
             List<Transfer> toProcess = new ArrayList<>();
             toProcess.add( root );
@@ -340,7 +396,7 @@ public class StoreContentListener
                             if( pathFilter.test( t.getPath() ) )
                             {
                                 logger.trace( "Adding file path to results: {}", t.getPath() );
-                                paths.add( t.getPath() );
+                                pathAction.accept( t.getPath() );
                             }
                             else
                             {
@@ -354,8 +410,6 @@ public class StoreContentListener
                     logger.error( String.format( "Failed to list contents of: %s. Reason: %s", next, e ), e );
                 }
             }
-
-            return paths;
         }
         catch ( IndyWorkflowException  e )
         {
@@ -368,49 +422,68 @@ public class StoreContentListener
                 root.unlock();
             }
         }
-
-        return Collections.emptySet();
     }
 
     /**
      * List the mergable paths in target store and clean up the paths in affected groups.
-     * @param stores
+     * @param event
      * @param pathFilter
      * @param deleteOriginPath
      */
-    private void processAllPaths( final Iterable<ArtifactStore> stores, Predicate<? super String> pathFilter, boolean deleteOriginPath )
+    private void processAllPaths( final IndyStoreEvent event, Predicate<? super String> pathFilter, boolean deleteOriginPath )
     {
-        StreamSupport.stream( stores.spliterator(), true ).forEach( ( store ) -> {
-            final StoreKey key = store.getKey();
+        DrainingExecutorCompletionService<Integer> clearService =
+                new DrainingExecutorCompletionService<>( cleanupExecutor );
 
-            Set<String> paths = listPaths( key, pathFilter );
-
-            if ( !paths.isEmpty() )
+        Set<StoreKey> keys = event.getStores().stream().map( store -> store.getKey() ).collect( Collectors.toSet() );
+        keys.forEach(key->{
+            final Set<Group> groups = new HashSet<>();
+            try
             {
-                Set<Group> groups = null;
-                try
-                {
-                    groups = storeDataManager.query().packageType( key.getPackageType() ).getGroupsAffectedBy( key );
-                }
-                catch ( IndyDataException e )
-                {
-                    e.printStackTrace();
-                }
+                groups.addAll(
+                        storeDataManager.query().packageType( key.getPackageType() ).getGroupsAffectedBy( key ) );
 
-                clearPaths( paths, key, groups, deleteOriginPath );
+                listPathsAnd( key, pathFilter, p->clearService.submit(clearPathProcessor( p, key, groups )) );
+            }
+            catch ( IndyDataException e )
+            {
+                logger.error( "Failed to retrieve groups affected by: " + key, e );
             }
         } );
+
+        drainAndCount( clearService, "stores: " + keys );
+    }
+
+    private int drainAndCount( final DrainingExecutorCompletionService<Integer> clearService, final String description )
+    {
+        AtomicInteger count = new AtomicInteger( 0 );
+        try
+        {
+            clearService.drain( partialCount -> count.addAndGet( partialCount ) );
+        }
+        catch ( InterruptedException | ExecutionException e )
+        {
+            logger.error( "Failed to clear paths related to change in " + description, e );
+        }
+
+        logger.debug( "Cleared {} paths for changes in {}", count.get(), description );
+
+        return count.get();
     }
 
     /**
      * Extensive version for clean up paths. This will clean all mergable files in affected groups regardless whether
      * the path is in the target store cache or not. It also clears NFC.
-     * @param stores
+     * @param event
      * @param pathFilter
      */
-    private void processAllPathsExt( final Iterable<ArtifactStore> stores, Predicate<? super String> pathFilter )
+    private void processAllPathsExt( final IndyStoreEvent event, Predicate<? super String> pathFilter )
     {
-        StreamSupport.stream( stores.spliterator(), true ).forEach( ( store ) -> {
+        DrainingExecutorCompletionService<Integer> clearService =
+                new DrainingExecutorCompletionService<>( cleanupExecutor );
+
+        Set<ArtifactStore> stores = new HashSet<>( event.getStores() );
+        stores.forEach(store->{
             final StoreKey key = store.getKey();
             try
             {
@@ -420,7 +493,11 @@ public class StoreContentListener
                 {
                     groups.add( (Group) store );
                 }
-                clearPaths( groups, pathFilter );
+
+                groups.forEach( g->{
+                    listPathsAnd( key, pathFilter, p->clearService.submit(clearPathProcessor( p, key, groups )) );
+                } );
+
                 nfc.clearMissing( LocationUtils.toLocation( store ) ); // clear NFC for this store
             }
             catch ( IndyDataException e )
@@ -428,29 +505,9 @@ public class StoreContentListener
                 e.printStackTrace();
             }
         } );
-    }
 
-    private void clearPaths( Set<Group> groups, Predicate<? super String> pathFilter )
-                    throws IndyDataException
-    {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-
-        groups.parallelStream().forEach( g->{
-            Set<String> paths = listPaths( g.getKey(), pathFilter );
-            logger.trace( "Clear mergable files for group: {}, paths: {}", g.getKey(), paths );
-            paths.forEach( p->{
-                try
-                {
-                    Transfer gt = directContentAccess.getTransfer( g, p );
-                    delete( gt );
-                }
-                catch ( IndyWorkflowException e )
-                {
-                    logger.error( String.format( "Failed to retrieve transfer for: %s in group: %s. Reason: %s", p, g.getName(), e.getMessage() ), e );
-                }
-            } );
-            nfc.clearMissing( LocationUtils.toLocation( g ) ); // clear NFC for this group
-        } );
+        Set<StoreKey> keys = event.getStores().stream().map( s -> s.getKey() ).collect( Collectors.toSet() );
+        drainAndCount( clearService, "stores: " + keys );
     }
 
     private Predicate<? super String> mergablePathStrings()

--- a/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
@@ -133,14 +133,14 @@ public abstract class AbstractMergedContentGenerator
 
         }
 
-        groups.parallelStream().forEach( group -> Stream.of(paths).forEach( path->{
+        groups.forEach( group -> Stream.of(paths).forEach( path->{
             logger.trace( "Clearing: '{}' in: {}", path, group );
             clearMergedFile( group, path );
         } ));
 
         if ( mergedContentActions != null )
         {
-            StreamSupport.stream( mergedContentActions.spliterator(), true )
+            StreamSupport.stream( mergedContentActions.spliterator(), false )
                          .forEach( action -> Stream.of(paths).forEach( path->{
                              logger.trace( "Executing clearMergedPath on action: {} for group: {} and path: {}", action, groups, path );
                              action.clearMergedPath( store, groups, path );

--- a/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
@@ -282,20 +282,18 @@ public class TimeoutEventListener
     }
 
     @Override
-    public void clearStoreContent( Set<String> paths, StoreKey originKey, Set<Group> affectedGroups,
+    public void clearStoreContent( String path, ArtifactStore store, Set<Group> affectedGroups,
                                    boolean clearOriginPath )
     {
-        paths.parallelStream().forEach( p->{
-            if ( clearOriginPath )
-            {
-                deleteExpiration( originKey, p );
-            }
+        if ( clearOriginPath )
+        {
+            deleteExpiration( store.getKey(), path );
+        }
 
-            if ( affectedGroups != null && !affectedGroups.isEmpty() )
-            {
-                affectedGroups.forEach( g -> deleteExpiration( g.getKey(), p ) );
-            }
-        } );
+        if ( affectedGroups != null && !affectedGroups.isEmpty() )
+        {
+            affectedGroups.forEach( g -> deleteExpiration( g.getKey(), path ) );
+        }
     }
 
     private void deleteExpiration( StoreKey key, String path )

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryArtifactStoreQuery.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryArtifactStoreQuery.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.mem.data;
 import org.commonjava.indy.data.ArtifactStoreQuery;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -390,6 +391,7 @@ public class MemoryArtifactStoreQuery<T extends ArtifactStore>
     }
 
     @Override
+    @Measure
     public Set<Group> getGroupsAffectedBy( Collection<StoreKey> keys )
             throws IndyDataException
     {

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <rwxVersion>2.3</rwxVersion>
     <jhttpcVersion>1.9</jhttpcVersion>
     <weftVersion>1.10-SNAPSHOT</weftVersion>
-    <httpTestserverVersion>1.5-SNAPSHOT</httpTestserverVersion>
+    <httpTestserverVersion>1.4</httpTestserverVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->
     <enforceStandards>false</enforceStandards>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <rwxVersion>2.3</rwxVersion>
     <jhttpcVersion>1.9</jhttpcVersion>
     <weftVersion>1.10-SNAPSHOT</weftVersion>
-    <httpTestserverVersion>1.4</httpTestserverVersion>
+    <httpTestserverVersion>1.5-SNAPSHOT</httpTestserverVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->
     <enforceStandards>false</enforceStandards>


### PR DESCRIPTION
I've reviewed the use of parallel streams and found the places where the work performed is non-trivial. For the other things, I've changed to use non-parallel streams. 

For non-trivial work, I've added use of a CompletionService implementation that I added to Weft, which allows us to load up a series of Callables and then watch the service as they complete, tallying or accumulating the results. This allows us to use Weft tor threadpool control and monitoring, while still allowing us to process results and wait for tasks to complete without having to know the number of tasks up front.

This change supercedes #1143.