### PR TITLE
Implement 4 golden signals directly in Indy metrics

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
@@ -45,7 +45,7 @@ import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
 
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.CONTENT_TRACKING_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.CONTENT_TRACKING_ID;
 import static org.commonjava.indy.folo.ctl.FoloConstants.ACCESS_CHANNEL;
 import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_KEY;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;

--- a/addons/httprox/common/pom.xml
+++ b/addons/httprox/common/pom.xml
@@ -37,6 +37,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-sli-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-jaxrs</artifactId>
     </dependency>
     <dependency>

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
@@ -15,15 +15,12 @@
  */
 package org.commonjava.indy.httprox.util;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.model.core.ArtifactStore;
-import org.commonjava.indy.model.core.RemoteRepository;
-import org.commonjava.indy.model.galley.KeyedLocation;
 import org.commonjava.indy.model.util.HttpUtils;
 import org.commonjava.indy.util.ApplicationHeader;
 import org.commonjava.indy.util.ApplicationStatus;
@@ -33,22 +30,17 @@ import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-import org.xnio.channels.Channels;
 import org.xnio.channels.StreamSinkChannel;
-import org.xnio.conduits.ConduitStreamSinkChannel;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.HTTP_STATUS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.HTTP_STATUS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.setContext;
 import static org.commonjava.indy.httprox.util.ChannelUtils.DEFAULT_READ_BUF_SIZE;
 import static org.commonjava.indy.httprox.util.ChannelUtils.flush;
 import static org.commonjava.indy.httprox.util.ChannelUtils.write;
@@ -106,7 +98,7 @@ public class HttpConduitWrapper
     public void writeStatus( final ApplicationStatus status )
             throws IOException
     {
-        MDC.put( HTTP_STATUS, String.valueOf( status.code() ) );
+        setContext( HTTP_STATUS, String.valueOf( status.code() ) );
 
         final ByteBuffer b =
                 ByteBuffer.wrap( String.format( "HTTP/1.1 %d %s\r\n", status.code(), status.message() ).getBytes() );
@@ -117,7 +109,7 @@ public class HttpConduitWrapper
     public void writeStatus( final int code, final String message )
             throws IOException
     {
-        MDC.put( HTTP_STATUS, String.valueOf( code ) );
+        setContext( HTTP_STATUS, String.valueOf( code ) );
 
         final ByteBuffer b = ByteBuffer.wrap( String.format( "HTTP/1.1 %d %s\r\n", code, message ).getBytes() );
         sinkChannel.write( b );

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyResponseHelper.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyResponseHelper.java
@@ -47,7 +47,6 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
 import java.io.IOException;
 import java.net.URL;
@@ -56,10 +55,11 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.CONTENT_ENTRY_POINT;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.METADATA_CONTENT;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.PACKAGE_TYPE;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.CONTENT_ENTRY_POINT;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.METADATA_CONTENT;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PACKAGE_TYPE;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.setContext;
 import static org.commonjava.indy.model.core.ArtifactStore.TRACKING_ID;
 import static org.commonjava.indy.model.core.GenericPackageTypeDescriptor.GENERIC_PKG_KEY;
 import static org.commonjava.maven.galley.io.SpecialPathConstants.PKG_TYPE_GENERIC_HTTP;
@@ -127,8 +127,8 @@ public class ProxyResponseHelper
             }
         }
 
-        MDC.put( PACKAGE_TYPE, store.getKey().getPackageType() );
-        MDC.put( CONTENT_ENTRY_POINT, store.getKey().toString() );
+        setContext( PACKAGE_TYPE, store.getKey().getPackageType() );
+        setContext( CONTENT_ENTRY_POINT, store.getKey().toString() );
 
         return store;
     }
@@ -290,8 +290,8 @@ public class ProxyResponseHelper
                    final boolean writeBody, final UserPass proxyUserPass )
                     throws IOException, IndyWorkflowException
     {
-        MDC.put( PATH, path );
-        MDC.put( METADATA_CONTENT, Boolean.toString( false ) );
+        setContext( PATH, path );
+        setContext( METADATA_CONTENT, Boolean.toString( false ) );
 
         if ( metricsConfig == null || metricRegistry == null )
         {

--- a/addons/sli/jaxrs/pom.xml
+++ b/addons/sli/jaxrs/pom.xml
@@ -29,7 +29,7 @@
   <dependencies>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-subsys-metrics</artifactId>
+      <artifactId>indy-subsys-metrics-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
@@ -38,6 +38,10 @@
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-model-core-java</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
@@ -70,28 +74,5 @@
       <artifactId>jboss-servlet-api_3.0_spec</artifactId>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>confset</id>
-            <goals>
-              <goal>single</goal>
-            </goals>
-            <phase>package</phase>
-            <configuration>
-              <descriptorRefs>
-                <descriptorRef>confset</descriptorRef>
-                <!-- <descriptorRef>dataset</descriptorRef> -->
-              </descriptorRefs>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
 </project>

--- a/addons/sli/jaxrs/pom.xml
+++ b/addons/sli/jaxrs/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-sli</artifactId>
+    <version>1.8.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>indy-sli-jaxrs</artifactId>
+  <name>Indy :: Add-Ons :: Service Level Indicators Reporting :: JAX-RS</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-db-memory</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-test-fixtures-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-test-harness-maven</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.atlas</groupId>
+      <artifactId>atlas-identities</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>confset</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>confset</descriptorRef>
+                <!-- <descriptorRef>dataset</descriptorRef> -->
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
@@ -1,7 +1,5 @@
 package org.commonjava.indy.sli.jaxrs;
 
-import org.commonjava.cdi.util.weft.ThreadContext;
-import org.commonjava.indy.metrics.IndyMetricsManager;
 import org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet;
 import org.slf4j.MDC;
 
@@ -14,8 +12,34 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REQUEST_LATENCY_NS;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.Integer.parseInt;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.HTTP_METHOD;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.HTTP_STATUS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.METADATA_CONTENT;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PACKAGE_TYPE;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REQUEST_LATENCY_NS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REST_ENDPOINT_PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.getContext;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_CONTENT;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_CONTENT_LISTING;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_CONTENT_MAVEN;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_CONTENT_NPM;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_METADATA;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_METADATA_MAVEN;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_METADATA_NPM;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_PROMOTION;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_REPO_MGMT;
+import static org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet.FN_TRACKING_RECORD;
 
 @ApplicationScoped
 public class GoldenSignalsFilter
@@ -45,32 +69,75 @@ public class GoldenSignalsFilter
             long end = System.nanoTime();
             MDC.put( REQUEST_LATENCY_NS, String.valueOf( end - start ) );
 
-            // TODO: Determine the function in play here, and whether it was an error.
-            String function = getFunction();
+            Set<String> functions = new HashSet<>( getFunctions() );
             boolean error = isError();
 
-            metricSet.function( function ).ifPresent( ms -> {
+            functions.forEach( function -> metricSet.function( function ).ifPresent( ms -> {
                 ms.latency( end-start ).call();
                 if ( error )
                 {
                     ms.error();
                 }
-            } );
+            } ) );
         }
     }
 
     private boolean isError()
     {
-        ThreadContext context = ThreadContext.getContext( false );
-
-        return false;
+        int status = parseInt( getContext( HTTP_STATUS, "200" ) );
+        return status > 499;
     }
 
-    private String getFunction()
-    {
-        ThreadContext context = ThreadContext.getContext( false );
+    private static final Set<String> MODIFY_METHODS = new HashSet<>( asList( "POST", "PUT", "DELETE" ) );
 
-        
+    private List<String> getFunctions()
+    {
+        String restPath = getContext( REST_ENDPOINT_PATH );
+        String method = getContext( HTTP_METHOD );
+
+        if ( restPath.matches( "/api/promotion/.+/promote" ) )
+        {
+            // this is a promotion request
+            return singletonList( FN_PROMOTION );
+        }
+        else if ( restPath.matches( "/api/admin/stores/.+" ) )
+        {
+            if ( MODIFY_METHODS.contains( method ))
+            {
+                // this is a store modification request
+                return singletonList( FN_REPO_MGMT );
+            }
+        }
+        else if ( restPath.matches( "/api/browse/.+" ) )
+        {
+            // this is a browse / list request
+            return singletonList( FN_CONTENT_LISTING );
+        }
+        else if ( restPath.matches( "/api/folo/admin/[^/]+/(record|report)" ) )
+        {
+            // this is a request for a tracking record
+            return singletonList( FN_TRACKING_RECORD );
+        }
+        else if ( restPath.matches( "/api/(content/.+|folo/track/[^/]+/.+)" ) )
+        {
+            boolean isMetadata = parseBoolean( getContext( METADATA_CONTENT, "false" ) );
+            String packageType = getContext( PACKAGE_TYPE );
+
+            if ( PKG_TYPE_MAVEN.equals( packageType ) )
+            {
+                return isMetadata ?
+                        asList( FN_METADATA, FN_METADATA_MAVEN ) :
+                        asList( FN_CONTENT, FN_CONTENT_MAVEN );
+            }
+            else if ( PKG_TYPE_NPM.equals( packageType ) )
+            {
+                return isMetadata ?
+                        asList( FN_METADATA, FN_METADATA_NPM ) :
+                        asList( FN_CONTENT, FN_CONTENT_NPM );
+            }
+        }
+
+        return emptyList();
     }
 
     @Override

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
@@ -1,0 +1,80 @@
+package org.commonjava.indy.sli.jaxrs;
+
+import org.commonjava.cdi.util.weft.ThreadContext;
+import org.commonjava.indy.metrics.IndyMetricsManager;
+import org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet;
+import org.slf4j.MDC;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import java.io.IOException;
+
+import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REQUEST_LATENCY_NS;
+
+@ApplicationScoped
+public class GoldenSignalsFilter
+    implements Filter
+{
+    @Inject
+    private GoldenSignalsMetricSet metricSet;
+
+    @Override
+    public void init( final FilterConfig filterConfig )
+    {
+    }
+
+    @Override
+    public void doFilter( final ServletRequest servletRequest, final ServletResponse servletResponse,
+                          final FilterChain filterChain )
+            throws IOException, ServletException
+    {
+        long start = System.nanoTime();
+
+        try
+        {
+            filterChain.doFilter( servletRequest, servletResponse );
+        }
+        finally
+        {
+            long end = System.nanoTime();
+            MDC.put( REQUEST_LATENCY_NS, String.valueOf( end - start ) );
+
+            // TODO: Determine the function in play here, and whether it was an error.
+            String function = getFunction();
+            boolean error = isError();
+
+            metricSet.function( function ).ifPresent( ms -> {
+                ms.latency( end-start ).call();
+                if ( error )
+                {
+                    ms.error();
+                }
+            } );
+        }
+    }
+
+    private boolean isError()
+    {
+        ThreadContext context = ThreadContext.getContext( false );
+
+        return false;
+    }
+
+    private String getFunction()
+    {
+        ThreadContext context = ThreadContext.getContext( false );
+
+        
+    }
+
+    @Override
+    public void destroy()
+    {
+    }
+}

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilterMapper.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilterMapper.java
@@ -13,7 +13,7 @@ import javax.servlet.DispatcherType;
 import javax.ws.rs.core.Application;
 
 @ApplicationScoped
-public class SLIDeploymentProvider
+public class GoldenSignalsFilterMapper
         extends IndyDeploymentProvider
 {
     @Inject
@@ -29,7 +29,11 @@ public class SLIDeploymentProvider
                                                             this.goldenSignalsFilter ) );
 
         di.addFilter( filterInfo )
-          .addFilterUrlMapping( filterInfo.getName(), "/api/*", DispatcherType.REQUEST );
+          .addFilterUrlMapping( filterInfo.getName(), "/api/folo*", DispatcherType.REQUEST )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/content*", DispatcherType.REQUEST )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/promote*", DispatcherType.REQUEST )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/admin/stores*", DispatcherType.REQUEST )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/browse*", DispatcherType.REQUEST );
 
         return di;
     }

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/SLIDeploymentProvider.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/SLIDeploymentProvider.java
@@ -1,0 +1,36 @@
+package org.commonjava.indy.sli.jaxrs;
+
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.FilterInfo;
+import io.undertow.servlet.util.ImmediateInstanceFactory;
+import org.commonjava.indy.bind.jaxrs.IndyDeploymentProvider;
+import org.commonjava.indy.bind.jaxrs.ResourceManagementFilter;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.DispatcherType;
+import javax.ws.rs.core.Application;
+
+@ApplicationScoped
+public class SLIDeploymentProvider
+        extends IndyDeploymentProvider
+{
+    @Inject
+    private GoldenSignalsFilter goldenSignalsFilter;
+
+    @Override
+    public DeploymentInfo getDeploymentInfo( final String contextRoot, final Application application )
+    {
+        DeploymentInfo di = new DeploymentInfo();
+
+        FilterInfo filterInfo = Servlets.filter( "SLI Reporting", GoldenSignalsFilter.class,
+                                                    new ImmediateInstanceFactory<GoldenSignalsFilter>(
+                                                            this.goldenSignalsFilter ) );
+
+        di.addFilter( filterInfo )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/*", DispatcherType.REQUEST );
+
+        return di;
+    }
+}

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsFunctionMetrics.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsFunctionMetrics.java
@@ -1,0 +1,55 @@
+package org.commonjava.indy.sli.metrics;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.Timer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+public class GoldenSignalsFunctionMetrics
+{
+    private String name;
+
+    private Timer latency = new Timer();
+
+    private Meter errors = new Meter();
+
+    private Meter throughput = new Meter();
+
+    GoldenSignalsFunctionMetrics( String name )
+    {
+        this.name = name;
+    }
+
+    Map<String, Metric> getMetrics()
+    {
+        Map<String, Metric> metrics = new HashMap<>();
+        metrics.put( name + ".latency", latency );
+        metrics.put( name + ".errors", errors );
+        metrics.put( name + ".throughput", throughput );
+
+        return metrics;
+    }
+
+    public GoldenSignalsFunctionMetrics latency( long duration )
+    {
+        latency.update( duration, NANOSECONDS );
+        return this;
+    }
+
+    public GoldenSignalsFunctionMetrics error()
+    {
+        errors.mark();
+        return this;
+    }
+
+    public GoldenSignalsFunctionMetrics call()
+    {
+        throughput.mark();
+        return this;
+    }
+}

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSet.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSet.java
@@ -41,12 +41,15 @@ public class GoldenSignalsMetricSet
             FN_PROMOTION, FN_TRACKING_RECORD, FN_CONTENT_LISTING, FN_REPO_MGMT
     };
 
-    private Map<String, GoldenSignalsFunctionMetrics> functionMetrics;
+    private Map<String, GoldenSignalsFunctionMetrics> functionMetrics = new HashMap<>();
 
     public GoldenSignalsMetricSet()
     {
         Stream.of( FUNCTIONS )
-              .forEach( function -> functionMetrics.put( function, new GoldenSignalsFunctionMetrics( function ) ) );
+              .forEach( function -> {
+                  System.out.println( "Wiring SLI metrics for: " + function );
+                  functionMetrics.put( function, new GoldenSignalsFunctionMetrics( function ) );
+              } );
     }
 
     @Override

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSet.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSet.java
@@ -1,0 +1,65 @@
+package org.commonjava.indy.sli.metrics;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+@ApplicationScoped
+public class GoldenSignalsMetricSet
+        implements MetricSet
+{
+    public static final String FN_CONTENT = "content";
+
+    public static final String FN_CONTENT_MAVEN = "content.maven";
+
+    public static final String FN_CONTENT_NPM = "content.npm";
+
+    public static final String FN_CONTENT_GENERIC = "content.generic";
+
+    public static final String FN_METADATA = "metadata";
+
+    public static final String FN_METADATA_MAVEN = "metadata.maven";
+
+    public static final String FN_METADATA_NPM = "metadata.npm";
+
+    public static final String FN_PROMOTION = "promotion";
+
+    public static final String FN_TRACKING_RECORD = "tracking.record";
+
+    public static final String FN_CONTENT_LISTING = "content.listing";
+
+    public static final String FN_REPO_MGMT = "repo.mgmt";
+
+    private static final String[] FUNCTIONS = {
+            FN_CONTENT, FN_CONTENT_MAVEN, FN_CONTENT_NPM, FN_CONTENT_GENERIC,
+            FN_METADATA, FN_METADATA_MAVEN, FN_METADATA_NPM,
+            FN_PROMOTION, FN_TRACKING_RECORD, FN_CONTENT_LISTING, FN_REPO_MGMT
+    };
+
+    private Map<String, GoldenSignalsFunctionMetrics> functionMetrics;
+
+    public GoldenSignalsMetricSet()
+    {
+        Stream.of( FUNCTIONS )
+              .forEach( function -> functionMetrics.put( function, new GoldenSignalsFunctionMetrics( function ) ) );
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics()
+    {
+        Map<String, Metric> metrics = new HashMap<>();
+        functionMetrics.values().forEach( ms -> metrics.putAll( ms.getMetrics() ) );
+
+        return metrics;
+    }
+
+    public Optional<GoldenSignalsFunctionMetrics> function( String name )
+    {
+        return functionMetrics.containsKey( name ) ? Optional.of( functionMetrics.get( name ) ) : Optional.empty();
+    }
+}

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSetProvider.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSetProvider.java
@@ -16,6 +16,6 @@ public class GoldenSignalsMetricSetProvider
     @Override
     public void registerMetricSet( final MetricRegistry registry )
     {
-        registry.register( "indy.sli.gs", metricSet );
+        registry.register( "sli.golden", metricSet );
     }
 }

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSetProvider.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsMetricSetProvider.java
@@ -1,0 +1,21 @@
+package org.commonjava.indy.sli.metrics;
+
+import com.codahale.metrics.MetricRegistry;
+import org.commonjava.indy.metrics.MetricSetProvider;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class GoldenSignalsMetricSetProvider
+        implements MetricSetProvider
+{
+    @Inject
+    private GoldenSignalsMetricSet metricSet;
+
+    @Override
+    public void registerMetricSet( final MetricRegistry registry )
+    {
+        registry.register( "indy.sli.gs", metricSet );
+    }
+}

--- a/addons/sli/pom.xml
+++ b/addons/sli/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 
     Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
@@ -18,35 +18,17 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.commonjava.indy</groupId>
-    <artifactId>indy-parent</artifactId>
+    <artifactId>indy-addons</artifactId>
     <version>1.8.0-SNAPSHOT</version>
   </parent>
-  
-  <artifactId>indy-addons</artifactId>
+  <artifactId>indy-sli</artifactId>
+  <name>Indy :: Add-Ons :: Service Level Indicators Reporting :: Parent</name>
   <packaging>pom</packaging>
 
-  <name>Indy :: Add-Ons :: Parent</name>
-  
   <modules>
-    <module>content-index</module>
-    <module>dot-maven</module>
-    <module>folo</module>
-    <module>httprox</module>
-    <module>implied-repos</module>
-    <module>koji</module>
-    <module>promote</module>
-    <module>revisions</module>
-    <module>pkg-maven</module>
-    <module>diagnostics</module>
-    <module>pkg-npm</module>
-    <module>hosted-by-archive</module>
-    <module>content-browse</module>
-    <module>changelog</module>
-    <module>event-audit</module>
-    <module>sli</module>
-    <!-- DO NOT REMOVE: append::addon -->
+    <module>jaxrs</module>
   </modules>
+
 </project>

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -17,7 +17,6 @@ package org.commonjava.indy.core.bind.jaxrs;
 
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
-import org.commonjava.indy.bind.jaxrs.RequestContextConstants;
 import org.commonjava.indy.bind.jaxrs.util.JaxRsRequestHelper;
 import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.content.ContentManager;
@@ -35,13 +34,11 @@ import org.commonjava.indy.util.ApplicationStatus;
 import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.indy.util.UriFormatter;
 import org.commonjava.maven.galley.event.EventMetadata;
-import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.SpecialPathInfo;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
-import org.commonjava.maven.galley.util.PathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -49,7 +46,6 @@ import org.slf4j.MDC;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.HttpMethod;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
@@ -60,19 +56,16 @@ import java.net.URI;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.CONTENT_ENTRY_POINT;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.HTTP_STATUS;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.METADATA_CONTENT;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.PACKAGE_TYPE;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.PATH;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithEntity;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.CONTENT_ENTRY_POINT;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.HTTP_STATUS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.METADATA_CONTENT;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PACKAGE_TYPE;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.setContext;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponseFromMetadata;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.setInfoHeaders;
-import static org.commonjava.indy.core.ctl.ContentController.CONTENT_BROWSE_API_ROOT;
 import static org.commonjava.indy.core.ctl.ContentController.LISTING_HTML_FILE;
-import static org.commonjava.indy.core.ctl.ContentController.CONTENT_BROWSE_ROOT;
-import static org.commonjava.indy.core.ctl.ContentController.BROWSER_USER_AGENT;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
 
 @ApplicationScoped
@@ -125,14 +118,14 @@ public class ContentAccessHandler
                               final HttpServletRequest request, EventMetadata eventMetadata,
                               final Supplier<URI> uriBuilder, final Consumer<ResponseBuilder> builderModifier )
     {
-        MDC.put( PACKAGE_TYPE, packageType );
-        MDC.put( PATH, path );
+        setContext( PACKAGE_TYPE, packageType );
+        setContext( PATH, path );
 
         final StoreType st = StoreType.get( type );
         StoreKey sk = new StoreKey( packageType, st, name );
 
         eventMetadata = eventMetadata.set( ContentManager.ENTRY_POINT_STORE, sk );
-        MDC.put( CONTENT_ENTRY_POINT, sk.toString() );
+        setContext( CONTENT_ENTRY_POINT, sk.toString() );
 
         Response response;
         final Transfer transfer;
@@ -146,7 +139,7 @@ public class ContentAccessHandler
 
             final URI uri = uriBuilder.get();
 
-            MDC.put( HTTP_STATUS, String.valueOf( 201 ) );
+            setContext( HTTP_STATUS, String.valueOf( 201 ) );
             ResponseBuilder builder = Response.created( uri );
             if ( builderModifier != null )
             {
@@ -173,8 +166,8 @@ public class ContentAccessHandler
     public Response doDelete( final String packageType, final String type, final String name, final String path,
                               EventMetadata eventMetadata, final Consumer<ResponseBuilder> builderModifier )
     {
-        MDC.put( PACKAGE_TYPE, packageType );
-        MDC.put( PATH, path );
+        setContext( PACKAGE_TYPE, packageType );
+        setContext( PATH, path );
 
         if ( !PackageTypes.contains( packageType ) )
         {
@@ -190,14 +183,14 @@ public class ContentAccessHandler
         StoreKey sk = new StoreKey( packageType, st, name );
 
         eventMetadata = eventMetadata.set( ContentManager.ENTRY_POINT_STORE, sk );
-        MDC.put( CONTENT_ENTRY_POINT, sk.toString() );
+        setContext( CONTENT_ENTRY_POINT, sk.toString() );
 
         Response response;
         try
         {
             final ApplicationStatus result = contentController.delete( sk, path, eventMetadata );
 
-            MDC.put( HTTP_STATUS, String.valueOf( result.code() ) );
+            setContext( HTTP_STATUS, String.valueOf( result.code() ) );
             ResponseBuilder builder = Response.status( result.code() );
             if ( builderModifier != null )
             {
@@ -225,8 +218,8 @@ public class ContentAccessHandler
                             final Boolean cacheOnly, final String baseUri, final HttpServletRequest request,
                             EventMetadata eventMetadata, final Consumer<ResponseBuilder> builderModifier )
     {
-        MDC.put( PACKAGE_TYPE, packageType );
-        MDC.put( PATH, path );
+        setContext( PACKAGE_TYPE, packageType );
+        setContext( PATH, path );
 
         if ( !PackageTypes.contains( packageType ) )
         {
@@ -242,7 +235,7 @@ public class ContentAccessHandler
         final StoreKey sk = new StoreKey( packageType, st, name );
 
         eventMetadata = eventMetadata.set( ContentManager.ENTRY_POINT_STORE, sk );
-        MDC.put( CONTENT_ENTRY_POINT, sk.toString() );
+        setContext( CONTENT_ENTRY_POINT, sk.toString() );
 
         Response response = null;
 
@@ -265,7 +258,7 @@ public class ContentAccessHandler
                     exists = item != null && item.exists();
 
                     SpecialPathInfo spi = specialPathManager.getSpecialPathInfo( item, packageType );
-                    MDC.put( METADATA_CONTENT, Boolean.toString( spi != null && spi.isMetadata() ) );
+                    setContext( METADATA_CONTENT, Boolean.toString( spi != null && spi.isMetadata() ) );
 
                     logger.debug( "Got transfer reference: {}", item );
                 }
@@ -296,12 +289,12 @@ public class ContentAccessHandler
                     if ( MDC.get( METADATA_CONTENT ) != null )
                     {
                         SpecialPathInfo spi = specialPathManager.getSpecialPathInfo( item, packageType );
-                        MDC.put( METADATA_CONTENT, Boolean.toString( spi != null && spi.isMetadata() ) );
+                        setContext( METADATA_CONTENT, Boolean.toString( spi != null && spi.isMetadata() ) );
                     }
 
                     logger.trace( "Building 200 response. Using HTTP metadata: {}", httpMetadata );
 
-                    MDC.put( HTTP_STATUS, String.valueOf( 200 ) );
+                    setContext( HTTP_STATUS, String.valueOf( 200 ) );
                     final ResponseBuilder builder = Response.ok();
 
                     // restrict the npm header contentType with json to avoid some parsing error
@@ -333,7 +326,7 @@ public class ContentAccessHandler
                     if ( response == null )
                     {
                         logger.debug( "No HTTP metadata; building generic 404 response." );
-                        MDC.put( HTTP_STATUS, String.valueOf( 404 ) );
+                        setContext( HTTP_STATUS, String.valueOf( 404 ) );
                         ResponseBuilder builder = Response.status( Status.NOT_FOUND );
                         if ( builderModifier != null )
                         {
@@ -363,8 +356,8 @@ public class ContentAccessHandler
                            final String baseUri, final HttpServletRequest request, EventMetadata eventMetadata,
                            final Consumer<ResponseBuilder> builderModifier )
     {
-        MDC.put( PACKAGE_TYPE, packageType );
-        MDC.put( PATH, path );
+        setContext( PACKAGE_TYPE, packageType );
+        setContext( PATH, path );
 
         if ( !PackageTypes.contains( packageType ) )
         {
@@ -380,7 +373,7 @@ public class ContentAccessHandler
         final StoreKey sk = new StoreKey( packageType, st, name );
 
         eventMetadata = eventMetadata.set( ContentManager.ENTRY_POINT_STORE, sk );
-        MDC.put( CONTENT_ENTRY_POINT, sk.toString() );
+        setContext( CONTENT_ENTRY_POINT, sk.toString() );
 
         final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.text_html );
         final String standardAccept = ApplicationContent.getStandardAccept( acceptInfo.getBaseAccept() );
@@ -404,7 +397,7 @@ public class ContentAccessHandler
                 final Transfer item = contentController.get( sk, path, eventMetadata );
 
                 SpecialPathInfo spi = specialPathManager.getSpecialPathInfo( item, packageType );
-                MDC.put( METADATA_CONTENT, Boolean.toString( spi != null && spi.isMetadata() ) );
+                setContext( METADATA_CONTENT, Boolean.toString( spi != null && spi.isMetadata() ) );
 
                 logger.debug( "HANDLE: retrieval of content: {}:{}", sk, path );
                 if ( item == null )

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -128,6 +128,10 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-pkg-npm-jaxrs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-sli-jaxrs</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.commonjava.indy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -738,6 +738,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-sli-jaxrs</artifactId>
+        <version>1.8.0-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.commonjava.indy.rest</groupId>
         <artifactId>indy-rest-api</artifactId>
         <type>yaml</type>

--- a/pom.xml
+++ b/pom.xml
@@ -878,6 +878,19 @@
         <artifactId>jgroups</artifactId>
         <version>${jgroupsVersion}</version>
       </dependency>
+<dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-sli-common</artifactId>
+        <version>1.8.0-SNAPSHOT</version>
+      </dependency>
+<dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-sli-common</artifactId>
+        <version>1.8.0-SNAPSHOT</version>
+        <classifier>confset</classifier>
+        <type>tar.gz</type>
+      </dependency>
+
       <!-- DO NOT REMOVE: append::depMgmt -->
 
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/MDCManager.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/MDCManager.java
@@ -15,12 +15,9 @@
  */
 package org.commonjava.indy.bind.jaxrs;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.commonjava.indy.conf.IndyConfiguration;
-import org.commonjava.indy.conf.EnvironmentConfig;
-import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -36,13 +33,14 @@ import java.util.UUID;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.CLIENT_ADDR;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.COMPONENT_ID;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.EXTERNAL_ID;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.HTTP_METHOD;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.HTTP_REQUEST_URI;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.INTERNAL_ID;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.PREFERRED_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.CLIENT_ADDR;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.COMPONENT_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.EXTERNAL_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.HTTP_METHOD;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.HTTP_REQUEST_URI;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.INTERNAL_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PREFERRED_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.setContext;
 
 @ApplicationScoped
 public class MDCManager
@@ -106,7 +104,8 @@ public class MDCManager
 
     public void putExtraHeaders( HttpServletRequest request )
     {
-        MDC.put( HTTP_METHOD, request.getMethod() );
+        // use setContext here so we get this value in ThreadContext too, for decision-making in the workflow, SLI classification, etc.
+        setContext( HTTP_METHOD, request.getMethod() );
         MDC.put( HTTP_REQUEST_URI, request.getRequestURI() );
         mdcHeadersList.forEach( ( header ) -> MDC.put( header, request.getHeader( header ) ) );
     }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RequestContextHelper.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RequestContextHelper.java
@@ -15,6 +15,9 @@
  */
 package org.commonjava.indy.bind.jaxrs;
 
+import org.commonjava.cdi.util.weft.ThreadContext;
+import org.slf4j.MDC;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -23,10 +26,45 @@ import static java.lang.annotation.RetentionPolicy.SOURCE;
 import static org.commonjava.indy.IndyRequestConstants.HEADER_COMPONENT_ID;
 
 /**
- * The scope annotations (Thread, Header, MDC) tell where the constant is available/used.
+ * The scope annotations (Thread, Header, MDC) tell where the constant is available/used. The static methods are used
+ * to manage contextual state in both MDC and ThreadContext.
  */
-public class RequestContextConstants
+public class RequestContextHelper
 {
+    public static void setContext( final String key, final String value )
+    {
+        org.slf4j.MDC.put( key, value );
+        ThreadContext.getContext( true ).computeIfAbsent( key, k -> value );
+    }
+
+    public static String getContext( final String key )
+    {
+        return getContext( key, null );
+    }
+
+    public static String getContext( final String key, final String defaultValue )
+    {
+        ThreadContext ctx = ThreadContext.getContext( false );
+        if ( ctx != null )
+        {
+            Object v = ctx.get( key );
+            return v == null ? defaultValue : String.valueOf( v );
+        }
+
+        return defaultValue;
+    }
+
+    public static void clearContext( final String key )
+    {
+        org.slf4j.MDC.remove( key );
+
+        ThreadContext ctx = ThreadContext.getContext( false );
+        if ( ctx != null )
+        {
+            ctx.remove( key );
+        }
+    }
+
     // Scope annotations
 
     @Target( { FIELD } )
@@ -43,16 +81,16 @@ public class RequestContextConstants
 
     //
 
-    @MDC
+    @Thread @MDC
     public static final String REST_CLASS_PATH = "REST-class-path";
 
-    @MDC
+    @Thread @MDC
     public static final String REST_METHOD_PATH = "REST-method-path";
 
-    @MDC
+    @Thread @MDC
     public static final String REST_ENDPOINT_PATH = "REST-endpoint-path";
 
-    @MDC
+    @Thread @MDC
     public static final String REST_CLASS = "REST-class";
 
     @MDC
@@ -67,25 +105,25 @@ public class RequestContextConstants
     @MDC
     public static final String REQUEST_PHASE = "request-phase";
 
-    @MDC
+    @Thread @MDC
     public static final String PACKAGE_TYPE = "package-type";
 
-    @MDC
+    @Thread @MDC
     public static final String METADATA_CONTENT = "metadata-content";
 
-    @MDC
+    @Thread @MDC
     public static final String CONTENT_ENTRY_POINT = "content-entry-point";
 
-    @MDC
+    @Thread @MDC
     public static final String HTTP_METHOD = "http-method";
 
-    @MDC
+    @Thread @MDC
     public static final String HTTP_REQUEST_URI = "http-request-uri";
 
-    @MDC
+    @Thread @MDC
     public static final String PATH = "path";
 
-    @MDC
+    @Thread @MDC
     public static final String HTTP_STATUS = "http-status";
 
     @Header @MDC

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
@@ -102,8 +102,6 @@ public class ResourceManagementFilter
     public void doFilter( final ServletRequest request, final ServletResponse response, final FilterChain chain )
             throws IOException, ServletException
     {
-        long start = System.nanoTime();
-
         String name = Thread.currentThread().getName();
         String clientAddr = request.getRemoteAddr();
 
@@ -184,10 +182,6 @@ public class ResourceManagementFilter
             {
                 logger.error( "Failed to cleanup resources", e );
             }
-
-            long end = System.nanoTime();
-            MDC.put( REQUEST_PHASE, REQUEST_PHASE_END );
-            MDC.put( REQUEST_LATENCY_NS, String.valueOf( end - start ) );
 
             restLogger.info( "END {}{} (from: {})", hsr.getRequestURL(), qs == null ? "" : "?" + qs, clientAddr );
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
@@ -40,15 +40,13 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.CLIENT_ADDR;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.EXTERNAL_ID;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.INTERNAL_ID;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.PREFERRED_ID;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REQUEST_LATENCY_NS;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REQUEST_PHASE;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REQUEST_PHASE_END;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REQUEST_PHASE_START;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.X_FORWARDED_FOR;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.CLIENT_ADDR;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.EXTERNAL_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.INTERNAL_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PREFERRED_ID;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REQUEST_PHASE;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REQUEST_PHASE_START;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.X_FORWARDED_FOR;
 
 @ApplicationScoped
 public class ResourceManagementFilter

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseUtils.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.commonjava.indy.IndyWorkflowException;
-import org.commonjava.indy.bind.jaxrs.MDCManager;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.dto.CreationDTO;
 import org.commonjava.indy.model.util.HttpUtils;
@@ -48,7 +47,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.HTTP_STATUS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.HTTP_STATUS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.setContext;
 
 public final class ResponseUtils
 {
@@ -307,11 +307,11 @@ public final class ResponseUtils
         ResponseBuilder builder = null;
         if ( code / 100 == 5 )
         {
-            MDC.put( HTTP_STATUS, String.valueOf( 502 ) );
+            setContext( HTTP_STATUS, String.valueOf( 502 ) );
             builder = Response.status( 502 );
         }
 
-        MDC.put( HTTP_STATUS, String.valueOf( code ) );
+        setContext( HTTP_STATUS, String.valueOf( code ) );
         builder = Response.status( code );
         if ( builderModifier != null )
         {
@@ -480,7 +480,7 @@ public final class ResponseUtils
             LOGGER.debug( "Sending response: {} {}\n{}", code.getStatusCode(), code.getReasonPhrase(), msg );
         }
 
-        MDC.put( HTTP_STATUS, code == null ? "000" : String.valueOf( code.getStatusCode() ) );
+        setContext( HTTP_STATUS, code == null ? "000" : String.valueOf( code.getStatusCode() ) );
 
         ResponseBuilder builder = Response.status( code ).type( MediaType.TEXT_PLAIN ).entity( msg );
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/RestInterceptor.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/RestInterceptor.java
@@ -1,21 +1,19 @@
 package org.commonjava.indy.bind.jaxrs.util;
 
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 
-import javax.inject.Inject;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.Interceptor;
 import javax.interceptor.InvocationContext;
 import javax.ws.rs.Path;
-import javax.ws.rs.core.Context;
-
 import java.nio.file.Paths;
 
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_CLASS;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_CLASS_PATH;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_ENDPOINT_PATH;
-import static org.commonjava.indy.bind.jaxrs.RequestContextConstants.REST_METHOD_PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REST_CLASS;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REST_CLASS_PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REST_ENDPOINT_PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REST_METHOD_PATH;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.getContext;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.setContext;
 
 @Interceptor
 @REST
@@ -33,26 +31,26 @@ public class RestInterceptor
         }
         while( classAnno == null && targetClass != null );
 
-        if ( MDC.get( REST_CLASS ) == null )
+        if ( getContext( REST_CLASS ) == null )
         {
             String targetName = context.getMethod().getDeclaringClass().getSimpleName();
-            MDC.put( REST_CLASS, targetName );
+            setContext( REST_CLASS, targetName );
 
             String classPath = "";
-            if ( classAnno != null && MDC.get( REST_CLASS_PATH ) == null )
+            if ( classAnno != null && getContext( REST_CLASS_PATH ) == null )
             {
                 classPath = classAnno.value();
-                MDC.put( REST_CLASS_PATH, classPath );
+                setContext( REST_CLASS_PATH, classPath );
             }
 
             Path methAnno = context.getMethod().getAnnotation( Path.class );
-            if ( methAnno != null && MDC.get( REST_METHOD_PATH ) == null  )
+            if ( methAnno != null && getContext( REST_METHOD_PATH ) == null  )
             {
                 String methodPath = methAnno.value();
-                MDC.put( REST_METHOD_PATH, methodPath );
+                setContext( REST_METHOD_PATH, methodPath );
 
                 String endpointPath = Paths.get( classPath, methodPath ).toString();
-                MDC.put( REST_ENDPOINT_PATH, endpointPath );
+                setContext( REST_ENDPOINT_PATH, endpointPath );
             }
         }
 


### PR DESCRIPTION
This approach will use a servlet filter to wrap REST traffic and analyze it using previously
established metadata (currently added to the MDC, but eventually copied to ThreadContext).
Then this analysis will be used to classify the Indy function that the request accessed, and
log metrics by function. Metrics will be limited to latency, errors, and throughput. Saturation
will be measured separately for now...until we understand it better.

I still need to add the actual classification logic, and copy the classification information
from the MDC into the ThreadContext. Using MDC for anything except logging is kind of an ugly hack.