### PR TITLE
Constrain path-mask calculation to maven-type archives from Koji/Brew

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -282,7 +282,9 @@ public abstract class KojiContentManagerDecorator
 
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.debug("When the koji is enabled , path:{},config instance is {}",path,config.toString());
+
         // TODO: This won't work for maven-metadata.xml files! We need to hit a POM or jar or something first.
+        // FIXME: This won't work for NPM!
         ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
         if ( pathInfo != null )
         {
@@ -459,7 +461,7 @@ public abstract class KojiContentManagerDecorator
                 }
 
                 // set pathMaskPatterns using build output paths
-                Set<String> patterns = pathFormatter.getPatterns( artifactRef, archives );
+                Set<String> patterns = pathFormatter.getPatterns( inStore, artifactRef, archives );
 
                 // pre-index the koji build artifacts and set authoritative index of the remote to let the
                 // koji remote repo directly go through the content index

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRepairManager.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRepairManager.java
@@ -228,7 +228,7 @@ public class KojiRepairManager
                         }
 
                         // set pathMaskPatterns using build output paths
-                        Set<String> patterns = kojiPathFormatter.getPatterns( artifactRef, archives, true );
+                        Set<String> patterns = kojiPathFormatter.getPatterns( store.getKey(), artifactRef, archives, true );
                         logger.debug( "For repo: {}, resetting path_mask_patterns to:\n\n{}\n\n", store.getKey(),
                                      patterns );
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <kafkaVersion>1.1.0</kafkaVersion>
     <logbackVersion>1.2.3</logbackVersion>
     <logbackContribVersion>0.1.5</logbackContribVersion>
-    <jacksonVersion>2.9.9</jacksonVersion>
+    <jackson-version>2.9.9</jackson-version>
     <metricsVersion>4.0.2</metricsVersion>
     <httpcoreVersion>4.4.9</httpcoreVersion>
     <httpclientVersion>4.5.9</httpclientVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <logbackVersion>1.2.3</logbackVersion>
     <logbackContribVersion>0.1.5</logbackContribVersion>
     <jackson-version>2.9.9</jackson-version>
-    <metricsVersion>4.0.2</metricsVersion>
+    <metrics.version>4.0.2</metrics.version>
     <httpcoreVersion>4.4.9</httpcoreVersion>
     <httpclientVersion>4.5.9</httpclientVersion>
 


### PR DESCRIPTION
This addresses a bug in production when we attempt to proxy a Koji build that contains a mixed bag of maven and non-maven archives.

Also included here are some fixes for property keys in the root pom.xml to address merge errors I introduced.