### PR TITLE
Store ArtifactStore after setting metadata IMPLIED_BY_STORES

### DIFF
--- a/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetectorTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetectorTest.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
+import java.util.Collections;
 import java.util.concurrent.Executors;
 
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
@@ -69,10 +70,11 @@ public class ImpliedRepositoryDetectorTest
         public TestImpliedRepositoryDetector( MavenPomReader pomReader, StoreDataManager storeManager,
                                               ImpliedRepoMetadataManager metadataManager,
                                               ArtifactStoreValidator remoteValidator, ScriptEngine scriptEngine,
-                                              ImpliedRepoConfig config )
+                                              ImpliedRepoConfig config,
+                                              IndyObjectMapper mapper )
         {
             super( pomReader, storeManager, metadataManager, remoteValidator, scriptEngine,
-                   Executors.newSingleThreadExecutor(), config );
+                   Executors.newSingleThreadExecutor(), config, mapper );
         }
     }
 
@@ -123,9 +125,11 @@ public class ImpliedRepositoryDetectorTest
 
         validator = new ArtifactStoreValidator( fixture.getTransferManager() );
 
+        final IndyObjectMapper mapper = new IndyObjectMapper( Collections.emptySet() );
+
         ScriptEngine engine = new ScriptEngine( dataFiles );
         detector = new TestImpliedRepositoryDetector( fixture.getPomReader(), storeManager, metadataManager, validator,
-                                                      engine, config );
+                                                      engine, config, mapper );
 
         summary = new ChangeSummary( ChangeSummary.SYSTEM_USER, "test setup" );
 

--- a/addons/implied-repos/model-java/src/main/java/org/commonjava/indy/implrepo/data/ImpliedRepoMetadataManager.java
+++ b/addons/implied-repos/model-java/src/main/java/org/commonjava/indy/implrepo/data/ImpliedRepoMetadataManager.java
@@ -154,11 +154,11 @@ public class ImpliedRepoMetadataManager
         }
     }
 
-    private static final class ImpliedRemotesWrapper
+    public static final class ImpliedRemotesWrapper
     {
         private List<StoreKey> items;
 
-        ImpliedRemotesWrapper( final List<StoreKey> items )
+        public ImpliedRemotesWrapper( final List<StoreKey> items )
         {
             this.items = items;
         }


### PR DESCRIPTION
When I test the other PR, two implied repo tests failed because of no metadata IMPLIED_BY_STORES in the origin repo. 
I found that the repo is not persisted after setting the metadata. These two cases passed in the past because of the memory store manager hold the instances in the memory. After switching it to ISPN store manager, we must persist it. 