### PR TITLE
Fix configuration merging problem for cluster ispn config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <weftVersion>1.14</weftVersion>
     <httpTestserverVersion>1.4</httpTestserverVersion>
     <propulsorVersion>1.4</propulsorVersion>
-    <auditQueryVersion>0.13.0</auditQueryVersion>
+    <auditQueryVersion>0.13.1-SNAPSHOT</auditQueryVersion>
     
     <!-- <enforceBestPractices>false</enforceBestPractices> -->
     <enforceStandards>false</enforceStandards>

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -180,13 +180,15 @@ public class CacheProducer
                 try
                 {
                     logger.info( "Using CLASSPATH resource Infinispan configuration:\n\n{}\n\n", resourceStr );
-                    mgr = new DefaultCacheManager(
-                            new ByteArrayInputStream( resourceStr.getBytes( StandardCharsets.UTF_8 ) ) );
+                    if ( mgr == null )
+                    {
+                        mgr = new DefaultCacheManager(
+                                new ByteArrayInputStream( resourceStr.getBytes( StandardCharsets.UTF_8 ) ) );
+                    }
                     if ( isCluster )
                     {
-                        mgr.startCaches( String.join( ",",  clusterCacheManager.getCacheNames()) );
+                        mgr.startCaches( String.join( ",", clusterCacheManager.getCacheNames() ) );
                     }
-
                 }
                 catch ( IOException e )
                 {


### PR DESCRIPTION
Currently when there are both class-path and customized ispn-cluster.xml, the merging logic is not correct which ignored the class-path one, because it always merging the config to default cacheManager but not clusterCacheManager.