### PR TITLE
[1.7.x] Indy promote perf

### DIFF
--- a/addons/promote/common/src/main/data/promote/rules/artifact-refs-via.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/artifact-refs-via.groovy
@@ -25,7 +25,7 @@ class ArtifactRefAvailability implements ValidationRule {
             if (it.endsWith(".pom")) {
                 def relationships = tools.getRelationshipsForPom(it, dc, request, verifyStoreKeys)
                 if (relationships != null) {
-                    tools.forEach(relationships, { rel ->
+                    tools.paralleledEach(relationships, { rel ->
                         def skip = false
                         if (rel.getType() == RelationshipType.DEPENDENCY) {
                             def dr = (DependencyRelationship) rel
@@ -42,7 +42,7 @@ class ArtifactRefAvailability implements ValidationRule {
                             def found = false
                             def foundPom = false
 
-                            tools.forEach(verifyStoreKeys, { verifyStoreKey ->
+                            tools.paralleledEach(verifyStoreKeys, { verifyStoreKey ->
                                 if (!found) {
                                     def txfr = tools.getTransfer(verifyStoreKey, path)
                                     logger.info("{} in {}: {}. Exists? {}", target, verifyStoreKey, txfr, txfr == null ? false : txfr.exists())

--- a/addons/promote/common/src/main/data/promote/rules/no-pre-existing-paths.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/no-pre-existing-paths.groovy
@@ -16,7 +16,7 @@ class NoPreExistingPaths implements ValidationRule {
         tools.paralleledEach(request.getSourcePaths(), { it ->
             def aref = tools.getArtifact(it);
             if (aref != null) {
-                tools.forEach(verifyStoreKeys, { verifyStoreKey ->
+                tools.paralleledEach(verifyStoreKeys, { verifyStoreKey ->
                     if (tools.exists(verifyStoreKey, it)) {
                         errors.add(String.format("%s is already available in: %s", it, verifyStoreKey))
                     }

--- a/addons/promote/common/src/main/data/promote/rules/no-pre-existing-paths.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/no-pre-existing-paths.groovy
@@ -10,17 +10,15 @@ class NoPreExistingPaths implements ValidationRule {
     String validate(ValidationRequest request) throws PromotionValidationException {
         def verifyStoreKeys = request.getTools().getValidationStoreKeys(request, false);
 
-        def errors = new ArrayList()
+        def errors = Collections.synchronizedList(new ArrayList());
         def tools = request.getTools()
 
         tools.paralleledEach(request.getSourcePaths(), { it ->
             def aref = tools.getArtifact(it);
             if (aref != null) {
-                tools.paralleledEach(verifyStoreKeys, { verifyStoreKey ->
+                tools.forEach(verifyStoreKeys, { verifyStoreKey ->
                     if (tools.exists(verifyStoreKey, it)) {
-                        synchronized (errors) {
-                            errors.add(String.format("%s is already available in: %s", it, verifyStoreKey))
-                        }
+                        errors.add(String.format("%s is already available in: %s", it, verifyStoreKey))
                     }
                 })
             }

--- a/addons/promote/common/src/main/data/promote/rules/no-snapshots.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/no-snapshots.groovy
@@ -26,7 +26,7 @@ class NoSnapshots implements ValidationRule {
 
                 def relationships = tools.getRelationshipsForPom(it, dc, request, verifyStoreKeys)
                 if (relationships != null) {
-                    tools.forEach(relationships, { rel ->
+                    tools.paralleledEach(relationships, { rel ->
                         def target = rel.getTarget()
                         if (!target.getVersionSpec().isRelease()) {
                             errors.add(String.format("%s uses a variable/snapshot version in: %s", target, it))

--- a/addons/promote/common/src/main/data/promote/rules/no-version-ranges.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/no-version-ranges.groovy
@@ -18,7 +18,7 @@ class NoVersionRanges implements ValidationRule {
             if (it.endsWith(".pom")) {
                 def relationships = tools.getRelationshipsForPom(it, dc, request, verifyStoreKeys)
                 if (relationships != null) {
-                    tools.forEach(relationships, { rel ->
+                    tools.paralleledEach(relationships, { rel ->
                         def target = rel.getTarget()
                         if (!target.getVersionSpec().isSingle()) {
                             errors.add(String.format("%s uses a compound version in: %s", target, it))

--- a/addons/promote/common/src/main/data/promote/rules/no-version-ranges.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/no-version-ranges.groovy
@@ -10,7 +10,7 @@ class NoVersionRanges implements ValidationRule {
     String validate(ValidationRequest request) {
         def verifyStoreKeys = request.getTools().getValidationStoreKeys(request, true)
 
-        def errors = new ArrayList()
+        def errors = Collections.synchronizedList(new ArrayList());
         def tools = request.getTools()
         def dc = new ModelProcessorConfig().setIncludeBuildSection(true).setIncludeManagedPlugins(true).setIncludeManagedDependencies(true)
 
@@ -18,12 +18,10 @@ class NoVersionRanges implements ValidationRule {
             if (it.endsWith(".pom")) {
                 def relationships = tools.getRelationshipsForPom(it, dc, request, verifyStoreKeys)
                 if (relationships != null) {
-                    tools.paralleledEach(relationships, { rel ->
+                    tools.forEach(relationships, { rel ->
                         def target = rel.getTarget()
                         if (!target.getVersionSpec().isSingle()) {
-                            synchronized(errors) {
-                                errors.add(String.format( "%s uses a compound version in: %s", target, it))
-                            }
+                            errors.add(String.format("%s uses a compound version in: %s", target, it))
                         }
                     })
                 }

--- a/addons/promote/common/src/main/data/promote/rules/parsable-pom.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/parsable-pom.groovy
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory
 class ParsablePom implements ValidationRule {
 
     String validate(ValidationRequest request) {
-        def errors = new ArrayList()
+        def errors = Collections.synchronizedList(new ArrayList());
         def tools = request.getTools()
         def logger = LoggerFactory.getLogger(ValidationRule.class)
         logger.info("Parsing POMs in:\n  {}.", request.getSourcePaths().join("\n  "))
@@ -20,9 +20,7 @@ class ParsablePom implements ValidationRule {
                     def pom = tools.readLocalPom(it, request)
                 }
                 catch (Exception e) {
-                    synchronized(errors) {
-                        errors.add(String.format("%s: Failed to parse POM. Error was: %s", it, e))
-                    }
+                    errors.add(String.format("%s: Failed to parse POM. Error was: %s", it, e))
                 }
             }
         })

--- a/addons/promote/common/src/main/data/promote/rules/project-artifacts.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/project-artifacts.groovy
@@ -11,7 +11,7 @@ class ProjectArtifacts implements ValidationRule {
 
     String validate(ValidationRequest request) throws Exception {
         def classifierAndTypeSet = request.getValidationParameter("classifierAndTypeSet")
-        def errors = new ArrayList()
+        def errors = Collections.synchronizedList(new ArrayList());
 
         if (classifierAndTypeSet != null) {
             def ctStrings = classifierAndTypeSet.split("\\s*,\\s*")
@@ -57,9 +57,7 @@ class ProjectArtifacts implements ValidationRule {
                     tcs.each { tc ->
                         logger.trace("Checking if TC: {} is in: {} for: {}", tc, entry.value, entry.key)
                         if (!entry.value.contains(tc)) {
-                            synchronized(errors) {
-                                errors.add(String.format("%s: missing artifact with type/classifier: %s", entry.key, tc))
-                            }
+                            errors.add(String.format("%s: missing artifact with type/classifier: %s", entry.key, tc))
                         }
                     }
                 }

--- a/addons/promote/common/src/main/data/promote/rules/project-version-pattern.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/project-version-pattern.groovy
@@ -9,7 +9,7 @@ class ProjectVersionPattern implements ValidationRule {
 
     String validate(ValidationRequest request) throws Exception {
         def versionPattern = request.getValidationParameter("versionPattern")
-        def errors = new ArrayList()
+        def errors = Collections.synchronizedList(new ArrayList());
 
         if (versionPattern != null) {
             def tools = request.getTools()
@@ -18,10 +18,8 @@ class ProjectVersionPattern implements ValidationRule {
                 if (ref != null) {
                     def vs = ref.getVersionString()
                     if (!vs.matches(versionPattern)) {
-                        synchronized (errors) {
-                            errors.add(String.format("%s does not match version pattern: '%s' (version was: '%s')",
-                                    it, versionPattern, vs))
-                        }
+                        errors.add(String.format("%s does not match version pattern: '%s' (version was: '%s')",
+                                it, versionPattern, vs))
                     }
                 }
             })

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -86,7 +86,7 @@ public class PromotionValidationTools
     @Deprecated
     public static final String AVAILABLE_IN_STORE_KEY = "availableInStoreKey";
 
-    private static final int DEFAULT_RULE_PARALLEL_WAIT_TIME_MINS = 10;
+    private static final int DEFAULT_RULE_PARALLEL_WAIT_TIME_MINS = 30;
 
     @Inject
     private ContentManager contentManager;
@@ -579,7 +579,12 @@ public class PromotionValidationTools
 
         try
         {
-            latch.await( DEFAULT_RULE_PARALLEL_WAIT_TIME_MINS, TimeUnit.MINUTES );
+            // true if the count reached zero and false if timeout
+            boolean finished = latch.await( DEFAULT_RULE_PARALLEL_WAIT_TIME_MINS, TimeUnit.MINUTES );
+            if ( !finished )
+            {
+                throw new RuntimeException( "Parallel execution timeout" );
+            }
         }
         catch ( InterruptedException e )
         {

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -79,6 +79,8 @@ import static org.commonjava.maven.galley.io.ChecksummingTransferDecorator.FORCE
  */
 public class PromotionValidationTools
 {
+    final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
     public static final String AVAILABLE_IN_STORES = "availableInStores";
 
     @Deprecated
@@ -561,7 +563,7 @@ public class PromotionValidationTools
 
     private <T> void runParallelAndWait( Collection<T> runCollection, Closure closure, Logger logger )
     {
-        Set<T> todo = new HashSet<>( runCollection);
+        Set<T> todo = new HashSet<>( runCollection );
         final CountDownLatch latch = new CountDownLatch( todo.size() );
         todo.forEach( e -> ruleParallelExecutor.execute( () -> {
             try
@@ -586,4 +588,22 @@ public class PromotionValidationTools
         }
     }
 
+    public <T> void forEach( Collection<T> collection, Closure closure )
+    {
+        logger.trace( "Exe on collection {} with closure {}", collection, closure );
+        collection.forEach( e -> closure.call( e ) );
+    }
+
+    public <T> void forEach( T[] array, Closure closure )
+    {
+        logger.trace( "Exe on array {} with closure {}", array, closure );
+        Arrays.asList( array ).forEach( e -> closure.call( e ) );
+    }
+
+    public <K, V> void forEach( Map<K, V> map, Closure closure )
+    {
+        Set<Map.Entry<K, V>> entries = map.entrySet();
+        logger.trace( "Exe on map {} with closure {}", entries, closure );
+        entries.forEach( e -> closure.call( e ) );
+    }
 }

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -178,7 +178,7 @@ public class PromotionManagerTest
                                                                           galleyParts.getMavenMetadataReader(),
                                                                           modelProcessor, galleyParts.getTypeMapper(),
                                                                           galleyParts.getTransferManager(),
-                                                                          contentDigester ), storeManager, downloadManager, validateService );
+                                                                          contentDigester ), storeManager, downloadManager, validateService, null );
 
         PromoteConfig config = new PromoteConfig();
 

--- a/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
+++ b/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
@@ -69,6 +69,11 @@ public class MetricsInterceptor
             measure = method.getDeclaringClass().getAnnotation( Measure.class );
         }
 
+        if ( measure == null )
+        {
+            return context.proceed();
+        }
+
         String defaultName = getDefaultName( context.getMethod().getDeclaringClass(), context.getMethod().getName() );
         logger.trace( "Gathering metrics for: {} using context: {}", defaultName, context.getContextData() );
 


### PR DESCRIPTION
This is for NOSSUP-45. Basically, the promotion ran very slowly. I looked at the grafana for Apr 4 and 5, and found (for some period):
1. promote-rules-executor and promote-rules-runner each run took up to 10 minutes (I suspect there was timeout. The default timeout is 10 minutes).
2. promote-rules-executor load-factor was up to 30,000 %. There are 200 threads in the pool. That adds up to 60,000 tasks waiting in the queue. 

I add a few changes in this PR:

1. remove synchronized(error) from groovy scripts. Use a synchronizedList() instead. This surely will help but not sure how much time it can save. 
2. add forEach() in the validation tool to do serialized execution. I use it to replace some nested paralleledEach() in groovy rules to reduce the parallel tasks to a level that Java can work properly considering threads swapping affects, etc. 
3. catch and throw the timeout exception. The old code just log the timeout but let the promotion go success. With this change, some prev build would have failed. To minimize the impact, I expend the timeout from 10 min to 30 which should allow as many promotions to pass. 
4. add metrics for each rule so that we know which rule takes the longest time. 
5. fix a minor issue in the MetricsInterceptor to return if Measure is null. Not sure why this old code does not throw NPE. It looks not right so I correct it. Let me know if there is any tricks here. 

I am not sure how the #2 works. Maybe we just add more threads to the pool? We may stick to the current prod groovy scripts and see what is going on by #4 metric. Once we identify the slowest rule, we can try the #2. 