### PR TITLE
[prod] Add JNDI DataSources (for ISPN) and validation rule pattern test

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -63,7 +63,7 @@ import static org.commonjava.indy.model.core.StoreKey.fromString;
 @ApplicationScoped
 @Default
 public class DefaultContentIndexManager
-        implements ContentIndexManager, BootupAction, ShutdownAction
+        implements ContentIndexManager, ShutdownAction
 {
     private static final int ITERATE_RESULT_SIZE = 1000;
 
@@ -136,31 +136,11 @@ public class DefaultContentIndexManager
 
 
     @Override
-    public void init()
-            throws IndyLifecycleException
-    {
-        //FIXME: Currently the content-index is GAV/Directory level, but NFC is not. That makes this NFC listener not usable
-        //       as it is clearing the directory resource from NFC but the real ones in NFC are file resource. Need to think
-        //       about implement NFC from GAV/Directory level too if we want to make this usable.
-//        logger.debug( "Register index cache listener for NFC" );
-//        contentIndex.execute( cache -> {
-//            cache.addListener( listener );
-//            return null;
-//        } );
-    }
-
-    @Override
     public void stop()
             throws IndyLifecycleException
     {
         logger.debug( "Shutdown index cache" );
         contentIndex.stop();
-    }
-
-    @Override
-    public int getBootPriority()
-    {
-        return 80;
     }
 
     @Override

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectVersionPatternRuleForTempBuildTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectVersionPatternRuleForTempBuildTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest.rule;
+
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.promote.model.GroupPromoteRequest;
+import org.commonjava.indy.promote.model.GroupPromoteResult;
+import org.commonjava.indy.promote.model.ValidationResult;
+import org.commonjava.indy.promote.model.ValidationRuleSet;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Validate version pattern rules for a complex pattern (of temporary build)
+ * When <br />
+ *
+ *  <ol>
+ *    <li>Hosted source and target group</li>
+ *    <li>source contains bunch of jar, javadoc, source jars</li>
+ *    <li>promotion validation rule-set that includes project-version-pattern.groovy, which predefine pattern
+ *    to limit some of the artifacts in source</li>
+ *    <li>by-group promotion request posted</li>
+ *  </ol>
+ *
+ *  Then <br />
+ *
+ *  <ol>
+ *    <li>promotion failed, and validation result contains errors for un-matched artifacts against pattern</li>
+ *  </ol>
+ *
+ */
+public class ProjectVersionPatternRuleForTempBuildTest
+        extends AbstractValidationRuleTest<Group>
+{
+
+    private static final String RULE = "project-version-pattern.groovy";
+
+    @Test
+    @Category( EventDependent.class )
+    public void run()
+            throws Exception
+    {
+        String invalidJar = "org/foo/invalid/1.0.0.redhat-00004/invalid-1.0.0.redhat-00004.jar";
+        String validJar = "org/foo/valid/1.0.0.temporary-redhat-00004/valid-1.0.0.temporary-redhat-00004.jar";
+        String invalidDocJar = "org/foo/invalid/1.0.0.redhat-00004/invalid-1.0.0.redhat-00004-javadoc.jar";
+        String validDocJar = "org/foo/valid/1.0.0.temporary-redhat-00004/valid-1.0.0.temporary-redhat-00004-javadoc.jar";
+        String invalidSrcJar = "org/foo/invalid/1.0.0.redhat-00004/invalid-1.0.0.redhat-00004-sources.jar";
+        String validSrcJar = "org/foo/valid/1.0.0.temporary-redhat-00004/valid-1.0.0.temporary-redhat-00004-sources.jar";
+//        Set<String> paths = new HashSet<>( 6 );
+//        paths.add(invalidJar);
+//        paths.add(validJar);
+//        paths.add(invalidDocJar);
+//        paths.add(validDocJar);
+//        paths.add(invalidSrcJar);
+//        paths.add(validSrcJar);
+
+        deploy( invalidJar, "just for test of invalid jar" );
+        deploy( validJar, "just for test of valid jar" );
+        deploy( invalidDocJar, "just for test of invalid javadoc jar" );
+        deploy( validDocJar, "just for test of valid javadoc jar" );
+        deploy( invalidSrcJar, "just for test of invalid source jar" );
+        deploy( validSrcJar, "just for test of valid source jar" );
+
+        waitForEventPropagation();
+
+        GroupPromoteRequest request = new GroupPromoteRequest( source.getKey(), target.getName() );
+        GroupPromoteResult result = module.promoteToGroup( request );
+//        PathsPromoteRequest request = new PathsPromoteRequest( source.getKey(), target.getKey(), paths  );
+//        PathsPromoteResult result = module.promoteByPath( request );
+        assertThat( result, notNullValue() );
+
+        ValidationResult validations = result.getValidations();
+        assertThat( validations, notNullValue() );
+        assertThat(validations.isValid(), equalTo( false ));
+
+        Map<String, String> validatorErrors = validations.getValidatorErrors();
+        assertThat( validatorErrors, notNullValue() );
+        assertThat( validatorErrors.size(), not( 0 ) );
+
+        logger.info( "Validation error:\n{}", validatorErrors );
+
+        String errors = validatorErrors.get( RULE );
+        assertThat( errors, notNullValue() );
+
+        assertThat( errors.contains( validJar ), equalTo( false ) );
+        assertThat( errors.contains( invalidJar ), equalTo( true ) );
+        assertThat( errors.contains( validDocJar ), equalTo( false ) );
+        assertThat( errors.contains( invalidDocJar ), equalTo( true ) );
+        assertThat( errors.contains( validSrcJar ), equalTo( false ) );
+        assertThat( errors.contains( invalidSrcJar ), equalTo( true ) );
+    }
+
+    public ProjectVersionPatternRuleForTempBuildTest()
+    {
+        super( Group.class );
+    }
+
+    @Override
+    protected String getRuleScriptFile()
+    {
+        return RULE;
+    }
+
+    @Override
+    protected String getRuleScriptContent()
+            throws IOException
+    {
+        String path = "promote/rules/" + RULE;
+        return readTestResource( path );
+    }
+
+    protected ValidationRuleSet getRuleSet()
+    {
+        ValidationRuleSet ruleSet = new ValidationRuleSet();
+        ruleSet.setName( "test" );
+        ruleSet.setStoreKeyPattern( "group:target" );
+        ruleSet.setRuleNames( Collections.singletonList( getRuleScriptFile() ) );
+        Map<String, String> params = new HashMap<>( 2 );
+        params.put( "classifierAndTypeSet", "javadoc:jar, sources:jar" );
+        params.put( "versionPattern",
+                    "\\d+\\.\\d+\\.\\d+\\.(?:[\\w_-]+-)?(?:(?:temporary)|(?:t\\d{8}-\\d{6}-\\d{3}))-redhat-\\d+" );
+        ruleSet.setValidationParameters( params );
+
+        return ruleSet;
+    }
+
+}

--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleManager.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleManager.java
@@ -45,16 +45,16 @@ public class IndyLifecycleManager
     private IndyVersioning versioning;
 
     @Inject
-    private Instance<BootupAction> bootupActionInstances;
+    private Instance<BootupAction> bootupActionCdiInstances;
 
     @Inject
-    private Instance<MigrationAction> migrationActionInstances;
+    private Instance<MigrationAction> migrationActionCdiInstances;
 
     @Inject
-    private Instance<StartupAction> startupActionInstances;
+    private Instance<StartupAction> startupActionCdiInstances;
 
     @Inject
-    private Instance<ShutdownAction> shutdownActionInstances;
+    private Instance<ShutdownAction> shutdownActionCdiInstances;
 
     @Inject
     private IndyLifecycleEventManager lifecycleEvents;
@@ -69,6 +69,14 @@ public class IndyLifecycleManager
     private List<StartupAction> startupActions;
 
     private List<ShutdownAction> shutdownActions;
+
+    private Iterable<BootupAction> bootupActionInstances;
+
+    private Iterable<MigrationAction> migrationActionInstances;
+
+    private Iterable<StartupAction> startupActionInstances;
+
+    private Iterable<ShutdownAction> shutdownActionInstances;
 
     protected IndyLifecycleManager()
     {
@@ -85,7 +93,7 @@ public class IndyLifecycleManager
     @PostConstruct
     public void init()
     {
-        initialize( bootupActionInstances, migrationActionInstances, startupActionInstances, shutdownActionInstances );
+        initialize( bootupActionCdiInstances, migrationActionCdiInstances, startupActionCdiInstances, shutdownActionCdiInstances );
     }
 
     private void initialize( final Iterable<BootupAction> bootupActionInstances,
@@ -93,54 +101,26 @@ public class IndyLifecycleManager
                              final Iterable<StartupAction> startupActionInstances,
                              final Iterable<ShutdownAction> shutdownActionInstances )
     {
-        try
-        {
-            bootupActions = new ArrayList<>();
-            for ( final BootupAction action : bootupActionInstances )
-            {
-                bootupActions.add( action );
-            }
-            bootupActions.addAll(userLifecycleManager.getUserLifecycleActions("boot",
-                    BootupAction.class));
-            Collections.sort( bootupActions, BOOT_PRIORITY_COMPARATOR );
-
-            migrationActions = new ArrayList<>();
-            for ( final MigrationAction action : migrationActionInstances )
-            {
-                migrationActions.add( action );
-            }
-            migrationActions.addAll(userLifecycleManager.getUserLifecycleActions("migrate",
-                    MigrationAction.class));
-            Collections.sort( migrationActions, MIGRATION_PRIORITY_COMPARATOR );
-
-            startupActions = new ArrayList<>();
-            for ( final StartupAction action : startupActionInstances )
-            {
-                startupActions.add( action );
-            }
-            startupActions.addAll(userLifecycleManager.getUserLifecycleActions("start",
-                    StartupAction.class));
-            Collections.sort( startupActions, START_PRIORITY_COMPARATOR );
-
-            shutdownActions = new ArrayList<>();
-            for ( final ShutdownAction action : shutdownActionInstances )
-            {
-                shutdownActions.add( action );
-            }
-            shutdownActions.addAll(userLifecycleManager.getUserLifecycleActions("shutdown",
-                    ShutdownAction.class));
-            Collections.sort( shutdownActions, SHUTDOWN_PRIORITY_COMPARATOR );
-        }
-        catch ( Throwable e )
-        {
-            Throwable realError = ( e instanceof InvocationTargetException ?
-                    ( (InvocationTargetException) e ).getTargetException() :
-                    e );
-
-            logger.error( "Failed to initialize Indy lifecycle components.", realError );
-
-            throw new IllegalStateException( "Failed to initialize lifecycle components", realError );
-        }
+        this.bootupActionInstances = bootupActionInstances;
+        this.migrationActionInstances = migrationActionInstances;
+        this.startupActionInstances = startupActionInstances;
+        this.shutdownActionInstances = shutdownActionInstances;
+//        try
+//        {
+//
+//
+//
+//        }
+//        catch ( Throwable e )
+//        {
+//            Throwable realError = ( e instanceof InvocationTargetException ?
+//                    ( (InvocationTargetException) e ).getTargetException() :
+//                    e );
+//
+//            logger.error( "Failed to initialize Indy lifecycle components.", realError );
+//
+//            throw new IllegalStateException( "Failed to initialize lifecycle components", realError );
+//        }
     }
 
     /**
@@ -197,6 +177,15 @@ public class IndyLifecycleManager
     private void runBootupActions()
         throws IndyLifecycleException
     {
+        bootupActions = new ArrayList<>();
+        for ( final BootupAction action : bootupActionInstances )
+        {
+            bootupActions.add( action );
+        }
+        bootupActions.addAll(userLifecycleManager.getUserLifecycleActions("boot",
+                                                                          BootupAction.class));
+        Collections.sort( bootupActions, BOOT_PRIORITY_COMPARATOR );
+
         if ( bootupActions != null )
         {
             logger.info( "Running bootup actions..." );
@@ -211,6 +200,15 @@ public class IndyLifecycleManager
     private void runMigrationActions()
         throws IndyLifecycleException
     {
+        migrationActions = new ArrayList<>();
+        for ( final MigrationAction action : migrationActionInstances )
+        {
+            migrationActions.add( action );
+        }
+        migrationActions.addAll(userLifecycleManager.getUserLifecycleActions("migrate",
+                                                                             MigrationAction.class));
+        Collections.sort( migrationActions, MIGRATION_PRIORITY_COMPARATOR );
+
         boolean changed = false;
         if ( migrationActions != null )
         {
@@ -226,6 +224,15 @@ public class IndyLifecycleManager
     private void runStartupActions()
         throws IndyLifecycleException
     {
+        startupActions = new ArrayList<>();
+        for ( final StartupAction action : startupActionInstances )
+        {
+            startupActions.add( action );
+        }
+        startupActions.addAll(userLifecycleManager.getUserLifecycleActions("start",
+                                                                           StartupAction.class));
+        Collections.sort( startupActions, START_PRIORITY_COMPARATOR );
+
         if ( startupActions != null )
         {
             logger.info( "Running startup actions..." );
@@ -240,6 +247,15 @@ public class IndyLifecycleManager
     private void runShutdownActions()
         throws IndyLifecycleException
     {
+        shutdownActions = new ArrayList<>();
+        for ( final ShutdownAction action : shutdownActionInstances )
+        {
+            shutdownActions.add( action );
+        }
+        shutdownActions.addAll(userLifecycleManager.getUserLifecycleActions("shutdown",
+                                                                            ShutdownAction.class));
+        Collections.sort( shutdownActions, SHUTDOWN_PRIORITY_COMPARATOR );
+
         if ( shutdownActions != null )
         {
             logger.info( "Running shutdown actions..." );

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -52,6 +52,7 @@ import org.infinispan.notifications.cachelistener.event.CacheEntryRemovedEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.enterprise.inject.Any;
@@ -86,7 +87,7 @@ import static org.commonjava.indy.core.change.StoreEnablementManager.TIMEOUT_USE
 @ApplicationScoped
 @Listener
 public class ScheduleManager
-        implements BootupAction, ShutdownAction
+        implements ShutdownAction
 {
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
@@ -127,7 +128,6 @@ public class ScheduleManager
     @Inject
     private Event<SchedulerEvent> eventDispatcher;
 
-    @Override
     public void init()
             throws IndyLifecycleException
     {
@@ -689,12 +689,6 @@ public class ScheduleManager
     public String getId()
     {
         return "Indy Scheduler";
-    }
-
-    @Override
-    public int getBootPriority()
-    {
-        return 80;
     }
 
     @Override

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManagerBooter.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManagerBooter.java
@@ -1,0 +1,35 @@
+package org.commonjava.indy.core.expire;
+
+import org.commonjava.indy.action.BootupAction;
+import org.commonjava.indy.action.IndyLifecycleException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class ScheduleManagerBooter
+        implements BootupAction
+{
+    @Inject
+    private Instance<ScheduleManager> scheduleManager;
+
+    @Override
+    public void init()
+            throws IndyLifecycleException
+    {
+        scheduleManager.get().init();
+    }
+
+    @Override
+    public int getBootPriority()
+    {
+        return 10;
+    }
+
+    @Override
+    public String getId()
+    {
+        return "Schedule Manager";
+    }
+}

--- a/deployments/cache-migrator/test-env/indy-env/conf.d/connection-pools.conf
+++ b/deployments/cache-migrator/test-env/indy-env/conf.d/connection-pools.conf
@@ -1,0 +1,20 @@
+[connection-pools]
+
+# This is where we initialize DataSources that should be registered via JNDI for use in things like Infinispan.
+#
+# You can specify a new datasource with:
+# pool-jndi-name = url=postgresql://my.host:5432/db-name,\
+#                  user=myuser,\
+#                  password=${injected-password},\
+#                  datasource.class=org.postgresql.ds.PGSimpleDataSource,\
+#                  autocommit=false,\
+#                  connectionTimeout=30000,\
+#                  connectionTestQuery=SELECT 1 FROM FOO,\
+#                  metrics=true,\
+#                  healthChecks=true,\
+#                  someProperty=some-value, etc...
+
+infinispan-caches = url=jdbc:postgresql://127.0.0.1:5432/test,\
+					user=test,\
+					password=test,\
+                    datasource.class=org.postgresql.ds.PGSimpleDataSource

--- a/deployments/cache-migrator/test-env/indy-env/infinispan.xml
+++ b/deployments/cache-migrator/test-env/indy-env/infinispan.xml
@@ -34,7 +34,7 @@
       <persistence>
         <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="false" key-to-string-mapper="org.commonjava.indy.koji.inject.KojiProjectRefStringKey2StringMapper">
           <write-behind />
-          <jdbc:connection-pool connection-url="jdbc:postgresql://localhost:5432/test" username="test" password="test" driver="org.postgresql.Driver"/>
+          <jdbc:data-source jndi-url="java:/comp/env/jdbc/infinispan-caches" />
 
           <jdbc:string-keyed-table prefix="indy_cache" fetch-size="10" batch-size="10" create-on-start="true" drop-on-exit="false">
             <jdbc:id-column name="id_column" type="TEXT" />
@@ -52,7 +52,7 @@
         <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="false" key-to-string-mapper="org.commonjava.indy.content.index.ISPFieldStringKey2StringMapper">
 
           <write-behind />
-          <jdbc:connection-pool connection-url="jdbc:postgresql://localhost:5432/test" username="test" password="test" driver="org.postgresql.Driver"/>
+          <jdbc:data-source jndi-url="java:/comp/env/jdbc/infinispan-caches" />
 
           <jdbc:string-keyed-table prefix="indy_cache" fetch-size="50" batch-size="50" create-on-start="true" drop-on-exit="false">
             <jdbc:id-column name="id_column" type="TEXT" />
@@ -73,7 +73,7 @@
         <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="false" key-to-string-mapper="org.commonjava.indy.pkg.maven.content.StoreKey2StringMapper">
 
           <write-behind />
-          <jdbc:connection-pool connection-url="jdbc:postgresql://localhost:5432/test" username="test" password="test" driver="org.postgresql.Driver"/>
+          <jdbc:data-source jndi-url="java:/comp/env/jdbc/infinispan-caches" />
 
           <jdbc:string-keyed-table prefix="indy_cache" fetch-size="10" batch-size="10" create-on-start="true" drop-on-exit="false">
             <jdbc:id-column name="id_column" type="TEXT" />
@@ -90,7 +90,7 @@
       <persistence>
         <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="false" key-to-string-mapper="org.commonjava.indy.core.expire.ScheduleCacheKey2StringMapper">
 
-          <jdbc:connection-pool connection-url="jdbc:postgresql://localhost:5432/test" username="test" password="test" driver="org.postgresql.Driver"/>
+          <jdbc:data-source jndi-url="java:/comp/env/jdbc/infinispan-caches" />
 
           <jdbc:string-keyed-table prefix="indy_cache" fetch-size="50" batch-size="50" create-on-start="true" drop-on-exit="false">
             <jdbc:id-column name="id_column" type="TEXT" />

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -69,6 +69,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-cpool</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-prefetch</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <jhttpcVersion>1.9</jhttpcVersion>
     <weftVersion>1.12</weftVersion>
     <httpTestserverVersion>1.4</httpTestserverVersion>
-    
+
     <!-- <enforceBestPractices>false</enforceBestPractices> -->
     <enforceStandards>false</enforceStandards>
     
@@ -456,6 +456,11 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-subsys-cpool</artifactId>
+        <version>1.7.4-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-client-core-java</artifactId>
         <version>1.7.4-SNAPSHOT</version>
       </dependency>
@@ -823,6 +828,11 @@
         <scope>provided</scope>
       </dependency>
 
+      <dependency>
+        <groupId>com.zaxxer</groupId>
+        <artifactId>HikariCP</artifactId>
+        <version>2.7.8</version>
+      </dependency>
 
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -1280,6 +1290,7 @@
         <artifactId>atlas-relationships-api</artifactId>
         <version>${atlasVersion}</version>
       </dependency>
+
       <dependency>
         <groupId>org.quartz-scheduler</groupId>
         <artifactId>quartz</artifactId>

--- a/subsys/cpool/pom.xml
+++ b/subsys/cpool/pom.xml
@@ -1,0 +1,79 @@
+<!--
+
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-subsystems</artifactId>
+    <version>1.7.4-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>indy-subsys-cpool</artifactId>
+
+  <name>Indy :: Subsystems :: Connection Pooling (DB)</name>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy.boot</groupId>
+      <artifactId>indy-booter-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.zaxxer</groupId>
+      <artifactId>HikariCP</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-core</artifactId>
+    </dependency>
+  </dependencies>
+  
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>confset</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>confset</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/subsys/cpool/src/main/conf/conf.d/connection-pools.conf
+++ b/subsys/cpool/src/main/conf/conf.d/connection-pools.conf
@@ -1,0 +1,21 @@
+[connection-pools]
+
+# This is where we initialize DataSources that should be registered via JNDI for use in things like Infinispan.
+#
+# CAUTION:
+#
+# If you end a connection specification with the '\' character, this config file may not be read correctly! It may
+# also prevent correct parsing of other parts of the Indy configuration files.
+#
+# You can specify a new datasource with:
+# pool-jndi-name = url=postgresql://my.host:5432/db-name,\
+#                  user=myuser,\
+#                  password=${injected-password},\
+#                  datasource.class=org.postgresql.ds.PGSimpleDataSource,\
+#                  autocommit=false,\
+#                  connectionTimeout=30000,\
+#                  connectionTestQuery=SELECT 1 FROM FOO,\
+#                  metrics=true,\
+#                  healthChecks=true,\
+#                  someProperty=some-value, etc...
+

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/CPInitialContextFactory.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/CPInitialContextFactory.java
@@ -1,0 +1,130 @@
+package org.commonjava.indy.subsys.cpool;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.Name;
+import javax.naming.NamingException;
+import javax.naming.spi.InitialContextFactory;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.Map;
+
+public class CPInitialContextFactory
+        implements InitialContextFactory
+{
+    private static CPInitialContext context;
+
+    @Override
+    public synchronized Context getInitialContext( final Hashtable<?, ?> hashtable )
+            throws NamingException
+    {
+        if ( context == null )
+        {
+            context = new CPInitialContext();
+        }
+
+        return context;
+    }
+
+    public static final class CPInitialContext extends  InitialContext
+    {
+
+        private Map<String, Object> bindings = new HashMap<>();
+
+        public CPInitialContext()
+                throws NamingException
+        {
+        }
+
+        public CPInitialContext( final Hashtable<?, ?> environment )
+                throws NamingException
+        {
+        }
+
+        @Override
+        protected void init( final Hashtable<?, ?> environment )
+                throws NamingException
+        {
+        }
+
+        @Override
+        public Context createSubcontext( final Name name )
+                throws NamingException
+        {
+            return this;
+        }
+
+        @Override
+        public Context createSubcontext( final String name )
+                throws NamingException
+        {
+            return this;
+        }
+
+        @Override
+        protected Context getDefaultInitCtx()
+                throws NamingException
+        {
+            return this;
+        }
+
+        @Override
+        public void bind( final Name name, final Object obj )
+                throws NamingException
+        {
+            bindings.put( toString( name ), obj );
+        }
+
+        @Override
+        public Object lookup( final String name )
+                throws NamingException
+        {
+            return bindings.get( name );
+        }
+
+        @Override
+        public Object lookup( final Name name )
+                throws NamingException
+        {
+            return bindings.get( toString( name ) );
+        }
+
+        @Override
+        public void bind( final String name, final Object obj )
+                throws NamingException
+        {
+            bindings.put( name, obj );
+        }
+
+        @Override
+        public void rebind( final String name, final Object obj )
+                throws NamingException
+        {
+            bindings.put( name, obj );
+        }
+
+        @Override
+        public void rebind( final Name name, final Object obj )
+                throws NamingException
+        {
+            bindings.put( toString( name ), obj );
+        }
+
+        private String toString( Name name )
+        {
+            StringBuilder sb = new StringBuilder();
+            for( Enumeration<String> e = name.getAll(); e.hasMoreElements(); )
+            {
+                String part = e.nextElement();
+                if ( sb.length() > 0 )
+                {
+                    sb.append( '/' );
+                }
+                sb.append( part );
+            }
+
+            return sb.toString();
+        }
+    }
+}

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolBooter.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolBooter.java
@@ -1,0 +1,40 @@
+package org.commonjava.indy.subsys.cpool;
+
+import org.commonjava.indy.action.BootupAction;
+import org.commonjava.indy.action.IndyLifecycleException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class ConnectionPoolBooter
+        implements BootupAction
+{
+    @Inject
+    private Instance<ConnectionPoolProvider> connectionPoolProvider;
+
+    @Override
+    public void init()
+            throws IndyLifecycleException
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.info( "\n\n\n\nStarting JNDI Connection Pools\n\n\n\n" );
+        connectionPoolProvider.get().init();
+        logger.info( "Connection pools started." );
+    }
+
+    @Override
+    public int getBootPriority()
+    {
+        return 100;
+    }
+
+    @Override
+    public String getId()
+    {
+        return "JNDI Connection Pools";
+    }
+}

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolConfig.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolConfig.java
@@ -1,0 +1,109 @@
+package org.commonjava.indy.subsys.cpool;
+
+import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.web.config.ConfigurationException;
+import org.commonjava.web.config.annotation.SectionName;
+import org.commonjava.web.config.section.MapSectionListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static java.lang.Boolean.TRUE;
+import static org.commonjava.indy.subsys.cpool.ConnectionPoolConfig.SECTION;
+
+@ApplicationScoped
+@SectionName(SECTION)
+public class ConnectionPoolConfig
+        extends MapSectionListener
+        implements IndyConfigInfo
+{
+    public static final String SECTION = "connection-pools";
+
+    public static final String URL_SUBKEY = "url";
+
+    private static final String USER_SUBKEY = "user";
+
+    private static final String PASSWORD_SUBKEY = "password";
+
+    private static final String DS_CLASS_SUBKEY = "datasource.class";
+
+    private static final String METRICS_SUBKEY = "metrics";
+
+    private static final String HEALTH_CHECKS_SUBKEY = "healthChecks";
+
+    private static final String DRIVER_CLASS_SUBKEY = "driver.class";
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private final Map<String, ConnectionPoolInfo> pools = new HashMap<>();
+
+    public Map<String, ConnectionPoolInfo> getPools()
+    {
+        return pools;
+    }
+
+    @Override
+    public void sectionStarted( final String name )
+            throws ConfigurationException
+    {
+        logger.info( "STARTED SECTION: {}", name );
+        super.sectionStarted( name );
+    }
+
+    @Override
+    public void parameter( final String name, final String value )
+            throws ConfigurationException
+    {
+        super.parameter( name, value );
+
+        // don't pass the param through to the background map, consume it here.
+        logger.info( "{}: Parsing connection pool {} from: '{}'", this, name, value );
+
+        Map<String, String> valueMap = toMap( value );
+        final ConnectionPoolInfo cp = new ConnectionPoolInfo( name, valueMap.remove( URL_SUBKEY ), valueMap.remove( USER_SUBKEY ),
+                                                              valueMap.remove( PASSWORD_SUBKEY ), valueMap.remove( DS_CLASS_SUBKEY ),
+                                                              valueMap.remove( DRIVER_CLASS_SUBKEY ),
+                                                              TRUE.toString().equals( valueMap.remove( METRICS_SUBKEY ) ),
+                                                              TRUE.toString().equals( valueMap.remove( HEALTH_CHECKS_SUBKEY ) ),
+                                                              valueMap );
+
+        logger.info( "{}: Adding: {}", this, cp );
+        pools.put( name, cp );
+    }
+
+    private Map<String,String> toMap( final String value )
+    {
+        Map<String, String> result = new HashMap<>();
+        Stream.of( value.split( "\\s*,\\s*" ) ).forEach( (s)->{
+            String[] parts = s.split( "\\s*=\\s*" );
+            if ( parts.length < 1 )
+            {
+                result.put( parts[0], Boolean.toString( TRUE ) );
+            }
+            else
+            {
+                result.put( parts[0], parts[1] );
+            }
+        } );
+
+        return result;
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return "default-connection-pools.conf";
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return new ByteArrayInputStream( ("[" + SECTION + "]").getBytes() );
+    }
+}

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolInfo.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolInfo.java
@@ -1,0 +1,99 @@
+package org.commonjava.indy.subsys.cpool;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+public class ConnectionPoolInfo
+{
+    private final String name;
+    private final String url;
+
+    private final String user;
+
+    private final String password;
+
+    private String dataSourceClassname;
+
+    private String driverClassname;
+
+    private boolean useMetrics;
+
+    private boolean useHealthChecks;
+
+    private final Map<String, String> properties;
+
+    public ConnectionPoolInfo( final String name, final String url, final String user, final String password,
+                               final String dataSourceClassname, final String driverClassname, final boolean useMetrics, final boolean useHealthChecks,
+                               final Map<String, String> properties )
+    {
+        this.name = name;
+        this.url = url;
+        this.user = user;
+        this.password = password;
+        this.dataSourceClassname = dataSourceClassname;
+        this.driverClassname = driverClassname;
+        this.useMetrics = useMetrics;
+        this.useHealthChecks = useHealthChecks;
+        this.properties = properties;
+    }
+
+    public boolean isValid()
+    {
+        return isNotBlank( name ) && isNotBlank( url ) && isNotBlank( dataSourceClassname );
+    }
+
+    public boolean isUseMetrics()
+    {
+        return useMetrics;
+    }
+
+    public boolean isUseHealthChecks()
+    {
+        return useHealthChecks;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getDataSourceClassname()
+    {
+        return dataSourceClassname;
+    }
+
+    public String getDriverClassname()
+    {
+        return driverClassname;
+    }
+
+    public String getUrl()
+    {
+        return url;
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    public Map<String, String> getProperties()
+    {
+        return Collections.unmodifiableMap( properties );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "ConnectionPoolInfo{" + "name='" + name + '\'' + ", url='" + url + '\'' + ", dataSourceClassname='"
+                + dataSourceClassname + '\'' + ", driverClassname='" + driverClassname + '\'' + ", useMetrics="
+                + useMetrics + ", useHealthChecks=" + useHealthChecks + ", properties=" + properties + '}';
+    }
+}

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolProvider.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolProvider.java
@@ -1,0 +1,154 @@
+package org.commonjava.indy.subsys.cpool;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.sun.jndi.rmi.registry.RegistryContextFactory;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.commonjava.cdi.util.weft.WeftExecutorService;
+import org.commonjava.indy.action.BootupAction;
+import org.commonjava.indy.action.IndyLifecycleException;
+import org.commonjava.indy.boot.PortFinder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.rmi.RemoteException;
+import java.rmi.registry.LocateRegistry;
+import java.rmi.registry.Registry;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
+
+@ApplicationScoped
+public class ConnectionPoolProvider
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+//    private Registry registry;
+//    private int registryPort;
+
+    @Inject
+    private ConnectionPoolConfig config;
+
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    @Inject
+    private HealthCheckRegistry healthCheckRegistry;
+
+    public void init()
+            throws IndyLifecycleException
+    {
+        logger.info( "Starting connection pool binding..." );
+//        if ( registry == null )
+//        {
+//            AtomicReference<IndyLifecycleException> err = new AtomicReference<>();
+//            registryPort = PortFinder.findPortFor( 16, (port)->{
+//                try
+//                {
+//                    registry = LocateRegistry.createRegistry( port );
+//                    logger.info( "Started RMI Registry on port: {} (for JNDI connection-pool bindings)", port );
+//                    return port;
+//                }
+//                catch ( RemoteException e )
+//                {
+//                    err.set( new IndyLifecycleException( "Failed to start RMI / JNDI registry on port 1099",
+//                                                         e ) );
+//                }
+//
+//                return -1;
+//            } );
+//
+//            if ( err.get() != null )
+//            {
+//                throw err.get();
+//            }
+//        }
+//
+//        logger.info( "RMI / JNDI Registry running on port: {}", registryPort );
+
+        Properties properties = System.getProperties();
+        properties.setProperty( INITIAL_CONTEXT_FACTORY, CPInitialContextFactory.class.getName() );
+//        properties.setProperty( "java.naming.provider.url", "rmi://127.0.0.1:" + registryPort );
+        System.setProperties( properties );
+
+        InitialContext ctx;
+        try
+        {
+            ctx = new InitialContext();
+        }
+        catch ( NamingException e )
+        {
+            throw new IndyLifecycleException( "Failed to create JNDI InitialContext for binding datasources", e );
+        }
+
+        Map<String, ConnectionPoolInfo> poolConfigs = config.getPools();
+        logger.info( "Creating bindings for {} pools from config: {}", poolConfigs.size(), config );
+        for ( ConnectionPoolInfo poolInfo : poolConfigs.values() )
+        {
+            HikariConfig cfg = new HikariConfig();
+            cfg.setPoolName( poolInfo.getName() );
+            cfg.setJdbcUrl( poolInfo.getUrl() );
+
+            if ( poolInfo.getUser() != null )
+            {
+                cfg.setUsername( poolInfo.getUser() );
+            }
+
+            if ( poolInfo.getPassword() != null )
+            {
+                cfg.setPassword( poolInfo.getPassword() );
+            }
+
+            if ( poolInfo.getDataSourceClassname() != null )
+            {
+                cfg.setDataSourceClassName( poolInfo.getDataSourceClassname() );
+            }
+
+            if ( poolInfo.getDriverClassname() != null )
+            {
+                cfg.setDriverClassName( poolInfo.getDriverClassname() );
+            }
+
+            if ( poolInfo.isUseMetrics() )
+            {
+                cfg.setMetricRegistry( metricRegistry );
+            }
+
+            if ( poolInfo.isUseHealthChecks() )
+            {
+                cfg.setHealthCheckRegistry( healthCheckRegistry );
+            }
+
+            Properties props = new Properties();
+            poolInfo.getProperties().forEach( props::setProperty );
+            if ( !props.isEmpty())
+            {
+                cfg.setDataSourceProperties( props );
+            }
+
+            HikariDataSource ds = new HikariDataSource( cfg );
+            try
+            {
+                String jndiName = "java:/comp/env/jdbc/" + poolInfo.getName();
+                logger.info( "Binding datasource: {}", jndiName );
+                ctx.rebind( jndiName, ds );
+            }
+            catch ( NamingException e )
+            {
+                throw new IndyLifecycleException( "Failed to bind datasource: " + poolInfo.getName(), e );
+            }
+        }
+    }
+
+}

--- a/subsys/cpool/src/test/java/org/commonjava/indy/subsys/cpool/ContextBindAndLookupTest.java
+++ b/subsys/cpool/src/test/java/org/commonjava/indy/subsys/cpool/ContextBindAndLookupTest.java
@@ -1,0 +1,45 @@
+package org.commonjava.indy.subsys.cpool;
+
+import org.junit.Test;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.Properties;
+
+import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ContextBindAndLookupTest
+{
+    @Test
+    public void bindAndLookup()
+            throws NamingException
+    {
+        String key = "java:/comp/env/foo";
+        String val = "BAR";
+
+        Properties properties = System.getProperties();
+        properties.setProperty( INITIAL_CONTEXT_FACTORY, CPInitialContextFactory.class.getName() );
+        System.setProperties( properties );
+
+        bind( key, val );
+        lookup( key, val );
+    }
+
+    private void lookup( final String key, final String val )
+            throws NamingException
+    {
+        InitialContext ctx = new InitialContext();
+        Object value = ctx.lookup( key );
+        assertThat( value == val, equalTo( true ) );
+    }
+
+    private void bind( final String key, final String val )
+            throws NamingException
+    {
+        InitialContext ctx = new InitialContext();
+        ctx.bind( key, val );
+    }
+}

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -7,14 +7,14 @@
 
   <cache-container default-cache="local" name="IndyCacheManager" shutdown-hook="DEFAULT" statistics="true">
     <local-cache-configuration name="local-template" statistics="true">
-      <eviction strategy="LRU" size="200000" type="COUNT"/>
-      <!--<memory>-->
+      <!--<eviction strategy="LRU" size="200000" type="COUNT"/>-->
+      <memory>
         <!--
           Limits the cache to this by the amount of entries in the cache.
           If choose memory or off-heap, make sure the key/value objects implements Serializable
         -->
-      <!--  <object size="200000"/>
-      </memory> -->
+        <object size="200000"/>
+      </memory>
     </local-cache-configuration>
 
     <local-cache name="local" configuration="local-template"/>

--- a/subsys/pom.xml
+++ b/subsys/pom.xml
@@ -40,6 +40,7 @@
     <module>metrics</module>
     <module>prefetch</module>
     <module>kafka</module>
+    <module>cpool</module>
   </modules>
   
 </project>


### PR DESCRIPTION
Porting validation rule test from indy-1.7.x branch (1cf4bebaf8b5fc95e0a6960419434552b22763fd)

Porting 3 commits from indy-1.7.x which add support for JNDI DataSources, which allow us to configure a single connection pool for all ISPN caches to use, instead of creating one connection pool per cache, which puts a lot of extra load on the DB.