### PR TITLE
Generate missing checksum for hosted repo content

### DIFF
--- a/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
@@ -38,6 +38,7 @@ import org.commonjava.indy.content.ContentDigester;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.DownloadManager;
+import org.commonjava.indy.core.content.ContentGeneratorManager;
 import org.commonjava.indy.core.content.DefaultContentDigester;
 import org.commonjava.indy.core.content.DefaultContentManager;
 import org.commonjava.indy.core.content.DefaultDirectContentAccess;
@@ -189,7 +190,7 @@ public class HttpProxyTest
 
         final ContentManager contentManager =
                 new DefaultContentManager( storeManager, downloadManager, mapper, new SpecialPathManagerImpl(),
-                                           new MemoryNotFoundCache(), contentDigester, Collections.emptySet() );
+                                           new MemoryNotFoundCache(), contentDigester, new ContentGeneratorManager() );
 
         DataFileManager dfm = new DataFileManager( temp.newFolder(), new DataFileEventManager() );
         final TemplatingEngine templates = new TemplatingEngine( new GStringTemplateEngine(), dfm );

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -471,6 +471,7 @@ public class MavenMetadataGenerator
             Transfer original = fileManager.getTransfer( group, path );
             if ( exists( original ) )
             {
+                logger.debug( "This is a checksum file, return the original path {}", path );
                 return original;
             }
         }

--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnUploadTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/RecursiveGroupMetadataClearOnUploadTest.java
@@ -116,13 +116,6 @@ public class RecursiveGroupMetadataClearOnUploadTest
               .store( hostedRepo.getKey(), path, new ByteArrayInputStream( firstPassContent.getBytes( "UTF-8" ) ) );
     }
 
-    @BMRule( name = "slow_down", targetClass = "org.commonjava.indy.content.index.ContentIndexManager",
-             targetMethod = "clearIndexedPathFrom",
-             targetLocation = "ENTRY",
-             binding = "tctx:org.commonjava.cdi.util.weft.ThreadContext = ThreadContext.getContext(true);"
-                     + "key:org.commonjava.indy.model.core.StoreKey = tctx.get(\"ContentIndex:originKey\");"
-                     + "isFlagged:boolean = \"groupA\".equals(key.getName());",
-             condition = "isFlagged", action = "System.out.println(\"Slowing down 4s\");" + "Thread.sleep(4000);" )
     @Test
     @Category( EventDependent.class )
     public void run()
@@ -141,7 +134,6 @@ public class RecursiveGroupMetadataClearOnUploadTest
         //        assertContent( groupA, secondPassContent );
         assertContent( groupB, path, secondPassContent );
 
-        Thread.currentThread().sleep( 4000 );
     }
 
     @Override

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -28,6 +28,7 @@ import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.DownloadManager;
 import org.commonjava.indy.content.IndyLocationExpander;
+import org.commonjava.indy.core.content.ContentGeneratorManager;
 import org.commonjava.indy.core.content.DefaultContentDigester;
 import org.commonjava.indy.core.content.DefaultContentManager;
 import org.commonjava.indy.core.content.DefaultDirectContentAccess;
@@ -161,7 +162,7 @@ public class PromotionManagerTest
 
         contentManager = new DefaultContentManager( storeManager, downloadManager, new IndyObjectMapper( true ),
                                                     new SpecialPathManagerImpl(), new MemoryNotFoundCache(),
-                                                    contentDigester, Collections.<ContentGenerator>emptySet() );
+                                                    contentDigester, new ContentGeneratorManager() );
 
         dataManager = new DataFileManager( temp.newFolder( "data" ), new DataFileEventManager() );
         validationsManager = new PromoteValidationsManager( dataManager, new PromoteConfig(),

--- a/core/src/main/java/org/commonjava/indy/core/content/ContentGeneratorManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/ContentGeneratorManager.java
@@ -1,0 +1,148 @@
+package org.commonjava.indy.core.content;
+
+import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.content.ContentGenerator;
+import org.commonjava.indy.content.StoreResource;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+@ApplicationScoped
+public class ContentGeneratorManager
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private Instance<ContentGenerator> contentGeneratorInstance;
+
+    private Set<ContentGenerator> contentGenerators;
+
+    public ContentGeneratorManager()
+    {
+        contentGenerators = new HashSet<>();
+    }
+
+    @PostConstruct
+    public void initialize()
+    {
+        if ( contentGeneratorInstance != null )
+        {
+            for ( final ContentGenerator producer : contentGeneratorInstance )
+            {
+                contentGenerators.add( producer );
+            }
+        }
+    }
+
+    public Transfer generateFileContentAnd( final ArtifactStore store, final String path,
+                                            final EventMetadata eventMetadata, Consumer<Transfer> consumer )
+                    throws IndyWorkflowException
+    {
+        Transfer item = null;
+        for ( final ContentGenerator generator : contentGenerators )
+        {
+            logger.trace( "Attempting to generate content, path: {}, store: {}, via: {}", path, store, generator );
+            item = generator.generateFileContent( store, path, eventMetadata );
+            if ( item != null )
+            {
+                consumer.accept( item );
+                break;
+            }
+        }
+        return item;
+    }
+
+    public Transfer generateGroupFileContent( Group group, List<ArtifactStore> members, String path,
+                                              EventMetadata eventMetadata ) throws IndyWorkflowException
+    {
+        Transfer item = null;
+        for ( final ContentGenerator generator : contentGenerators )
+        {
+            if ( generator.canProcess( path ) )
+            {
+                item = generator.generateGroupFileContent( group, members, path, eventMetadata );
+                logger.trace( "From content {}.generateGroupFileContent: {} (exists? {})",
+                              generator.getClass().getSimpleName(), item, item != null && item.exists() );
+                if ( item != null && item.exists() )
+                {
+                    break;
+                }
+            }
+        }
+        return item;
+    }
+
+    public void generateGroupFileContentAnd( Group group, List<ArtifactStore> members, String path,
+                                             EventMetadata eventMetadata, Consumer<Transfer> consumer )
+                    throws IndyWorkflowException
+    {
+        for ( final ContentGenerator generator : contentGenerators )
+        {
+            final Transfer txfr = generator.generateGroupFileContent( group, members, path, eventMetadata );
+            if ( txfr != null )
+            {
+                consumer.accept( txfr );
+            }
+        }
+    }
+
+    public void handleContentStorage( ArtifactStore transferStore, String path, Transfer txfr,
+                                      EventMetadata eventMetadata ) throws IndyWorkflowException
+    {
+        for ( final ContentGenerator generator : contentGenerators )
+        {
+            logger.debug( "{} Handling content storage of: {} in: {}", generator, path, transferStore.getKey() );
+            generator.handleContentStorage( transferStore, path, txfr, eventMetadata );
+        }
+    }
+
+    public void handleContentDeletion( ArtifactStore member, String path, EventMetadata eventMetadata )
+                    throws IndyWorkflowException
+    {
+        for ( final ContentGenerator generator : contentGenerators )
+        {
+            generator.handleContentDeletion( member, path, eventMetadata );
+        }
+    }
+
+    public void generateGroupDirectoryContentAnd( Group group, List<ArtifactStore> members, String path,
+                                                  EventMetadata eventMetadata, Consumer<List<StoreResource>> consumer )
+                    throws IndyWorkflowException
+    {
+        for ( final ContentGenerator generator : contentGenerators )
+        {
+            final List<StoreResource> generated =
+                            generator.generateGroupDirectoryContent( group, members, path, eventMetadata );
+            if ( generated != null )
+            {
+                consumer.accept( generated );
+            }
+        }
+    }
+
+    public void generateDirectoryContentAnd( ArtifactStore store, String path, List<StoreResource> listed,
+                                             EventMetadata metadata, Consumer<List<StoreResource>> consumer )
+                    throws IndyWorkflowException
+    {
+        for ( final ContentGenerator producer : contentGenerators )
+        {
+            final List<StoreResource> produced = producer.generateDirectoryContent( store, path, listed, metadata );
+            if ( produced != null )
+            {
+                consumer.accept( produced );
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/content/ContentMetadataGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/ContentMetadataGenerator.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.content;
+
+import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.content.ContentGenerator;
+import org.commonjava.indy.content.DownloadManager;
+import org.commonjava.indy.content.StoreResource;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.checksum.TransferMetadata;
+import org.commonjava.maven.galley.model.Transfer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class ContentMetadataGenerator
+                implements ContentGenerator
+{
+    public static final String FORCE_CHECKSUM_AND_WRITE = "force-checksum-and-write";
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final Set<String> HANDLED_FILENAMES = Collections.unmodifiableSet( new HashSet<String>()
+    {
+        {
+            add( ".md5" );
+            add( ".sha1" );
+            add( ".sha256" );
+        }
+    } );
+
+    @Inject
+    private DefaultContentDigester contentDigester;
+
+    @Inject
+    private DownloadManager downloads;
+
+    @Override
+    public Transfer generateFileContent( final ArtifactStore store, final String path,
+                                         final EventMetadata eventMetadata ) throws IndyWorkflowException
+    {
+        if ( !canProcess( path ) || ( store.getType() != StoreType.hosted ) ) // only generate for hosted checksum
+        {
+            return null;
+        }
+
+        String contentPath = path.substring( 0, path.lastIndexOf( "." ) );
+        eventMetadata.set( FORCE_CHECKSUM_AND_WRITE, Boolean.TRUE );
+        TransferMetadata ret = contentDigester.digest( store.getKey(), contentPath, eventMetadata );
+
+        if ( ret == null || ret.getDigests() == null || ret.getDigests().isEmpty() )
+        {
+            logger.debug( "Content metadata generated failed, path: {}, meta: {}", path, ret );
+            return null;
+        }
+
+        Transfer transfer = downloads.getStorageReference( store, path );
+        if ( transfer != null && transfer.exists() )
+        {
+            logger.debug( "Content metadata generated, path: {}", path );
+            return transfer;
+        }
+
+        return null;
+    }
+
+    @Override
+    public List<StoreResource> generateDirectoryContent( final ArtifactStore store, final String path,
+                                                         final List<StoreResource> existing,
+                                                         final EventMetadata eventMetadata )
+                    throws IndyWorkflowException
+    {
+        return null;
+    }
+
+    @Override
+    public Transfer generateGroupFileContent( final Group group, final List<ArtifactStore> members, final String path,
+                                              final EventMetadata eventMetadata ) throws IndyWorkflowException
+    {
+        return null;
+    }
+
+    @Override
+    public List<StoreResource> generateGroupDirectoryContent( final Group group, final List<ArtifactStore> members,
+                                                              final String path, final EventMetadata eventMetadata )
+                    throws IndyWorkflowException
+    {
+        return null;
+    }
+
+    @Override
+    @Deprecated
+    public void handleContentStorage( final ArtifactStore store, final String path, final Transfer result,
+                                      final EventMetadata eventMetadata ) throws IndyWorkflowException
+    {
+    }
+
+    @Override
+    public void handleContentDeletion( final ArtifactStore store, final String path, final EventMetadata eventMetadata )
+                    throws IndyWorkflowException
+    {
+        HANDLED_FILENAMES.forEach( ext -> {
+            final Transfer meta = downloads.getStorageReference( store, path + ext );
+            if ( meta.exists() )
+            {
+                try
+                {
+                    meta.delete( false );
+                }
+                catch ( final IOException e )
+                {
+                    logger.debug( "Failed to delete content metadata: " + meta, e );
+                }
+            }
+        } );
+    }
+
+    @Override
+    public boolean canProcess( final String path )
+    {
+        for ( final String filename : HANDLED_FILENAMES )
+        {
+            if ( path.endsWith( filename ) )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
@@ -24,8 +24,6 @@ import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.galley.KeyedLocation;
 import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.maven.galley.event.EventMetadata;
-import org.commonjava.maven.galley.io.ChecksummingTransferDecorator;
-import org.commonjava.maven.galley.io.checksum.ContentDigest;
 import org.commonjava.maven.galley.io.checksum.TransferMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 import org.slf4j.Logger;
@@ -35,13 +33,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
-import static org.apache.commons.codec.binary.Hex.encodeHexString;
 import static org.commonjava.maven.galley.io.ChecksummingTransferDecorator.FORCE_CHECKSUM;
 
 /**
@@ -76,7 +69,7 @@ public class DefaultContentDigester
     }
 
     @Override
-    public synchronized void addMetadata( final Transfer transfer, final TransferMetadata transferData )
+    public void addMetadata( final Transfer transfer, final TransferMetadata transferData )
     {
         if ( transferData != null )
         {
@@ -86,7 +79,7 @@ public class DefaultContentDigester
         }
     }
 
-    public synchronized boolean needsMetadataFor( final Transfer transfer )
+    public boolean needsMetadataFor( final Transfer transfer )
     {
         return true;
     }
@@ -98,7 +91,7 @@ public class DefaultContentDigester
     }
 
     @Override
-    public synchronized void removeMetadata( final Transfer transfer )
+    public void removeMetadata( final Transfer transfer )
     {
         String cacheKey = generateCacheKey( transfer );
         TransferMetadata meta = metadataCache.remove( cacheKey );
@@ -106,7 +99,7 @@ public class DefaultContentDigester
     }
 
     @Override
-    public synchronized TransferMetadata getContentMetadata( final Transfer transfer )
+    public TransferMetadata getContentMetadata( final Transfer transfer )
     {
         String cacheKey = generateCacheKey( transfer );
         logger.trace( "Getting TransferMetadata for: {}", cacheKey );
@@ -143,7 +136,6 @@ public class DefaultContentDigester
         logger.debug( "TransferMetadata missing for: {}. Re-reading with FORCE_CHECKSUM now to calculate it.",
                       cacheKey );
 
-        // FIXME: This IS NOT WORKING! It results in NPE for callers assuming a non-null TransferMetadata response.
         EventMetadata forcedEventMetadata = new EventMetadata( eventMetadata ).set( FORCE_CHECKSUM, Boolean.TRUE );
         try(InputStream stream = transfer.openInputStream( false, forcedEventMetadata ) )
         {

--- a/core/src/main/java/org/commonjava/indy/core/content/RepairChecksumAdvisor.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/RepairChecksumAdvisor.java
@@ -1,0 +1,51 @@
+package org.commonjava.indy.core.content;
+
+import org.commonjava.indy.content.IndyChecksumAdvisor;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.galley.KeyedLocation;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+import static org.commonjava.indy.core.content.ContentMetadataGenerator.FORCE_CHECKSUM_AND_WRITE;
+import static org.commonjava.maven.galley.io.checksum.ChecksummingDecoratorAdvisor.ChecksumAdvice.CALCULATE_AND_WRITE;
+
+public class RepairChecksumAdvisor
+                implements IndyChecksumAdvisor
+{
+    @Override
+    public Optional<ChecksummingDecoratorAdvisor.ChecksumAdvice> getChecksumReadAdvice( Transfer transfer,
+                                                                                        TransferOperation operation,
+                                                                                        EventMetadata eventMetadata )
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+
+        Location loc = transfer.getLocation();
+        Object forceObj = eventMetadata.get( FORCE_CHECKSUM_AND_WRITE );
+        boolean force = Boolean.TRUE.equals( forceObj ) || Boolean.parseBoolean( String.valueOf( forceObj ) );
+
+        if ( force && ( loc instanceof KeyedLocation
+                        && ( (KeyedLocation) loc ).getKey().getType() == StoreType.hosted ) )
+        {
+            logger.debug( "Enable checksumming for {} of: {} with advice: CALCULATE_AND_WRITE", operation, transfer );
+            return Optional.of( CALCULATE_AND_WRITE );
+        }
+
+        logger.debug( "Skip checksumming for {} of: {}", operation, transfer );
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ChecksummingDecoratorAdvisor.ChecksumAdvice> getChecksumWriteAdvice( Transfer transfer,
+                                                                                         TransferOperation operation,
+                                                                                         EventMetadata eventMetadata )
+    {
+        return Optional.empty();
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreCacheProducer.java
@@ -30,6 +30,7 @@ import javax.inject.Inject;
 public class CoreCacheProducer
 {
 
+    // for content-metadata we mean checksum, md5, sha1, etc
     private static final String CONTENT_METADATA_NAME = "content-metadata";
 
     @Inject

--- a/core/src/test/java/org/commonjava/indy/core/content/DefaultDownloadManagerTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/content/DefaultDownloadManagerTest.java
@@ -128,7 +128,7 @@ public class DefaultDownloadManagerTest
 
         contentManager = new DefaultContentManager( storeManager, downloadManager, new IndyObjectMapper( true ),
                                                     new SpecialPathManagerImpl(), new MemoryNotFoundCache(),
-                                                    contentDigester, Collections.<ContentGenerator>emptySet() );
+                                                    contentDigester, new ContentGeneratorManager() );
     }
 
     @Test

--- a/core/src/test/java/org/commonjava/indy/core/ctl/ContentControllerTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/ctl/ContentControllerTest.java
@@ -23,6 +23,7 @@ import org.commonjava.indy.content.ContentGenerator;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.DirectContentAccess;
 import org.commonjava.indy.content.DownloadManager;
+import org.commonjava.indy.core.content.ContentGeneratorManager;
 import org.commonjava.indy.core.content.DefaultContentDigester;
 import org.commonjava.indy.core.content.DefaultContentManager;
 import org.commonjava.indy.core.content.DefaultDirectContentAccess;
@@ -112,7 +113,7 @@ public class ContentControllerTest
                                            new SpecialPathManagerImpl(), new MemoryNotFoundCache(),
                                            new DefaultContentDigester( dca, new CacheHandle<String, TransferMetadata>(
                                                    "content-metadata", contentMetadata ) ),
-                                           Collections.<ContentGenerator>emptySet() );
+                                           new ContentGeneratorManager() );
 
         final TemplatingEngine templates = new TemplatingEngine( new GStringTemplateEngine(), new DataFileManager(
                 fixture.getTemp().newFolder( "indy-home" ), new DataFileEventManager() ) );

--- a/embedder/src/test/resources/logback-test.xml
+++ b/embedder/src/test/resources/logback-test.xml
@@ -43,7 +43,7 @@
     </appender>
 
   <logger name="org.commonjava.indy" level="TRACE"/>
-  <logger name="org.commonjava.maven.galley" level="DEBUG"/>
+  <logger name="org.commonjava.maven.galley" level="TRACE"/>
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedGenerateMissingChecksumTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedGenerateMissingChecksumTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>A hosted with org/foo/bar/1/bar-1.pom</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Access org/foo/bar/1/bar-1.pom.md5 in the hosted</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>The .md5 is generated and returned</li>
+ * </ul>
+ */
+public class HostedGenerateMissingChecksumTest
+                extends AbstractContentManagementTest
+{
+    private HostedRepository hosted;
+
+    private final String HOSTED = "hosted";
+
+    private final String POM_PATH = "org/foo/bar/1/bar-1.pom";
+
+    private final String POM_MD5_PATH = "org/foo/bar/1/bar-1.pom.md5";
+
+    private final String POM_SHA1_PATH = "org/foo/bar/1/bar-1.pom.sha1";
+
+    private final String POM_CONTENT = "This is the pom";
+
+    private final byte[] POM_CONTENT_BYTES = POM_CONTENT.getBytes();
+
+    @Before
+    public void setupTest() throws Exception
+    {
+        String change = "setup";
+        hosted = client.stores().create( new HostedRepository( "maven", HOSTED ), change, HostedRepository.class );
+        client.content().store( hosted.getKey(), POM_PATH, new ByteArrayInputStream( POM_CONTENT.getBytes() ) );
+    }
+
+    @Test
+    public void run() throws Exception
+    {
+        String expectedMD5 = Hex.encodeHexString( MessageDigest.getInstance( "MD5" ).digest( POM_CONTENT_BYTES ) );
+        String expectedSHA1 = Hex.encodeHexString( MessageDigest.getInstance( "SHA-1" ).digest( POM_CONTENT_BYTES ) );
+
+        try (InputStream inputStream = client.content().get( hosted.getKey(), POM_PATH ))
+        {
+            assertThat( inputStream, notNullValue() );
+        }
+
+        validateIt(POM_MD5_PATH, expectedMD5);
+        validateIt(POM_SHA1_PATH, expectedSHA1);
+    }
+
+    private void validateIt( String checksumPath, String expected ) throws Exception
+    {
+        try (InputStream inputStream = client.content().get( hosted.getKey(), checksumPath ))
+        {
+            assertThat( inputStream, notNullValue() );
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            IOUtils.copy( inputStream, out );
+            String checksum = out.toString();
+            //System.out.println( ">>>" + checksum );
+            assertThat( checksum, equalTo( expected ) );
+        }
+    }
+}


### PR DESCRIPTION
This is to address NOS-1885 -- Allow automatic generation of checksums also for hosted repos.
The word "metadata" is misleading. It means content metadata, e.g, the checksum files, and probably the http-metadata (not in this case). I borrow this concept from Galley.
Briefly, if there is any file in hosted repo missing checksum, this will generate the checksum for them once requested.
I added the ContentMetaGenerator and found the usage of Generators scattered in different places. So I add a manager for them to align their behavior. One major change: in the past if the canProcess returns true, but the generate fails (return null), we ignore the other generators. In this pr, I don't only rely on canProcess but also the return value of generateFileContent. If this method returns null, we keep trying the rest of Generators.
This aligns with what we do for the other Instance&lt;Something&gt;, and make a lot of sense in this case.
As you know, the maven-metadata-generator already handles the .md5/sha generation, but only for maven-metadata.xml. The new generator handles the checksum for .pom/.jar/etc.