### PR TITLE
[1.7.x] Fix baseUrl

### DIFF
--- a/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
+++ b/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
@@ -46,6 +46,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
+import static org.commonjava.indy.bind.jaxrs.util.JaxRsUriFormatter.getBaseUrlByStoreKey;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.ALL_MASKS;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.MASK;
@@ -86,15 +87,8 @@ public class KojiRepairResource
     {
         try
         {
-            PackageTypeDescriptor packageTypeDescriptor =
-                            PackageTypes.getPackageTypeDescriptor( request.getSource().getPackageType() );
-
             String user = securityManager.getUser( securityContext, servletRequest );
-            final String baseUrl = uriInfo.getBaseUriBuilder()
-                                          .path( packageTypeDescriptor.getContentRestBasePath() )
-                                          .build( request.getSource().getType().singularEndpointName(),
-                                                  request.getSource().getName() )
-                                          .toString();
+            final String baseUrl = getBaseUrlByStoreKey( uriInfo, request.getSource() );
             return repairManager.repairVol( request, user, baseUrl );
         }
         catch ( KojiRepairException | KojiClientException e )

--- a/addons/promote/common/src/main/data/promote/rules/parsable-pom.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/parsable-pom.groovy
@@ -11,7 +11,7 @@ class ParsablePom implements ValidationRule {
         def errors = Collections.synchronizedList(new ArrayList());
         def tools = request.getTools()
         def logger = LoggerFactory.getLogger(ValidationRule.class)
-        logger.info("Parsing POMs in:\n  {}.", request.getSourcePaths().join("\n  "))
+        logger.info("Parsing POMs in:\n  {}", request.getSourcePaths().join("\n  "))
 
         tools.paralleledEach(request.getSourcePaths(), { it ->
             if (it.endsWith(".pom")) {

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
@@ -335,6 +335,8 @@ public class PromotionValidator
     {
         final ArtifactStore store;
         final Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.info( "Promotion baseUrl: {} ", baseUrl );
+
         if ( needTempRepo( promoteRequest ) )
         {
             logger.info( "Promotion temporary repo is needed for {}, points to {} ", promoteRequest.getSource(),

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/AbstractValidationRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/AbstractValidationRuleTest.java
@@ -155,7 +155,7 @@ public abstract class AbstractValidationRuleTest<T extends ArtifactStore> extend
     {
         ValidationRuleSet ruleSet = new ValidationRuleSet();
         ruleSet.setName( "test" );
-        ruleSet.setStoreKeyPattern( new StoreKey( group, TARGET_NAME ).toString() );
+        ruleSet.setStoreKeyPattern( "maven:[^:]+:" + TARGET_NAME );
         ruleSet.setRuleNames( Collections.singletonList( getRuleScriptFile() ) );
 
         return ruleSet;

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ParsablePomRuleByPathTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ParsablePomRuleByPathTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest.rule;
+
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.promote.model.PathsPromoteRequest;
+import org.commonjava.indy.promote.model.PathsPromoteResult;
+import org.commonjava.indy.promote.model.ValidationResult;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class ParsablePomRuleByPathTest
+                extends AbstractValidationRuleTest<HostedRepository>
+{
+
+    private static final String RULE = "parsable-pom.groovy";
+
+    @Test
+    @Category( EventDependent.class )
+    public void run() throws Exception
+    {
+        String invalid = "org/foo/invalid/1/invalid-1.pom";
+        String valid = "org/foo/valid/1/valid-1.pom";
+
+        deploy( invalid, "This is not parsable" );
+        deploy( valid, "<?xml version=\"1.0\"?>\n<project><modelVersion>4.0.0</modelVersion><groupId>org.foo</groupId>"
+                        + "<artifactId>valid</artifactId><version>1</version></project>" );
+
+        waitForEventPropagation();
+
+        PathsPromoteRequest request = new PathsPromoteRequest( source.getKey(), target.getKey() );
+        request.setPaths( new HashSet( Arrays.asList( invalid, valid )) );
+
+        PathsPromoteResult result = module.promoteByPath( request );
+        assertThat( result, notNullValue() );
+
+        ValidationResult validations = result.getValidations();
+        assertThat( validations, notNullValue() );
+
+        Map<String, String> validatorErrors = validations.getValidatorErrors();
+        assertThat( validatorErrors, notNullValue() );
+
+        System.out.println( validatorErrors );
+
+        String errors = validatorErrors.get( RULE );
+        assertThat( errors, notNullValue() );
+
+        System.out.println( validatorErrors );
+        assertThat( errors.contains( valid ), equalTo( false ) );
+        assertThat( errors.contains( invalid ), equalTo( true ) );
+    }
+
+    public ParsablePomRuleByPathTest()
+    {
+        super( HostedRepository.class );
+    }
+
+    @Override
+    protected String getRuleScriptFile()
+    {
+        return RULE;
+    }
+
+    @Override
+    protected String getRuleScriptContent() throws IOException
+    {
+        String path = "promote/rules/" + RULE;
+        return readTestResource( path );
+    }
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JaxRsUriFormatter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JaxRsUriFormatter.java
@@ -19,6 +19,9 @@ import static org.apache.commons.lang.StringUtils.join;
 
 import java.net.MalformedURLException;
 
+import org.commonjava.indy.model.core.PackageTypeDescriptor;
+import org.commonjava.indy.model.core.PackageTypes;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.util.UriFormatter;
 import org.commonjava.atlas.maven.ident.util.JoinString;
 import org.commonjava.maven.galley.util.PathUtils;
@@ -26,8 +29,10 @@ import org.commonjava.maven.galley.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.ws.rs.core.UriInfo;
+
 public class JaxRsUriFormatter
-    implements UriFormatter
+                implements UriFormatter
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -55,31 +60,16 @@ public class JaxRsUriFormatter
         logger.debug( "Resulting URL: '{}'", url );
 
         return url;
-
-        //        URL baseUrl = null;
-        //        String path = base;
-        //        try
-        //        {
-        //            baseUrl = new URL( base );
-        //            path = baseUrl.getPath();
-        //        }
-        //        catch ( MalformedURLException e )
-        //        {
-        //            // not a URL.
-        //        }
-        //        
-        //        path = PathUtils.normalize( base, PathUtils.normalize( parts ) );
-        //        if ( !path.startsWith( "/" ) )
-        //        {
-        //            path = "/" + path;
-        //        }
-        //        
-        //        if ( baseUrl != null )
-        //        {
-        //            // reconstruct...
-        //        }
-        //
-        //        return path;
     }
 
+    public static String getBaseUrlByStoreKey( UriInfo uriInfo, StoreKey storeKey )
+    {
+        PackageTypeDescriptor typeDescriptor = PackageTypes.getPackageTypeDescriptor( storeKey.getPackageType() );
+        return uriInfo.getBaseUriBuilder()
+                      .path( typeDescriptor.getContentRestBasePath() )
+                      .path( storeKey.getType().singularEndpointName() )
+                      .path( storeKey.getName() )
+                      .build()
+                      .toString();
+    }
 }


### PR DESCRIPTION
The way we use to generate a baseUrl is wrong. This will fail all bypath validations. Briefly, the build(...) is used to pass parameters' values to the path, not append path elements. When doing byPath validation, we create a temp remote repo with this baseUrl as the 'remoteUrl'.
See also NOS-1694.