### PR TITLE
Remove exception stacktrace for remote url Malformed exception

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -206,7 +206,7 @@ public class RemoteRepository
         }
         catch ( final MalformedURLException e )
         {
-            LOGGER.error( String.format( "Failed to parse repository URL: '%s'. Reason: %s", this.url, e.getMessage() ), e );
+            LOGGER.error( String.format( "Failed to parse repository URL: '%s'. Reason: %s", this.url, e.getMessage() ) );
         }
 
         if ( url == null )


### PR DESCRIPTION
I really don't think this exception stack trace is needed as all
useful info has been logged, And it occupied bunch of the log space and
polluted the log reading. So removed it.