### PR TITLE
Set path promotion failWhenExists default to false

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -592,8 +592,6 @@ public class PromotionManager
             PathsPromoteRequest newRequest = new PathsPromoteRequest( request.getTarget(), request.getSource(),
                                                                       result.getCompletedPaths() );
             newRequest.setPurgeSource( true );
-            newRequest.setFailWhenExists( false ); // so the un-purged prev source files won't bring any trouble
-
 
             PathsPromoteResult ret;
             try

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -249,7 +249,7 @@ public class PromotionManagerTest
         }
 
         result = manager.promotePaths(
-                        new PathsPromoteRequest( source1.getKey(), target.getKey(), path ).setFailWhenExists( false ),
+                        new PathsPromoteRequest( source1.getKey(), target.getKey(), path ),
                         FAKE_BASE_URL );
 
         assertThat( result.getRequest().getSource(), equalTo( source1.getKey() ) );

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteRequest.java
@@ -53,10 +53,9 @@ public class PathsPromoteRequest
     private boolean fireEvents;
 
     /**
-     * Default is true. For internal use, e.g., rollback. When doing rollback, set it to false so the previously
-     * un-purged files won't bring any trouble.
+     * Keep it in case when we need to enforce this rule
      */
-    private boolean failWhenExists = true;
+    private boolean failWhenExists;
 
     public PathsPromoteRequest()
     {


### PR DESCRIPTION
 We agree to check pre-existence of artifacts by validation rule. The flag only used for internal use (ftest).