### PR TITLE
[1.7.x] Add skipVersionTest flag when doing Koji path mask repair

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiPathPatternFormatter.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiPathPatternFormatter.java
@@ -46,11 +46,16 @@ public class KojiPathPatternFormatter
 
     public Set<String> getPatterns( ArtifactRef artifactRef, List<KojiArchiveInfo> archives )
     {
+        return getPatterns( artifactRef, archives, false );
+    }
+
+    public Set<String> getPatterns( ArtifactRef artifactRef, List<KojiArchiveInfo> archives, boolean skipVersionTest )
+    {
         Set<String> patterns = new HashSet<>();
         for ( KojiArchiveInfo a : archives )
         {
             ArtifactRef ar = a.asArtifact();
-            if ( !kojiUtils.isVersionSignatureAllowedWithVersion( a.getVersion() ) )
+            if ( !skipVersionTest && !kojiUtils.isVersionSignatureAllowedWithVersion( a.getVersion() ) )
             {
                 logger.warn(
                         "Cannot use Koji archive for path_mask_patterns: {}. Version '{}' is not allowed from Koji.", a,

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRepairManager.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRepairManager.java
@@ -228,7 +228,7 @@ public class KojiRepairManager
                         }
 
                         // set pathMaskPatterns using build output paths
-                        Set<String> patterns = kojiPathFormatter.getPatterns( artifactRef, archives );
+                        Set<String> patterns = kojiPathFormatter.getPatterns( artifactRef, archives, true );
                         logger.debug( "For repo: {}, resetting path_mask_patterns to:\n\n{}\n\n", store.getKey(),
                                      patterns );
 


### PR DESCRIPTION
This is for NOSSUP-45 where we want to repair the koji repo's path mask but blocked by the pattern test. After applying this fix, we can do the repair again. 