### PR TITLE
Maven metadata cache values should be gzipped bytes

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -24,7 +24,7 @@ import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
 import org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -62,8 +62,8 @@ public class MetadataMergePomChangeListener
     private IndyFileEventManager fileEvent;
 
     @Inject
-    @MavenVersionMetadataCache
-    private CacheHandle<StoreKey, Map> versionMetadataCache;
+    @MavenMetadataCache
+    private CacheHandle<StoreKey, Map> mavenMetadataCache;
 
     /**
      * this listener observes {@link org.commonjava.maven.galley.event.FileStorageEvent}
@@ -106,7 +106,7 @@ public class MetadataMergePomChangeListener
                 {
                     if ( doClear( hosted, clearPath ) )
                     {
-                        versionMetadataCache.remove( hosted.getKey() );
+                        mavenMetadataCache.remove( hosted.getKey() );
                     }
                 }
                 catch ( final IOException e )
@@ -125,7 +125,7 @@ public class MetadataMergePomChangeListener
                         {
                             if ( doClear( group, clearPath ) )
                             {
-                                versionMetadataCache.remove( group.getKey() );
+                                mavenMetadataCache.remove( group.getKey() );
                             }
                         }
                         catch ( final IOException e )

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -42,12 +42,11 @@ import org.commonjava.indy.core.content.AbstractMergedContentGenerator;
 import org.commonjava.indy.core.content.group.GroupMergeHelper;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.measure.annotation.Measure;
-import org.commonjava.indy.measure.annotation.MetricNamed;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
-import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
 import org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger;
 import org.commonjava.indy.pkg.maven.content.group.MavenMetadataProvider;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
@@ -74,7 +73,6 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -82,6 +80,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -91,7 +90,6 @@ import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_EXISTS;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_GENERATED;
 import static org.commonjava.indy.core.ctl.PoolUtils.detectOverloadVoid;
-import static org.commonjava.indy.measure.annotation.MetricNamed.DEFAULT;
 import static org.commonjava.maven.galley.io.SpecialPathConstants.HTTP_METADATA_EXT;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
@@ -127,8 +125,8 @@ public class MavenMetadataGenerator
     private static final String CLASSIFIER = "classifier";
 
     @Inject
-    @MavenVersionMetadataCache
-    private CacheHandle<StoreKey, Map> versionMetadataCache;
+    @MavenMetadataCache
+    private CacheHandle<StoreKey, Map> mavenMetadataCache;
 
     private static final Set<String> HANDLED_FILENAMES = Collections.unmodifiableSet( new HashSet<String>()
     {
@@ -614,19 +612,9 @@ public class MavenMetadataGenerator
     @Measure
     private void putToMetadataCache( StoreKey key, String toMergePath, MetadataInfo meta )
     {
-        synchronized ( versionMetadataCache )
-        {
-            Map<String, MetadataInfo> cacheMap = versionMetadataCache.get( key );
-            if ( cacheMap == null )
-            {
-                cacheMap = new HashMap<>();
-            }
-
-            cacheMap.put( toMergePath, meta );
-            versionMetadataCache.put( key, cacheMap );
-
-            logger.trace( "Cached metadata: {} for: {}", toMergePath, key );
-        }
+        Map<String, MetadataInfo> cacheMap = mavenMetadataCache.computeIfAbsent( key, k -> new ConcurrentHashMap() );
+        cacheMap.put( toMergePath, new MetadataInfoWrapper().wrap( meta ) );
+        logger.trace( "Cached metadata: {} for: {}", toMergePath, key );
     }
 
     @Measure
@@ -888,9 +876,9 @@ public class MavenMetadataGenerator
 
     private MetadataInfo getMetaInfoFromCache( final StoreKey key, final String path )
     {
-        Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( key );
+        Map<String, MetadataInfo> metadataMap = mavenMetadataCache.get( key );
 
-        if ( metadataMap != null && !metadataMap.isEmpty() )
+        if ( metadataMap != null )
         {
             return metadataMap.get( path );
         }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataInfo.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataInfo.java
@@ -29,6 +29,10 @@ public class MetadataInfo
 
     private String metadataMergeInfo;
 
+    public MetadataInfo()
+    {
+    }
+
     public MetadataInfo( final Metadata metadata )
     {
         this.metadata = metadata;

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataInfoWrapper.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataInfoWrapper.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.content;
+
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import static org.commonjava.indy.pkg.maven.util.MetadataZipUtils.unzip;
+import static org.commonjava.indy.pkg.maven.util.MetadataZipUtils.zip;
+
+/**
+ * Wrapper MetadataInfo around byte arrays which contain gzipped, serialized Metadata / MetadataInfo content
+ * so we can minimize the heap usage.
+ */
+public class MetadataInfoWrapper
+                extends MetadataInfo
+                implements Externalizable
+{
+    private byte[] metadataBytes;
+
+    private byte[] metadataMergeInfoBytes;
+
+    public MetadataInfoWrapper()
+    {
+    }
+
+    @Override
+    public void setMetadata( Metadata metadata )
+    {
+        try
+        {
+            this.metadataBytes = zip( metadata );
+        }
+        catch ( IOException e )
+        {
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.error( "Failed to zip", e );
+        }
+    }
+
+    @Override
+    public void setMetadataMergeInfo( String metadataMergeInfo )
+    {
+        this.metadataMergeInfoBytes = metadataMergeInfo.getBytes();
+    }
+
+    @Override
+    public Metadata getMetadata()
+    {
+        try
+        {
+            return unzip( metadataBytes );
+        }
+        catch ( Exception e )
+        {
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.error( "Failed to unzip", e );
+        }
+        return null;
+    }
+
+    @Override
+    public String getMetadataMergeInfo()
+    {
+        try
+        {
+            return unzip( metadataMergeInfoBytes );
+        }
+        catch ( Exception e )
+        {
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.error( "Failed to unzip", e );
+        }
+        return null;
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput objectOutput ) throws IOException
+    {
+        objectOutput.writeInt( metadataBytes.length );
+        objectOutput.write( metadataBytes );
+        objectOutput.writeInt( metadataMergeInfoBytes.length );
+        objectOutput.write( metadataMergeInfoBytes );
+    }
+
+    @Override
+    public void readExternal( ObjectInput objectInput ) throws IOException, ClassNotFoundException
+    {
+        int len = objectInput.readInt();
+        metadataBytes = new byte[len];
+        objectInput.read( metadataBytes );
+        len = objectInput.readInt();
+        metadataMergeInfoBytes = new byte[len];
+        objectInput.read( metadataMergeInfoBytes );
+    }
+
+    public MetadataInfoWrapper wrap( MetadataInfo metadataInfo )
+    {
+        this.setMetadata( metadataInfo.getMetadata() );
+        this.setMetadataMergeInfo( metadataInfo.getMetadataMergeInfo() );
+        return this;
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
@@ -20,7 +20,7 @@ import org.commonjava.indy.content.MergedContentAction;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,8 +46,8 @@ public class MetadataMergeListener
     private DirectContentAccess fileManager;
 
     @Inject
-    @MavenVersionMetadataCache
-    private CacheHandle<StoreKey, Map> versionMetadataCache;
+    @MavenMetadataCache
+    private CacheHandle<StoreKey, Map> mavenMetadataCache;
 
     /**
      * Will clear the both merge path and merge info file of member and group contains that member(cascaded)
@@ -56,7 +56,7 @@ public class MetadataMergeListener
     @Override
     public void clearMergedPath( ArtifactStore originatingStore, Set<Group> affectedGroups, String path )
     {
-        final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( originatingStore.getKey() );
+        final Map<String, MetadataInfo> metadataMap = mavenMetadataCache.get( originatingStore.getKey() );
 
         if ( metadataMap != null && !metadataMap.isEmpty() )
         {
@@ -64,7 +64,7 @@ public class MetadataMergeListener
             {
                 metadataMap.remove( path );
                 affectedGroups.forEach( group -> {
-                    final Map<String, MetadataInfo> grpMetaMap = versionMetadataCache.get( group.getKey() );
+                    final Map<String, MetadataInfo> grpMetaMap = mavenMetadataCache.get( group.getKey() );
                     if ( grpMetaMap != null && !grpMetaMap.isEmpty() )
                     {
                         grpMetaMap.remove( path );

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
@@ -25,7 +25,7 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.model.galley.KeyedLocation;
-import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.event.FileDeletionEvent;
@@ -38,11 +38,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
@@ -65,8 +62,8 @@ public class MetadataStoreListener
     private StoreDataManager storeManager;
 
     @Inject
-    @MavenVersionMetadataCache
-    private CacheHandle<StoreKey, Map> versionMetadataCache;
+    @MavenMetadataCache
+    private CacheHandle<StoreKey, Map> mavenMetadataCache;
 
     /**
      * Listen to an #{@link ArtifactStorePreUpdateEvent} and clear the metadata cache due to changed memeber in that event
@@ -223,7 +220,7 @@ public class MetadataStoreListener
     {
         logger.trace( "Removing cached metadata for: {}", store.getKey() );
 
-        versionMetadataCache.remove( store.getKey() );
+        mavenMetadataCache.remove( store.getKey() );
         try
         {
             storeManager.query().getGroupsAffectedBy( store.getKey() ).forEach( g -> clearGroupMetaCache( g, store ) );
@@ -236,7 +233,7 @@ public class MetadataStoreListener
 
     private void clearGroupMetaCache( final Group group, final ArtifactStore store )
     {
-        final Map<String, MetadataInfo> metadataMap = versionMetadataCache.get( group.getKey() );
+        final Map<String, MetadataInfo> metadataMap = mavenMetadataCache.get( group.getKey() );
 
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.trace( "Clearing metadata for group: {} on store update: {}\n{}", group.getKey(), store.getKey(), metadataMap );
@@ -261,7 +258,7 @@ public class MetadataStoreListener
         logger.trace( "Clearing cached, merged paths for: {} as a result of change in: {} (paths: {})", group.getKey(),
                       store.getKey(), pathsList );
 
-        versionMetadataCache.remove( group.getKey() );
+        mavenMetadataCache.remove( group.getKey() );
     }
 
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MavenMetadataCache.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MavenMetadataCache.java
@@ -22,13 +22,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Qualifier used to supply "metadata-cache" cache in infinispan.xml.
- */
 @Qualifier
 @Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD } )
 @Retention( RetentionPolicy.RUNTIME )
 @Documented
-public @interface MavenVersionMetadataCache
+public @interface MavenMetadataCache
 {
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -34,11 +34,11 @@ public class MetadataCacheProducer
     private DataFileConfiguration config;
 
 
-    @MavenVersionMetadataCache
+    @MavenMetadataCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<StoreKey, Map> mavenVersionMetaCacheCfg()
+    public CacheHandle<StoreKey, Map> getMavenMetadataCache()
     {
-        return cacheProducer.getCache( "maven-version-metadata-cache" );
+        return cacheProducer.getCache( "maven-metadata" );
     }
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/util/MetadataZipUtils.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/util/MetadataZipUtils.java
@@ -1,0 +1,44 @@
+package org.commonjava.indy.pkg.maven.util;
+
+import org.apache.commons.lang3.SerializationUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.zip.DataFormatException;
+import java.util.zip.GZIPOutputStream;
+import java.util.zip.Inflater;
+
+public class MetadataZipUtils
+{
+    public static byte[] zip( Serializable obj ) throws IOException
+    {
+        byte[] dataToCompress = SerializationUtils.serialize( obj );
+
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+                        GZIPOutputStream zipStream = new GZIPOutputStream( out ))
+        {
+            zipStream.write( dataToCompress );
+            return out.toByteArray();
+        }
+    }
+
+    public static <T> T unzip( byte[] compressedData ) throws IOException, DataFormatException
+    {
+        Inflater decompressor = new Inflater();
+        decompressor.setInput( compressedData );
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        byte[] buf = new byte[1024];
+        while ( !decompressor.finished() )
+        {
+            int count = decompressor.inflate( buf );
+            bos.write( buf, 0, count );
+        }
+        bos.close();
+        byte[] decompressedData = bos.toByteArray();
+
+        T obj = SerializationUtils.deserialize( decompressedData );
+        return obj;
+    }
+
+}

--- a/subsys/infinispan/src/main/resources/infinispan-jdbc.xml
+++ b/subsys/infinispan/src/main/resources/infinispan-jdbc.xml
@@ -73,7 +73,7 @@
 
     <local-cache name="content-metadata" configuration="local-template"/>
 
-    <local-cache name="maven-version-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
+    <local-cache name="maven-metadata" deadlock-detection-spin="10000" configuration="local-template">
       <persistence>
         <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="true" key-to-string-mapper="org.commonjava.indy.pkg.maven.content.StoreKey2StringMapper">
           <write-behind />

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -41,7 +41,7 @@
 
     <local-cache name="content-metadata" configuration="local-template"/>
 
-    <local-cache name="maven-version-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
+    <local-cache name="maven-metadata" deadlock-detection-spin="10000" configuration="local-template">
       <memory>
         <object size="2000" strategy="REMOVE" />
       </memory>


### PR DESCRIPTION
This is for NOS-1643 - Maven metadata cache values should be gzipped serialized objects
But I really not sure whether we need it. It saves some memory, but complicates the code and use more CPU resource. 
I make it as Draft PR. 
P.S. This renames the cache MavenVersionMetadataCache to MavenMetadataCache since it also contains plugin metadata. 