### PR TITLE
Change maven-metadata cache key type to avoid manipulating paths map

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -43,10 +43,9 @@ import java.io.IOException;
 import java.util.Set;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
-import static org.commonjava.indy.pkg.maven.content.MetadataUtil.removeAll;
+import static org.commonjava.indy.pkg.maven.content.MetadataUtil.getMetadataPath;
+import static org.commonjava.indy.pkg.maven.content.MetadataUtil.remove;
 import static org.commonjava.indy.util.LocationUtils.getKey;
-import static org.commonjava.maven.galley.util.PathUtils.normalize;
-import static org.commonjava.maven.galley.util.PathUtils.parentPath;
 
 @javax.enterprise.context.ApplicationScoped
 public class MetadataMergePomChangeListener
@@ -97,8 +96,7 @@ public class MetadataMergePomChangeListener
         }
 
         final StoreKey key = getKey( event );
-        final String versionPath = normalize( parentPath( path ) );
-        final String clearPath = normalize( normalize( parentPath( versionPath ) ), MavenMetadataMerger.METADATA_NAME );
+        final String clearPath = getMetadataPath( path );
         try
         {
             if ( hosted == key.getType() )
@@ -108,7 +106,7 @@ public class MetadataMergePomChangeListener
                 {
                     if ( doClear( hosted, clearPath ) )
                     {
-                        removeAll( hosted.getKey(), metadataCache );
+                        remove( hosted.getKey(), clearPath, metadataCache );
                     }
                 }
                 catch ( final IOException e )
@@ -127,7 +125,7 @@ public class MetadataMergePomChangeListener
                         {
                             if ( doClear( group, clearPath ) )
                             {
-                                removeAll( group.getKey(), metadataCache );
+                                remove( group.getKey(), clearPath, metadataCache );
                             }
                         }
                         catch ( final IOException e )

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -24,7 +24,9 @@ import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.pkg.maven.content.cache.MavenVersionMetadataCache;
+import org.commonjava.indy.pkg.maven.content.MetadataCacheKey;
+import org.commonjava.indy.pkg.maven.content.MetadataInfo;
+import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
 import org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -38,10 +40,10 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Set;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.pkg.maven.content.MetadataUtil.removeAll;
 import static org.commonjava.indy.util.LocationUtils.getKey;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
@@ -62,8 +64,8 @@ public class MetadataMergePomChangeListener
     private IndyFileEventManager fileEvent;
 
     @Inject
-    @MavenVersionMetadataCache
-    private CacheHandle<StoreKey, Map> versionMetadataCache;
+    @MavenMetadataCache
+    private CacheHandle<MetadataCacheKey, MetadataInfo> metadataCache;
 
     /**
      * this listener observes {@link org.commonjava.maven.galley.event.FileStorageEvent}
@@ -106,7 +108,7 @@ public class MetadataMergePomChangeListener
                 {
                     if ( doClear( hosted, clearPath ) )
                     {
-                        versionMetadataCache.remove( hosted.getKey() );
+                        removeAll( hosted.getKey(), metadataCache );
                     }
                 }
                 catch ( final IOException e )
@@ -125,7 +127,7 @@ public class MetadataMergePomChangeListener
                         {
                             if ( doClear( group, clearPath ) )
                             {
-                                versionMetadataCache.remove( group.getKey() );
+                                removeAll( group.getKey(), metadataCache );
                             }
                         }
                         catch ( final IOException e )

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheKey.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheKey.java
@@ -1,0 +1,65 @@
+package org.commonjava.indy.pkg.maven.content;
+
+import org.commonjava.indy.model.core.StoreKey;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public final class MetadataCacheKey
+                implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    private final StoreKey storeKey;
+
+    private final String path;
+
+    public MetadataCacheKey( StoreKey storeKey, String path )
+    {
+        this.storeKey = storeKey;
+        this.path = path;
+    }
+
+    public StoreKey getStoreKey()
+    {
+        return storeKey;
+    }
+
+    public String getPath()
+    {
+        return path;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+            return true;
+        if ( o == null || getClass() != o.getClass() )
+            return false;
+        MetadataCacheKey that = (MetadataCacheKey) o;
+        return storeKey.equals( that.storeKey ) && path.equals( that.path );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( storeKey, path );
+    }
+
+    private static final String DELIMIT = "#";
+
+    @Override
+    public String toString()
+    {
+        return storeKey.toString() + DELIMIT + path; // e.g., maven:remote:central#/foo/bar/1.0/bar-1.0.pom
+    }
+
+    public static MetadataCacheKey fromString( String str )
+    {
+        int idx = str.lastIndexOf( DELIMIT );
+        String storekey = str.substring( 0, idx );
+        String path = str.substring( idx + 1 );
+        return new MetadataCacheKey( StoreKey.fromString( storekey ), path );
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheKey.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheKey.java
@@ -38,7 +38,7 @@ public final class MetadataCacheKey
         if ( o == null || getClass() != o.getClass() )
             return false;
         MetadataCacheKey that = (MetadataCacheKey) o;
-        return storeKey.equals( that.storeKey ) && path.equals( that.path );
+        return Objects.equals( storeKey, that.storeKey ) && Objects.equals( path, that.path );
     }
 
     @Override

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheKey2StringMapper.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheKey2StringMapper.java
@@ -1,0 +1,26 @@
+package org.commonjava.indy.pkg.maven.content;
+
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
+
+public final class MetadataCacheKey2StringMapper
+                implements TwoWayKey2StringMapper
+{
+
+    @Override
+    public Object getKeyMapping( String s )
+    {
+        return MetadataCacheKey.fromString( s );
+    }
+
+    @Override
+    public boolean isSupportedType( Class<?> aClass )
+    {
+        return aClass == MetadataCacheKey.class;
+    }
+
+    @Override
+    public String getStringMapping( Object o )
+    {
+        return o.toString();
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataStoreListener.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.pkg.maven.content.MetadataUtil.getAllPaths;
+import static org.commonjava.indy.pkg.maven.content.MetadataUtil.remove;
 import static org.commonjava.indy.pkg.maven.content.MetadataUtil.removeAll;
 import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
 
@@ -254,7 +255,7 @@ public class MetadataStoreListener
         logger.trace( "Clearing cached, merged paths for: {} as a result of change in: {} (paths: {})", group.getKey(),
                       store.getKey(), paths );
 
-        removeAll( group.getKey(), metadataCache );
+        remove( group.getKey(), paths, metadataCache );
     }
 
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataUtil.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataUtil.java
@@ -6,6 +6,10 @@ import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
+import static org.commonjava.maven.galley.util.PathUtils.parentPath;
+
 public class MetadataUtil
 {
     public static void removeAll( StoreKey storeKey, CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
@@ -19,6 +23,17 @@ public class MetadataUtil
         } );
     }
 
+    public static void remove( StoreKey storeKey, Set<String> paths,
+                               CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
+    {
+        paths.forEach( p -> cacheHandle.remove( new MetadataCacheKey( storeKey, p ) ) );
+    }
+
+    public static void remove( StoreKey storeKey, String path, CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
+    {
+        cacheHandle.remove( new MetadataCacheKey( storeKey, path ) );
+    }
+
     public static Set<String> getAllPaths( StoreKey storeKey, CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
     {
         return cacheHandle.executeCache( ( cache ) -> cache.keySet()
@@ -26,5 +41,11 @@ public class MetadataUtil
                                                            .filter( ( k ) -> k.getStoreKey().equals( storeKey ) )
                                                            .map( ( k ) -> k.getPath() )
                                                            .collect( Collectors.toSet() ) );
+    }
+
+    public static String getMetadataPath( String pomPath )
+    {
+        final String versionPath = normalize( parentPath( pomPath ) );
+        return normalize( normalize( parentPath( versionPath ) ), METADATA_NAME );
     }
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataUtil.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataUtil.java
@@ -1,0 +1,30 @@
+package org.commonjava.indy.pkg.maven.content;
+
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MetadataUtil
+{
+    public static void removeAll( StoreKey storeKey, CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
+    {
+        cacheHandle.executeCache( ( cache ) -> {
+            cache.keySet()
+                 .stream()
+                 .filter( ( k ) -> k.getStoreKey().equals( storeKey ) )
+                 .forEach( ( k ) -> cache.remove( k ) );
+            return null;
+        } );
+    }
+
+    public static Set<String> getAllPaths( StoreKey storeKey, CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
+    {
+        return cacheHandle.executeCache( ( cache ) -> cache.keySet()
+                                                           .stream()
+                                                           .filter( ( k ) -> k.getStoreKey().equals( storeKey ) )
+                                                           .map( ( k ) -> k.getPath() )
+                                                           .collect( Collectors.toSet() ) );
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MavenMetadataCache.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MavenMetadataCache.java
@@ -22,13 +22,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * Qualifier used to supply "metadata-cache" cache in infinispan.xml.
- */
 @Qualifier
 @Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD } )
 @Retention( RetentionPolicy.RUNTIME )
 @Documented
-public @interface MavenVersionMetadataCache
+public @interface MavenMetadataCache
 {
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -15,14 +15,14 @@
  */
 package org.commonjava.indy.pkg.maven.content.cache;
 
-import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.maven.content.MetadataCacheKey;
+import org.commonjava.indy.pkg.maven.content.MetadataInfo;
 import org.commonjava.indy.subsys.datafile.conf.DataFileConfiguration;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
-import java.util.Map;
 
 @ApplicationScoped
 public class MetadataCacheProducer
@@ -34,11 +34,11 @@ public class MetadataCacheProducer
     private DataFileConfiguration config;
 
 
-    @MavenVersionMetadataCache
+    @MavenMetadataCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<StoreKey, Map> mavenVersionMetaCacheCfg()
+    public CacheHandle<MetadataCacheKey, MetadataInfo> mavenMetaCacheCfg()
     {
-        return cacheProducer.getCache( "maven-version-metadata-cache" );
+        return cacheProducer.getCache( "maven-metadata-cache" );
     }
 }

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupDeleteFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupDeleteFileTest.java
@@ -15,14 +15,17 @@
  */
 package org.commonjava.indy.pkg.npm.content;
 
+import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.After;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 
+import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -113,8 +116,11 @@ public class NPMGroupDeleteFileTest
         client.content().delete( groupC.getKey(), REAL_PATH );
 
         assertThat( client.content().exists( groupA.getKey(), PATH ), equalTo( true ) );
-        assertThat( client.content().exists( groupB.getKey(), REAL_PATH ), equalTo( false ) );
-        assertThat( client.content().exists( groupC.getKey(), REAL_PATH ), equalTo( false ) );
+
+        // We disable cascade deletion in DefaultContentManager.delete() by default.
+        // As of now, we just leave out these two lines. Rui
+        //assertThat( client.content().exists( groupB.getKey(), REAL_PATH ), equalTo( false ) );
+        //assertThat( client.content().exists( groupC.getKey(), REAL_PATH ), equalTo( false ) );
     }
 
     @Override

--- a/models/core-java/src/main/java/org/commonjava/indy/IndyContentConstants.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/IndyContentConstants.java
@@ -23,7 +23,8 @@ public final class IndyContentConstants
 
     public static final String CHECK_CACHE_ONLY = "cache-only";
 
-    private IndyContentConstants(){}
+    public static final String CASCADE = "cascade";
 
+    private IndyContentConstants(){}
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
     <kafkaVersion>1.1.0</kafkaVersion>
     <logbackVersion>1.2.3</logbackVersion>
     <logbackContribVersion>0.1.5</logbackContribVersion>
-    <propulsorVersion>1.4-SNAPSHOT</propulsorVersion>
     <weldVersion>2.4.6.Final</weldVersion>
     <jacksonVersion>2.9.8</jacksonVersion>
     <metricsVersion>4.0.2</metricsVersion>
@@ -593,13 +592,6 @@
         <artifactId>indy-koji-jaxrs</artifactId>
         <version>1.8.0-SNAPSHOT</version>
       </dependency>
-      <!--
-      <dependency>
-        <groupId>org.commonjava.indy</groupId>
-        <artifactId>indy-ftests-koji</artifactId>
-        <version>1.6.1-SNAPSHOT</version>
-      </dependency>
-      -->
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>

--- a/subsys/infinispan/src/main/resources/infinispan-jdbc.xml
+++ b/subsys/infinispan/src/main/resources/infinispan-jdbc.xml
@@ -73,9 +73,9 @@
 
     <local-cache name="content-metadata" configuration="local-template"/>
 
-    <local-cache name="maven-version-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
+    <local-cache name="maven-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
       <persistence>
-        <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="true" key-to-string-mapper="org.commonjava.indy.pkg.maven.content.StoreKey2StringMapper">
+        <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="true" key-to-string-mapper="org.commonjava.indy.pkg.maven.content.MetadataCacheKey2StringMapper">
           <write-behind />
           <jdbc:connection-pool connection-url="jdbc:postgresql://${datasource_server}:${datasource_port}/${datasource_name}" username="${datasource_user}" password="${datasource_password}" driver="org.postgresql.Driver"/>
           <jdbc:string-keyed-table drop-on-exit="false" create-on-start="true" prefix="indy_cache">


### PR DESCRIPTION
The current maven-metadata cache value is a map which does not align with ISPN well. Once we put a new entry to cache, we have to put the whole map again. This also makes the cache expiration malfunction when some cache is used frequently. 
This pr also fixes a deletion problem (mention in NOS-1836). When we get a cache-only DELETE request, we should not return too soon. Actually, we just need to follow the normal code path. 