### PR TITLE
Fix by-Path promotion doesn't merge maven-metadata issue

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -168,7 +168,8 @@ public class PromotionManager
                              DownloadManager downloadManager, StoreDataManager storeManager,
                              Locker<StoreKey> byGroupTargetLocks,
                              PromoteConfig config, NotFoundCache nfc, WeftExecutorService asyncPromotionService,
-                             WeftExecutorService transferService )
+                             WeftExecutorService transferService,
+                             SpecialPathManager specialPathManager )
     {
         this.validator = validator;
         this.contentManager = contentManager;
@@ -180,6 +181,7 @@ public class PromotionManager
         this.transferService = transferService;
         this.promotionHelper = new PromotionHelper( storeManager, downloadManager, contentManager, nfc );
         this.conflictManager = new PathConflictManager();
+        this.specialPathManager = specialPathManager;
     }
 
     @Measure

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -867,6 +867,30 @@ public class PromotionManager
         if ( target != null && target.exists() )
         {
             /*
+             * if we hit an existing metadata.xml, we remove it from both target repo and affected groups. The metadata
+             * will be regenerated on next request.
+             */
+            SpecialPathInfo pathInfo = specialPathManager.getSpecialPathInfo( target, tgt.getPackageType() );
+            if ( pathInfo != null && pathInfo.isMetadata() )
+            {
+                try
+                {
+                    target.delete( true );
+                    result.skipped = true;
+                    logger.info( "Metadata exists, mark as skipped and remove it, target: {}", target );
+                }
+                catch ( IOException e )
+                {
+                    String msg = String.format( "Failed to promote: %s. Target: %s. Failed to remove metadata.",
+                                                transfer, request.getTarget() );
+                    logger.info( msg );
+                    result.error = msg;
+                }
+
+                return result;
+            }
+
+            /*
              * e.g., fail in case of promotion of built artifacts into pnc-builds while it should pass (skip them)
              * in case of promotion of dependencies into shared-imports.
              */

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/data/PromotionManagerTest.java
@@ -59,6 +59,7 @@ import org.commonjava.maven.galley.maven.rel.MavenModelProcessor;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.nfc.MemoryNotFoundCache;
+import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.testing.maven.GalleyMavenFixture;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -121,6 +122,8 @@ public class PromotionManagerTest
 
     private static Cache<String, TransferMetadata> contentMetadata;
 
+    private SpecialPathManager specialPathManager;
+
     @BeforeClass
     public static void setupClass()
     {
@@ -160,8 +163,10 @@ public class PromotionManagerTest
         ContentDigester contentDigester = new DefaultContentDigester( dca, new CacheHandle<String, TransferMetadata>(
                 "content-metadata", contentMetadata ) );
 
+        specialPathManager = new SpecialPathManagerImpl();
+
         contentManager = new DefaultContentManager( storeManager, downloadManager, new IndyObjectMapper( true ),
-                                                    new SpecialPathManagerImpl(), new MemoryNotFoundCache(),
+                                                    specialPathManager, new MemoryNotFoundCache(),
                                                     contentDigester, new ContentGeneratorManager() );
 
         dataManager = new DataFileManager( temp.newFolder( "data" ), new DataFileEventManager() );
@@ -187,7 +192,7 @@ public class PromotionManagerTest
 
         manager =
                 new PromotionManager( validator, contentManager, downloadManager, storeManager,
-                                      new Locker<>(), config, nfc, svc, svc );
+                                      new Locker<>(), config, nfc, svc, svc, specialPathManager );
 
         executor = Executors.newCachedThreadPool();
     }

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/HostedMetadataRemergedOnPathPromoteTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/HostedMetadataRemergedOnPathPromoteTest.java
@@ -15,10 +15,13 @@
  */
 package org.commonjava.indy.promote.ftest;
 
+import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.IndyClientModule;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.promote.client.IndyPromoteClientModule;
 import org.commonjava.indy.promote.model.PathsPromoteRequest;
@@ -27,12 +30,17 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.Collections;
 
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -41,8 +49,9 @@ import static org.junit.Assert.assertThat;
  * GIVEN:
  * <ul>
  *     <li>HostedRepositories A and B</li>
- *     <li>HostedRepositories A and B both contain metadata path P</li>
+ *     <li>HostedRepositories A and B both contain metadata path P, and pom path P2</li>
  *     <li>Each metadata file contains different versions of the same project</li>
+ *     <li>Group G contains A</li>
  * </ul>
  * <br/>
  * WHEN:
@@ -54,6 +63,7 @@ import static org.junit.Assert.assertThat;
  * THEN:
  * <ul>
  *     <li>HostedRepository A's metadata path P should reflect values in HostedRepository B's metadata path P</li>
+ *     <li>Group G's metadata path P should reflect values in A and B</li>
  * </ul>
  */
 public class HostedMetadataRemergedOnPathPromoteTest
@@ -62,10 +72,14 @@ public class HostedMetadataRemergedOnPathPromoteTest
     private static final String HOSTED_A_NAME= "A";
     private static final String HOSTED_B_NAME= "B";
 
+    private static final String GROUP_G_NAME= "G";
+
     private static final String A_VERSION = "1.0";
     private static final String B_VERSION = "1.1";
 
     private static final String PATH = "/org/foo/bar/maven-metadata.xml";
+
+    private static final String POM_PATH_TEMPLATE = "/org/foo/bar/%version%/bar-%version%.pom";
 
     /* @formatter:off */
     private static final String REPO_CONTENT_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -73,8 +87,8 @@ public class HostedMetadataRemergedOnPathPromoteTest
         "  <groupId>org.foo</groupId>\n" +
         "  <artifactId>bar</artifactId>\n" +
         "  <versioning>\n" +
-        "    <latest>%version%</latest>\n" +
         "    <release>%version%</release>\n" +
+        "    <latest>%version%</latest>\n" +
         "    <versions>\n" +
         "      <version>%version%</version>\n" +
         "    </versions>\n" +
@@ -83,14 +97,31 @@ public class HostedMetadataRemergedOnPathPromoteTest
         "</metadata>\n";
     /* @formatter:on */
 
+    private static final String POM_CONTENT_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<project>\n" +
+        "  <modelVersion>4.0.0</modelVersion>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <version>%version%</version>\n" +
+        "  <name>Bar</name>\n" +
+        "  <dependencies>\n" +
+        "    <dependency>\n" +
+        "      <groupId>org.something</groupId>\n" +
+        "      <artifactId>oh</artifactId>\n" +
+        "      <version>1.0.1</version>\n" +
+        "    </dependency>\n" +
+        "  </dependencies>\n" +
+        "</project>\n";
+    /* @formatter:on */
+
     /* @formatter:off */
     private static final String AFTER_PROMOTE_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
         "<metadata>\n" +
         "  <groupId>org.foo</groupId>\n" +
         "  <artifactId>bar</artifactId>\n" +
         "  <versioning>\n" +
-        "    <latest>1.1</latest>\n" +
         "    <release>1.1</release>\n" +
+        "    <latest>1.1</latest>\n" +
         "    <versions>\n" +
         "      <version>1.0</version>\n" +
         "      <version>1.1</version>\n" +
@@ -102,9 +133,16 @@ public class HostedMetadataRemergedOnPathPromoteTest
 
     private HostedRepository a;
     private HostedRepository b;
+    private Group g;
 
     private String aPreContent;
     private String bContent;
+
+    private String aPomPath;
+    private String aPomContent;
+
+    private String bPomPath;
+    private String bPomContent;
 
     private final IndyPromoteClientModule promote = new IndyPromoteClientModule();
 
@@ -117,17 +155,34 @@ public class HostedMetadataRemergedOnPathPromoteTest
         a = client.stores().create( new HostedRepository( PKG_TYPE_MAVEN, HOSTED_A_NAME ), message, HostedRepository.class );
         b = client.stores().create( new HostedRepository( PKG_TYPE_MAVEN, HOSTED_B_NAME ), message, HostedRepository.class );
 
+        g = client.stores().create( new Group( PKG_TYPE_MAVEN, GROUP_G_NAME, a.getKey() ), message, Group.class );
+
+        aPomPath = POM_PATH_TEMPLATE.replaceAll( "%version%", A_VERSION );
+        aPomContent = POM_CONTENT_TEMPLATE.replaceAll( "%version%", A_VERSION );
+
+        client.content()
+              .store( a.getKey(), aPomPath, new ByteArrayInputStream(
+                              aPomContent.getBytes() ) );
+
         aPreContent = REPO_CONTENT_TEMPLATE.replaceAll( "%version%", A_VERSION );
 
         client.content()
               .store( a.getKey(), PATH, new ByteArrayInputStream(
-                      aPreContent.getBytes() ) );
+                              aPreContent.getBytes() ) );
+
+        //
+        bPomPath = POM_PATH_TEMPLATE.replaceAll( "%version%", B_VERSION );
+        bPomContent = POM_CONTENT_TEMPLATE.replaceAll( "%version%", B_VERSION );
+
+        client.content()
+              .store( b.getKey(), bPomPath, new ByteArrayInputStream(
+                              bPomContent.getBytes() ) );
 
         bContent = REPO_CONTENT_TEMPLATE.replaceAll( "%version%", B_VERSION );
 
         client.content()
               .store( b.getKey(), PATH, new ByteArrayInputStream(
-                      bContent.getBytes() ) );
+                              bContent.getBytes() ) );
     }
 
     @Test
@@ -136,9 +191,9 @@ public class HostedMetadataRemergedOnPathPromoteTest
             throws Exception
     {
         // verify our initial state
-        assertContent( a, PATH, aPreContent );
+        assertMetadataContent( a, PATH, aPreContent );
 
-        PathsPromoteRequest request = new PathsPromoteRequest( a.getKey(), b.getKey(), PATH );
+        PathsPromoteRequest request = new PathsPromoteRequest( b.getKey(), a.getKey(), new String[] { PATH, bPomPath } );
 
         // Pre-existing maven-metadata.xml should NOT cause a failure!
         request.setFailWhenExists( true );
@@ -149,8 +204,12 @@ public class HostedMetadataRemergedOnPathPromoteTest
 
         waitForEventPropagation();
 
+        // Group G's metadata path P should reflect values in A and B
+        assertMetadataContent( g, PATH, AFTER_PROMOTE_CONTENT );
+
         // Promotion to repo A should trigger re-merge of maven-metadata.xml, adding the version from repo B to that in A.
-        assertContent( a, PATH, AFTER_PROMOTE_CONTENT );
+        assertMetadataContent( a, PATH, AFTER_PROMOTE_CONTENT );
+
     }
 
     @Override
@@ -164,4 +223,71 @@ public class HostedMetadataRemergedOnPathPromoteTest
     {
         return false;
     }
+
+    protected String assertMetadataContent( ArtifactStore store, String path, String expected )
+                    throws IndyClientException, IOException
+    {
+        try (InputStream in = client.content().get( store.getKey(), path ))
+        {
+            assertThat( "Content not found: " + path + " in store: " + store.getKey(), in, notNullValue() );
+
+            String foundContent = IOUtils.toString( in );
+
+            foundContent = groom( foundContent );
+            expected = groom( expected );
+
+            logger.info( "Checking content result from path: {} in store: {} with value:\n\n{}\n\nagainst expected value:\n\n{}",
+                         path, store.getKey(), foundContent, expected );
+
+            assertThat( "Content is wrong: " + path + " in store: " + store.getKey(), foundContent,
+                        equalTo( expected ) );
+
+            return foundContent;
+        }
+    }
+
+    /**
+     * Normalize xml, ignore the lastUpdated, sort the versioning release/latest, etc
+     */
+    private String groom( String metadataXML ) throws IOException
+    {
+        String release = null;
+        String latest = null;
+
+        StringBuilder sb = new StringBuilder();
+        BufferedReader reader = new BufferedReader(
+                        new InputStreamReader( new ByteArrayInputStream( metadataXML.getBytes() ) ) );
+        while ( reader.ready() )
+        {
+            String line = reader.readLine();
+            if ( line.contains( "<?xml" ) )
+            {
+                sb.append( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" );
+            }
+            else if ( line.contains( "<lastUpdated>" ) )
+            {
+                ; // skip
+            }
+            else if ( line.contains( "<release>" ) )
+            {
+                release = line;
+            }
+            else if ( line.contains( "<latest>" ) )
+            {
+                latest = line;
+            }
+            else
+            {
+                if ( line.contains( "<versions>" ) )
+                {
+                    sb.append( release + "\n" );
+                    sb.append( latest + "\n" );
+                }
+                sb.append( line + "\n" );
+            }
+        }
+        reader.close();
+        return sb.toString();
+    }
+
 }

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -44,7 +44,9 @@
     <local-cache name="maven-metadata-cache" configuration="local-template"/>
 
     <local-cache name="maven-metadata-key-cache" configuration="local-template">
-      <indexing index="LOCAL" auto-config="true"/>
+      <indexing index="LOCAL">
+        <property name="default.directory_provider">ram</property>
+      </indexing>
     </local-cache>
 
     <local-cache name="indy-nfs-owner-cache" deadlock-detection-spin="10000" configuration="local-template">


### PR DESCRIPTION
This is to fix (NOS-1903) By-Path promotion doesn't merge maven-metadata.xml
This includes the test code in https://github.com/Commonjava/indy/pull/1272
To make it a real case, I add a pom file to A and B repo. Those pom files are necessary for generating metadata.xml. 
In order to compare metadata files, I have to groom them a bit. See details in the test case. 