### PR TITLE
Improve maven metadata cache query via keyCache

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -24,11 +24,8 @@ import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.pkg.maven.content.MetadataCacheKey;
-import org.commonjava.indy.pkg.maven.content.MetadataInfo;
-import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
+import org.commonjava.indy.pkg.maven.content.MetadataCacheManager;
 import org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger;
-import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.event.FileDeletionEvent;
 import org.commonjava.maven.galley.event.FileEvent;
@@ -44,7 +41,6 @@ import java.util.Set;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
 import static org.commonjava.indy.pkg.maven.content.MetadataUtil.getMetadataPath;
-import static org.commonjava.indy.pkg.maven.content.MetadataUtil.remove;
 import static org.commonjava.indy.util.LocationUtils.getKey;
 
 @javax.enterprise.context.ApplicationScoped
@@ -63,8 +59,7 @@ public class MetadataMergePomChangeListener
     private IndyFileEventManager fileEvent;
 
     @Inject
-    @MavenMetadataCache
-    private CacheHandle<MetadataCacheKey, MetadataInfo> metadataCache;
+    private MetadataCacheManager cacheManager;
 
     /**
      * this listener observes {@link org.commonjava.maven.galley.event.FileStorageEvent}
@@ -106,7 +101,7 @@ public class MetadataMergePomChangeListener
                 {
                     if ( doClear( hosted, clearPath ) )
                     {
-                        remove( hosted.getKey(), clearPath, metadataCache );
+                        cacheManager.remove( hosted.getKey(), clearPath );
                     }
                 }
                 catch ( final IOException e )
@@ -125,7 +120,7 @@ public class MetadataMergePomChangeListener
                         {
                             if ( doClear( group, clearPath ) )
                             {
-                                remove( group.getKey(), clearPath, metadataCache );
+                                cacheManager.remove( group.getKey(), clearPath );
                             }
                         }
                         catch ( final IOException e )

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheManager.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheManager.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.content;
+
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
+import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataKeyCache;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class MetadataCacheManager
+{
+    protected final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    @MavenMetadataCache
+    private CacheHandle<MetadataKey, MetadataInfo> metadataCache;
+
+    @Inject
+    @MavenMetadataKeyCache
+    private CacheHandle<MetadataKey, MetadataKey> metadataKeyCache;
+
+    private QueryFactory queryFactory;
+
+    public MetadataCacheManager()
+    {
+    }
+
+    @PostConstruct
+    private void init()
+    {
+        this.queryFactory = Search.getQueryFactory( metadataKeyCache.getCache() );
+    }
+
+    public MetadataCacheManager( CacheHandle<MetadataKey, MetadataInfo> metadataCache,
+                                 CacheHandle<MetadataKey, MetadataKey> metadataKeyCache )
+    {
+        this.metadataCache = metadataCache;
+        this.metadataKeyCache = metadataKeyCache;
+        this.queryFactory = Search.getQueryFactory( metadataKeyCache.getCache() );
+    }
+
+    public void put( MetadataKey metadataKey, MetadataInfo metadataInfo )
+    {
+        metadataKeyCache.put( metadataKey, metadataKey );
+        metadataCache.put( metadataKey, metadataInfo );
+    }
+
+    public MetadataInfo get( MetadataKey metadataKey )
+    {
+        return metadataCache.get( metadataKey );
+    }
+
+    public void remove( StoreKey storeKey, String path )
+    {
+        remove( new MetadataKey( storeKey, path ) );
+    }
+
+    public void remove( StoreKey key, Set<String> paths )
+    {
+        paths.forEach( p -> remove( new MetadataKey( key, p ) ) );
+    }
+
+    public void remove( MetadataKey metadataKey )
+    {
+        metadataKeyCache.remove( metadataKey );
+        metadataCache.remove( metadataKey );
+    }
+
+    public void removeAll( StoreKey key )
+    {
+        getMatches( key ).forEach( k -> remove( k ) );
+    }
+
+    public Set<String> getAllPaths( StoreKey key )
+    {
+        return getMatches( key ).stream().map( ( k ) -> k.getPath() ).collect( Collectors.toSet() );
+    }
+
+    private List<MetadataKey> getMatches( StoreKey key )
+    {
+        Query query = queryFactory.from( MetadataKey.class )
+                                  .having( "storeKey.packageType" )
+                                  .eq( key.getPackageType() )
+                                  .and()
+                                  .having( "storeKey.type" )
+                                  .eq( key.getType().toString() )
+                                  .and()
+                                  .having( "storeKey.name" )
+                                  .eq( key.getName() )
+                                  .build();
+        List<MetadataKey> matches = query.list();
+
+        logger.debug( "Query metadataKeyCache for storeKey: {}, size: {}", key, matches.size() );
+        return matches;
+    }
+
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKey.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKey.java
@@ -1,20 +1,27 @@
 package org.commonjava.indy.pkg.maven.content;
 
 import org.commonjava.indy.model.core.StoreKey;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
 
 import java.io.Serializable;
 import java.util.Objects;
 
-public final class MetadataCacheKey
+@Indexed
+public final class MetadataKey
                 implements Serializable
 {
     private static final long serialVersionUID = 1L;
 
+    @Field( index = Index.YES, analyze = Analyze.NO )
     private final StoreKey storeKey;
 
+    @Field( index = Index.NO, analyze = Analyze.NO )
     private final String path;
 
-    public MetadataCacheKey( StoreKey storeKey, String path )
+    public MetadataKey( StoreKey storeKey, String path )
     {
         this.storeKey = storeKey;
         this.path = path;
@@ -37,7 +44,7 @@ public final class MetadataCacheKey
             return true;
         if ( o == null || getClass() != o.getClass() )
             return false;
-        MetadataCacheKey that = (MetadataCacheKey) o;
+        MetadataKey that = (MetadataKey) o;
         return Objects.equals( storeKey, that.storeKey ) && Objects.equals( path, that.path );
     }
 
@@ -55,11 +62,11 @@ public final class MetadataCacheKey
         return storeKey.toString() + DELIMIT + path; // e.g., maven:remote:central#/foo/bar/1.0/bar-1.0.pom
     }
 
-    public static MetadataCacheKey fromString( String str )
+    public static MetadataKey fromString( String str )
     {
         int idx = str.lastIndexOf( DELIMIT );
         String storekey = str.substring( 0, idx );
         String path = str.substring( idx + 1 );
-        return new MetadataCacheKey( StoreKey.fromString( storekey ), path );
+        return new MetadataKey( StoreKey.fromString( storekey ), path );
     }
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKey.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKey.java
@@ -3,6 +3,7 @@ package org.commonjava.indy.pkg.maven.content;
 import org.commonjava.indy.model.core.StoreKey;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.Indexed;
 
@@ -16,6 +17,7 @@ public final class MetadataKey
     private static final long serialVersionUID = 1L;
 
     @Field( index = Index.YES, analyze = Analyze.NO )
+    @FieldBridge( impl = StoreKeyBridge.class )
     private final StoreKey storeKey;
 
     @Field( index = Index.NO, analyze = Analyze.NO )
@@ -54,12 +56,12 @@ public final class MetadataKey
         return Objects.hash( storeKey, path );
     }
 
-    private static final String DELIMIT = "#";
+    private static final String DELIMIT = ",";
 
     @Override
     public String toString()
     {
-        return storeKey.toString() + DELIMIT + path; // e.g., maven:remote:central#/foo/bar/1.0/bar-1.0.pom
+        return storeKey.toString() + DELIMIT + path; // e.g., maven:remote:central,/foo/bar/1.0/bar-1.0.pom
     }
 
     public static MetadataKey fromString( String str )

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKey2StringMapper.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKey2StringMapper.java
@@ -2,20 +2,20 @@ package org.commonjava.indy.pkg.maven.content;
 
 import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
 
-public final class MetadataCacheKey2StringMapper
+public final class MetadataKey2StringMapper
                 implements TwoWayKey2StringMapper
 {
 
     @Override
     public Object getKeyMapping( String s )
     {
-        return MetadataCacheKey.fromString( s );
+        return MetadataKey.fromString( s );
     }
 
     @Override
     public boolean isSupportedType( Class<?> aClass )
     {
-        return aClass == MetadataCacheKey.class;
+        return aClass == MetadataKey.class;
     }
 
     @Override

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKeyTransformer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKeyTransformer.java
@@ -1,0 +1,19 @@
+package org.commonjava.indy.pkg.maven.content;
+
+import org.infinispan.query.Transformer;
+
+public class MetadataKeyTransformer
+                implements Transformer
+{
+    @Override
+    public Object fromString( String s )
+    {
+        return MetadataKey.fromString( s );
+    }
+
+    @Override
+    public String toString( Object o )
+    {
+        return o.toString();
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataMergeListener.java
@@ -19,8 +19,6 @@ import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.MergedContentAction;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
-import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
-import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +42,7 @@ public class MetadataMergeListener
     private DirectContentAccess fileManager;
 
     @Inject
-    @MavenMetadataCache
-    private CacheHandle<MetadataCacheKey, MetadataInfo> metadataCache;
+    private MetadataCacheManager cacheManager;
 
     /**
      * Will clear the both merge path and merge info file of member and group contains that member(cascaded)
@@ -55,9 +52,9 @@ public class MetadataMergeListener
     public void clearMergedPath( ArtifactStore originatingStore, Set<Group> affectedGroups, String path )
     {
         logger.debug( "Clear merged path {}, origin: {}, affected: {}", path, originatingStore, affectedGroups );
-        metadataCache.remove( new MetadataCacheKey( originatingStore.getKey(), path ) );
+        cacheManager.remove( new MetadataKey( originatingStore.getKey(), path ) );
         affectedGroups.forEach( group -> {
-            metadataCache.remove( new MetadataCacheKey( group.getKey(), path ) );
+            cacheManager.remove( new MetadataKey( group.getKey(), path ) );
         } );
     }
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataUtil.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataUtil.java
@@ -1,48 +1,14 @@
 package org.commonjava.indy.pkg.maven.content;
 
-import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.subsys.infinispan.CacheHandle;
-
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import static org.commonjava.indy.pkg.maven.content.group.MavenMetadataMerger.METADATA_NAME;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
 
 public class MetadataUtil
 {
-    public static void removeAll( StoreKey storeKey, CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
-    {
-        cacheHandle.executeCache( ( cache ) -> {
-            cache.keySet()
-                 .stream()
-                 .filter( ( k ) -> k.getStoreKey().equals( storeKey ) )
-                 .forEach( ( k ) -> cache.remove( k ) );
-            return null;
-        } );
-    }
-
-    public static void remove( StoreKey storeKey, Set<String> paths,
-                               CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
-    {
-        paths.forEach( p -> cacheHandle.remove( new MetadataCacheKey( storeKey, p ) ) );
-    }
-
-    public static void remove( StoreKey storeKey, String path, CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
-    {
-        cacheHandle.remove( new MetadataCacheKey( storeKey, path ) );
-    }
-
-    public static Set<String> getAllPaths( StoreKey storeKey, CacheHandle<MetadataCacheKey, MetadataInfo> cacheHandle )
-    {
-        return cacheHandle.executeCache( ( cache ) -> cache.keySet()
-                                                           .stream()
-                                                           .filter( ( k ) -> k.getStoreKey().equals( storeKey ) )
-                                                           .map( ( k ) -> k.getPath() )
-                                                           .collect( Collectors.toSet() ) );
-    }
-
+    /**
+     * Get the path/to/metadata.xml given a pom or jar file path.
+     */
     public static String getMetadataPath( String pomPath )
     {
         final String versionPath = normalize( parentPath( pomPath ) );

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/StoreKeyBridge.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/StoreKeyBridge.java
@@ -1,0 +1,14 @@
+package org.commonjava.indy.pkg.maven.content;
+
+import org.commonjava.indy.model.core.StoreKey;
+import org.hibernate.search.bridge.StringBridge;
+
+public class StoreKeyBridge
+                implements StringBridge
+{
+    @Override
+    public String objectToString( Object o )
+    {
+        return ( (StoreKey) o ).toString();
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MavenMetadataKeyCache.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MavenMetadataKeyCache.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.content.cache;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD } )
+@Retention( RetentionPolicy.RUNTIME )
+@Documented
+public @interface MavenMetadataKeyCache
+{
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -17,8 +17,13 @@ package org.commonjava.indy.pkg.maven.content.cache;
 
 import org.commonjava.indy.pkg.maven.content.MetadataKey;
 import org.commonjava.indy.pkg.maven.content.MetadataInfo;
+import org.commonjava.indy.pkg.maven.content.MetadataKeyTransformer;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
+import org.infinispan.query.Search;
+import org.infinispan.query.spi.SearchManagerImplementor;
+
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
@@ -26,6 +31,10 @@ import javax.inject.Inject;
 @ApplicationScoped
 public class MetadataCacheProducer
 {
+    private static final String METADATA_KEY_CACHE = "maven-metadata-key-cache";
+
+    private static final String METADATA_CACHE = "maven-metadata-cache";
+
     @Inject
     private CacheProducer cacheProducer;
 
@@ -34,7 +43,7 @@ public class MetadataCacheProducer
     @ApplicationScoped
     public CacheHandle<MetadataKey, MetadataInfo> mavenMetadataCacheCfg()
     {
-        return cacheProducer.getCache( "maven-metadata-cache" );
+        return cacheProducer.getCache( METADATA_CACHE );
     }
 
     @MavenMetadataKeyCache
@@ -42,6 +51,22 @@ public class MetadataCacheProducer
     @ApplicationScoped
     public CacheHandle<MetadataKey, MetadataKey> mavenMetadataKeyCacheCfg()
     {
-        return cacheProducer.getCache( "maven-metadata-key-cache" );
+        return cacheProducer.getCache( METADATA_KEY_CACHE );
+    }
+
+    @PostConstruct
+    public void initIndexing()
+    {
+        registerTransformer();
+    }
+
+    private void registerTransformer()
+    {
+        final CacheHandle<MetadataKey, MetadataKey> handler = cacheProducer.getCache( METADATA_KEY_CACHE );
+        handler.executeCache( cache -> {
+            SearchManagerImplementor searchManager = (SearchManagerImplementor) Search.getSearchManager( cache );
+            searchManager.registerKeyTransformer( MetadataKey.class, MetadataKeyTransformer.class );
+            return null;
+        } );
     }
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -15,9 +15,8 @@
  */
 package org.commonjava.indy.pkg.maven.content.cache;
 
-import org.commonjava.indy.pkg.maven.content.MetadataCacheKey;
+import org.commonjava.indy.pkg.maven.content.MetadataKey;
 import org.commonjava.indy.pkg.maven.content.MetadataInfo;
-import org.commonjava.indy.subsys.datafile.conf.DataFileConfiguration;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import javax.enterprise.context.ApplicationScoped;
@@ -30,15 +29,19 @@ public class MetadataCacheProducer
     @Inject
     private CacheProducer cacheProducer;
 
-    @Inject
-    private DataFileConfiguration config;
-
-
     @MavenMetadataCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<MetadataCacheKey, MetadataInfo> mavenMetaCacheCfg()
+    public CacheHandle<MetadataKey, MetadataInfo> mavenMetadataCacheCfg()
     {
         return cacheProducer.getCache( "maven-metadata-cache" );
+    }
+
+    @MavenMetadataKeyCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<MetadataKey, MetadataKey> mavenMetadataKeyCacheCfg()
+    {
+        return cacheProducer.getCache( "maven-metadata-key-cache" );
     }
 }

--- a/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MetadataCacheManagerTest.java
+++ b/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MetadataCacheManagerTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.content;
+
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.CacheProducer;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.DefaultCacheManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class MetadataCacheManagerTest
+{
+    private MetadataCacheManager metadataCacheManager;
+
+    private CacheProducer cacheProducer;
+
+    @Before
+    public void setup() throws Exception
+    {
+        DefaultCacheManager cacheManager =
+                        new DefaultCacheManager( new ConfigurationBuilder().simpleCache( true ).build() );
+        cacheProducer = new CacheProducer( null, cacheManager, null );
+        CacheHandle<MetadataKey, MetadataKey> metadataKeyCache = cacheProducer.getCache( "maven-metadata-key-cache" );
+        CacheHandle<MetadataKey, MetadataInfo> metadataCache = cacheProducer.getCache( "maven-metadata-cache" );
+        metadataCacheManager = new MetadataCacheManager( metadataCache, metadataKeyCache );
+    }
+
+    @Test
+    public void query() throws Exception
+    {
+        final MetadataInfo info = new MetadataInfo( null );
+        StoreKey hosted = StoreKey.fromString( "maven:hosted:test" );
+        StoreKey remote = StoreKey.fromString( "maven:remote:test" );
+
+        Set<String> paths = new HashSet<>();
+        for ( int i = 0; i < 20; i++ )
+        {
+            paths.add( "path/to/" + i );
+        }
+
+        paths.forEach( p -> {
+            metadataCacheManager.put( new MetadataKey( hosted, p ), info );
+            metadataCacheManager.put( new MetadataKey( remote, p ), info );
+        } );
+
+        String somePath = "path/to/3";
+
+        MetadataInfo ret = metadataCacheManager.get( new MetadataKey( hosted, somePath ) );
+        assertNotNull( ret );
+
+        Set<String> allPaths = metadataCacheManager.getAllPaths( hosted );
+        assertTrue( allPaths.size() == 20 );
+
+        metadataCacheManager.removeAll( hosted );
+        allPaths = metadataCacheManager.getAllPaths( hosted );
+        assertTrue( allPaths.size() == 0 );
+
+        ret = metadataCacheManager.get( new MetadataKey( hosted, somePath ) );
+        assertNull( ret );
+
+        ret = metadataCacheManager.get( new MetadataKey( remote, somePath ) );
+        assertNotNull( ret );
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        cacheProducer.stop();
+    }
+
+}

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/infinispan/CacheProducerMergeXmlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/infinispan/CacheProducerMergeXmlTest.java
@@ -72,7 +72,7 @@ public class CacheProducerMergeXmlTest
         assertThat( manager.getCacheConfiguration( "indy-nfs-owner-cache" ).memory().addressCount(), equalTo( 1048576 ) );
         assertThat( manager.getCacheConfiguration( "nfc" ), notNullValue() );
         assertThat( manager.getCacheConfiguration( "schedule-expire-cache" ), notNullValue() );
-        assertThat( manager.getCacheConfiguration( "maven-version-metadata-cache" ), notNullValue() );
+        assertThat( manager.getCacheConfiguration( "maven-metadata-cache" ), notNullValue() );
     }
 
     @Override

--- a/subsys/infinispan/src/main/resources/infinispan-jdbc.xml
+++ b/subsys/infinispan/src/main/resources/infinispan-jdbc.xml
@@ -73,9 +73,9 @@
 
     <local-cache name="content-metadata" configuration="local-template"/>
 
-    <local-cache name="maven-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
+    <local-cache name="maven-metadata-cache" configuration="local-template">
       <persistence>
-        <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="true" key-to-string-mapper="org.commonjava.indy.pkg.maven.content.MetadataCacheKey2StringMapper">
+        <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="true" key-to-string-mapper="org.commonjava.indy.pkg.maven.content.MetadataKey2StringMapper">
           <write-behind />
           <jdbc:connection-pool connection-url="jdbc:postgresql://${datasource_server}:${datasource_port}/${datasource_name}" username="${datasource_user}" password="${datasource_password}" driver="org.postgresql.Driver"/>
           <jdbc:string-keyed-table drop-on-exit="false" create-on-start="true" prefix="indy_cache">
@@ -85,6 +85,21 @@
           </jdbc:string-keyed-table>
         </jdbc:string-keyed-jdbc-store>
       </persistence>
+    </local-cache>
+
+    <local-cache name="maven-metadata-key-cache" configuration="local-template">
+      <persistence>
+        <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="true" key-to-string-mapper="org.commonjava.indy.pkg.maven.content.MetadataKey2StringMapper">
+          <write-behind />
+          <jdbc:connection-pool connection-url="jdbc:postgresql://${datasource_server}:${datasource_port}/${datasource_name}" username="${datasource_user}" password="${datasource_password}" driver="org.postgresql.Driver"/>
+          <jdbc:string-keyed-table drop-on-exit="false" create-on-start="true" prefix="indy_cache">
+            <jdbc:id-column name="id_column" type="TEXT" />
+            <jdbc:data-column name="data_column" type="BYTEA" />
+            <jdbc:timestamp-column name="timestamp_column" type="BIGINT" />
+          </jdbc:string-keyed-table>
+        </jdbc:string-keyed-jdbc-store>
+      </persistence>
+      <indexing index="LOCAL" auto-config="true"/>
     </local-cache>
 
     <local-cache name="indy-nfs-owner-cache" deadlock-detection-spin="10000" configuration="local-template">

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -41,10 +41,10 @@
 
     <local-cache name="content-metadata" configuration="local-template"/>
 
-    <local-cache name="maven-version-metadata-cache" deadlock-detection-spin="10000" configuration="local-template">
-      <memory>
-        <object size="2000" strategy="REMOVE" />
-      </memory>
+    <local-cache name="maven-metadata-cache" configuration="local-template"/>
+
+    <local-cache name="maven-metadata-key-cache" configuration="local-template">
+      <indexing index="LOCAL" auto-config="true"/>
     </local-cache>
 
     <local-cache name="indy-nfs-owner-cache" deadlock-detection-spin="10000" configuration="local-template">


### PR DESCRIPTION
As talked, I use a keyCache to improve query performance. I stick to the ISPN cache to store values since we are moving to cluster. A disk-based value store won't match well there. 