### PR TITLE
[1.7.x] Promotion error consistency and improved by-path lock scoping

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -529,25 +529,67 @@ public class PromotionManager
             pending.add( transfer.getPath() );
         }
 
-        ValidationResult validation = new ValidationResult();
-        ValidationRequest validationRequest = validator.validate( request, validation, baseUrl );
-        if ( request.isDryRun() )
+        AtomicReference<Exception> ex = new AtomicReference<>();
+
+        PathsPromoteResult promoteResult = byPathTargetLocks.lockAnd( request.getTargetKey(), config.getLockTimeoutSeconds(), k -> {
+            try
+            {
+                ValidationResult validation = new ValidationResult();
+                ValidationRequest validationRequest = validator.validate( request, validation, baseUrl );
+                if ( request.isDryRun() )
+                {
+                    return new PathsPromoteResult( request, pending, Collections.emptySet(), Collections.emptySet(),
+                                                   validation );
+                }
+                else if ( validation.isValid() )
+                {
+                    PathsPromoteResult result = runPathPromotions( request, pending, Collections.emptySet(), Collections.emptySet(),
+                                                                   contents, validation, validationRequest );
+                    doPathPromoteMetrics( contents.size(), result );
+                    return result;
+                }
+                else
+                {
+                    return new PathsPromoteResult( request, pending, Collections.emptySet(), Collections.emptySet(),
+                                                   validation );
+                }
+            }
+            catch ( PromotionValidationException e )
+            {
+                ex.set( e );
+            }
+            catch ( IndyWorkflowException e )
+            {
+                ex.set( e );
+            }
+
+            return null;
+        }, ( k, lock ) -> {
+            String error = String.format( "Failed to acquire promotion lock on target: %s in %d seconds.",
+                                          request.getTargetKey(), config.getLockTimeoutSeconds() );
+
+            logger.error( error );
+            ex.set( new IndyWorkflowException( error ) );
+
+            return false;
+        } );
+
+        Exception e = ex.get();
+        if ( e != null )
         {
-            return new PathsPromoteResult( request, pending, Collections.emptySet(), Collections.emptySet(),
-                                           validation );
+            if ( e instanceof PromotionValidationException )
+            {
+                throw (PromotionValidationException) e;
+            }
+            else if ( e instanceof IndyWorkflowException )
+            {
+                throw (IndyWorkflowException) e;
+            }
+
+            throw new IndyWorkflowException( "Promotion failed.", e );
         }
-        else if ( validation.isValid() )
-        {
-            PathsPromoteResult result = runPathPromotions( request, pending, Collections.emptySet(), Collections.emptySet(), contents,
-                                                           validation, validationRequest );
-            doPathPromoteMetrics( contents.size(), result );
-            return result;
-        }
-        else
-        {
-            return new PathsPromoteResult( request, pending, Collections.emptySet(), Collections.emptySet(),
-                                           validation );
-        }
+
+        return promoteResult;
     }
 
     private void doPathPromoteMetrics( int total, PathsPromoteResult result )
@@ -899,69 +941,49 @@ public class PromotionManager
 
             AtomicReference<IndyWorkflowException> wfError = new AtomicReference<>();
 
-            Set<PathTransferResult> results =
-                    byPathTargetLocks.lockAnd( targetKey, config.getLockTimeoutSeconds(), k -> {
-                        logger.info( "Running promotions from: {} (key: {})\n  to: {} (key: {})", src,
-                                     request.getSource(), tgt, request.getTarget() );
+            logger.info( "Running promotions from: {} (key: {})\n  to: {} (key: {})", src, request.getSource(), tgt,
+                         request.getTarget() );
 
-                        DrainingExecutorCompletionService<PathTransferResult> svc =
-                                new DrainingExecutorCompletionService<>( transferService );
+            DrainingExecutorCompletionService<PathTransferResult> svc =
+                    new DrainingExecutorCompletionService<>( transferService );
 
-                        try
-                        {
-                            detectOverloadVoid( () -> contents.forEach( ( transfer ) -> svc.submit(
-                                    newPathsPromoteTransfer( transfer, src, tgt, request ) ) ) );
+            Set<PathTransferResult> results = new HashSet<>();
+            detectOverloadVoid( () -> contents.forEach( ( transfer ) -> svc.submit(
+                    newPathsPromoteTransfer( transfer, src, tgt, request ) ) ) );
 
-                            Set<PathTransferResult> pathResults = new HashSet<>();
-                            try
-                            {
-                                svc.drain( ptr -> pathResults.add( ptr ) );
-                            }
-                            catch ( InterruptedException | ExecutionException e )
-                            {
-                                Set<String> paths;
-                                try
-                                {
-                                    paths = validationRequest.getSourcePaths();
-                                }
-                                catch ( PromotionValidationException e1 )
-                                {
-                                    paths = contents.stream()
-                                                    .map( txfr -> txfr.getPath() )
-                                                    .collect( Collectors.toSet() );
-                                }
+            try
+            {
+                svc.drain( ptr -> results.add( ptr ) );
+            }
+            catch ( InterruptedException | ExecutionException e )
+            {
+                Set<String> paths;
+                try
+                {
+                    paths = validationRequest.getSourcePaths();
+                }
+                catch ( PromotionValidationException e1 )
+                {
+                    paths = contents.stream()
+                                    .map( txfr -> txfr.getPath() )
+                                    .collect( Collectors.toSet() );
+                }
 
-                                logger.error(
-                                        String.format( "Error waiting for promotion of: %s to: %s\nPaths:\n\n%s\n\n",
-                                                       request.getSource(), targetKey, paths ), e );
-                            }
+                logger.error(
+                        String.format( "Error waiting for promotion of: %s to: %s\nPaths:\n\n%s\n\n",
+                                       request.getSource(), targetKey, paths ), e );
+            }
 
-                            try
-                            {
-                                clearStoreNFC( validationRequest.getSourcePaths(), tgt );
-                            }
-                            catch ( IndyDataException | PromotionValidationException e )
-                            {
-                                String msg = String.format( "Failed to promote to: %s. Reason: %s", tgt, e.getMessage() );
-                                errors.add( msg );
-                                logger.error( msg, e );
-                            }
-                            return pathResults;
-                        }
-                        catch ( IndyWorkflowException e )
-                        {
-                            wfError.set( e );
-                            return null;
-                        }
-                    }, ( k, lock ) -> {
-                        String error = String.format( "Failed to acquire promotion lock on target: %s in %d seconds.",
-                                                      targetKey, config.getLockTimeoutSeconds() );
-
-                        errors.add( error );
-                        logger.warn( error );
-
-                        return false;
-                    } );
+            try
+            {
+                clearStoreNFC( validationRequest.getSourcePaths(), tgt );
+            }
+            catch ( IndyDataException | PromotionValidationException e )
+            {
+                String msg = String.format( "Failed to promote to: %s. Reason: %s", tgt, e.getMessage() );
+                errors.add( msg );
+                logger.error( msg, e );
+            }
 
             if ( wfError.get() != null )
             {
@@ -1008,6 +1030,7 @@ public class PromotionManager
             PathsPromoteCompleteEvent evt = new PathsPromoteCompleteEvent( result );
             fireEvent( promoteCompleteEvent, evt );
         }
+
         return result;
     }
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteFailsValidationAsyncTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteFailsValidationAsyncTest.java
@@ -56,7 +56,8 @@ public class GroupPromoteFailsValidationAsyncTest
         assertThat( result.getRequest()
                           .getTargetGroup(), equalTo( target.getName() ) );
 
-        assertThat( result.getError(), nullValue() );
+        assertThat( result.getError(), notNullValue() );
+        assertThat( result.succeeded(), equalTo( false ) );
 
         ValidationResult validations = result.getValidations();
         assertThat( validations, notNullValue() );

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteFailsValidationTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/GroupPromoteFailsValidationTest.java
@@ -52,7 +52,8 @@ public class GroupPromoteFailsValidationTest
         assertThat( result.getRequest()
                           .getTargetGroup(), equalTo( target.getName() ) );
 
-        assertThat( result.getError(), nullValue() );
+        assertThat( result.getError(), notNullValue() );
+        assertThat( result.succeeded(), equalTo( false ) );
 
         ValidationResult validations = result.getValidations();
         assertThat( validations, notNullValue() );

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/AbstractPromoteResult.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/AbstractPromoteResult.java
@@ -22,7 +22,7 @@ import java.util.UUID;
 /**
  * Created by ruhan on 12/5/18.
  */
-public class AbstractPromoteResult<T extends AbstractPromoteResult>
+public abstract class AbstractPromoteResult<T extends AbstractPromoteResult>
 {
     public static final String DONE = "DONE";
 
@@ -33,6 +33,20 @@ public class AbstractPromoteResult<T extends AbstractPromoteResult>
 
     @ApiModelProperty( "Result code" )
     protected String resultCode = DONE; // default
+
+    @ApiModelProperty( "Result of validation rule executions, if applicable" )
+    protected ValidationResult validations;
+
+    @ApiModelProperty( "Error message, if promotion failed" )
+    protected String error;
+
+    protected AbstractPromoteResult(){}
+
+    protected AbstractPromoteResult( final String error, final ValidationResult validations )
+    {
+        this.validations = validations;
+        this.error = error == null && validations.isValid() ? null : "Promotion validation failed";
+    }
 
     public String getPromotionId()
     {
@@ -64,5 +78,30 @@ public class AbstractPromoteResult<T extends AbstractPromoteResult>
     {
         this.promotionId = promotionId;
         return (T) this;
+    }
+
+    public boolean succeeded()
+    {
+        return error == null && ( validations == null || validations.isValid() );
+    }
+
+    public String getError()
+    {
+        return error;
+    }
+
+    public void setError( final String error )
+    {
+        this.error = error;
+    }
+
+    public ValidationResult getValidations()
+    {
+        return validations;
+    }
+
+    public void setValidations( ValidationResult validations )
+    {
+        this.validations = validations;
     }
 }

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/GroupPromoteResult.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/GroupPromoteResult.java
@@ -30,46 +30,26 @@ public class GroupPromoteResult extends AbstractPromoteResult<GroupPromoteResult
     @ApiModelProperty( "Original request" )
     private GroupPromoteRequest request;
 
-    @ApiModelProperty( "Result of validation rule executions, if applicable" )
-    private ValidationResult validations;
-
-    @ApiModelProperty( "Error message, if promotion failed" )
-    private String error;
-
     public GroupPromoteResult()
     {
     }
 
     public GroupPromoteResult( final GroupPromoteRequest request, final String error )
     {
+        super( error, null );
         this.request = request;
         this.error = error;
     }
 
     public GroupPromoteResult( GroupPromoteRequest request, ValidationResult validations )
     {
+        super( null, validations );
         this.request = request;
-        this.validations = validations;
     }
 
     public GroupPromoteResult( GroupPromoteRequest request )
     {
         this.request = request;
-    }
-
-    public boolean succeeded()
-    {
-        return error == null && ( validations == null || validations.isValid() );
-    }
-
-    public String getError()
-    {
-        return error;
-    }
-
-    public void setError( final String error )
-    {
-        this.error = error;
     }
 
     public GroupPromoteRequest getRequest()
@@ -82,20 +62,11 @@ public class GroupPromoteResult extends AbstractPromoteResult<GroupPromoteResult
         this.request = request;
     }
 
-    public ValidationResult getValidations()
-    {
-        return validations;
-    }
-
-    public void setValidations( ValidationResult validations )
-    {
-        this.validations = validations;
-    }
-
     @Override
     public String toString()
     {
-        return String.format( "GroupPromoteResult [\n  request=%s\n  error=%s\n  validations:\n  %s\n]", request, error, validations );
+        return String.format( "GroupPromoteResult [\n  request=%s\n  error=%s\n  validations:\n  %s\n]", request,
+                              getError(), getValidations() );
     }
 
 }

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteResult.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteResult.java
@@ -42,12 +42,6 @@ public class PathsPromoteResult extends AbstractPromoteResult<PathsPromoteResult
     @ApiModelProperty( "List of paths that were skipped (path already exists in target location)" )
     private Set<String> skippedPaths;
 
-    @ApiModelProperty( "Result of validation rule executions, if applicable" )
-    private ValidationResult validations;
-
-    @ApiModelProperty( "Error message, if promotion failed" )
-    private String error;
-
     public PathsPromoteResult()
     {
     }
@@ -55,6 +49,7 @@ public class PathsPromoteResult extends AbstractPromoteResult<PathsPromoteResult
     public PathsPromoteResult( final PathsPromoteRequest request, final Set<String> pending, final Set<String> complete,
                                final Set<String> skipped, final String error, ValidationResult validations )
     {
+        super( error, validations );
         this.request = request;
         this.pendingPaths = pending;
         this.completedPaths = complete;
@@ -66,12 +61,11 @@ public class PathsPromoteResult extends AbstractPromoteResult<PathsPromoteResult
     public PathsPromoteResult( final PathsPromoteRequest request, final Set<String> pending, final Set<String> complete,
                                final Set<String> skipped, final ValidationResult validations )
     {
+        super( null, validations );
         this.request = request;
         this.pendingPaths = pending;
         this.completedPaths = complete;
         this.skippedPaths = skipped;
-        this.validations = validations;
-        this.error = null;
     }
 
     public PathsPromoteResult( PathsPromoteRequest request )
@@ -83,16 +77,6 @@ public class PathsPromoteResult extends AbstractPromoteResult<PathsPromoteResult
     {
         this.request = request;
         this.error = error;
-    }
-
-    public ValidationResult getValidations()
-    {
-        return validations;
-    }
-
-    public void setValidations( ValidationResult validations )
-    {
-        this.validations = validations;
     }
 
     public Set<String> getPendingPaths()
@@ -123,16 +107,6 @@ public class PathsPromoteResult extends AbstractPromoteResult<PathsPromoteResult
     public void setSkippedPaths( Set<String> skippedPaths )
     {
         this.skippedPaths = skippedPaths;
-    }
-
-    public String getError()
-    {
-        return error;
-    }
-
-    public void setError( final String error )
-    {
-        this.error = error;
     }
 
     public PathsPromoteRequest getRequest()


### PR DESCRIPTION
Set a top-level error if validation fails, and add a succeeded() method too. Also, pull the error/validation handling up into the abstract class, and set a constructor so we can call super()