### PR TITLE
[Draft] Implement 4 golden signals directly in Indy metrics

### DIFF
--- a/addons/sli/jaxrs/pom.xml
+++ b/addons/sli/jaxrs/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-sli</artifactId>
+    <version>1.8.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>indy-sli-jaxrs</artifactId>
+  <name>Indy :: Add-Ons :: Service Level Indicators Reporting :: JAX-RS</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-db-memory</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-test-fixtures-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-test-harness-maven</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.atlas</groupId>
+      <artifactId>atlas-identities</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>confset</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>confset</descriptorRef>
+                <!-- <descriptorRef>dataset</descriptorRef> -->
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
@@ -1,0 +1,80 @@
+package org.commonjava.indy.sli.jaxrs;
+
+import org.commonjava.cdi.util.weft.ThreadContext;
+import org.commonjava.indy.metrics.IndyMetricsManager;
+import org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet;
+import org.slf4j.MDC;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REQUEST_LATENCY_NS;
+
+@ApplicationScoped
+public class GoldenSignalsFilter
+    implements Filter
+{
+    @Inject
+    private GoldenSignalsMetricSet metricSet;
+
+    @Override
+    public void init( final FilterConfig filterConfig )
+    {
+    }
+
+    @Override
+    public void doFilter( final ServletRequest servletRequest, final ServletResponse servletResponse,
+                          final FilterChain filterChain )
+            throws IOException, ServletException
+    {
+        long start = System.nanoTime();
+
+        try
+        {
+            filterChain.doFilter( servletRequest, servletResponse );
+        }
+        finally
+        {
+            long end = System.nanoTime();
+            MDC.put( REQUEST_LATENCY_NS, String.valueOf( end - start ) );
+
+            // TODO: Determine the function in play here, and whether it was an error.
+            String function = getFunction();
+            boolean error = isError();
+
+            metricSet.function( function ).ifPresent( ms -> {
+                ms.latency( end-start ).call();
+                if ( error )
+                {
+                    ms.error();
+                }
+            } );
+        }
+    }
+
+    private boolean isError()
+    {
+        ThreadContext context = ThreadContext.getContext( false );
+
+        return false;
+    }
+
+    private String getFunction()
+    {
+        ThreadContext context = ThreadContext.getContext( false );
+
+        
+    }
+
+    @Override
+    public void destroy()
+    {
+    }
+}

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/SLIDeploymentProvider.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/SLIDeploymentProvider.java
@@ -1,0 +1,36 @@
+package org.commonjava.indy.sli.jaxrs;
+
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.FilterInfo;
+import io.undertow.servlet.util.ImmediateInstanceFactory;
+import org.commonjava.indy.bind.jaxrs.IndyDeploymentProvider;
+import org.commonjava.indy.bind.jaxrs.ResourceManagementFilter;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.DispatcherType;
+import javax.ws.rs.core.Application;
+
+@ApplicationScoped
+public class SLIDeploymentProvider
+        extends IndyDeploymentProvider
+{
+    @Inject
+    private GoldenSignalsFilter goldenSignalsFilter;
+
+    @Override
+    public DeploymentInfo getDeploymentInfo( final String contextRoot, final Application application )
+    {
+        DeploymentInfo di = new DeploymentInfo();
+
+        FilterInfo filterInfo = Servlets.filter( "SLI Reporting", GoldenSignalsFilter.class,
+                                                    new ImmediateInstanceFactory<GoldenSignalsFilter>(
+                                                            this.goldenSignalsFilter ) );
+
+        di.addFilter( filterInfo )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/*", DispatcherType.REQUEST );
+
+        return di;
+    }
+}

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsFunctionMetrics.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsFunctionMetrics.java
@@ -1,0 +1,55 @@
+package org.commonjava.indy.sli.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.Timer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class GoldenSignalsFunctionMetrics
+{
+    private String name;
+
+    private Timer latency = new Timer();
+
+    private Meter errors = new Meter();
+
+    private Meter throughput = new Meter();
+
+    GoldenSignalsFunctionMetrics( String name )
+    {
+        this.name = name;
+    }
+
+    Map<String, Metric> getMetrics()
+    {
+        Map<String, Metric> metrics = new HashMap<>();
+        metrics.put( name + ".latency", latency );
+        metrics.put( name + ".errors", errors );
+        metrics.put( name + ".throughput", throughput );
+
+        return metrics;
+    }
+
+    public GoldenSignalsFunctionMetrics latency( long duration )
+    {
+        latency.update( duration, NANOSECONDS );
+        return this;
+    }
+
+    public GoldenSignalsFunctionMetrics error()
+    {
+        errors.mark();
+        return this;
+    }
+
+    public GoldenSignalsFunctionMetrics call()
+    {
+        throughput.mark();
+        return this;
+    }
+}

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSet.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSet.java
@@ -1,0 +1,65 @@
+package org.commonjava.indy.sli.metrics;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@ApplicationScoped
+public class GoldenSignalsMetricSet
+        implements MetricSet
+{
+    public static final String FN_CONTENT = "content";
+
+    public static final String FN_CONTENT_MAVEN = "content.maven";
+
+    public static final String FN_CONTENT_NPM = "content.npm";
+
+    public static final String FN_CONTENT_GENERIC = "content.generic";
+
+    public static final String FN_METADATA = "metadata";
+
+    public static final String FN_METADATA_MAVEN = "metadata.maven";
+
+    public static final String FN_METADATA_NPM = "metadata.npm";
+
+    public static final String FN_PROMOTION = "promotion";
+
+    public static final String FN_TRACKING_RECORD = "tracking.record";
+
+    public static final String FN_CONTENT_LISTING = "content.listing";
+
+    public static final String FN_REPO_MGMT = "repo.mgmt";
+
+    private static final String[] FUNCTIONS = {
+            FN_CONTENT, FN_CONTENT_MAVEN, FN_CONTENT_NPM, FN_CONTENT_GENERIC,
+            FN_METADATA, FN_METADATA_MAVEN, FN_METADATA_NPM,
+            FN_PROMOTION, FN_TRACKING_RECORD, FN_CONTENT_LISTING, FN_REPO_MGMT
+    };
+
+    private Map<String, GoldenSignalsFunctionMetrics> functionMetrics;
+
+    public GoldenSignalsMetricSet()
+    {
+        Stream.of( FUNCTIONS )
+              .forEach( function -> functionMetrics.put( function, new GoldenSignalsFunctionMetrics( function ) ) );
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics()
+    {
+        Map<String, Metric> metrics = new HashMap<>();
+        functionMetrics.values().forEach( ms -> metrics.putAll( ms.getMetrics() ) );
+
+        return metrics;
+    }
+
+    public Optional<GoldenSignalsFunctionMetrics> function( String name )
+    {
+        return functionMetrics.containsKey( name ) ? Optional.of( functionMetrics.get( name ) ) : Optional.empty();
+    }
+}

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSetProvider.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSetProvider.java
@@ -1,0 +1,21 @@
+package org.commonjava.indy.sli.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import org.commonjava.indy.metrics.MetricSetProvider;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class GoldenSignalsMetricSetProvider
+        implements MetricSetProvider
+{
+    @Inject
+    private GoldenSignalsMetricSet metricSet;
+
+    @Override
+    public void registerMetricSet( final MetricRegistry registry )
+    {
+        registry.register( "indy.sli.gs", metricSet );
+    }
+}

--- a/addons/sli/pom.xml
+++ b/addons/sli/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 
     Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
@@ -18,35 +18,17 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.commonjava.indy</groupId>
-    <artifactId>indy-parent</artifactId>
+    <artifactId>indy-addons</artifactId>
     <version>1.8.0-SNAPSHOT</version>
   </parent>
-  
-  <artifactId>indy-addons</artifactId>
+  <artifactId>indy-sli</artifactId>
+  <name>Indy :: Add-Ons :: Service Level Indicators Reporting :: Parent</name>
   <packaging>pom</packaging>
 
-  <name>Indy :: Add-Ons :: Parent</name>
-  
   <modules>
-    <module>content-index</module>
-    <module>dot-maven</module>
-    <module>folo</module>
-    <module>httprox</module>
-    <module>implied-repos</module>
-    <module>koji</module>
-    <module>promote</module>
-    <module>revisions</module>
-    <module>pkg-maven</module>
-    <module>diagnostics</module>
-    <module>pkg-npm</module>
-    <module>hosted-by-archive</module>
-    <module>content-browse</module>
-    <module>changelog</module>
-    <module>event-audit</module>
-    <module>sli</module>
-    <!-- DO NOT REMOVE: append::addon -->
+    <module>jaxrs</module>
   </modules>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -878,6 +878,19 @@
         <artifactId>jgroups</artifactId>
         <version>${jgroupsVersion}</version>
       </dependency>
+<dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-sli-common</artifactId>
+        <version>1.8.0-SNAPSHOT</version>
+      </dependency>
+<dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-sli-common</artifactId>
+        <version>1.8.0-SNAPSHOT</version>
+        <classifier>confset</classifier>
+        <type>tar.gz</type>
+      </dependency>
+
       <!-- DO NOT REMOVE: append::depMgmt -->
 
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
@@ -102,8 +102,6 @@ public class ResourceManagementFilter
     public void doFilter( final ServletRequest request, final ServletResponse response, final FilterChain chain )
             throws IOException, ServletException
     {
-        long start = System.nanoTime();
-
         String name = Thread.currentThread().getName();
         String clientAddr = request.getRemoteAddr();
 
@@ -184,10 +182,6 @@ public class ResourceManagementFilter
             {
                 logger.error( "Failed to cleanup resources", e );
             }
-
-            long end = System.nanoTime();
-            MDC.put( REQUEST_PHASE, REQUEST_PHASE_END );
-            MDC.put( REQUEST_LATENCY_NS, String.valueOf( end - start ) );
 
             restLogger.info( "END {}{} (from: {})", hsr.getRequestURL(), qs == null ? "" : "?" + qs, clientAddr );
 


### PR DESCRIPTION
This approach will use a servlet filter to wrap REST traffic and analyze it using previously
established metadata (currently added to the MDC, but eventually copied to ThreadContext).
Then this analysis will be used to classify the Indy function that the request accessed, and
log metrics by function. Metrics will be limited to latency, errors, and throughput. Saturation
will be measured separately for now...until we understand it better.

I still need to add the actual classification logic, and copy the classification information
from the MDC into the ThreadContext. Using MDC for anything except logging is kind of an ugly hack.