### PR TITLE
DRAFT - Switch back to datafile definitions manager for repos / groups

### DIFF
--- a/deployments/launcher/src/main/resources/META-INF/beans.xml
+++ b/deployments/launcher/src/main/resources/META-INF/beans.xml
@@ -17,7 +17,7 @@
   <alternatives>
     <stereotype>org.commonjava.indy.inject.Production</stereotype>
 
-    <class>org.commonjava.indy.infinispan.data.InfinispanStoreDataManager</class>
+    <class>org.commonjava.indy.flat.data.DataFileStoreDataManager</class>
   </alternatives>
   
   <interceptors>

--- a/embedder/src/main/resources/META-INF/beans.xml
+++ b/embedder/src/main/resources/META-INF/beans.xml
@@ -24,7 +24,7 @@
   <alternatives>
     <stereotype>org.commonjava.indy.inject.Production</stereotype>
 
-    <class>org.commonjava.indy.infinispan.data.InfinispanStoreDataManager</class>
+    <class>org.commonjava.indy.flat.data.DataFileStoreDataManager</class>
   </alternatives>
 
   <interceptors>


### PR DESCRIPTION
We'll have to do a more controlled rollout of this when we can afford the testing time, and when we have a migration path for existing repository definitions.