### PR TITLE
Fix remote metadata expiration regression

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -750,12 +750,14 @@ public class ScheduleManager
         if ( !e.isPre() )
         {
             final ScheduleKey expiredKey = e.getKey();
+/*
             if ( scheduleEventLockCache.containsKey( expiredKey ) )
             {
                 logger.info( "Another instance {} is still handling expiration event for {}", expiredKey,
                              scheduleEventLockCache.containsKey( expiredKey ) );
                 return;
             }
+*/
             final Map expiredContent = e.getValue();
             if ( expiredKey != null && expiredContent != null )
             {
@@ -763,9 +765,11 @@ public class ScheduleManager
                 final String type = (String) expiredContent.get( ScheduleManager.JOB_TYPE );
                 final String data = (String) expiredContent.get( ScheduleManager.PAYLOAD );
                 fireEvent( eventDispatcher, new SchedulerTriggerEvent( type, data ) );
+/*
                 scheduleEventLockCache.executeCache( cache -> cache.put( expiredKey, nodeHolder.getLocalIndyNode(),
                                                                          schedulerConfig.getClusterLockExpiration(),
                                                                          TimeUnit.SECONDS ) );
+*/
             }
         }
     }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataTimeoutTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.ftest.core.category.TimingDependent;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static java.lang.Thread.sleep;
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Wait for the metadata.xml to expire. Then retrieve it and wait for it to expire, and check again.
+ */
+public class MetadataTimeoutTest
+                extends AbstractMetadataTimeoutWorkingTest
+{
+    private final int METADATA_TIMEOUT_SECONDS = 1;
+
+    private final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 2000;
+
+    @Test
+    @Category( TimingDependent.class )
+    public void timeout() throws Exception
+    {
+        // make the metadata.xml timeout
+        sleep( METADATA_TIMEOUT_WAITING_MILLISECONDS );
+        assertThat( "Metadata not removed when timeout", metadataFile.exists(), equalTo( false ) );
+
+        // retrieve it again
+        client.content().get( new StoreKey( MAVEN_PKG_KEY, remote, repoId ), metadataPath ).close();
+
+        sleep( METADATA_TIMEOUT_WAITING_MILLISECONDS );
+        assertThat( "(Second) Metadata not removed when timeout", metadataFile.exists(), equalTo( false ) );
+    }
+
+    @Override
+    protected RemoteRepository createRemoteRepository()
+    {
+        RemoteRepository repository = new RemoteRepository( MAVEN_PKG_KEY, repoId, server.formatUrl( repoId ) );
+        repository.setMetadataTimeoutSeconds( METADATA_TIMEOUT_SECONDS );
+        return repository;
+    }
+}


### PR DESCRIPTION
This is to fix NOS-1846 (Remote metadata expiration does not work correctly). 
I got the same test result as @pkocandr. Briefly, we find that the metadata.xml is cleaned correctly when it timeout. But if we retrieve it again, it will stay there forever. This is caused by scheduleEventLockCache. I see we put stuff in it but never clean them. Then the code checks it and returns/blocks the event propagation. 
The ftest in this PR shows the second time expiration check fails before the fix. 
This cache might have something to do with cluster but apparently, we have to leave out it for now. 
@ligangty might know more about it. 