### PR TITLE
drain all pending clearPath() operations before returning from StoreContentListener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
     <connection>scm:git:https://github.com/Commonjava/indy.git</connection>
     <developerConnection>scm:git:git@github.com:Commonjava/indy.git</developerConnection>
     <url>http://github.com/Commonjava/indy</url>
-    <tag>indy-parent-1.8.0</tag>
   </scm>
 
   <repositories>


### PR DESCRIPTION
We have a race condition reported, and it's because we started processing the clearance of metadata files asynchronously on group membership change. We need to go back to using a process that waits for all files to be cleared appropriately before returning. 