### PR TITLE
Enable path conflict check only when failWhenExists is true

### DIFF
--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteRequest.java
@@ -53,7 +53,9 @@ public class PathsPromoteRequest
     private boolean fireEvents;
 
     /**
-     * Keep it in case when we need to enforce this rule
+     * If true, path conflict check (against concurrent promotions) is enabled and the promotion fails if pre-existent files are detected.
+     * For repos holding target build artifacts, we need to make sure no conflicts and no files are overridden.
+     * For repos like shared-imports holding download files, we don't need these checks.
      */
     private boolean failWhenExists;
 


### PR DESCRIPTION
PNC build group runs concurrent builds which promote to shared-imports where paths always conflict. This PR enables the conflict-check only when the failWhenExists is true. 
Briefly, when they promote to pnc-builds, this flag should be true. When promoting to shared-imports, this should be false. 