### PR TITLE
Fix httprox latency / request summary reporting

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyMeter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyMeter.java
@@ -63,14 +63,17 @@ public class ProxyMeter
             setContext( HTTP_METHOD, method );
 
             // log SLI metrics
-            sliMetricSet.function( GoldenSignalsMetricSet.FN_CONTENT_GENERIC ).ifPresent( ms ->{
-                ms.latency( latency ).call();
+            if ( sliMetricSet != null )
+            {
+                sliMetricSet.function( GoldenSignalsMetricSet.FN_CONTENT_GENERIC ).ifPresent( ms ->{
+                    ms.latency( latency ).call();
 
-                if ( parseInt( getContext( HTTP_STATUS, "200" ) ) > 499 )
-                {
-                    ms.error();
-                }
-            } );
+                    if ( parseInt( getContext( HTTP_STATUS, "200" ) ) > 499 )
+                    {
+                        ms.error();
+                    }
+                } );
+            }
 
             MDC.put( REQUEST_PHASE, REQUEST_PHASE_END );
             restLogger.info( "END {} (from: {})", requestLine, peerAddress );


### PR DESCRIPTION
REST latency / request summary reporting happens when Indy logical execution is complete,
but BEFORE the content transfer is finished (this usually happens via a StreamingOutput
implementation, or is otherwise rendered as a string if it's not normal content.

In contrast, generic proxy latency is currently measured when the socket is closed,
which means it's after the content is completely transferred. This is a flawed conception
of latency, which is meant to measure the time it takes to START transferring content
back to the client.

This patch corrects the situation by reporting latency and the request summary in a
finally clause at the end of the ProxyResponseWriter.doHandleEvent() method, which is
only responsible for setting up a socket-close listener...not actually closing the socket.

It also adds another layer of metric reporting for CONNECT requests: one for the initial
CONNECT, and a second for the embedded HTTP request.