### PR TITLE
MDC additions, and connection pool simplification

### DIFF
--- a/addons/changelog/jaxrs/src/main/java/org/commonjava/indy/changelog/bind/jaxrs/RepoChangelogResource.java
+++ b/addons/changelog/jaxrs/src/main/java/org/commonjava/indy/changelog/bind/jaxrs/RepoChangelogResource.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.changelog.cache.RepoChangelogCache;
 import org.commonjava.indy.changelog.conf.RepoChangelogConfiguration;
 import org.commonjava.indy.changelog.model.RepositoryChangeLog;
@@ -50,6 +51,7 @@ import java.util.List;
         + "and will not return all results. It should not be used for any real operations" )
 @Path( "/api/repo/changelog" )
 @ApplicationScoped
+@REST
 public class RepoChangelogResource
         implements IndyResources
 {

--- a/addons/content-browse/jaxrs/src/main/java/org/commonjava/indy/content/browse/bind/jaxrs/ContentBrowseResource.java
+++ b/addons/content-browse/jaxrs/src/main/java/org/commonjava/indy/content/browse/bind/jaxrs/ContentBrowseResource.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.JaxRsRequestHelper;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.bind.jaxrs.util.ResponseUtils;
 import org.commonjava.indy.content.browse.ContentBrowseController;
 import org.commonjava.indy.content.browse.model.ContentBrowseResult;
@@ -60,6 +61,7 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponse
 @Api( value = "Indy Directory Content Browse", description = "Browse directory content in indy repository" )
 @Path( "/api/browse/{packageType}/{type: (hosted|group|remote)}/{name}" )
 @ApplicationScoped
+@REST
 public class ContentBrowseResource
         implements IndyResources
 {

--- a/addons/diagnostics/jaxrs/src/main/java/org/commonjava/indy/diag/bind/jaxrs/DiagnosticsResource.java
+++ b/addons/diagnostics/jaxrs/src/main/java/org/commonjava/indy/diag/bind/jaxrs/DiagnosticsResource.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.diag.data.DiagnosticsManager;
 import org.commonjava.indy.util.ApplicationHeader;
 import org.slf4j.Logger;
@@ -47,6 +48,7 @@ import static org.commonjava.indy.util.ApplicationContent.text_plain;
 @Api( value = "Diagnostics",
       description = "Tools to aid users when something goes wrong on the server, and you don't have access to logs." )
 @Path( "/api/diag" )
+@REST
 public class DiagnosticsResource
         implements IndyResources
 {

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/DeprecatedFoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/DeprecatedFoloContentAccessResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.folo.model.TrackingKey;
@@ -63,6 +64,7 @@ import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAV
 @Api( value = "FOLO Tracked Content Access and Storage",
       description = "Tracks retrieval and management of file/artifact content." )
 @Path( "/api/folo/track/{id}/{type: (hosted|group|remote)}/{name}" )
+@REST
 public class DeprecatedFoloContentAccessResource
         implements IndyResources
 {

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.folo.ctl.FoloAdminController;
 import org.commonjava.indy.folo.ctl.FoloConstants;
@@ -63,6 +64,7 @@ import static org.commonjava.indy.util.ApplicationContent.application_zip;
 @Api( value = "FOLO Tracking Record Access", description = "Manages FOLO tracking records." )
 @Path( "/api/folo/admin" )
 @ApplicationScoped
+@REST
 public class FoloAdminResource
         implements IndyResources
 {

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
@@ -44,8 +44,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
 
-
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.CONTENT_TRACKING_ID;
 import static org.commonjava.indy.folo.ctl.FoloConstants.ACCESS_CHANNEL;
 import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_KEY;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
@@ -97,8 +97,10 @@ public class FoloContentAccessResource
         EventMetadata metadata =
                 new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO ).set(
                         STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
+
+        Class cls = FoloContentAccessResource.class;
         return handler.doCreate( packageType, type, name, path, request, metadata, () -> uriInfo.getBaseUriBuilder()
-                                                                                   .path( getClass() )
+                                                                                   .path( cls )
                                                                                    .path( path )
                                                                                    .build( id, packageType, type, name ) );
     }
@@ -124,7 +126,7 @@ public class FoloContentAccessResource
         EventMetadata metadata =
                 new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO );
 
-        MDC.put( TRACKING_KEY, id );
+        MDC.put( CONTENT_TRACKING_ID, id );
 
         return handler.doHead( packageType, type, name, path, cacheOnly, baseUri, request, metadata );
     }
@@ -149,7 +151,7 @@ public class FoloContentAccessResource
         EventMetadata metadata =
                 new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO );
 
-        MDC.put( TRACKING_KEY, id );
+        MDC.put( CONTENT_TRACKING_ID, id );
 
         return handler.doGet( packageType, type, name, path, baseUri, request, metadata );
     }

--- a/addons/hosted-by-archive/jaxrs/src/main/java/org/commonjava/indy/hostedbyarc/bind/jaxrs/IndyHostedByArchiveResource.java
+++ b/addons/hosted-by-archive/jaxrs/src/main/java/org/commonjava/indy/hostedbyarc/bind/jaxrs/IndyHostedByArchiveResource.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.ctl.AdminController;
 import org.commonjava.indy.hostedbyarc.HostedByArchiveManager;
 import org.commonjava.indy.hostedbyarc.config.HostedByArchiveConfig;
@@ -64,6 +65,7 @@ import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAV
 @Api( value = "Hosted by archive", description = "Create a new maven hosted store by zip file" )
 @Path( "/api/admin/stores/maven/hosted/{name}/compressed-content" )
 @ApplicationScoped
+@REST
 public class IndyHostedByArchiveResource
         implements IndyResources
 {

--- a/addons/httprox/common/pom.xml
+++ b/addons/httprox/common/pom.xml
@@ -37,6 +37,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-keycloak</artifactId>
     </dependency>
     <dependency>

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
@@ -33,6 +33,7 @@ import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.xnio.channels.Channels;
 import org.xnio.channels.StreamSinkChannel;
 import org.xnio.conduits.ConduitStreamSinkChannel;
@@ -47,6 +48,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.HTTP_STATUS;
 import static org.commonjava.indy.httprox.util.ChannelUtils.DEFAULT_READ_BUF_SIZE;
 import static org.commonjava.indy.httprox.util.ChannelUtils.flush;
 import static org.commonjava.indy.httprox.util.ChannelUtils.write;
@@ -104,6 +106,8 @@ public class HttpConduitWrapper
     public void writeStatus( final ApplicationStatus status )
             throws IOException
     {
+        MDC.put( HTTP_STATUS, String.valueOf( status.code() ) );
+
         final ByteBuffer b =
                 ByteBuffer.wrap( String.format( "HTTP/1.1 %d %s\r\n", status.code(), status.message() ).getBytes() );
         sinkChannel.write( b );
@@ -113,6 +117,8 @@ public class HttpConduitWrapper
     public void writeStatus( final int code, final String message )
             throws IOException
     {
+        MDC.put( HTTP_STATUS, String.valueOf( code ) );
+
         final ByteBuffer b = ByteBuffer.wrap( String.format( "HTTP/1.1 %d %s\r\n", code, message ).getBytes() );
         sinkChannel.write( b );
     }

--- a/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
+++ b/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiResponse;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.koji.data.KojiRepairException;
 import org.commonjava.indy.koji.data.KojiRepairManager;
 import org.commonjava.indy.koji.model.KojiMultiRepairResult;
@@ -59,6 +60,7 @@ import static org.commonjava.indy.util.ApplicationContent.application_json;
 @Api( value = "Koji repairVolume operation", description = "Repair Koji remote repositories." )
 @Path( "/api/" + REPAIR_KOJI )
 @Produces( { application_json } )
+@REST
 public class KojiRepairResource
                 implements IndyResources
 {

--- a/addons/pkg-maven/jaxrs/src/main/java/org/commonjava/indy/pkg/maven/jaxrs/MavenContentAccessResource.java
+++ b/addons/pkg-maven/jaxrs/src/main/java/org/commonjava/indy/pkg/maven/jaxrs/MavenContentAccessResource.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.bind.jaxrs.PackageContentAccessResource;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
@@ -50,6 +51,7 @@ import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEA
 @Api( value = "Maven Content Access and Storage",
       description = "Handles retrieval and management of Maven artifact content. This is the main point of access for Maven/Gradle users." )
 @Path( "/api/content/maven/{type: (hosted|group|remote)}/{name}" )
+@REST
 public class MavenContentAccessResource
         implements PackageContentAccessResource
 {
@@ -82,9 +84,10 @@ public class MavenContentAccessResource
     {
         final EventMetadata metadata = new EventMetadata().set( STORE_HTTP_HEADERS,
                                                                 RequestUtils.extractRequestHeadersToMap( request ) );
+        Class cls = MavenContentAccessResource.class;
         return handler.doCreate( MAVEN_PKG_KEY, type, name, path, request,
                                  metadata, () -> uriInfo.getBaseUriBuilder()
-                                                                   .path( getClass() )
+                                                                   .path( cls )
                                                                    .path( path )
                                                                    .build( MAVEN_PKG_KEY, type, name ) );
     }

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.binary.Base64;
 import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
@@ -71,6 +72,7 @@ import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 
 @ApplicationScoped
 @NPMContentHandler
+@REST
 public class NPMContentAccessHandler
         extends ContentAccessHandler
 {

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.bind.jaxrs.PackageContentAccessResource;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.pkg.npm.inject.NPMContentHandler;
@@ -52,6 +53,7 @@ import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEA
 @Api( value = "NPM Content Access and Storage", description = "Handles retrieval and management of NPM artifact content. This is the main point of access for NPM users." )
 @Path( "/api/content/npm/{type: (hosted|group|remote)}/{name}" )
 @ApplicationScoped
+@REST
 public class NPMContentAccessResource
                 implements PackageContentAccessResource
 {
@@ -88,9 +90,10 @@ public class NPMContentAccessResource
                 new EventMetadata().set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() )
                                                          .set( STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
 
+        Class cls = NPMContentAccessResource.class;
         return handler.doCreate( NPM_PKG_KEY, type, name, packageName, request, eventMetadata,
                                  () -> uriInfo.getBaseUriBuilder()
-                                              .path( getClass() )
+                                              .path( cls )
                                               .path( packageName )
                                               .build( NPM_PKG_KEY, type, name ) );
     }
@@ -109,8 +112,9 @@ public class NPMContentAccessResource
             final @Context HttpServletRequest request )
     {
         final String path = Paths.get( packageName, versionTarball ).toString();
+        Class cls = NPMContentAccessResource.class;
         return handler.doCreate( NPM_PKG_KEY, type, name, path, request, new EventMetadata(), () -> uriInfo.getBaseUriBuilder()
-                                                                                                           .path( getClass() )
+                                                                                                           .path( cls )
                                                                                                            .path( path )
                                                                                                            .build( NPM_PKG_KEY,
                                                                                                                    type,

--- a/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteResource.java
+++ b/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteResource.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.promote.data.PromotionException;
 import org.commonjava.indy.promote.data.PromotionManager;
 import org.commonjava.indy.promote.model.GroupPromoteRequest;
@@ -56,6 +57,7 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
 @Api( value="Content Promotion", description = "Promote content from a source repository to a target repository or group." )
 @Path( "/api/promotion" )
 @Produces( { application_json } )
+@REST
 public class PromoteResource
         implements IndyResources
 {

--- a/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/ChangelogResource.java
+++ b/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/ChangelogResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.revisions.RevisionsManager;
@@ -43,6 +44,7 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponse
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 
 @Path( "/api/revisions/changelog" )
+@REST
 public class ChangelogResource
         implements IndyResources
 {

--- a/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/RevisionsAdminResource.java
+++ b/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/RevisionsAdminResource.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.bind.jaxrs.util.ResponseUtils;
 import org.commonjava.indy.revisions.RevisionsManager;
 import org.commonjava.indy.revisions.jaxrs.dto.ChangeSummaryDTO;
@@ -45,6 +46,7 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 @Api( "Data-Directory Revisions" )
 @Path( "/api/admin/revisions" )
 @ApplicationScoped
+@REST
 public class RevisionsAdminResource
         implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/DeprecatedContentAccessResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/DeprecatedContentAccessResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -53,6 +54,7 @@ import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEA
       description = "Handles retrieval and management of file/artifact content. This is the main point of access for most users." )
 @Path( "/api/{type: (hosted|group|remote)}/{name}" )
 @ApplicationScoped
+@REST
 public class DeprecatedContentAccessResource
         implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/GenericContentAccessResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/GenericContentAccessResource.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +50,7 @@ import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAV
       description = "Handles retrieval and management of Maven artifact content. This is the main point of access for Maven/Gradle users." )
 @Path( "/api/content/generic-http/{type: (hosted|group|remote)}/{name}" )
 @ApplicationScoped
+@REST
 public class GenericContentAccessResource
         implements PackageContentAccessResource
 {
@@ -79,9 +81,10 @@ public class GenericContentAccessResource
             final @PathParam( "path" ) String path, final @Context UriInfo uriInfo,
             final @Context HttpServletRequest request )
     {
+        Class cls = GenericContentAccessResource.class;
         return handler.doCreate( GENERIC_PKG_KEY, type, name, path, request,
                                  new EventMetadata(), () -> uriInfo.getBaseUriBuilder()
-                                                                   .path( getClass() )
+                                                                   .path( cls )
                                                                    .path( path )
                                                                    .build( GENERIC_PKG_KEY, type, name ) );
     }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/NfcResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/NfcResource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.ctl.NfcController;
 import org.commonjava.indy.core.model.Page;
 import org.commonjava.indy.model.core.StoreKey;
@@ -52,6 +53,7 @@ import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAV
 
 @Api( description = "REST resource that manages the not-found cache", value = "Not-Found Cache" )
 @Path( "/api/nfc" )
+@REST
 public class NfcResource
         implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/PackageContentAccessResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/PackageContentAccessResource.java
@@ -20,6 +20,7 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
@@ -39,6 +40,7 @@ import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 /**
  * Created by jdcasey on 5/10/17.
  */
+@REST
 public interface PackageContentAccessResource
         extends IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/RootResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/RootResource.java
@@ -27,8 +27,10 @@ import javax.ws.rs.core.UriBuilderException;
 import javax.ws.rs.core.UriInfo;
 
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 
 //@Path( "/" )
+@REST
 public class RootResource
     implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/DeprecatedStoreAdminHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/DeprecatedStoreAdminHandler.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.ctl.AdminController;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
@@ -77,6 +78,7 @@ import static org.commonjava.indy.util.ApplicationContent.application_json;
 @Api( description = "DEPRECATED: Resource for accessing and managing artifact store definitions", value = "Store Administration" )
 @Path( "/api/admin/{type: (hosted|group|remote)}" )
 @ApplicationScoped
+@REST
 public class DeprecatedStoreAdminHandler
     implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
@@ -34,6 +34,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.core.ctl.IspnCacheController;
 import org.commonjava.indy.model.core.StoreKey;
@@ -45,6 +46,7 @@ import java.nio.file.Paths;
 
 @Api( value="Maintenance", description = "Basic repository maintenance functions" )
 @Path( "/api/admin/maint" )
+@REST
 public class MaintenanceHandler
     implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/ReplicationHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/ReplicationHandler.java
@@ -39,6 +39,7 @@ import io.swagger.annotations.ApiOperation;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.ctl.ReplicationController;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.dto.ReplicationDTO;
@@ -51,6 +52,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Api( description = "Replicate the artifact stores on a remote Indy instance, either by proxying the remote system's stores or by cloning the store definitions",
       value = "Indy Repository Replication" )
 @Path( "/api/admin/replicate" )
+@REST
 public class ReplicationHandler
         implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/SchedulerHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/SchedulerHandler.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.bind.jaxrs.util.ResponseUtils;
 import org.commonjava.indy.core.ctl.SchedulerController;
 import org.commonjava.indy.core.expire.Expiration;
@@ -50,6 +51,7 @@ import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAV
       description = "Retrieve and manipulate scheduled expirations for various parts of Indy" )
 @Path( "/api/admin/schedule" )
 @Produces( ApplicationContent.application_json )
+@REST
 public class SchedulerHandler
         implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/StoreAdminHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/StoreAdminHandler.java
@@ -61,6 +61,7 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.bind.jaxrs.util.ResponseUtils;
 import org.commonjava.indy.core.ctl.AdminController;
 import org.commonjava.indy.model.core.ArtifactStore;
@@ -77,6 +78,7 @@ import org.slf4j.LoggerFactory;
 @Api( description = "Resource for accessing and managing artifact store definitions", value = "Store Administration" )
 @Path( "/api/admin/stores/{packageType}/{type: (hosted|group|remote)}" )
 @ApplicationScoped
+@REST
 public class StoreAdminHandler
     implements IndyResources
 {

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/stats/StatsHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/stats/StatsHandler.java
@@ -39,6 +39,7 @@ import io.swagger.annotations.ApiResponse;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.ctl.StatsController;
 import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.dto.EndpointViewListing;
@@ -53,6 +54,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Api( description = "Various read-only operations for retrieving information about the system.", value = "Generic Infrastructure Queries (UI Support)" )
 @Path( "/api/stats" )
+@REST
 public class StatsHandler
     implements IndyResources
 {

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -151,6 +151,7 @@ public class ContentController
     {
         final ArtifactStore store = getStore( key );
 
+        validatePath( key, path );
         return contentManager.retrieve( store, path, eventMetadata );
     }
 
@@ -184,9 +185,19 @@ public class ContentController
     {
         final ArtifactStore store = getStore( key );
 
+        validatePath( key, path );
         logger.info( "Storing: {} in: {} with event metadata: {}", path, store, eventMetadata );
 
         return contentManager.store( store, path, stream, TransferOperation.UPLOAD, eventMetadata );
+    }
+
+    private void validatePath( final StoreKey key, final String path )
+            throws IndyWorkflowException
+    {
+        if ( path.contains( "{" ) || path.contains( "}" ) || path.contains("@@") || path.contains("%") )
+        {
+            throw new IndyWorkflowException( 400, "Invalid path: %s (target repo: %s)", path, key );
+        }
     }
 
     public void rescan( final StoreKey key )
@@ -309,6 +320,8 @@ public class ContentController
         {
             path = normalize( parentPath( path ) );
         }
+
+        validatePath( key, path );
 
         final List<StoreResource> listed = getListing( key, path, eventMetadata );
         if ( ApplicationContent.application_json.equals( acceptHeader ) )
@@ -456,6 +469,8 @@ public class ContentController
     public List<StoreResource> getListing( final StoreKey key, final String path, final EventMetadata eventMetadata )
         throws IndyWorkflowException
     {
+        validatePath( key, path );
+
         final ArtifactStore store = getStore( key );
         return contentManager.list( store, path, eventMetadata );
     }
@@ -502,6 +517,7 @@ public class ContentController
     public Transfer getTransfer( final StoreKey storeKey, final String path, final TransferOperation op )
         throws IndyWorkflowException
     {
+        validatePath( storeKey, path );
         return contentManager.getTransfer( storeKey, path, op );
     }
 
@@ -519,6 +535,7 @@ public class ContentController
     }
 
     public boolean exists(StoreKey sk, String path) throws IndyWorkflowException {
+        validatePath( sk, path );
         return contentManager.exists( getStore( sk ), path );
     }
 }

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
 
@@ -194,7 +195,8 @@ public class ContentController
     private void validatePath( final StoreKey key, final String path )
             throws IndyWorkflowException
     {
-        if ( path.contains( "{" ) || path.contains( "}" ) || path.contains("@@") || path.contains("%") )
+        if ( isNotBlank( path ) && ( path.contains( "{" ) || path.contains( "}" ) || path.contains( "@@" )
+                || path.contains( "%" ) ) )
         {
             throw new IndyWorkflowException( 400, "Invalid path: %s (target repo: %s)", path, key );
         }

--- a/deployments/launcher/src/main/resources/META-INF/beans.xml
+++ b/deployments/launcher/src/main/resources/META-INF/beans.xml
@@ -21,6 +21,7 @@
   </alternatives>
   
   <interceptors>
+    <class>org.commonjava.indy.bind.jaxrs.util.RestInterceptor</class>
     <class>org.commonjava.indy.metrics.jaxrs.interceptor.MetricsInterceptor</class>
   </interceptors>
 

--- a/embedder/src/main/resources/META-INF/beans.xml
+++ b/embedder/src/main/resources/META-INF/beans.xml
@@ -28,6 +28,7 @@
   </alternatives>
 
   <interceptors>
+    <class>org.commonjava.indy.bind.jaxrs.util.RestInterceptor</class>
     <class>org.commonjava.indy.metrics.jaxrs.interceptor.MetricsInterceptor</class>
   </interceptors>
 

--- a/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/jaxrs/MetricsTestResource.java
+++ b/ftests/metrics/src/main/java/org/commonjava/indy/ftest/metrics/jaxrs/MetricsTestResource.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.measure.annotation.MetricNamed;
 import org.slf4j.Logger;

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolInfo.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolInfo.java
@@ -15,15 +15,13 @@
  */
 package org.commonjava.indy.subsys.cpool;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.Properties;
-
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 public class ConnectionPoolInfo
 {
     private final String name;
+
+    private Properties datasourceProperties;
 
     private boolean useMetrics;
 

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolInfo.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolInfo.java
@@ -21,8 +21,6 @@ public class ConnectionPoolInfo
 {
     private final String name;
 
-    private Properties datasourceProperties;
-
     private boolean useMetrics;
 
     private boolean useHealthChecks;

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolProvider.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolProvider.java
@@ -17,32 +17,20 @@ package org.commonjava.indy.subsys.cpool;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
-import com.sun.jndi.rmi.registry.RegistryContextFactory;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import org.commonjava.cdi.util.weft.WeftExecutorService;
-import org.commonjava.indy.action.BootupAction;
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import java.rmi.RemoteException;
-import java.rmi.registry.LocateRegistry;
-import java.rmi.registry.Registry;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 @ApplicationScoped
 public class ConnectionPoolProvider

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyResources.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyResources.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.indy.bind.jaxrs;
 
+import org.commonjava.indy.bind.jaxrs.util.REST;
+
 /**
  * Marker interface that denotes a class providing JAX-RS resource methods. This is used to collect resources for use in an undertow/resteasy 
  * deployment.

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/MDCManager.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/MDCManager.java
@@ -39,6 +39,7 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.CLIENT_ADDR;
 import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.COMPONENT_ID;
 import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.EXTERNAL_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.HTTP_METHOD;
 import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.INTERNAL_ID;
 import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.PREFERRED_ID;
 
@@ -104,6 +105,7 @@ public class MDCManager
 
     public void putExtraHeaders( HttpServletRequest request )
     {
+        MDC.put( HTTP_METHOD, request.getMethod() );
         mdcHeadersList.forEach( ( header ) -> MDC.put( header, request.getHeader( header ) ) );
     }
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RequestContextConstants.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RequestContextConstants.java
@@ -43,6 +43,42 @@ public class RequestContextConstants
 
     //
 
+    @MDC
+    public static final String REST_CLASS_PATH = "REST-class-path";
+
+    @MDC
+    public static final String REST_METHOD_PATH = "REST-method-path";
+
+    @MDC
+    public static final String REST_CLASS = "REST-class";
+
+    @MDC
+    public static final String CONTENT_TRACKING_ID = "tracking-id";
+
+    @MDC
+    public static final String ACCESS_CHANNEL = "access-channel";
+
+    @MDC
+    public static final String REQUEST_LATENCY_NS = "request-latency-ns";
+
+    @MDC
+    public static final String PACKAGE_TYPE = "package-type";
+
+    @MDC
+    public static final String METADATA_CONTENT = "metadata-content";
+
+    @MDC
+    public static final String CONTENT_ENTRY_POINT = "content-entry-point";
+
+    @MDC
+    public static final String HTTP_METHOD = "http-method";
+
+    @MDC
+    public static final String PATH = "path";
+
+    @MDC
+    public static final String HTTP_STATUS = "http-status";
+
     @Header @MDC
     public static final String COMPONENT_ID = HEADER_COMPONENT_ID; // "component-id";
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RequestContextConstants.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RequestContextConstants.java
@@ -50,6 +50,9 @@ public class RequestContextConstants
     public static final String REST_METHOD_PATH = "REST-method-path";
 
     @MDC
+    public static final String REST_ENDPOINT_PATH = "REST-endpoint-path";
+
+    @MDC
     public static final String REST_CLASS = "REST-class";
 
     @MDC

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/SecurityResource.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/SecurityResource.java
@@ -21,6 +21,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.subsys.keycloak.rest.SecurityController;
 import org.commonjava.indy.util.ApplicationHeader;
 import org.slf4j.Logger;
@@ -39,6 +40,7 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 
 @Api( "Security Infrastructure" )
 @Path( "/api/security" )
+@REST
 public class SecurityResource
         implements IndyResources
 {

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/REST.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/REST.java
@@ -1,0 +1,15 @@
+package org.commonjava.indy.bind.jaxrs.util;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Target( { TYPE } )
+@Retention( RUNTIME )
+public @interface REST
+{
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.bind.jaxrs.MDCManager;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.dto.CreationDTO;
 import org.commonjava.indy.model.util.HttpUtils;
@@ -31,6 +32,7 @@ import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
@@ -45,7 +47,8 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
+
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.HTTP_STATUS;
 
 public final class ResponseUtils
 {
@@ -304,9 +307,11 @@ public final class ResponseUtils
         ResponseBuilder builder = null;
         if ( code / 100 == 5 )
         {
+            MDC.put( HTTP_STATUS, String.valueOf( 502 ) );
             builder = Response.status( 502 );
         }
 
+        MDC.put( HTTP_STATUS, String.valueOf( code ) );
         builder = Response.status( code );
         if ( builderModifier != null )
         {
@@ -474,6 +479,8 @@ public final class ResponseUtils
         {
             LOGGER.debug( "Sending response: {} {}\n{}", code.getStatusCode(), code.getReasonPhrase(), msg );
         }
+
+        MDC.put( HTTP_STATUS, String.valueOf( code ) );
 
         ResponseBuilder builder = Response.status( code ).type( MediaType.TEXT_PLAIN ).entity( msg );
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/RestInterceptor.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/RestInterceptor.java
@@ -1,0 +1,54 @@
+package org.commonjava.indy.bind.jaxrs.util;
+
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import javax.ws.rs.Path;
+
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_CLASS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_CLASS_PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_METHOD_PATH;
+
+@Interceptor
+@REST
+public class RestInterceptor
+{
+    @AroundInvoke
+    public Object operation( InvocationContext context ) throws Exception
+    {
+        Class<?> targetClass = context.getTarget().getClass();
+        Path classAnno = null;
+        do
+        {
+            classAnno = targetClass.getAnnotation( Path.class );
+            targetClass = targetClass.getSuperclass();
+        }
+        while( classAnno == null && targetClass != null );
+
+        if ( MDC.get( REST_CLASS ) == null )
+        {
+            String targetName = context.getTarget().getClass().getSimpleName();
+            MDC.put( REST_CLASS, targetName );
+
+            if ( classAnno != null && MDC.get( REST_CLASS_PATH ) == null )
+            {
+                MDC.put( REST_CLASS_PATH, classAnno.value() );
+            }
+
+            Path methAnno = context.getMethod().getAnnotation( Path.class );
+            if ( methAnno != null && MDC.get( REST_METHOD_PATH ) == null  )
+            {
+                MDC.put( REST_METHOD_PATH, methAnno.value() );
+            }
+        }
+
+        LoggerFactory.getLogger( context.getTarget().getClass() ).info( "Interceptor decorating MDC." );
+
+        return context.proceed();
+    }
+
+
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/RestInterceptor.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/RestInterceptor.java
@@ -8,8 +8,11 @@ import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import javax.ws.rs.Path;
 
+import java.nio.file.Paths;
+
 import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_CLASS;
 import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_CLASS_PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_ENDPOINT_PATH;
 import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_METHOD_PATH;
 
 @Interceptor
@@ -33,15 +36,21 @@ public class RestInterceptor
             String targetName = context.getTarget().getClass().getSimpleName();
             MDC.put( REST_CLASS, targetName );
 
+            String classPath = "";
             if ( classAnno != null && MDC.get( REST_CLASS_PATH ) == null )
             {
-                MDC.put( REST_CLASS_PATH, classAnno.value() );
+                classPath = classAnno.value();
+                MDC.put( REST_CLASS_PATH, classPath );
             }
 
             Path methAnno = context.getMethod().getAnnotation( Path.class );
             if ( methAnno != null && MDC.get( REST_METHOD_PATH ) == null  )
             {
-                MDC.put( REST_METHOD_PATH, methAnno.value() );
+                String methodPath = methAnno.value();
+                MDC.put( REST_METHOD_PATH, methodPath );
+
+                String endpointPath = Paths.get( classPath, methodPath ).toString();
+                MDC.put( REST_ENDPOINT_PATH, endpointPath );
             }
         }
 

--- a/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/Measure.java
+++ b/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/Measure.java
@@ -33,11 +33,5 @@ public @interface Measure
 
     @Nonbinding MetricNamed[] timers() default {};
 
-    @Nonbinding MetricNamed[] guages() default {};
-
-    @Nonbinding MetricNamed[] counters() default {};
-
-    @Nonbinding MetricNamed[] hisograms() default {};
-
     @Nonbinding MetricNamed[] exceptions() default {};
 }

--- a/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/MetricsConstants.java
+++ b/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/MetricsConstants.java
@@ -1,0 +1,11 @@
+package org.commonjava.indy.metrics;
+
+public class MetricsConstants
+{
+    public static final String METRICS_PHASE = "metrics-phase";
+
+    public static final String PRELIMINARY_METRICS = "preliminary";
+
+    public static final String FINAL_METRICS = "final";
+
+}


### PR DESCRIPTION
I thought I had already submitted / merged a PR for the connection pool simplification, but it came up here, so I'm submitting it again to make sure it goes through.

The rest of this is adding MDC information to make it easier to produce graphs for SLI analysis and tracking, along with production support (by adding parameters we can filter on and avoid all kinds of partial string searches). I'm also adding two new log statements in the MetricsInterceptor that will push the stats we're putting into our metrics system as MDC parameters. This might allow us to try out using ES / Kibana as a replacement (or refinement) for Graphite + Grafana.