### PR TITLE
Added changes for NOS.1889 Issue

### DIFF
--- a/api/src/main/java/org/commonjava/indy/data/ArtifactStoreValidateData.java
+++ b/api/src/main/java/org/commonjava/indy/data/ArtifactStoreValidateData.java
@@ -1,0 +1,78 @@
+package org.commonjava.indy.data;
+
+import org.apache.kafka.common.protocol.types.Field;
+import org.bouncycastle.util.Store;
+import org.commonjava.indy.model.core.StoreType;
+
+public class ArtifactStoreValidateData {
+
+    private boolean valid;
+    private String repositoryUrl;
+    private StoreType storeType;
+
+    private ArtifactStoreValidateData() {
+    }
+
+
+    public static class Builder {
+
+        private boolean valid;
+        private String repositoryUrl;
+        private StoreType storeType;
+
+        public Builder(boolean valid) {
+            this.valid = valid;
+        }
+
+
+        public Builder setRepositoryUrl(String repositoryUrl) {
+            this.repositoryUrl = repositoryUrl;
+            return this;
+        }
+
+        public Builder setStoreType(StoreType storeType) {
+            this.storeType = storeType;
+            return this;
+        }
+
+        public ArtifactStoreValidateData build() {
+            ArtifactStoreValidateData artifactStoreValidateData = new ArtifactStoreValidateData();
+            artifactStoreValidateData.valid = this.valid;
+            artifactStoreValidateData.repositoryUrl = this.repositoryUrl;
+            artifactStoreValidateData.storeType = this.storeType;
+            return artifactStoreValidateData;
+        }
+    }
+
+    public boolean isValid() {
+        return valid;
+    }
+
+    public String getRepositoryUrl() {
+        return repositoryUrl;
+    }
+
+    public void setValid(boolean valid) {
+        this.valid = valid;
+    }
+
+    public void setRepositoryUrl(String repositoryUrl) {
+        this.repositoryUrl = repositoryUrl;
+    }
+
+    public StoreType getStoreType() {
+        return storeType;
+    }
+
+    public void setStoreType(StoreType storeType) {
+        this.storeType = storeType;
+    }
+
+    @Override
+    public String toString() {
+        return "ArtifactStoreValidateData={ valid:" + this.valid +
+            ", repositoryUrl:" + this.repositoryUrl +
+            ", storeType: " + this.storeType +
+            "}";
+    }
+}

--- a/api/src/main/java/org/commonjava/indy/data/InvalidArtifactStoreException.java
+++ b/api/src/main/java/org/commonjava/indy/data/InvalidArtifactStoreException.java
@@ -1,0 +1,7 @@
+package org.commonjava.indy.data;
+
+public class InvalidArtifactStoreException extends IndyDataException {
+    public InvalidArtifactStoreException(String message, Throwable cause, Object... params) {
+        super(message, cause, params);
+    }
+}

--- a/api/src/main/java/org/commonjava/indy/data/RemoteStoreValidator.java
+++ b/api/src/main/java/org/commonjava/indy/data/RemoteStoreValidator.java
@@ -1,0 +1,13 @@
+package org.commonjava.indy.data;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE, ElementType.PARAMETER})
+public @interface RemoteStoreValidator {
+}

--- a/api/src/main/java/org/commonjava/indy/data/StoreValidator.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreValidator.java
@@ -1,0 +1,24 @@
+package org.commonjava.indy.data;
+
+
+import org.commonjava.indy.model.core.ArtifactStore;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.net.MalformedURLException;
+
+/**
+ * Store Validator  used to validate URL for for {@link ArtifactStore} instances and
+ * check if appropriate http method calls are availible at validated url endpoint
+ *
+ * @author ggeorgie
+ */
+
+@ApplicationScoped
+public interface StoreValidator {
+
+    /*
+        Validate ArtifactStore instances
+     */
+    public ArtifactStoreValidateData validate(ArtifactStore artifactStore)
+        throws InvalidArtifactStoreException, MalformedURLException;
+}

--- a/api/src/main/java/org/commonjava/indy/data/StoreValidatorRemote.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreValidatorRemote.java
@@ -1,0 +1,162 @@
+package org.commonjava.indy.data;
+
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.commonjava.indy.model.core.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.*;
+
+
+@RemoteStoreValidator
+public class StoreValidatorRemote implements StoreValidator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StoreValidatorRemote.class);
+    private final CountDownLatch httpRequestsLatch = new CountDownLatch(2);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(2);
+    private static final String REMOTE = "remote";
+
+
+    @Override
+    public ArtifactStoreValidateData validate(ArtifactStore artifactStore)
+        throws InvalidArtifactStoreException, MalformedURLException {
+        // Parse Remote Repository for checking if it is a valid URL
+        try {
+            //#region
+//            LOGGER.info("=> ArtifactStore Type: " + artifactStore.getType().singularEndpointName());
+            if (REMOTE.equalsIgnoreCase(artifactStore.getType().singularEndpointName())
+                || artifactStore instanceof RemoteRepository) {
+                // Cast to Remote Repository
+                RemoteRepository remoteRepository = (RemoteRepository) artifactStore;
+                //Validate URL from remote Repository URL
+                Optional<URL> remoteUrl = Optional.of(new URL(remoteRepository.getUrl()));
+                // Execute HTTP GET & HEAD requests in separate thread pool from executor service
+                Future<Boolean> httpGetStatus = executorService.submit(new HttpGetTask(new HttpGet(remoteUrl.get().toURI())));
+                Future<Boolean> httpHeadStatus = executorService.submit(new HttpHeadTask(new HttpHead(remoteUrl.get().toURI())));
+                // Waiting for Http GET & HEAD Request Executor tasks to finish
+                httpRequestsLatch.await();
+                // Check for Sucessfull Validation
+                if (httpGetStatus.get() && httpHeadStatus.get()) {
+                    LOGGER.info("=> Succesfull Validation for Remote Repository: " + remoteUrl.get());
+                    return new ArtifactStoreValidateData
+                        .Builder(true)
+                        .setRepositoryUrl(remoteUrl.get().toExternalForm())
+                        .setStoreType(remoteRepository.getType())
+                        .build();
+                }
+            } else {
+                LOGGER.warn("=> It's not Remote Artifact Store Repository: " + artifactStore.getType().singularEndpointName());
+            }
+            //#endregion
+        } catch (MalformedURLException mue) {
+            LOGGER.error("=> Mailformed URL: ", mue);
+            throw new MalformedURLException("=> Mailformed URL: " + ((RemoteRepository) artifactStore).getUrl());
+        } catch (Exception e) {
+            LOGGER.error(" => Not Valid Remote Repository, \n => Exception: " + e);
+            throw new InvalidArtifactStoreException("=> Not valid remote Repository: " + artifactStore.getType().singularEndpointName(), e);
+        } finally {
+            if (executorService.isShutdown()) {
+                try {
+                    executorService.awaitTermination(60, TimeUnit.SECONDS);
+                } catch (InterruptedException ie) {
+                    LOGGER.warn("=> Some of Http Executors Tasks are still in waiting state after 60s timeout");
+                    executorService.shutdownNow();
+                }
+            }
+        }
+
+        if (artifactStore instanceof RemoteRepository) {
+            return new ArtifactStoreValidateData
+                .Builder(false)
+                .setRepositoryUrl(((RemoteRepository) artifactStore).getUrl())
+                .setStoreType(artifactStore.getType())
+                .build();
+        } else if (artifactStore instanceof HostedRepository) {
+            return new ArtifactStoreValidateData
+                .Builder(false)
+                .setRepositoryUrl(((HostedRepository) artifactStore).getStorage())
+                .setStoreType(artifactStore.getType())
+                .build();
+        } else {
+            return new ArtifactStoreValidateData
+                .Builder(false)
+                .setRepositoryUrl("/")
+                .setStoreType(artifactStore.getType())
+                .build();
+        }
+
+    }
+
+    private boolean allowedGet(List<String> allowed) {
+        return allowed.indexOf("GET") != -1 ? true : false;
+    }
+
+    private boolean allowedHead(List<String> allowed) {
+        return allowed.indexOf("HEAD") != -1 ? true : false;
+    }
+
+    class HttpGetTask implements Callable<Boolean> {
+
+        private HttpGet httpGetCall;
+
+        public HttpGetTask(HttpGet httpGetCall) {
+            this.httpGetCall = httpGetCall;
+        }
+
+        @Override
+        public Boolean call() throws Exception {
+
+            CloseableHttpClient closeableHttpClient = HttpClientBuilder.create().build();
+
+            try (CloseableHttpResponse response = closeableHttpClient.execute(httpGetCall)) {
+                httpRequestsLatch.countDown();
+                LOGGER.warn("=> HTTP GET Response code: " + response.getStatusLine().getStatusCode());
+                return (response.getStatusLine().getStatusCode() < 400) ? true : false;
+            } catch (IOException ioe) {
+                LOGGER.error(" => Not Successfull HTTP GET request from StoreValidatorRemote, \n => Exception: " + ioe);
+                throw new InvalidArtifactStoreException("Not valid remote Repository", ioe);
+            } catch (Exception e) {
+                LOGGER.error(" => Not Successfull HTTP GET request from StoreValidatorRemote, \n => Exception: " + e);
+                throw new Exception("=> Not valid remote Repository", e);
+            }
+        }
+    }
+
+    class HttpHeadTask implements Callable<Boolean> {
+
+        private HttpHead httpHeadCall;
+
+        public HttpHeadTask(HttpHead httpHeadCall) {
+            this.httpHeadCall = httpHeadCall;
+        }
+
+        @Override
+        public Boolean call() throws Exception {
+
+            CloseableHttpClient closeableHttpClient = HttpClientBuilder.create().build();
+
+            try (CloseableHttpResponse response = closeableHttpClient.execute(httpHeadCall)) {
+                httpRequestsLatch.countDown();
+                LOGGER.warn("=> HTTP HEAD Response code: " + response.getStatusLine().getStatusCode());
+                return response.getStatusLine().getStatusCode() < 400 ? true : false;
+            } catch (IOException ioe) {
+                LOGGER.error(" => Not Successfull HTTP HEAD request from StoreValidatorRemote, \n => Exception: " + ioe);
+                throw new InvalidArtifactStoreException("Not valid remote Repository", ioe);
+            } catch (Exception e) {
+                LOGGER.error(" => Not Successfull HTTP HEAD request from StoreValidatorRemote, \n => Exception: " + e);
+                throw new Exception("=> Not valid remote Repository", e);
+            }
+        }
+    }
+
+}

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -18,10 +18,7 @@ package org.commonjava.indy.db.common;
 import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
-import org.commonjava.indy.data.ArtifactStoreQuery;
-import org.commonjava.indy.data.IndyDataException;
-import org.commonjava.indy.data.StoreDataManager;
-import org.commonjava.indy.data.StoreEventDispatcher;
+import org.commonjava.indy.data.*;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -31,6 +28,7 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -52,6 +50,10 @@ public abstract class AbstractStoreDataManager
     protected final Locker<StoreKey> opLocks = new Locker<>(); // used internally
 
     abstract protected StoreEventDispatcher getStoreEventDispatcher();
+
+    @Inject
+    @RemoteStoreValidator
+    StoreValidatorRemote storeValidatorRemote;
 
     @Override
     public ArtifactStoreQuery<ArtifactStore> query()

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -17,9 +17,7 @@ package org.commonjava.indy.infinispan.data;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.commonjava.indy.audit.ChangeSummary;
-import org.commonjava.indy.data.IndyDataException;
-import org.commonjava.indy.data.NoOpStoreEventDispatcher;
-import org.commonjava.indy.data.StoreEventDispatcher;
+import org.commonjava.indy.data.*;
 import org.commonjava.indy.db.common.AbstractStoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
@@ -52,6 +50,10 @@ public class InfinispanStoreDataManager
     @Inject
     @StoreDataCache
     private CacheHandle<StoreKey, String> stores;
+
+    @Inject
+    @RemoteStoreValidator
+    StoreValidatorRemote storeValidatorRemote;
 
     @Inject
     private CacheProducer cacheProducer;


### PR DESCRIPTION
Added changes for issue nos-1889 with validating on remote repositories ( for now just them ) with predicament of checking allowed http methods for remote endpoint ( http get & head ) and malformed url.
Validation bean is injected into StoreDataManager implementations for future validating pre store repositories.