### PR TITLE
Fix byPath promotion metadata problem and add snapshot merging test

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMerger.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMerger.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static org.commonjava.atlas.maven.ident.util.SnapshotUtils.LOCAL_SNAPSHOT_VERSION_PART;
+
 @ApplicationScoped
 public class MavenMetadataMerger
 {
@@ -151,7 +153,10 @@ public class MavenMetadataMerger
             {
                 String latest = versionObjects.get( versionObjects.size() - 1 ).renderStandard();
                 versioning.setLatest( latest );
-                versioning.setRelease( latest );
+                if ( !latest.endsWith( LOCAL_SNAPSHOT_VERSION_PART ) )
+                {
+                    versioning.setRelease( latest );
+                }
             }
         }
     }

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/HostedMetadataRemergedOnPathPromoteSnapshotTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/HostedMetadataRemergedOnPathPromoteSnapshotTest.java
@@ -15,12 +15,10 @@
  */
 package org.commonjava.indy.promote.ftest;
 
-import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.IndyClientModule;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.ftest.core.category.EventDependent;
-import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.promote.client.IndyPromoteClientModule;
@@ -30,17 +28,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Collection;
 import java.util.Collections;
 
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -66,7 +59,7 @@ import static org.junit.Assert.assertThat;
  *     <li>Group G's metadata path P should reflect values in A and B</li>
  * </ul>
  */
-public class HostedMetadataRemergedOnPathPromoteTest
+public class HostedMetadataRemergedOnPathPromoteSnapshotTest
         extends AbstractContentManagementTest
 {
     private static final String HOSTED_A_NAME= "A";
@@ -74,8 +67,8 @@ public class HostedMetadataRemergedOnPathPromoteTest
 
     private static final String GROUP_G_NAME= "G";
 
-    private static final String A_VERSION = "1.0";
-    private static final String B_VERSION = "1.1";
+    private static final String A_VERSION = "1.0-SNAPSHOT";
+    private static final String B_VERSION = "1.1-SNAPSHOT";
 
     private static final String PATH = "/org/foo/bar/maven-metadata.xml";
 
@@ -87,7 +80,6 @@ public class HostedMetadataRemergedOnPathPromoteTest
         "  <groupId>org.foo</groupId>\n" +
         "  <artifactId>bar</artifactId>\n" +
         "  <versioning>\n" +
-        "    <release>%version%</release>\n" +
         "    <latest>%version%</latest>\n" +
         "    <versions>\n" +
         "      <version>%version%</version>\n" +
@@ -120,11 +112,10 @@ public class HostedMetadataRemergedOnPathPromoteTest
         "  <groupId>org.foo</groupId>\n" +
         "  <artifactId>bar</artifactId>\n" +
         "  <versioning>\n" +
-        "    <release>1.1</release>\n" +
-        "    <latest>1.1</latest>\n" +
+        "    <latest>1.1-SNAPSHOT</latest>\n" +
         "    <versions>\n" +
-        "      <version>1.0</version>\n" +
-        "      <version>1.1</version>\n" +
+        "      <version>1.0-SNAPSHOT</version>\n" +
+        "      <version>1.1-SNAPSHOT</version>\n" +
         "    </versions>\n" +
         "    <lastUpdated>20150722164334</lastUpdated>\n" +
         "  </versioning>\n" +
@@ -152,8 +143,13 @@ public class HostedMetadataRemergedOnPathPromoteTest
     {
         String message = "test setup";
 
-        a = client.stores().create( new HostedRepository( PKG_TYPE_MAVEN, HOSTED_A_NAME ), message, HostedRepository.class );
-        b = client.stores().create( new HostedRepository( PKG_TYPE_MAVEN, HOSTED_B_NAME ), message, HostedRepository.class );
+        a = new HostedRepository( PKG_TYPE_MAVEN, HOSTED_A_NAME );
+        a.setAllowSnapshots( true );
+        a = client.stores().create( a, message, HostedRepository.class );
+
+        b = new HostedRepository( PKG_TYPE_MAVEN, HOSTED_B_NAME );
+        b.setAllowSnapshots( true );
+        b = client.stores().create( b, message, HostedRepository.class );
 
         g = client.stores().create( new Group( PKG_TYPE_MAVEN, GROUP_G_NAME, a.getKey() ), message, Group.class );
 

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -208,7 +208,7 @@ public class AbstractContentManagementTest
             {
                 sb.append( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" );
             }
-            else if ( line.contains( "<lastUpdated>" ) )
+            else if ( line.contains( "<lastUpdated>" ) || line.contains( "<updated>" ) )
             {
                 ; // skip
             }

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.ftest.core;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.commonjava.indy.model.core.StoreType.group;
 import static org.commonjava.indy.model.core.StoreType.remote;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -22,9 +23,11 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
+import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
@@ -164,4 +167,74 @@ public class AbstractContentManagementTest
               .store( repo.getKey(), path,
                       new ByteArrayInputStream( template.replaceAll( "%version%", version ).getBytes() ) );
     }
+
+    protected String assertMetadataContent( ArtifactStore store, String path, String expected )
+                    throws IndyClientException, IOException
+    {
+        try (InputStream in = client.content().get( store.getKey(), path ))
+        {
+            assertThat( "Content not found: " + path + " in store: " + store.getKey(), in, notNullValue() );
+
+            String foundContent = IOUtils.toString( in );
+
+            foundContent = groom( foundContent );
+            expected = groom( expected );
+
+            logger.info( "Checking content result from path: {} in store: {} with value:\n\n{}\n\nagainst expected value:\n\n{}",
+                         path, store.getKey(), foundContent, expected );
+
+            assertThat( "Content is wrong: " + path + " in store: " + store.getKey(), foundContent,
+                        equalTo( expected ) );
+
+            return foundContent;
+        }
+    }
+
+    /**
+     * Normalize xml, ignore the lastUpdated, sort the versioning release/latest, etc
+     */
+    private String groom( String metadataXML ) throws IOException
+    {
+        String release = null;
+        String latest = null;
+
+        StringBuilder sb = new StringBuilder();
+        BufferedReader reader = new BufferedReader(
+                        new InputStreamReader( new ByteArrayInputStream( metadataXML.getBytes() ) ) );
+        while ( reader.ready() )
+        {
+            String line = reader.readLine();
+            if ( line.contains( "<?xml" ) )
+            {
+                sb.append( "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" );
+            }
+            else if ( line.contains( "<lastUpdated>" ) )
+            {
+                ; // skip
+            }
+            else if ( line.contains( "<release>" ) )
+            {
+                release = line;
+            }
+            else if ( line.contains( "<latest>" ) )
+            {
+                latest = line;
+            }
+            else
+            {
+                if ( line.contains( "<versions>" ) )
+                {
+                    if ( isNotBlank( release ) )
+                    {
+                        sb.append( release + "\n" );
+                    }
+                    sb.append( latest + "\n" );
+                }
+                sb.append( line + "\n" );
+            }
+        }
+        reader.close();
+        return sb.toString();
+    }
+
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMetadataMergeSnapshotTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMetadataMergeSnapshotTest.java
@@ -25,6 +25,8 @@ public class HostedMetadataMergeSnapshotTest
 
     private static final String PATH = "/org/foo/bar/maven-metadata.xml";
 
+    private static final String SNAPSHOT_METADATA_PATH = "/org/foo/bar/%version%/maven-metadata.xml";
+
     private static final String POM_PATH_TEMPLATE = "/org/foo/bar/%version%/bar-%version%.pom";
 
     /* @formatter:off */
@@ -57,6 +59,25 @@ public class HostedMetadataMergeSnapshotTest
         "    <lastUpdated>20150722164334</lastUpdated>\n" +
         "  </versioning>\n" +
         "</metadata>\n";
+
+    private static final String SNAPSHOT_METADATA_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+        + "<metadata>\n"
+        + "  <groupId>org.foo</groupId>\n"
+        + "  <artifactId>bar</artifactId>\n"
+        + "  <version>1.1-SNAPSHOT</version>\n"
+        + "  <versioning>\n"
+        + "    <snapshot>\n"
+        + "      <localCopy>true</localCopy>\n"
+        + "    </snapshot>\n"
+        + "    <snapshotVersions>\n"
+        + "      <snapshotVersion>\n"
+        + "        <extension>pom</extension>\n"
+        + "        <value>1.1-SNAPSHOT</value>\n"
+        + "        <updated>20190629074244</updated>\n"
+        + "      </snapshotVersion>\n"
+        + "    </snapshotVersions>\n"
+        + "  </versioning>\n"
+        + "</metadata>\n";
     /* @formatter:on */
 
     private HostedRepository hosted;
@@ -96,6 +117,9 @@ public class HostedMetadataMergeSnapshotTest
                     throws Exception
     {
         assertMetadataContent( hosted, PATH, AFTER_PROMOTE_CONTENT );
+
+        assertMetadataContent( hosted, SNAPSHOT_METADATA_PATH.replaceAll( "%version%", B_VERSION ),
+                               SNAPSHOT_METADATA_CONTENT );
     }
 
     @Override

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMetadataMergeSnapshotTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedMetadataMergeSnapshotTest.java
@@ -1,0 +1,108 @@
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.ByteArrayInputStream;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+
+/**
+ * Given two snapshot pom paths and test the metadata merge.
+ */
+public class HostedMetadataMergeSnapshotTest
+                extends AbstractContentManagementTest
+{
+    private static final String HOSTED_A_NAME= "A";
+
+    private static final String A_VERSION = "1.0-SNAPSHOT";
+    private static final String B_VERSION = "1.1-SNAPSHOT";
+
+    private static final String PATH = "/org/foo/bar/maven-metadata.xml";
+
+    private static final String POM_PATH_TEMPLATE = "/org/foo/bar/%version%/bar-%version%.pom";
+
+    /* @formatter:off */
+    private static final String POM_CONTENT_TEMPLATE = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<project>\n" +
+        "  <modelVersion>4.0.0</modelVersion>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <version>%version%</version>\n" +
+        "  <name>Bar</name>\n" +
+        "  <dependencies>\n" +
+        "    <dependency>\n" +
+        "      <groupId>org.something</groupId>\n" +
+        "      <artifactId>oh</artifactId>\n" +
+        "      <version>1.0.1</version>\n" +
+        "    </dependency>\n" +
+        "  </dependencies>\n" +
+        "</project>\n";
+
+    private static final String AFTER_PROMOTE_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+        "<metadata>\n" +
+        "  <groupId>org.foo</groupId>\n" +
+        "  <artifactId>bar</artifactId>\n" +
+        "  <versioning>\n" +
+        "    <latest>1.1-SNAPSHOT</latest>\n" +
+        "    <versions>\n" +
+        "      <version>1.0-SNAPSHOT</version>\n" +
+        "      <version>1.1-SNAPSHOT</version>\n" +
+        "    </versions>\n" +
+        "    <lastUpdated>20150722164334</lastUpdated>\n" +
+        "  </versioning>\n" +
+        "</metadata>\n";
+    /* @formatter:on */
+
+    private HostedRepository hosted;
+
+    private String aPomPath;
+    private String aPomContent;
+
+    private String bPomPath;
+    private String bPomContent;
+
+    @Before
+    public void setupRepos()
+                    throws IndyClientException
+    {
+        String message = "test setup";
+
+        hosted = new HostedRepository( PKG_TYPE_MAVEN, HOSTED_A_NAME );
+        hosted.setAllowSnapshots( true );
+        hosted = client.stores().create( hosted, message, HostedRepository.class );
+
+        aPomPath = POM_PATH_TEMPLATE.replaceAll( "%version%", A_VERSION );
+        aPomContent = POM_CONTENT_TEMPLATE.replaceAll( "%version%", A_VERSION );
+        client.content()
+              .store( hosted.getKey(), aPomPath, new ByteArrayInputStream(
+                              aPomContent.getBytes() ) );
+
+        bPomPath = POM_PATH_TEMPLATE.replaceAll( "%version%", B_VERSION );
+        bPomContent = POM_CONTENT_TEMPLATE.replaceAll( "%version%", B_VERSION );
+        client.content()
+              .store( hosted.getKey(), bPomPath, new ByteArrayInputStream(
+                              bPomContent.getBytes() ) );
+    }
+
+    @Test
+    @Category( EventDependent.class )
+    public void run()
+                    throws Exception
+    {
+        assertMetadataContent( hosted, PATH, AFTER_PROMOTE_CONTENT );
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+
+
+}


### PR DESCRIPTION
I found a problem when doing more test for snapshot metadata merging. Briefly, my new test failed and I get the new metadata when retrieving it. But I expect to get a merged one. 
This is because for some reason the promote begins with the pom file. When it is copied, it triggered the clean up of parent metadata (artifact level metadata.xml). Then the new artifact level metadata is copied and no existing file there ATM, so it is copied there. 
The main fix is at PromoteManager doPathTransfer() where I take special action for metadata. I.e., if the target is metadata, we just simply do not copy it (skip it). Furthermore, if the file exists we remove it and trigger clean-up in affected groups as well. 
With this fix, we leave out all metadata during the promotion. ie., we deal with it by 2 principles: 1. skip all of them, 2. clean previous ones if exist.
The other minor fix is to skip inserting &lt;release&gt; when the versions are snapshots. (sortVersions)