### PR TITLE
Improve the cache clean-up on store dis/enable and update events

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataStoreContentAction.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataStoreContentAction.java
@@ -1,0 +1,35 @@
+package org.commonjava.indy.pkg.maven.change;
+
+import org.commonjava.indy.content.StoreContentAction;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.pkg.maven.content.MetadataCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Set;
+
+@ApplicationScoped
+public class MetadataStoreContentAction
+                implements StoreContentAction
+{
+    private Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private MetadataCacheManager cacheManager;
+
+    public MetadataStoreContentAction()
+    {
+    }
+
+    @Override
+    public void clearStoreContent( String path, ArtifactStore store, Set<Group> affectedGroups,
+                                   boolean clearOriginPath )
+    {
+        logger.debug( "Clearing metadata cache, path: {}, store: {}, affected: {}", path, store.getKey(), affectedGroups );
+        cacheManager.remove( store.getKey(), path );
+        affectedGroups.forEach( group -> cacheManager.remove( group.getKey(), path ) );
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreChangeUtil.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreChangeUtil.java
@@ -1,0 +1,183 @@
+package org.commonjava.indy.core.change;
+
+import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.content.DirectContentAccess;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.maven.galley.model.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static org.commonjava.maven.galley.util.PathUtils.ROOT;
+
+public class StoreChangeUtil
+{
+    private static final Logger logger = LoggerFactory.getLogger( StoreChangeUtil.class );
+
+    /**
+     * Get an array of sets [s1, s2] where s1 holds the added members and s2 is for removed members.
+     */
+    public static Set<StoreKey>[] getDiffMembers( Group newGroup, Group oldGroup )
+    {
+        List<StoreKey> newMembers = newGroup.getConstituents();
+        logger.debug( "New members of {}: {}", newGroup, newMembers );
+
+        List<StoreKey> oldMembers = oldGroup.getConstituents();
+        logger.debug( "Old members of {}: {}", oldGroup, oldMembers );
+
+        return getDiff( newMembers, oldMembers );
+    }
+
+    static <T> Set<T>[] getDiff( List<T> newMembers, List<T> oldMembers )
+    {
+        List<T> s1 = new ArrayList<>( newMembers );
+        s1.removeAll( oldMembers );
+        Set<T> added = new HashSet<>( s1 );
+
+        List<T> s2 = new ArrayList<>( oldMembers );
+        s2.removeAll( newMembers );
+        Set<T> removed = new HashSet<>( s2 );
+
+        return new Set[] { added, removed };
+    }
+
+    /**
+     * Get groups' members after diverged point. e.g, old = [a, b, c, d], new = [a, b, e], the result will be [c, d, e].
+     * We need to improve the way to do clean-up. e.g, if some group got 700 members and we remove 1 in the middle,
+     * the diverged would be 350, which is huge listing/cleaning work.
+     *
+     * We move to getDiffMembers and keep this method for reference for review purpose.
+     */
+    @Deprecated
+    public static Set<StoreKey> getDivergedMembers( Group newGroup, Group oldGroup )
+    {
+        List<StoreKey> newMembers = newGroup.getConstituents();
+        logger.debug( "New members of {}: {}", newGroup, newMembers );
+
+        List<StoreKey> oldMembers = oldGroup.getConstituents();
+        logger.debug( "Old members of {}: {}", oldGroup, oldMembers );
+
+        return getDiverged( newMembers, oldMembers );
+
+    }
+
+    static <T> Set<T> getDiverged( List<T> newMembers, List<T> oldMembers )
+    {
+        Set<T> diverged = new HashSet<>();
+
+        int newSize = newMembers.size();
+        int oldSize = oldMembers.size();
+
+        int min = Math.min( newSize, oldSize );
+
+        int divergencePoint = -1;
+        for ( int i = 0; i < min; i++ )
+        {
+            if ( !oldMembers.get( i ).equals( newMembers.get( i ) ) )
+            {
+                divergencePoint = i;
+                break;
+            }
+        }
+        if ( divergencePoint < 0 )
+        {
+            divergencePoint = min;
+        }
+
+        diverged.addAll( oldMembers.subList( divergencePoint, oldSize ) );
+        diverged.addAll( newMembers.subList( divergencePoint, newSize ) );
+
+        return diverged;
+    }
+
+    /**
+     * List paths in the target store and execute pathAction for accepted paths. Return the accepted paths count.
+     */
+    public static int listPathsAnd( StoreKey key, Predicate<? super String> pathFilter, Consumer<String> pathAction,
+                                     DirectContentAccess contentAccess )
+    {
+        final AtomicInteger accepted = new AtomicInteger( 0 );
+        logger.debug( "List paths for: {}", key );
+        Transfer root;
+        try
+        {
+            root = contentAccess.getTransfer( key, ROOT );
+        }
+        catch ( IndyWorkflowException e )
+        {
+            logger.error( String.format( "Failed to retrieve root directory for: %s. Reason: %s", key, e ), e );
+            return 0;
+        }
+
+        List<Transfer> toProcess = new ArrayList<>();
+        toProcess.add( root );
+        while ( !toProcess.isEmpty() )
+        {
+            Transfer next = toProcess.remove( 0 );
+            try
+            {
+                Stream.of( next.list() ).forEach( filename -> {
+                    Transfer t = next.getChild( filename );
+                    if ( t.isDirectory() )
+                    {
+                        logger.trace( "Adding directory path for processing: {}", t.getPath() );
+                        toProcess.add( t );
+                    }
+                    else
+                    {
+                        if ( pathFilter.test( t.getPath() ) )
+                        {
+                            logger.trace( "Accept file path: {}", t.getPath() );
+                            accepted.incrementAndGet();
+                            pathAction.accept( t.getPath() );
+                        }
+                        else
+                        {
+                            logger.trace( "Skipping file path: {}", t.getPath() );
+                        }
+                    }
+                } );
+            }
+            catch ( IOException e )
+            {
+                logger.error( String.format( "Failed to list contents of: %s. Reason: %s", next, e ), e );
+            }
+        }
+        return accepted.get();
+    }
+
+    public static boolean delete( Transfer t )
+    {
+        if ( t != null && t.exists() )
+        {
+            try
+            {
+                logger.debug( "Deleting: {}", t );
+                boolean deleted = t.delete( true );
+                if ( t.exists() )
+                {
+                    logger.error( "{} WAS NOT DELETED!", t );
+                }
+
+                return deleted;
+            }
+            catch ( IOException e )
+            {
+                logger.error( String.format( "Failed to delete: %s. Reason: %s", t, e.getMessage() ), e );
+            }
+        }
+
+        return false;
+    }
+
+}

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
@@ -24,21 +24,17 @@ import org.commonjava.indy.change.event.ArtifactStoreDeletePreEvent;
 import org.commonjava.indy.change.event.ArtifactStoreEnablementEvent;
 import org.commonjava.indy.change.event.ArtifactStorePreUpdateEvent;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
-import org.commonjava.indy.change.event.IndyStoreEvent;
 import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.StoreContentAction;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.measure.annotation.Measure;
-import org.commonjava.indy.measure.annotation.MetricNamed;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.model.SpecialPathInfo;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
-import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,25 +42,21 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
-import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static org.commonjava.indy.measure.annotation.MetricNamed.DEFAULT;
+import static org.commonjava.indy.core.change.StoreChangeUtil.delete;
+import static org.commonjava.indy.core.change.StoreChangeUtil.getDiffMembers;
+import static org.commonjava.indy.core.change.StoreChangeUtil.listPathsAnd;
 import static org.commonjava.indy.model.core.StoreType.group;
-import static org.commonjava.maven.galley.util.PathUtils.ROOT;
 
 /**
  * Created by jdcasey on 1/27/17.
@@ -88,9 +80,6 @@ public class StoreContentListener
     private DirectContentAccess directContentAccess;
 
     @Inject
-    private NotFoundCache nfc;
-
-    @Inject
     @WeftManaged
     @ExecutorConfig( threads=20, priority=7, named="content-cleanup" )
     private WeftExecutorService cleanupExecutor;
@@ -101,42 +90,25 @@ public class StoreContentListener
     @Measure
     public void onStoreEnablement( @Observes final ArtifactStoreEnablementEvent event )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
         logger.trace( "Got store-enablement event: {}", event );
-
         if ( event.isPreprocessing() )
         {
-            if ( event.isDisabling() )
-            {
-                /* For disablement, we remove the merged metadata files by paths via listing mergable files in the target repo's local cache.
-                 * We do not cache pom/jar files in affected groups so don't worry about them.
-                 */
-                processAllPaths( event, mergablePathStrings(), false );
-            }
-            else
-            {
-                /* When enabling a repo, we have to clean all (mergable) content from containing groups' cache because
-                 * we don't have complete listing of the enabled repo and listing it is very slow. The only option how to keep
-                 * the cache consistent is to drop everything from it.
-                 */
-                processAllPathsExt( event, mergablePathStrings() );
-            }
+            Set<StoreKey> keys = event.getStores().stream().map( ArtifactStore::getKey ).collect( Collectors.toSet() );
+            clearPaths( keys, mergablePath(), false );
         }
     }
 
-    @Measure( timers = @MetricNamed( DEFAULT ) )
+    @Measure
     public void onStoreDeletion( @Observes final ArtifactStoreDeletePreEvent event )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
         logger.trace( "Got store-delete event: {}", event );
-
-        processAllPaths( event, p->true, true );
+        Set<StoreKey> keys = event.getStores().stream().map( ArtifactStore::getKey ).collect( Collectors.toSet() );
+        clearPaths( keys, allPath(), true );
     }
 
-    @Measure( timers = @MetricNamed( DEFAULT ) )
+    @Measure
     public void onStoreUpdate( @Observes final ArtifactStorePreUpdateEvent event )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
         logger.trace( "Got store-update event: {}", event );
 
         // we're only interested in existing stores, since new stores cannot have indexed keys
@@ -144,176 +116,68 @@ public class StoreContentListener
         {
             for ( ArtifactStore store : event )
             {
-                removeAllSupercededMemberContent( store, event.getChangeMap() );
+                // we're only interested in groups, since only adjustments to group memberships can invalidate cached content.
+                if ( group == store.getKey().getType() )
+                {
+                    cleanSupercededMemberContent( (Group) store, event.getChangeMap() );
+                }
             }
         }
     }
 
-    // TODO: If we find points where a new HostedRepository is added, we should be using its comprehensive index to minimize the index damage to the group.
-    private void removeAllSupercededMemberContent( final ArtifactStore store,
-                                                   final Map<ArtifactStore, ArtifactStore> changeMap )
+    /**
+     * Get the added and removed members and clear mergable paths for added and all paths for removed.
+     * We don't cache normal files in groups but need to cleaning NFC, content-index, etc, via storeContentActions.
+     */
+    private void cleanSupercededMemberContent( final Group group,
+                                               final Map<ArtifactStore, ArtifactStore> changeMap )
     {
-        StoreKey key = store.getKey();
-        // we're only interested in groups, since only adjustments to group memberships can invalidate indexed content.
-        if ( group == key.getType() )
-        {
-            List<StoreKey> newMembers = ( (Group) store ).getConstituents();
-            logger.debug( "New members of: {} are: {}", store, newMembers );
+        Set<StoreKey>[] diffMembers = getDiffMembers( group, (Group) changeMap.get( group ) );
 
-            Group group = (Group) changeMap.get( store );
-            List<StoreKey> oldMembers = group.getConstituents();
-            logger.debug( "Old members of: {} are: {}", group, oldMembers );
+        Set<StoreKey> added = diffMembers[0];
+        Set<StoreKey> removed = diffMembers[1];
 
-            int commonSize = Math.min( newMembers.size(), oldMembers.size() );
-            int divergencePoint;
+        logger.debug( "Diff members, added: {}, removed: {}", added, removed );
 
-            // look in the members that overlap in new/old groups and see if there are changes that would
-            // indicate member reordering. If so, it might lead previously suppressed results to be prioritized,
-            // which would invalidate part of the content index for the group.
-            boolean foundDivergence = false;
-            for ( divergencePoint = 0; divergencePoint < commonSize; divergencePoint++ )
-            {
-                logger.debug( "Checking for common member at index: {}", divergencePoint );
-                if ( !oldMembers.get( divergencePoint ).equals( newMembers.get( divergencePoint ) ) )
-                {
-                    foundDivergence = true;
-                    break;
-                }
-            }
+        Set<Group> groups = new HashSet<>();
+        groups.add( group );
 
-            // [NOS-128]
-            // 1. If membership has shrunk, we can remove origin-indexed paths, which will remove merged group content
-            //      based on the removed member's content.
-            // 2. If membership has grown, we should iterate new members' indexed content looking for mergable paths.
-            //      For each of these, we need to removeIndexedStorePaths using the group and the mergable path.
-            // [addendum]
-            // 3. If membership is the same size but has been reordered, we need to iterate from the divergence point
-            //    and invalidate the non-mergable files. This is because the reordering may change what artifacts
-            //    should obscure which other physical artifacts.
-            //
-            // NOTE: In any case, once we isolate the changes, we need to handle matches in two ways:
-            // 1. deleteTransfers()
-            // 2. add the indexedStorePath to the removed Set so we can propagage their removal through any groups
-            //      that include the one we're affecting directly here...using clearIndexedPathFrom() to do this.
-            if ( !foundDivergence )
-            {
-                if ( newMembers.size() < oldMembers.size() )
-                {
-                    divergencePoint = commonSize;
-                }
-                else
-                {
-                    divergencePoint = newMembers.size();
-                }
-            }
-
-            logger.debug( "group membership divergence point: {}", divergencePoint );
-
-            Set<StoreKey> affectedMembers = new HashSet<>();
-            boolean removeMergableOnly = divergencePoint >= oldMembers.size();
-
-            // if we can iterate some old members that have been removed or reordered, invalidate the
-            // group content index entries for those.
-            if ( divergencePoint < oldMembers.size() )
-            {
-                for ( int i = divergencePoint; i < oldMembers.size(); i++ )
-                {
-                    affectedMembers.add( oldMembers.get( i ) );
-                }
-            }
-            else
-            {
-                // for new added members, need to clear the indexed path with this group store for repo metadata merging
-                // See [NOS-128]
-                for ( int i = divergencePoint - 1; i >= commonSize; i-- )
-                {
-                    affectedMembers.add( newMembers.get( i ) );
-                }
-            }
-
-            logger.debug( "Got members affected by membership divergence: {}", affectedMembers );
-            if ( !affectedMembers.isEmpty() )
-            {
-                Set<Group> groups = new HashSet<>();
-                groups.add( group );
-
-                try
-                {
-                    groups.addAll( storeDataManager.query()
-                                                   .packageType( group.getPackageType() )
-                                                   .getGroupsAffectedBy( group.getKey() ) );
-                }
-                catch ( IndyDataException e )
-                {
-                    logger.error( String.format( "Cannot retrieve groups affected by: %s. Reason: %s", group.getKey(),
-                                                 e.getMessage() ), e );
-                }
-
-                logger.debug( "Got affected groups: {}", groups );
-
-                DrainingExecutorCompletionService<Integer> clearService =
-                        new DrainingExecutorCompletionService<>( cleanupExecutor );
-
-                final Predicate<? super String> mergableFilter = removeMergableOnly ? mergablePathStrings() : ( p ) -> true;
-
-                // NOTE: We're NOT checking load for this executor, since this is an async process that is critical to
-                // data integrity.
-                affectedMembers.forEach( ( memberKey ) -> {
-                    logger.debug( "Listing all {}paths in: {}", ( removeMergableOnly ? "mergeable " : "" ), memberKey );
-                    listPathsAnd( memberKey, mergableFilter, p -> clearService.submit(
-                            clearPathProcessor( p, memberKey, groups ) ) );
-
-                } );
-
-                drainAndCount( clearService, "store: " + store.getKey() );
-            }
-        }
-    }
-
-    private Callable<Integer> clearPathProcessor( final String path, final StoreKey key, final Set<Group> groups )
-    {
         try
         {
-            ArtifactStore store = storeDataManager.getArtifactStore( key );
-            return clearPathProcessor( path, store, groups );
+            groups.addAll( storeDataManager.query()
+                                           .packageType( group.getPackageType() )
+                                           .getGroupsAffectedBy( group.getKey() ) );
         }
         catch ( IndyDataException e )
         {
-            logger.error( "Cannot clear paths for missing / inaccessible store: " + key, e );
+            logger.error( "Failed to retrieve groups affected by: {}", group.getKey(), e );
         }
 
-        return ()->0;
-    }
+        logger.debug( "Affected groups: {}", groups );
 
-    private Callable<Integer> clearPathProcessor( final String path, final ArtifactStore store, final Set<Group> groups )
-    {
-        return () -> {
-            logger.debug( "Got mergable transfer from diverged portion of membership: {}", path );
+        final boolean deleteOriginPath = false;
 
-            int cleared = clearPath( path, store, groups, false );
-            return cleared;
-        };
+        clearPaths( added, mergablePath(), groups, deleteOriginPath );
+        clearPaths( removed, allPath(), groups, deleteOriginPath );
     }
 
     private int clearPath( String path, ArtifactStore origin, Set<Group> affectedGroups, boolean deleteOriginPath )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-        final boolean isReadonlyHosted = storeDataManager.isReadonly( origin );
+        logger.debug( "Clear path: {}, origin: {}, affectedGroups: {}", path, origin.getKey(), affectedGroups );
+
         AtomicInteger cleared = new AtomicInteger( 0 );
-        if ( deleteOriginPath && !isReadonlyHosted )
+        if ( deleteOriginPath && !storeDataManager.isReadonly( origin ) )
         {
             try
             {
                 if ( delete( directContentAccess.getTransfer( origin, path ) ) )
                 {
-                    nfc.clearMissing( LocationUtils.toLocation( origin ) ); // clear NFC for this group
                     cleared.incrementAndGet();
                 }
             }
             catch ( IndyWorkflowException e )
             {
-                logger.error( String.format( "Failed to retrieve transfer for: %s in origin store: %s. Reason: %s", path,
-                                             origin.getKey(), e.getMessage() ), e );
+                logger.warn( "Failed to delete path: {}, store: {}", path, origin.getKey(), e );
             }
         }
 
@@ -328,198 +192,109 @@ public class StoreContentListener
             }
             catch ( IndyWorkflowException e )
             {
-                logger.error( String.format( "Failed to retrieve transfer for: %s in group: %s. Reason: %s", path,
-                                             g.getName(), e.getMessage() ), e );
+                logger.error( "Failed to retrieve transfer for: {} in group: {}", path, g.getName(), e );
             }
         } );
 
-        logger.debug( "Clearing content via supplemental store-content actions..." );
+        logger.debug( "Clearing via store-content actions..." );
         StreamSupport.stream( storeContentActions.spliterator(), false )
-                     .forEach(
-                             action -> action.clearStoreContent( path, origin, affectedGroups, deleteOriginPath ) );
-        logger.debug( "All store-content actions done executing." );
+                     .forEach( action -> action.clearStoreContent( path, origin, affectedGroups, deleteOriginPath ) );
 
+        logger.debug( "Clear path done" );
         return cleared.get();
     }
 
-    private boolean delete( Transfer t )
+    private void clearPaths( Set<StoreKey> keys, Predicate<? super String> pathFilter, boolean deleteOriginPath )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-        if ( t != null && t.exists() )
-        {
-            try
-            {
-                logger.debug( "Deleting: {}", t );
-                boolean deleted = t.delete( true );
-                if ( t.exists() )
-                {
-                    logger.error( "{} WAS NOT DELETED!", t );
-                }
-
-                return deleted;
-            }
-            catch ( IOException e )
-            {
-                logger.error( String.format( "Failed to delete: %s. Reason: %s", t, e.getMessage() ), e );
-            }
-        }
-
-        return false;
+        clearPaths( keys, pathFilter, null, deleteOriginPath );
     }
 
-    private void listPathsAnd( StoreKey key, Predicate<? super String> pathFilter, Consumer<String> pathAction )
+    /**
+     * List the paths in target store and clean up the paths in affected groups.
+     *
+     * If groups are given, use them (for group update since all members share same group hierarchy). Otherwise,
+     * query the affected groups (for store deletion and dis/enable event).
+     */
+    private void clearPaths( final Set<StoreKey> keys, Predicate<? super String> pathFilter, final Set<Group> groups,
+                             final boolean deleteOriginPath )
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
+        // ### Not use completion service and drain. We need to make this thread-off since the clean-up may take long time.
+        //
+        //DrainingExecutorCompletionService<Integer> clearService =
+        //                new DrainingExecutorCompletionService<>( cleanupExecutor );
 
-        Transfer root = null;
-        try
-        {
-            root = directContentAccess.getTransfer( key, ROOT );
-
-//            root.lockWrite();
-
-            List<Transfer> toProcess = new ArrayList<>();
-            toProcess.add( root );
-            while ( !toProcess.isEmpty() )
+        keys.forEach( key -> {
+            ArtifactStore origin;
+            try
             {
-                Transfer next = toProcess.remove( 0 );
+                origin = storeDataManager.getArtifactStore( key );
+            }
+            catch ( IndyDataException e )
+            {
+                logger.error( "Failed to retrieve store: " + key, e );
+                return;
+            }
+
+            Set<Group> affected = groups;
+            if ( affected == null )
+            {
                 try
                 {
-                    Stream.of(next.list()).forEach( filename->{
-                        Transfer t = next.getChild( filename );
-                        if ( t.isDirectory() )
-                        {
-                            logger.debug( "Adding directory path for processing: {}", t.getPath() );
-                            toProcess.add( t );
-                        }
-                        else
-                        {
-                            logger.trace( "Testing file path: {}", t.getPath() );
-                            if( pathFilter.test( t.getPath() ) )
-                            {
-                                logger.trace( "Adding file path to results: {}", t.getPath() );
-                                pathAction.accept( t.getPath() );
-                            }
-                            else
-                            {
-                                logger.trace( "Skipping file path: {}", t.getPath() );
-                            }
-                        }
-                    } );
+                    affected = ( storeDataManager.query().packageType( key.getPackageType() ).getGroupsAffectedBy( key ) );
                 }
-                catch ( IOException e )
+                catch ( IndyDataException e )
                 {
-                    logger.error( String.format( "Failed to list contents of: %s. Reason: %s", next, e ), e );
+                    logger.error( "Failed to retrieve groups affected by: " + key, e );
+                    return;
                 }
             }
-        }
-        catch ( IndyWorkflowException  e )
-        {
-            logger.error( String.format( "Failed to retrieve root directory reference for: %s. Reason: %s", key, e ), e );
-        }
-        finally
-        {
-            if ( root != null )
-            {
-                root.unlock();
-            }
-        }
-    }
 
-    /**
-     * List the mergable paths in target store and clean up the paths in affected groups.
-     * @param event
-     * @param pathFilter
-     * @param deleteOriginPath
-     */
-    private void processAllPaths( final IndyStoreEvent event, Predicate<? super String> pathFilter, boolean deleteOriginPath )
-    {
-        DrainingExecutorCompletionService<Integer> clearService =
-                new DrainingExecutorCompletionService<>( cleanupExecutor );
-
-        Set<StoreKey> keys = event.getStores().stream().map( store -> store.getKey() ).collect( Collectors.toSet() );
-        keys.forEach(key->{
-            final Set<Group> groups = new HashSet<>();
+            logger.debug( "Submit clean job for origin: {}", origin );
+            final Set<Group> affectedGroups = affected;
+            Future<Integer> job = cleanupExecutor.submit(
+                            clearPathsProcessor( origin, pathFilter, affectedGroups, deleteOriginPath ) );
+            /*
+             * For debug only. When ftest fails due to not waiting enough time, use below to ascertain that is just timing problem.
+             *
             try
             {
-                groups.addAll(
-                        storeDataManager.query().packageType( key.getPackageType() ).getGroupsAffectedBy( key ) );
-
-                listPathsAnd( key, pathFilter, p->clearService.submit(clearPathProcessor( p, key, groups )) );
+                job.get();
             }
-            catch ( IndyDataException e )
-            {
-                logger.error( "Failed to retrieve groups affected by: " + key, e );
-            }
-        } );
-
-        drainAndCount( clearService, "stores: " + keys );
-    }
-
-    private int drainAndCount( final DrainingExecutorCompletionService<Integer> clearService, final String description )
-    {
-        AtomicInteger count = new AtomicInteger( 0 );
-        try
-        {
-            clearService.drain( partialCount -> count.addAndGet( partialCount ) );
-        }
-        catch ( InterruptedException | ExecutionException e )
-        {
-            logger.error( "Failed to clear paths related to change in " + description, e );
-        }
-
-        logger.debug( "Cleared {} paths for changes in {}", count.get(), description );
-
-        return count.get();
-    }
-
-    /**
-     * Extensive version for clean up paths. This will clean all mergable files in affected groups regardless whether
-     * the path is in the target store cache or not. It also clears NFC.
-     * @param event
-     * @param pathFilter
-     */
-    private void processAllPathsExt( final IndyStoreEvent event, Predicate<? super String> pathFilter )
-    {
-        DrainingExecutorCompletionService<Integer> clearService =
-                new DrainingExecutorCompletionService<>( cleanupExecutor );
-
-        Set<ArtifactStore> stores = new HashSet<>( event.getStores() );
-        stores.forEach(store->{
-            final StoreKey key = store.getKey();
-            try
-            {
-                Set<Group> groups =
-                                storeDataManager.query().packageType( key.getPackageType() ).getGroupsAffectedBy( key );
-                if ( store instanceof Group )
-                {
-                    groups.add( (Group) store );
-                }
-
-                groups.forEach( g->{
-                    listPathsAnd( key, pathFilter, p->clearService.submit(clearPathProcessor( p, key, groups )) );
-                } );
-
-                nfc.clearMissing( LocationUtils.toLocation( store ) ); // clear NFC for this store
-            }
-            catch ( IndyDataException e )
+            catch ( Exception e )
             {
                 e.printStackTrace();
-            }
+            }*/
         } );
 
-        Set<StoreKey> keys = event.getStores().stream().map( s -> s.getKey() ).collect( Collectors.toSet() );
-        drainAndCount( clearService, "stores: " + keys );
+        //drainAndCount( clearService, "stores: " + keys );
     }
 
-    private Predicate<? super String> mergablePathStrings()
+    private Callable<Integer> clearPathsProcessor( ArtifactStore origin, Predicate<? super String> pathFilter,
+                                          Set<Group> affectedGroups, boolean deleteOriginPath )
+    {
+        return () ->
+            listPathsAnd( origin.getKey(), pathFilter,
+                          p -> clearPath( p, origin, affectedGroups, deleteOriginPath ),
+                          this.directContentAccess );
+    }
+
+    private Predicate<? super String> mergablePath()
     {
         return ( path ) -> {
-            // here we care if it's mergable or not, since this may be triggered by a new file being stored.
-            SpecialPathInfo specialPathInfo = specialPathManager.getSpecialPathInfo( path );
-            return ( specialPathInfo != null && specialPathInfo.isMergable() );
+            SpecialPathInfo pathInfo = specialPathManager.getSpecialPathInfo( path );
+            return ( pathInfo != null && pathInfo.isMergable() );
         };
     }
 
+    /**
+     * Use listable to filter paths of http-metadata, checksum, etc.
+     */
+    private Predicate<? super String> allPath()
+    {
+        return ( path ) -> {
+            SpecialPathInfo pathInfo = specialPathManager.getSpecialPathInfo( path );
+            return ( pathInfo != null && pathInfo.isListable() );
+        };
+    }
 
 }

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
@@ -251,19 +251,7 @@ public class StoreContentListener
 
             logger.debug( "Submit clean job for origin: {}", origin );
             final Set<Group> affectedGroups = affected;
-            Future<Integer> job = cleanupExecutor.submit(
-                            clearPathsProcessor( origin, pathFilter, affectedGroups, deleteOriginPath ) );
-            /*
-             * For debug only. When ftest fails due to not waiting enough time, use below to ascertain that is just timing problem.
-             *
-            try
-            {
-                job.get();
-            }
-            catch ( Exception e )
-            {
-                e.printStackTrace();
-            }*/
+            cleanupExecutor.submit( clearPathsProcessor( origin, pathFilter, affectedGroups, deleteOriginPath ) );
         } );
 
         //drainAndCount( clearService, "stores: " + keys );
@@ -287,14 +275,11 @@ public class StoreContentListener
     }
 
     /**
-     * Use listable to filter paths of http-metadata, checksum, etc.
+     * Clean all paths including http-metadata, checksum, etc, for complete data integrity.
      */
     private Predicate<? super String> allPath()
     {
-        return ( path ) -> {
-            SpecialPathInfo pathInfo = specialPathManager.getSpecialPathInfo( path );
-            return ( pathInfo != null && pathInfo.isListable() );
-        };
+        return ( path ) -> true;
     }
 
 }

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -682,27 +682,6 @@ public class ScheduleManager
         return null;
     }
 
-    public boolean deleteJob( final String group, final String name )
-    {
-        if ( !schedulerConfig.isEnabled() )
-        {
-            logger.debug( "Scheduler disabled." );
-            return false;
-        }
-
-        // We're responding to a cache expiration...the following isn't necessary, because it already expired.
-        // In fact, this leads to circularity if the notification is processed synchronously.
-//        final ScheduleKey cacheKey = ScheduleKey.fromGroupWithName( group, name );
-//        if ( scheduleCache.containsKey( cacheKey ) )
-//        {
-//            removeCache( cacheKey );
-//            return true;
-//        }
-//
-//        return false;
-        return true;
-    }
-
     @Override
     public String getId()
     {

--- a/core/src/test/java/org/commonjava/indy/core/change/StoreChangeUtilTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/change/StoreChangeUtilTest.java
@@ -1,0 +1,46 @@
+package org.commonjava.indy.core.change;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.commonjava.indy.core.change.StoreChangeUtil.getDiverged;
+import static org.commonjava.indy.core.change.StoreChangeUtil.getDiff;
+import static org.junit.Assert.assertTrue;
+
+public class StoreChangeUtilTest
+{
+    private List<String> newMembers = Arrays.asList( "a", "b", "c", "d" );
+
+    private List<String> oldMembers = Arrays.asList( "a", "b", "e" );
+
+    @Test
+    public void getDivergedTest()
+    {
+        Set<String> affectedMembers = getDiverged( newMembers, oldMembers );
+        //System.out.println( affectedMembers );
+
+        List<String> expected = Arrays.asList( "c", "d", "e" );
+
+        assertTrue( affectedMembers.containsAll( expected ) );
+        assertTrue( expected.containsAll( affectedMembers ) );
+    }
+
+    @Test
+    public void getDiffTest()
+    {
+        Set<String>[] diffMembers = getDiff( newMembers, oldMembers );
+
+        Set<String> added = new HashSet<>( Arrays.asList( "c", "d" ) );
+        Set<String> removed = new HashSet<>( Arrays.asList( "e" ) );
+
+        assertTrue( added.containsAll( diffMembers[0] ) );
+        assertTrue( diffMembers[0].containsAll( added ) );
+
+        assertTrue( removed.containsAll( diffMembers[1] ) );
+        assertTrue( diffMembers[1].containsAll( removed ) );
+    }
+}


### PR DESCRIPTION
I have done below to clean up the cache clean-up (both cached files and ISPN), and fix the threading and performance issues. 

1. Use getDiffMembers to replace getDivergedMembers (in StoreChangeUtil.java)
The getDiverged code finds the divergence point and iterates to clean-up for all repos after it. E.g, if pnc-builds group got 700+ members and we remove 1 in the middle, the diverged would be 350, which means we have to do clean-up for the rest 350 repos. It is not necessary AIUI. The new one getDiff find the added and removed repos, and only clean-up these. 

2. Abandon DrainingExecutorCompletionService in StoreContentListener. We need to make the clean-up completely thread-off since it may take a very long time. I also use bigger granularity. I throw all paths for a single repo to one thread. The old code does it per path which I think is too fine. I thought about batching it to do 50 or 100 paths at a time but decide not to use batch ATM. Given that the clean-up is threaded off, this won't be very necessary. 

3. Add NfcStoreContentAction to separate concern for NFC clean-up. 

4. Remove useless code due to the removal of ScheduleManager.deleteJob. This method has been abandoned and I remove the code that uses it. This introduces some cascade deletion. If you find some code is removed, look into it and at last, you will find it is calling deleteJob. 

5. Some other refactor to groom the code, mainly in StoreContentListener. It is a piece of cake now. Hopefully, you will find it easy to review. 