### PR TITLE
[1.7.x] Fix typo of Storertifact.copyBase()

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -233,7 +233,7 @@ public abstract class ArtifactStore
 
     protected void copyBase( ArtifactStore store )
     {
-        store.setRescanInProgress( store.isRescanInProgress() );
+        store.setRescanInProgress( isRescanInProgress() );
         store.setDescription( getDescription() );
         store.setDisabled( isDisabled() );
         store.setMetadata( getMetadata() );


### PR DESCRIPTION
I think this is a typo of the method. Correct me if I'm wrong.