### PR TITLE
Integrate kafka log appender changes and align promotion request styles

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -21,7 +21,6 @@ import com.redhat.red.build.koji.model.xmlrpc.KojiArchiveInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildArchiveCollection;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiBuildState;
-import com.redhat.red.build.koji.model.xmlrpc.KojiSessionInfo;
 import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
 import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.Versioning;

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -39,7 +39,6 @@ import org.commonjava.indy.content.MergedContentAction;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.content.AbstractMergedContentGenerator;
 import org.commonjava.indy.core.content.group.GroupMergeHelper;
-import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.measure.annotation.MetricNamed;
@@ -85,7 +84,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -71,7 +71,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -404,7 +404,13 @@ public class PromotionManager
                 logger.warn( msg );
                 ret = new GroupPromoteResult( request, msg ).withPromotionId( result.getPromotionId() );
             }
-            return callbackHelper.callback( ret.getRequest().getCallback(), ret );
+
+            if ( ret.getRequest().getCallback() != null )
+            {
+                return callbackHelper.callback( ret.getRequest().getCallback(), ret );
+            }
+
+            return ret;
         } ) );
     }
 
@@ -601,7 +607,12 @@ public class PromotionManager
                 ret = new PathsPromoteResult( request, msg ).withPromotionId( result.getPromotionId() );
             }
 
-            return callbackHelper.callback( ret.getRequest().getCallback(), ret );
+            if ( ret.getRequest().getCallback() != null )
+            {
+                return callbackHelper.callback( ret.getRequest().getCallback(), ret );
+            }
+
+            return ret;
         } ) );
     }
 
@@ -676,7 +687,13 @@ public class PromotionManager
                 logger.warn( msg );
                 ret = new PathsPromoteResult( request, msg ).withPromotionId( result.getPromotionId() );
             }
-            return callbackHelper.callback( ret.getRequest().getCallback(), ret );
+
+            if ( ret.getRequest().getCallback() != null )
+            {
+                return callbackHelper.callback( ret.getRequest().getCallback(), ret );
+            }
+
+            return ret;
         } ) );
     }
 

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
@@ -50,10 +50,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static java.lang.String.format;
 import static org.apache.commons.lang.StringUtils.join;

--- a/api/src/main/java/org/commonjava/indy/content/StoreContentAction.java
+++ b/api/src/main/java/org/commonjava/indy/content/StoreContentAction.java
@@ -17,7 +17,6 @@ package org.commonjava.indy.content;
 
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
-import org.commonjava.indy.model.core.StoreKey;
 
 import java.util.Set;
 

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
@@ -35,9 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.Future;
 
 import static org.commonjava.indy.core.ctl.PoolUtils.detectOverloadVoid;

--- a/deployments/launcher/src/main/etc/indy/logging/logback.xml
+++ b/deployments/launcher/src/main/etc/indy/logging/logback.xml
@@ -119,6 +119,47 @@
     </headers>
   </appender -->
 
+  <!-- This example configuration is probably most unreliable under
+    failure conditions but wont block your application at all -->
+  <!-- The encoder part is using JsonLayout format encoder to generate structured logs using json format -->
+  <!-- use async delivery. the application threads are not blocked by logging -->
+  <!--
+    ProducerConfigs as below:
+     * acks=0: don't wait for a broker to ack the reception of a batch.
+     * linger.ms=1000: wait up to 1000ms and collect log messages before sending them as a batch
+     * max.block.ms=0: even if the producer buffer runs full, do not block the application but start to drop messages
+     * client.id=client.id=${HOSTNAME}-${CONTEXT_NAME}-logback-relaxed: define a client-id that you use to identify yourself against the kafka broker
+  -->
+  <!-- there is no fallback <appender-ref>. If this appender cannot deliver, it will drop its messages. -->
+  <!--
+  <appender name="KAFKA" class="com.github.danielwegener.logback.kafka.KafkaAppender">
+    <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+      <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+        <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter"/>
+        <appendLineSeparator>true</appendLineSeparator>
+      </layout>
+    </encoder>
+
+    <topic>indy-logs</topic>
+    <keyingStrategy class="com.github.danielwegener.logback.kafka.keying.HostNameKeyingStrategy" />
+    <deliveryStrategy class="com.github.danielwegener.logback.kafka.delivery.AsynchronousDeliveryStrategy" />
+
+    <producerConfig>bootstrap.servers=localhost:9092</producerConfig>
+    <producerConfig>acks=0</producerConfig>
+    <producerConfig>linger.ms=1000</producerConfig>
+    <producerConfig>max.block.ms=0</producerConfig>
+    <producerConfig>client.id=${HOSTNAME}-${CONTEXT_NAME}-logback-relaxed</producerConfig>
+  </appender>
+  -->
+
+  <!-- Followed with kafka appender, to prevent a metadata blocking problem -->
+  <!--
+  <logger name="org.apache.kafka" additivity="false" level="INFO">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="FILE" />
+  </logger>
+  -->
+
   <logger name="org.jboss" level="ERROR"/>
   <!-- <logger name="org.jboss.resteasy" level="DEBUG"/> -->
 
@@ -148,6 +189,10 @@
   <root level="INFO">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
+    <!-- if kafka function is on, include KAFKA appender -->
+    <!--
+    <appender-ref ref="KAFKA" />
+    -->
 
     <!-- if elasticsearch function is on, include ELASTIC appender-->
     <!-- if condition='property("elasticsearch.enable").equalsIgnoreCase("true")'>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <rwxVersion>2.3</rwxVersion>
     <jhttpcVersion>1.9</jhttpcVersion>
     <weftVersion>1.10-SNAPSHOT</weftVersion>
-    <httpTestserverVersion>1.5-SNAPSHOT</httpTestserverVersion>
+    <httpTestserverVersion>1.4</httpTestserverVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->
     <enforceStandards>false</enforceStandards>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <rwxVersion>2.3</rwxVersion>
     <jhttpcVersion>1.9</jhttpcVersion>
     <weftVersion>1.10-SNAPSHOT</weftVersion>
-    <httpTestserverVersion>1.4</httpTestserverVersion>
+    <httpTestserverVersion>1.5-SNAPSHOT</httpTestserverVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->
     <enforceStandards>false</enforceStandards>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,8 @@
 
     <!-- thirdparty projects -->
     <javaVersion>1.8</javaVersion>
-    <slf4j-version>1.6.1</slf4j-version>
+    <slf4j-version>1.7.16</slf4j-version>
+    <logback-version>1.2.3</logback-version>
     <infinispanVersion>8.2.4.Final</infinispanVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <hibernateVersion>5.8.1.Final</hibernateVersion>
@@ -1447,13 +1448,18 @@
         <version>${logbackVersion}</version>
       </dependency>
       <dependency>
-        <groupId>ch.qos.logback.contrib</groupId>
-        <artifactId>logback-jackson</artifactId>
-        <version>${logbackContribVersion}</version>
+        <groupId>com.github.danielwegener</groupId>
+        <artifactId>logback-kafka-appender</artifactId>
+        <version>0.2.0-RC2</version>
       </dependency>
       <dependency>
         <groupId>ch.qos.logback.contrib</groupId>
         <artifactId>logback-json-classic</artifactId>
+        <version>${logbackContribVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback.contrib</groupId>
+        <artifactId>logback-jackson</artifactId>
         <version>${logbackContribVersion}</version>
       </dependency>
     </dependencies>
@@ -1463,6 +1469,18 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.danielwegener</groupId>
+      <artifactId>logback-kafka-appender</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback.contrib</groupId>
+      <artifactId>logback-json-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback.contrib</groupId>
+      <artifactId>logback-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.enterprise</groupId>


### PR DESCRIPTION
Promotion requests used to bypass the request threadpool for sync calls, which also bypassed the load check in the threadpool. This change uses the Future<> from those async versions of the call and simply performs a Future.get(), returning the result afterward. That will force all requests to go through the threadpool, which subjects them all to the same capacity check.

Also, incorporating the kafka log appender so we can start learning to send logs to Kafka.