### PR TITLE
Use string for storekey in repo change log for auditquery compatible

### DIFF
--- a/addons/changelog/common/src/main/java/org/commonjava/indy/changelog/RepoChangeHandler.java
+++ b/addons/changelog/common/src/main/java/org/commonjava/indy/changelog/RepoChangeHandler.java
@@ -95,7 +95,7 @@ public class RepoChangeHandler
                 String patchString = diffRepoChanges( store, origin );
 
                 RepositoryChangeLog changeLog = new RepositoryChangeLog();
-                changeLog.setStoreKey( store.getKey() );
+                changeLog.setStoreKey( store.getKey().toString() );
                 changeLog.setChangeTime( new Date() );
                 changeLog.setDiffContent( patchString );
                 changeLog.setChangeType( origin == null ? RepoChangeType.CREATE : RepoChangeType.UPDATE );

--- a/addons/changelog/ftests/src/main/java/org/commonjava/indy/changelog/RepoChangelogStoreTest.java
+++ b/addons/changelog/ftests/src/main/java/org/commonjava/indy/changelog/RepoChangelogStoreTest.java
@@ -74,7 +74,7 @@ public class RepoChangelogStoreTest
         final AtomicInteger createCount = new AtomicInteger( 0 );
         final AtomicInteger updateCount = new AtomicInteger( 0 );
         logs.forEach( c -> {
-            assertThat( c.getStoreKey(), equalTo( hostedKey ) );
+            assertThat( c.getStoreKey(), equalTo( hostedKey.toString() ) );
             if ( c.getChangeType() == RepoChangeType.CREATE )
             {
                 createCount.getAndIncrement();
@@ -98,7 +98,7 @@ public class RepoChangelogStoreTest
             {
                 updateCount2.getAndIncrement();
             }
-            if ( c.getStoreKey().equals( hostedKey ) )
+            if ( c.getStoreKey().equals( hostedKey.toString() ) )
             {
                 testRepoCount.getAndIncrement();
             }

--- a/addons/changelog/jaxrs/src/main/java/org/commonjava/indy/changelog/bind/jaxrs/RepoChangelogResource.java
+++ b/addons/changelog/jaxrs/src/main/java/org/commonjava/indy/changelog/bind/jaxrs/RepoChangelogResource.java
@@ -107,7 +107,7 @@ public class RepoChangelogResource
         return changeLogCache.execute( c -> {
             for ( RepositoryChangeLog log : c.values() )
             {
-                if ( log.getStoreKey().equals( storeKey ) )
+                if ( log.getStoreKey().equals( storeKey.toString() ) )
                 {
                     results.add( log );
                 }

--- a/addons/changelog/model-java/src/main/java/org/commonjava/indy/changelog/model/RepositoryChangeLog.java
+++ b/addons/changelog/model-java/src/main/java/org/commonjava/indy/changelog/model/RepositoryChangeLog.java
@@ -30,7 +30,7 @@ public class RepositoryChangeLog
     @ApiModelProperty( required = true, dataType = "string",
                        value = "Serialized store key, of the form: '[hosted|group|remote]:name'" )
     @JsonProperty
-    private StoreKey storeKey;
+    private String storeKey;
 
     @ApiModelProperty( required = true, dataType = "java.util.Date", value = "Timestamp for this changing" )
     @JsonProperty
@@ -56,14 +56,19 @@ public class RepositoryChangeLog
     @JsonProperty
     private String diffContent;
 
-    public StoreKey getStoreKey()
+    public String getStoreKey()
     {
         return storeKey;
     }
 
-    public void setStoreKey( StoreKey storeKey )
+    public void setStoreKey( String storeKey )
     {
         this.storeKey = storeKey;
+    }
+
+    public StoreKey getStoreKeyObj()
+    {
+        return StoreKey.fromString( storeKey );
     }
 
     public Date getChangeTime()


### PR DESCRIPTION
To avoid copy StoreKey class to auditquery service, we should keep all fields in RepositoryChangelog pojo using primitive or string for compatible.