### PR TITLE
[1.8.x] Apply maven ContentsFilteringTransfer and NPM PackageMaskingTransfer decorators

### DIFF
--- a/addons/httprox/ftests/pom.xml
+++ b/addons/httprox/ftests/pom.xml
@@ -61,6 +61,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-maven</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>

--- a/addons/pkg-maven/common/pom.xml
+++ b/addons/pkg-maven/common/pom.xml
@@ -82,6 +82,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-test-fixtures-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.maven.galley</groupId>
       <artifactId>galley-test-harness-maven</artifactId>
       <scope>test</scope>

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenContentsFilteringTransferDecorator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenContentsFilteringTransferDecorator.java
@@ -1,0 +1,324 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.content;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.atlas.maven.ident.util.SnapshotUtils;
+import org.commonjava.atlas.maven.ident.version.part.SnapshotPart;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.AbstractTransferDecorator;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.io.OverriddenBooleanValue;
+import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
+import org.commonjava.maven.galley.util.TransferUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Represents a decorator responsible for filtering out location contents based on location settings. Effectively it is
+ * designed to filter out snapshot or release versions from remote repositories when configured to not
+ * provide the snapshot or release versions.
+ *
+ * @author pkocandr
+ */
+@ApplicationScoped
+public class MavenContentsFilteringTransferDecorator
+                extends AbstractTransferDecorator
+{
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    @Override
+    public OverriddenBooleanValue decorateExists( final Transfer transfer, final EventMetadata metadata )
+    {
+        final Location loc = transfer.getLocation();
+        final boolean isHttp = loc instanceof HttpLocation;
+        final boolean filtered = TransferUtils.filterTransfer( transfer );
+        if ( isHttp && filtered )
+        {
+            return OverriddenBooleanValue.OVERRIDE_FALSE;
+        }
+        return OverriddenBooleanValue.DEFER;
+    }
+
+    @Override
+    public OutputStream decorateWrite( final OutputStream stream, final Transfer transfer, final TransferOperation op,
+                                       final EventMetadata metadata ) throws IOException
+    {
+        final Location loc = transfer.getLocation();
+        final boolean allowsSnapshots = loc.allowsSnapshots();
+        final boolean allowsReleases = loc.allowsReleases();
+        if ( loc instanceof HttpLocation && ( !allowsSnapshots || !allowsReleases ) && transfer.getFullPath()
+                                                                                               .endsWith( "maven-metadata.xml" ) )
+        {
+            return new MetadataFilteringOutputStream( stream, allowsSnapshots, allowsReleases, transfer );
+        }
+        else
+        {
+            return stream;
+        }
+    }
+
+    /**
+     * Alters the listing to filter out artifacts belonging to a version that
+     * should not be provided via the proxy.
+     */
+    @Override
+    public String[] decorateListing( final Transfer transfer, final String[] listing, final EventMetadata metadata )
+                    throws IOException
+    {
+        final Location loc = transfer.getLocation();
+        final boolean allowsSnapshots = loc.allowsSnapshots();
+        final boolean allowsReleases = loc.allowsReleases();
+
+        // process only proxied locations, i.e. HttpLocation instances
+        if ( loc instanceof HttpLocation && ( !allowsSnapshots || !allowsReleases ) )
+        {
+            final String[] pathElements = transfer.getPath().split( "/" );
+            // process only paths that *can* be a GAV
+            if ( pathElements.length >= 3 )
+            {
+                final String artifactId = pathElements[pathElements.length - 2];
+                final String version = pathElements[pathElements.length - 1];
+                final boolean snapshotVersion = SnapshotUtils.isSnapshotVersion( version );
+                // NOS-1434 Forbid all snapshot files if allowSnapshots not enabled
+                if ( ( allowsSnapshots && snapshotVersion ) || ( allowsReleases && !snapshotVersion ) )
+                {
+                    return listing;
+                }
+                return new String[0];
+            }
+            else
+            {
+                // process paths that does not contain version.
+                // if list element contains snapshot folder, ignore them.
+                if ( !allowsSnapshots )
+                {
+                    final List<String> result = new ArrayList<>( listing.length );
+                    for ( final String element : listing )
+                    {
+                        String version = element;
+                        if ( element.endsWith( "/" ) )
+                        {
+                            version = element.substring( 0, version.length() - 1 );
+                        }
+                        if ( !SnapshotUtils.isSnapshotVersion( version ) )
+                        {
+                            result.add( element );
+                        }
+                    }
+                    return result.toArray( new String[0] );
+                }
+            }
+        }
+        return listing;
+    }
+
+    /**
+     * Checks if the given element is an artifact. Artifacts always starts with
+     * &lt;artifactId&gt;-&lt;version&gt;.
+     */
+    private boolean isArtifact( final String element, final String artifactId, final String version )
+    {
+        if ( element.endsWith( "/" ) )
+        {
+            return false;
+        }
+
+        boolean isRemoteSnapshot = false;
+        if ( SnapshotUtils.isSnapshotVersion( version ) && element.startsWith( artifactId + '-' )
+                        && !element.startsWith( artifactId + '-' + version ) )
+        {
+            final SnapshotPart snapshotPart = SnapshotUtils.extractSnapshotVersionPart( version );
+            final int artIdLenght = artifactId.length() + 1 + version.length() - snapshotPart.getLiteral().length() + 1;
+            isRemoteSnapshot = SnapshotUtils.isRemoteSnapshotVersionPart(
+                            StringUtils.substring( element, artIdLenght, artIdLenght + 17 ) );
+        }
+
+        return element.startsWith( artifactId + '-' + version + '-' ) || element.startsWith(
+                        artifactId + '-' + version + '.' ) || isRemoteSnapshot;
+    }
+
+    private static class MetadataFilteringOutputStream
+                    extends FilterOutputStream
+    {
+        private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+        private static final String LATEST = "<latest>([^<]+)</latest>";
+
+        private static final String RELEASE = "<release>([^<]+)</release>";
+
+        private static final String VERSION = "<version>([^<]+)</version>";
+
+        private static final String VERSIONS = "<versions>[\\s]*(?:(" + VERSION + ")[\\s]*)+</versions>";
+
+        private StringBuilder buffer = new StringBuilder();
+
+        private final boolean allowsSnapshots;
+
+        private final boolean allowsReleases;
+
+        private Transfer transfer;
+
+        private MetadataFilteringOutputStream( final OutputStream stream, final boolean allowsSnapshots,
+                                               final boolean allowsReleases, Transfer transfer )
+        {
+            super( stream );
+            this.allowsSnapshots = allowsSnapshots;
+            this.allowsReleases = allowsReleases;
+            this.transfer = transfer;
+        }
+
+        private String filterMetadata()
+        {
+
+            if ( buffer.length() == 0 )
+            {
+                return "";
+            }
+
+            // filter versions from GA metadata
+            final Pattern versionsPattern = Pattern.compile( VERSIONS, Pattern.MULTILINE );
+            final Matcher m = versionsPattern.matcher( buffer );
+            final List<String> versions = new ArrayList<>();
+            if ( m.find() )
+            {
+                final Pattern versionPattern = Pattern.compile( VERSION );
+                final Matcher versionMatcher = versionPattern.matcher( m.group() );
+                while ( versionMatcher.find() )
+                {
+                    versions.add( versionMatcher.group( 1 ) );
+                }
+            }
+
+            boolean changed = false;
+            for ( final String version : new ArrayList<>( versions ) )
+            {
+                final boolean isSnapshot = SnapshotUtils.isSnapshotVersion( version );
+                if ( !allowsSnapshots && isSnapshot || !allowsReleases && !isSnapshot )
+                {
+                    logger.debug( "FILTER: Removing prohibited version: {} from: {}", version, transfer );
+                    versions.remove( version );
+                    changed = true;
+                }
+            }
+
+            String filteredMetadata = buffer.toString();
+            if ( changed )
+            {
+                String filteredVersions;
+                if ( versions.size() == 0 )
+                {
+                    filteredVersions = "<versions></versions>";
+                }
+                else
+                {
+                    filteredVersions = "<versions>\n<version>" + StringUtils.join( versions, "</version>\n<version>" )
+                                    + "</version>\n</versions>";
+                }
+                filteredMetadata = filteredMetadata.replaceFirst( VERSIONS, filteredVersions );
+            }
+
+            final Pattern latestPattern = Pattern.compile( LATEST );
+            final Matcher latestMatcher = latestPattern.matcher( filteredMetadata );
+            if ( latestMatcher.find() )
+            {
+                final String latestVersion = latestMatcher.group( 1 );
+                final boolean isSnapshot = latestVersion.endsWith( "-SNAPSHOT" );
+                if ( !allowsSnapshots && isSnapshot || !allowsReleases && !isSnapshot )
+                {
+                    logger.debug( "FILTER: Recalculating LATEST version; supplied value is prohibited: {} from: {}",
+                                  latestVersion, transfer );
+
+                    String newLatest;
+                    if ( versions.size() > 0 )
+                    {
+                        newLatest = "<latest>" + versions.get( versions.size() - 1 ) + "</latest>";
+                    }
+                    else
+                    {
+                        newLatest = "<latest></latest>";
+                    }
+                    filteredMetadata = filteredMetadata.replaceFirst( LATEST, newLatest );
+                }
+            }
+
+            if ( !allowsReleases )
+            {
+                final Pattern releasePattern = Pattern.compile( RELEASE );
+                final Matcher releaseMatcher = releasePattern.matcher( filteredMetadata );
+                if ( releaseMatcher.find() )
+                {
+                    logger.debug( "FILTER: Suppressing prohibited release fields from: {}", transfer );
+
+                    filteredMetadata = filteredMetadata.replaceFirst( RELEASE, "<release></release>" );
+                }
+            }
+
+            // filter snapshots from GAV metadata
+            if ( !allowsSnapshots )
+            {
+                logger.debug( "FILTER: Suppressing prohibited snapshot fields from: {}", transfer );
+
+                final String snapshots = StringUtils.substringBetween( filteredMetadata, "<snapshotVersions>",
+                                                                       "</snapshotVersions>" );
+                if ( snapshots != null )
+                {
+                    filteredMetadata = filteredMetadata.replace( snapshots, "" );
+                }
+
+                final String snapshot = StringUtils.substringBetween( filteredMetadata, "<snapshot>", "</snapshot>" );
+                if ( snapshot != null )
+                {
+                    filteredMetadata = filteredMetadata.replace( snapshot, "" );
+                }
+            }
+
+            return filteredMetadata;
+        }
+
+        @Override
+        public void write( final int b ) throws IOException
+        {
+            buffer.append( (char) b );
+        }
+
+        @Override
+        public void flush() throws IOException
+        {
+            try
+            {
+                out.write( filterMetadata().getBytes() );
+                out.flush();
+            }
+            finally
+            {
+                buffer = new StringBuilder();
+            }
+        }
+    }
+}

--- a/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenContentFilteringTransferDecoratorTest.java
+++ b/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/MavenContentFilteringTransferDecoratorTest.java
@@ -1,0 +1,224 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.maven.content;
+
+import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.pkg.maven.content.MavenContentsFilteringTransferDecorator;
+import org.commonjava.indy.test.fixture.core.HttpTestFixture;
+import org.commonjava.maven.galley.config.TransportMetricConfig;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.transport.htcli.internal.HttpDownload;
+import org.commonjava.maven.galley.transport.htcli.model.SimpleHttpLocation;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class MavenContentFilteringTransferDecoratorTest
+{
+    @Rule
+    public HttpTestFixture fixture = new HttpTestFixture( "test", new MavenContentsFilteringTransferDecorator() );
+
+    private static MetricRegistry metricRegistry = new MetricRegistry();
+
+    private static TransportMetricConfig metricConfig = new TransportMetricConfig()
+    {
+        @Override
+        public boolean isEnabled()
+        {
+            return true;
+        }
+
+        @Override
+        public String getNodePrefix()
+        {
+            return null;
+        }
+
+        @Override
+        public String getMetricUniqueName( Location location )
+        {
+            if ( location.getName().equals( "test" ) )
+            {
+                return location.getName();
+            }
+            return null;
+        }
+    };
+
+    @Test
+    public void metadataFilteringWhenSnapshotsNotAllowed() throws Exception
+    {
+        final String fname = "/commons-codec/commons-codec/maven-metadata.xml";
+
+        // @formatter:off
+        final String content = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<metadata modelVersion=\"1.1.0\">"
+            + "  <groupId>commons-codec</groupId>"
+            + "  <artifactId>commons-codec</artifactId>"
+            + "  <versioning>"
+            + "    <latest>1.2</latest>"
+            + "    <release>1.2</release>"
+            + "    <versions>"
+            + "      <version>1.1</version>"
+            + "      <version>1.1-SNAPSHOT</version>"
+            + "      <version>1.2</version>"
+            + "    </versions>"
+            + "    <lastUpdated>20171020231327</lastUpdated>"
+            + "  </versioning>"
+            + "</metadata>";
+        // @formatter:on
+
+        final String baseUri = fixture.getBaseUri();
+        final SimpleHttpLocation location = new SimpleHttpLocation( "test", baseUri, false, true, true, true, null );
+        final Transfer transfer = fixture.getTransfer( new ConcreteResource( location, fname ) );
+        final String url = fixture.formatUrl( fname );
+
+        assertThat( transfer.exists(), equalTo( false ) );
+
+        try (OutputStream stream = transfer.openOutputStream( TransferOperation.UPLOAD ))
+        {
+            IOUtils.write( content, stream );
+        }
+
+        try (InputStream in = transfer.openInputStream())
+        {
+            List<String> filtered = IOUtils.readLines( in );
+            assertThat( filtered, notNullValue() );
+            StringBuilder builder = new StringBuilder();
+            filtered.forEach( builder::append );
+            String result = builder.toString();
+            assertThat( result.contains( "1.1" ), equalTo( true ) );
+            assertThat( result.contains( "1.2" ), equalTo( true ) );
+            assertThat( result.contains( "1.1-SNAPTHOT" ), equalTo( false ) );
+        }
+    }
+
+    @Test
+    public void snapshotNotExistsWhenSnapshotsNotAllowed()
+            throws Exception
+    {
+        final String fname = "/commons-codec/commons-codec/11-SNAPSHOT/maven-metadata.xml.md5";
+        final String content = "kljsjdlfkjsdlkj123j13=20=s0dfjklxjkj";
+        Transfer result = getTestHttpTransfer( fname, content );
+        assertThat( result.exists(), equalTo( false ) );
+    }
+
+
+    @Test
+    public void artifactNotExistsWhenSnapshotsNotAllowed()
+            throws Exception
+    {
+        final String fname = "/commons-codec/commons-codec/11-SNAPSHOT/commons-codec-11-SNAPSHOT.jar";
+        final String content = "This is a jar";
+        Transfer result = getTestHttpTransfer( fname, content );
+        assertThat( result.exists(), equalTo( false ) );
+    }
+
+    private Transfer getTestHttpTransfer(final String path, final String content) throws Exception{
+        fixture.expect( "GET", fixture.formatUrl( path ), 200, content );
+
+        final String baseUri = fixture.getBaseUri();
+        final SimpleHttpLocation location = new SimpleHttpLocation( "test", baseUri, false, true, true, true, null );
+        final Transfer transfer = fixture.getTransfer( new ConcreteResource( location, path ) );
+        final String url = fixture.formatUrl( path );
+
+        assertThat( transfer.exists(), equalTo( false ) );
+
+        HttpDownload dl = new HttpDownload( url, location, transfer, new HashMap<Transfer, Long>(), new EventMetadata(),
+                                            fixture.getHttp().getHttp(), new ObjectMapper(), metricRegistry, metricConfig );
+
+        return dl.call().getTransfer();
+    }
+
+    @Test
+    public void releaseListingInWhenSnapshotsNotAllowedWithVersionPath()
+            throws Exception
+    {
+        final String fname = "commons-codec/commons-codec/1.1/";
+        final SimpleHttpLocation location =
+                new SimpleHttpLocation( "test", "http://test", false, true, false, false, null );
+        final ConcreteResource resource = new ConcreteResource( location, fname );
+        final Transfer transfer = new Transfer( resource, null, null, null );
+        final List<String> listElems =
+                Arrays.asList( "commons-codec-1.1.jar", "commons-codec-1.1-source.jar", "maven-metadata.xml" );
+
+        String[] listing = listElems.toArray( new String[3] );
+        MavenContentsFilteringTransferDecorator decorator = new MavenContentsFilteringTransferDecorator();
+        listing = decorator.decorateListing( transfer, listing, new EventMetadata() );
+
+        assertThat( listing, CoreMatchers.<String[]>notNullValue() );
+        assertThat( listing.length, equalTo( 3 ) );
+        assertThat( Arrays.asList( listing ).containsAll( listElems ), equalTo( true ) );
+    }
+
+    @Test
+    public void snapshotListingNotInWhenSnapshotsNotAllowedWithNoVersionPath()
+            throws Exception
+    {
+        final String fname = "commons-codec/commons-codec/";
+        final SimpleHttpLocation location =
+                new SimpleHttpLocation( "test", "http://test", false, true, false, false, null );
+        final ConcreteResource resource = new ConcreteResource( location, fname );
+        final Transfer transfer = new Transfer( resource, null, null, null );
+
+        String[] listing = Arrays.asList( "1.0/", "1.0-SNAPSHOT/", "1.1/", "1.1-SNAPSHOT/" ).toArray( new String[4] );
+        MavenContentsFilteringTransferDecorator decorator = new MavenContentsFilteringTransferDecorator();
+        listing = decorator.decorateListing( transfer, listing, new EventMetadata() );
+
+        System.out.println( Arrays.asList( listing ) );
+
+        assertThat( listing, CoreMatchers.<String[]>notNullValue() );
+        assertThat( listing.length, equalTo( 2 ) );
+        assertThat( Arrays.asList( listing ).contains( "1.0-SNAPSHOT/" ), equalTo( false ) );
+        assertThat( Arrays.asList( listing ).contains( "1.1-SNAPSHOT/" ), equalTo( false ) );
+    }
+
+    @Test
+    public void snapshotListingNotInWhenSnapshotsNotAllowedWithVersionPath()
+            throws Exception
+    {
+        final String fname = "commons-codec/commons-codec/1.1-SNAPSHOT/";
+        final SimpleHttpLocation location =
+                new SimpleHttpLocation( "test", "http://test", false, true, false, false, null );
+        final ConcreteResource resource = new ConcreteResource( location, fname );
+        final Transfer transfer = new Transfer( resource, null, null, null );
+
+        String[] listing = Arrays.asList( "commons-codec-1.1-SNAPSHOT.jar", "commons-codec-1.1-SNAPSHOT-source.jar",
+                                          "maven-metadata.xml" ).toArray( new String[4] );
+        MavenContentsFilteringTransferDecorator decorator = new MavenContentsFilteringTransferDecorator();
+        listing = decorator.decorateListing( transfer, listing, new EventMetadata() );
+
+        assertThat( listing, CoreMatchers.<String[]>notNullValue() );
+        assertThat( listing.length, equalTo( 0 ) );
+    }
+
+}

--- a/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMergerTest.java
+++ b/addons/pkg-maven/common/src/test/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMergerTest.java
@@ -15,40 +15,17 @@
  */
 package org.commonjava.indy.pkg.maven.content.group;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.maven.artifact.repository.metadata.Metadata;
-import org.apache.maven.artifact.repository.metadata.Versioning;
-import org.apache.maven.artifact.repository.metadata.io.xpp3.MetadataXpp3Reader;
-import org.commonjava.indy.IndyWorkflowException;
-import org.commonjava.indy.model.core.Group;
-import org.commonjava.indy.model.core.HostedRepository;
-import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.util.LocationUtils;
-import org.commonjava.atlas.maven.ident.util.VersionUtils;
-import org.commonjava.atlas.maven.ident.version.SingleVersion;
 import org.commonjava.maven.galley.cache.FileCacheProvider;
 import org.commonjava.maven.galley.event.NoOpFileEventManager;
 import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
 import org.commonjava.maven.galley.io.NoOpTransferDecorator;
-import org.commonjava.maven.galley.model.ConcreteResource;
-import org.commonjava.maven.galley.model.Transfer;
-import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -71,7 +48,7 @@ public class MavenMetadataMergerTest
             throws Exception
     {
         cacheProvider = new FileCacheProvider( temp.newFolder( "cache" ), new HashedLocationPathGenerator(),
-                                               new NoOpFileEventManager(), new NoOpTransferDecorator(), false );
+                                               new NoOpFileEventManager(), new TransferDecoratorManager( new NoOpTransferDecorator() ), false );
     }
 
 //    @Test

--- a/addons/pkg-npm/common/pom.xml
+++ b/addons/pkg-npm/common/pom.xml
@@ -37,6 +37,11 @@
             <groupId>org.commonjava.indy</groupId>
             <artifactId>indy-pkg-npm-model-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.commonjava.indy</groupId>
+            <artifactId>indy-test-fixtures-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/DecoratorUtils.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/DecoratorUtils.java
@@ -1,0 +1,56 @@
+package org.commonjava.indy.pkg.npm.content;
+
+import org.commonjava.maven.galley.util.UrlUtils;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class DecoratorUtils
+{
+    /**
+     * Replace tarball urls with context urls, e.g., "https://registry.npmjs.org/jquery/-/jquery-1.5.1.tgz" to
+     * "http://${indy}/api/content/npm/remote/test/jquery/-/jquery-1.5.1.tgz".
+     */
+    public static String updatePackageJson( String raw, String contextURL ) throws IOException
+    {
+        StringBuilder sb = new StringBuilder();
+        int index;
+        while ( ( index = raw.indexOf( "\"tarball\"" ) ) >= 0 )
+        {
+            int colon = raw.indexOf( ":", index );
+            String s = raw.substring( 0, colon + 1 );
+            sb.append( s );
+
+            raw = raw.substring( colon + 1 );
+            int quote = raw.indexOf( "\"" );
+            s = raw.substring( 0, quote ); // blanks between : and "
+            sb.append( s );
+
+            int nextQuote = raw.indexOf( "\"", quote + 1 );
+            String url = raw.substring( quote + 1, nextQuote );
+            String path = getPath( url );
+
+            url = UrlUtils.buildUrl( contextURL, path );
+            sb.append( "\"" + url + "\"" );
+            raw = raw.substring( nextQuote + 1 );
+        }
+        sb.append( raw );
+        return sb.toString();
+    }
+
+    private static String getPath( String url ) throws IOException
+    {
+        URL url1;
+        try
+        {
+            url1 = new URL( url );
+        }
+        catch ( MalformedURLException e )
+        {
+            throw new IOException( "Failed to parse URL " + url, e ); // should not happen
+        }
+        return url1.getPath();
+    }
+
+}

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
@@ -1,0 +1,166 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.galley.KeyedLocation;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.AbstractTransferDecorator;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.util.UrlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.commonjava.indy.content.ContentManager.ENTRY_POINT_BASE_URI;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.indy.pkg.npm.content.DecoratorUtils.updatePackageJson;
+import static org.jsoup.helper.StringUtil.isBlank;
+
+@ApplicationScoped
+public class NPMPackageMaskingTransferDecorator
+                extends AbstractTransferDecorator
+{
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    public NPMPackageMaskingTransferDecorator()
+    {
+    }
+
+    @Override
+    public InputStream decorateRead( final InputStream stream, final Transfer transfer, EventMetadata metadata )
+                    throws IOException
+    {
+        logger.debug( "Masking decorator decorateRead, transfer: {}", transfer );
+        Location loc = transfer.getLocation();
+        if ( !( loc instanceof KeyedLocation ) )
+        {
+            return stream;
+        }
+
+        KeyedLocation keyedLocation = (KeyedLocation) loc;
+        if ( !( PKG_TYPE_NPM.equals( keyedLocation.getKey().getPackageType() ) ) )
+        {
+            return stream;
+        }
+
+        if ( !( transfer.getFullPath().endsWith( "package.json" ) ) )
+        {
+            return stream;
+        }
+
+        String baseURI = (String) metadata.get( ENTRY_POINT_BASE_URI );
+        if ( isBlank( baseURI ) )
+        {
+            logger.trace( "Skip masking decorator (no baseURI), metadata: {}", metadata );
+            return stream;
+        }
+
+        StoreKey key = keyedLocation.getKey();
+        String contextURL = UrlUtils.buildUrl( baseURI, key.getType().name(), key.getName() );
+        logger.debug( "Use contextURL: {}", contextURL );
+        return new PackageMaskingInputStream( stream, contextURL );
+    }
+
+    private static class PackageMaskingInputStream
+                    extends FilterInputStream
+    {
+        final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+        int position;
+
+        private String contextURL;
+
+        private byte[] bytes;
+
+        boolean masked;
+
+        private PackageMaskingInputStream( final InputStream stream, final String contextURL )
+        {
+            super( stream );
+            this.contextURL = contextURL;
+        }
+
+        @Override
+        public synchronized int read() throws IOException
+        {
+            if ( !masked )
+            {
+                mask( contextURL );
+            }
+            if ( position < bytes.length )
+            {
+                return bytes[position++];
+            }
+            return -1;
+        }
+
+        @Override
+        public synchronized int read( byte[] b, int off, int len ) throws IOException
+        {
+            if ( !masked )
+            {
+                mask( contextURL );
+            }
+            if ( position >= bytes.length )
+            {
+                return -1;
+            }
+            int read = 0;
+            for ( int i = 0; i < len; i++ )
+            {
+                if ( position < bytes.length )
+                {
+                    b[off + i] = bytes[position++];
+                    read++;
+                }
+                else
+                {
+                    break;
+                }
+            }
+            return read;
+        }
+
+        private void mask( String contextURL ) throws IOException
+        {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            int read;
+            while ( ( read = super.read() ) >= 0 )
+            {
+                bos.write( read );
+            }
+            byte[] rawBytes = bos.toByteArray();
+            String raw = new String( rawBytes, UTF_8 );
+
+            logger.trace( "Mask for raw:\n{}", raw );
+
+            String s = updatePackageJson( raw, contextURL );
+
+            logger.trace( "Masked:\n{}", s );
+            bytes = s.getBytes();
+            masked = true;
+        }
+    }
+
+}

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/DecoratorUtilsTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/DecoratorUtilsTest.java
@@ -1,0 +1,50 @@
+package org.commonjava.indy.pkg.npm.content;
+
+import org.junit.Test;
+
+import static org.commonjava.indy.pkg.npm.content.DecoratorUtils.updatePackageJson;
+import static org.junit.Assert.assertEquals;
+
+public class DecoratorUtilsTest
+{
+
+    String raw = "\"versions\": {\n"
+                    + "\"1.5.1\": {\n"
+                    + "  \"dist\": \n"
+                    + "  {\n"
+                    + "    \"shasum\": \"2ae2d661e906c1a01e044a71bb5b2743942183e5\",\n"
+                    + "    \"tarball\": \"http://registry.npmjs.org/jquery/-/jquery-1.5.1.tgz\"\n"
+                    + "  },\n"
+                    + "\"1.5.2\": {\n"
+                    + "  \"dist\": \n"
+                    + "  {\n"
+                    + "    \"shasum\": \"et3d7g61e906c1a01e044a71bb5b27439421834t\",\n"
+                    + "    \"tarball\": \"http://registry.npmjs.redhat.com/jquery/-/jquery-1.5.2.tgz\"\n"
+                    + "  }\n"
+                    + "}";
+
+    String expected = "\"versions\": {\n"
+                    + "\"1.5.1\": {\n"
+                    + "  \"dist\": \n"
+                    + "  {\n"
+                    + "    \"shasum\": \"2ae2d661e906c1a01e044a71bb5b2743942183e5\",\n"
+                    + "    \"tarball\": \"http://indy.psi.redhat.com/api/content/group/a/jquery/-/jquery-1.5.1.tgz\"\n"
+                    + "  },\n"
+                    + "\"1.5.2\": {\n"
+                    + "  \"dist\": \n"
+                    + "  {\n"
+                    + "    \"shasum\": \"et3d7g61e906c1a01e044a71bb5b27439421834t\",\n"
+                    + "    \"tarball\": \"http://indy.psi.redhat.com/api/content/group/a/jquery/-/jquery-1.5.2.tgz\"\n"
+                    + "  }\n"
+                    + "}";
+
+    @Test
+    public void testUpdateString() throws Exception
+    {
+        String contextURL = "http://indy.psi.redhat.com/api/content/group/a";
+        String s = updatePackageJson( raw, contextURL );
+        //System.out.println( ">>>\n" + s );
+        assertEquals( expected, s );
+    }
+
+}

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecoratorTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecoratorTest.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.model.galley.GroupLocation;
+import org.commonjava.indy.model.galley.KeyedLocation;
+import org.commonjava.indy.test.fixture.core.TestCacheProvider;
+import org.commonjava.indy.test.fixture.core.TestFileEventManager;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.TransferDecoratorManager;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Transfer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+
+import static org.commonjava.indy.content.ContentManager.ENTRY_POINT_BASE_URI;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test the npm masking decorator which converts dist/tarball url to indy url.
+ */
+public class NPMPackageMaskingTransferDecoratorTest
+{
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    @Test
+    public void testDecorator() throws Exception
+    {
+        String path = "package.json";
+        KeyedLocation location = new GroupLocation( PKG_TYPE_NPM, "test" );
+        File file = new File( temp.newFolder( location.getName() ), path );
+
+        IOUtils.copy( getResourceAsStream( "metadata/package-1.json" ), new FileOutputStream( file ) );
+
+        ConcreteResource resource = new ConcreteResource( location, path );
+        TestCacheProvider provider = new TestCacheProvider( temp.getRoot(), new TestFileEventManager(),
+                                                            new TransferDecoratorManager( new NPMPackageMaskingTransferDecorator() ) );
+        Transfer transfer = provider.getTransfer( resource );
+
+        InputStream stream = transfer.openInputStream( false, new EventMetadata().set( ENTRY_POINT_BASE_URI,
+                                                                                       "http://localhost/api/content/npm" ) );
+        String ret = IOUtils.toString( stream );
+
+        String expected = IOUtils.toString( getResourceAsStream( "metadata/package-1-decorated.json" ) );
+        assertEquals( expected, ret );
+    }
+
+    private InputStream getResourceAsStream( String path )
+    {
+        return getClass().getClassLoader().getResourceAsStream( path );
+    }
+
+}

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
@@ -32,6 +32,7 @@ import org.commonjava.maven.galley.cache.FileCacheProvider;
 import org.commonjava.maven.galley.event.NoOpFileEventManager;
 import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
 import org.commonjava.maven.galley.io.NoOpTransferDecorator;
+import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
@@ -70,7 +71,7 @@ public class PackageMetadataMergerTest
     public void setup() throws Exception
     {
         cacheProvider = new FileCacheProvider( temp.newFolder( "cache" ), new HashedLocationPathGenerator(),
-                                               new NoOpFileEventManager(), new NoOpTransferDecorator(), false );
+                                               new NoOpFileEventManager(), new TransferDecoratorManager( new NoOpTransferDecorator() ), false );
     }
 
     @Test

--- a/addons/pkg-npm/common/src/test/resources/metadata/package-1-decorated.json
+++ b/addons/pkg-npm/common/src/test/resources/metadata/package-1-decorated.json
@@ -1,0 +1,95 @@
+{
+  "_id": "jquery",
+  "_rev": "503-dea6298026b47a40bc7e38ad234e119f",
+  "name": "jquery",
+  "description": "JavaScript library for DOM operations",
+  "dist-tags": {
+    "beta": "2.2.1",
+    "latest": "2.2.1"
+  },
+  "versions": {
+    "1.5.1": {
+      "name": "jquery",
+      "description": "jQuery: The Write Less, Do More, JavaScript Library",
+      "url": "jquery.com",
+      "keywords": [
+        "util",
+        "dom",
+        "jquery"
+      ],
+      "author": {
+        "name": "John Resig",
+        "email": "jeresig@gmail.com"
+      },
+      "contributors": [],
+      "dependencies": {
+        "jsdom": "=0.1.20",
+        "htmlparser": ">= 1.7.3"
+      },
+      "lib": "lib",
+      "main": "./dist/node-jquery.js",
+      "version": "1.5.1",
+      "_id": "jquery@1.5.1",
+      "engines": {
+        "node": "*"
+      },
+      "_engineSupported": true,
+      "_npmVersion": "0.3.15",
+      "_nodeVersion": "v0.4.2",
+      "directories": {
+        "lib": "./lib"
+      },
+      "files": [
+        ""
+      ],
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "2ae2d661e906c1a01e044a71bb5b2743942183e5",
+        "tarball": "http://localhost/api/content/npm/group/test/jquery/-/jquery-1.5.1.tgz"
+      },
+      "deprecated": "Versions of the jquery npm package older than 1.9.0 are patched versions that don't work in web browsers. Please upgrade to >=1.11.0."
+    }
+  },
+  "maintainers": [
+    {
+      "name": "dmethvin",
+      "email": "dave.methvin@gmail.com"
+    },
+    {
+      "name": "mgol",
+      "email": "m.goleb@gmail.com"
+    }
+  ],
+  "time": {
+    "modified": "2017-04-23T10:57:14.309Z",
+    "created": "2011-03-19T07:19:56.392Z",
+    "1.6.2": "2011-07-06T16:13:21.519Z",
+    "1.5.1": "2011-03-19T07:19:56.956Z",
+    "1.6.3": "2011-09-12T19:05:34.373Z"
+  },
+  "author": {
+    "name": "JS Foundation and other contributors",
+    "url": "https://github.com/jquery/jquery/blob/3.2.1/AUTHORS.txt"
+  },
+  "users": {
+    "dodo": true,
+    "fgribreau": false,
+    "parroit": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jquery1/jquery1.git"
+  },
+  "readme": "# jQuery\n\n> jQuery is a fast, small, and feature-rich JavaScript library.\n\nFor information on how to get started and how to use jQuery, please see [jQuery's documentation](http://api.jquery.com/).\nFor source files and issues, please visit the [jQuery repo](https://github.com/jquery/jquery).\n\nIf upgrading, please see the [blog post for 3.2.1](https://blog.jquery.com/2017/03/20/jquery-3-2-1-now-available/). This includes notable differences from the previous version and a more readable changelog.\n\n## Including jQuery\n\nBelow are some of the most common ways to include jQuery.\n\n### Browser\n\n#### Script tag\n\n```html\n<script src=\"https://code.jquery.com/jquery-3.2.1.min.js\"></script>\n```\n\n#### Babel\n\n[Babel](http://babeljs.io/) is a next generation JavaScript compiler. One of the features is the ability to use ES6/ES2015 modules now, even though browsers do not yet support this feature natively.\n\n```js\nimport $ from \"jquery\";\n```\n\n#### Browserify/Webpack\n\nThere are several ways to use [Browserify](http://browserify.org/) and [Webpack](https://webpack.github.io/). For more information on using these tools, please refer to the corresponding project's documention. In the script, including jQuery will usually look like this...\n\n```js\nvar $ = require(\"jquery\");\n```\n\n#### AMD (Asynchronous Module Definition)\n\nAMD is a module format built for the browser. For more information, we recommend [require.js' documentation](http://requirejs.org/docs/whyamd.html).\n\n```js\ndefine([\"jquery\"], function($) {\n\n});\n```\n\n### Node\n\nTo include jQuery in [Node](nodejs.org), first install with npm.\n\n```sh\nnpm install jquery\n```\n\nFor jQuery to work in Node, a window with a document is required. Since no such window exists natively in Node, one can be mocked by tools such as [jsdom](https://github.com/tmpvar/jsdom). This can be useful for testing purposes.\n\n```js\nrequire(\"jsdom\").env(\"\", function(err, window) {\n\tif (err) {\n\t\tconsole.error(err);\n\t\treturn;\n\t}\n\n\tvar $ = require(\"jquery\")(window);\n});\n```\n",
+  "readmeFilename": "README1.md",
+  "homepage": "https://jquery1.com",
+  "keywords": [
+    "jquery",
+    "javascript"
+  ],
+  "bugs": {
+    "url": "https://github.com/jquery1/jquery1/issues"
+  },
+  "license": "MIT1",
+  "_attachments": {}
+}

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupContentMergeRetrieveTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupContentMergeRetrieveTest.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.pkg.npm.content;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.commonjava.indy.client.core.util.UrlUtils;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
@@ -90,7 +91,10 @@ public class NPMGroupContentMergeRetrieveTest
         assertThat( remote, notNullValue() );
         assertThat( group, notNullValue() );
 
-        assertThat( IOUtils.toString( remote ), equalTo( CONTENT_1 ) );
+        String contextUrl = UrlUtils.buildUrl( fixture.getUrl(), "content", NPM_PKG_KEY, repoX.getType().name(), REPO_X );
+        String maskedUrl = contextUrl + "/jquery/-/jquery-1.5.1.tgz";
+
+        assertThat( IOUtils.toString( remote ), equalTo( CONTENT_1.replace( "https://registry.npmjs.org/jquery/-/jquery-1.5.1.tgz", maskedUrl ) ) );
 
         IndyObjectMapper mapper = new IndyObjectMapper( true );
         PackageMetadata merged = mapper.readValue( IOUtils.toString( group ), PackageMetadata.class );

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemoteMetadataContentDecoratorTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMRemoteMetadataContentDecoratorTest.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.client.core.util.UrlUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This case tests if package.json metadata can be retrieved and DECORATED.
+ * when: <br />
+ * <ul>
+ *      <li>creates remote repo A and expect metadata file in it</li>
+ *      <li>creates group G containing A</li>
+ *      <li>retrieve the metadata file from the remote repo A and group G</li>
+ * </ul>
+ * then: <br />
+ * <ul>
+ *     <li>the metadata content can be retrieved with all tarball urls decorated to proper context indy urls</li>
+ * </ul>
+ */
+public class NPMRemoteMetadataContentDecoratorTest
+                extends AbstractContentManagementTest
+{
+    protected static final String GROUP = "G";
+
+    @Test
+    public void test() throws Exception
+    {
+        final String packageContent = IOUtils.toString(
+                        Thread.currentThread().getContextClassLoader().getResourceAsStream( "package-1.5.1.json" ) );
+
+        final String packagePath = "jquery";
+
+        final String tarballUrl = "https://registry.npmjs.org/jquery/-/jquery-1.5.1.tgz";
+
+        server.expect( server.formatUrl( STORE, packagePath ), 200,
+                       new ByteArrayInputStream( packageContent.getBytes() ) );
+
+        final RemoteRepository remoteRepository = new RemoteRepository( NPM_PKG_KEY, STORE, server.formatUrl( STORE ) );
+        client.stores().create( remoteRepository, "adding npm remote repo", RemoteRepository.class );
+
+        final Group group = new Group( NPM_PKG_KEY, GROUP, remoteRepository.getKey() );
+        client.stores().create( group, "adding group", Group.class );
+
+        // retrieve from remote repo
+        StoreKey storeKey = remoteRepository.getKey();
+        InputStream stream = client.content().get( storeKey, packagePath );
+        assertThat( stream, notNullValue() );
+        String contextUrl =
+                        UrlUtils.buildUrl( fixture.getUrl(), "content", NPM_PKG_KEY, storeKey.getType().name(), STORE );
+        String decoratedContent = packageContent.replaceAll( tarballUrl, contextUrl + "/jquery/-/jquery-1.5.1.tgz" );
+        assertThat( IOUtils.toString( stream ), equalTo( decoratedContent ) );
+        stream.close();
+
+        // retrieve from group G
+        StoreKey groupKey = group.getKey();
+        stream = client.content().get( groupKey, packagePath );
+        assertThat( stream, notNullValue() );
+        contextUrl = UrlUtils.buildUrl( fixture.getUrl(), "content", NPM_PKG_KEY, groupKey.getType().name(), GROUP );
+        String maskedUrl = contextUrl + "/jquery/-/jquery-1.5.1.tgz";
+        // group metadata is not a simple copy of the remote repo so we only check if the decorated tarball url exists
+        assertThat( IOUtils.toString( stream ), containsString( maskedUrl ) );
+        stream.close();
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -305,7 +305,8 @@ public class NPMContentAccessHandler
         final StoreType st = StoreType.get( type );
         final StoreKey sk = new StoreKey( packageType, st, name );
 
-        eventMetadata = eventMetadata.set( ContentManager.ENTRY_POINT_STORE, sk );
+        eventMetadata.set( ContentManager.ENTRY_POINT_STORE, sk );
+        eventMetadata.set( ContentManager.ENTRY_POINT_BASE_URI, baseUri );
 
         final AcceptInfo acceptInfo = jaxRsRequestHelper.findAccept( request, ApplicationContent.text_html );
         final String standardAccept = ApplicationContent.getStandardAccept( acceptInfo.getBaseAccept() );

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/fixture/GalleyFixture.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/fixture/GalleyFixture.java
@@ -32,10 +32,10 @@ import org.commonjava.maven.galley.internal.xfer.ListingHandler;
 import org.commonjava.maven.galley.internal.xfer.UploadHandler;
 import org.commonjava.maven.galley.io.NoOpTransferDecorator;
 import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
+import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.nfc.MemoryNotFoundCache;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
-import org.commonjava.maven.galley.spi.io.TransferDecorator;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.commonjava.maven.galley.spi.transport.TransportManager;
 import org.commonjava.maven.galley.transport.TransportManagerImpl;
@@ -53,7 +53,7 @@ public class GalleyFixture
 
     private final FileEventManager events;
 
-    private final TransferDecorator decorator;
+    private final TransferDecoratorManager decorator;
 
     private final ExecutorService executor;
 
@@ -70,7 +70,7 @@ public class GalleyFixture
         transports = new TransportManagerImpl( new HttpClientTransport( new HttpImpl(passwordManager) ) );
 
         events = new IndyFileEventManager();
-        decorator = new NoOpTransferDecorator();
+        decorator = new TransferDecoratorManager( new NoOpTransferDecorator() );
         cache = new FileCacheProvider( repoRoot, new IndyPathGenerator(), events, decorator );
         executor = Executors.newFixedThreadPool( 2 );
         batchExecutor = Executors.newFixedThreadPool( 2 );
@@ -107,7 +107,7 @@ public class GalleyFixture
         return events;
     }
 
-    public TransferDecorator getDecorator()
+    public TransferDecoratorManager getDecorator()
     {
         return decorator;
     }

--- a/api/src/main/java/org/commonjava/indy/content/ContentManager.java
+++ b/api/src/main/java/org/commonjava/indy/content/ContentManager.java
@@ -39,6 +39,8 @@ public interface ContentManager
 
     String ENTRY_POINT_STORE = "entry-point-store";
 
+    String ENTRY_POINT_BASE_URI = "entry-point-base-uri";
+
     String SUPPRESS_EVENTS = "suppress-events";
 
     /**

--- a/core/src/test/java/org/commonjava/indy/fixture/GalleyFixture.java
+++ b/core/src/test/java/org/commonjava/indy/fixture/GalleyFixture.java
@@ -32,11 +32,11 @@ import org.commonjava.maven.galley.internal.xfer.ListingHandler;
 import org.commonjava.maven.galley.internal.xfer.UploadHandler;
 import org.commonjava.maven.galley.io.NoOpTransferDecorator;
 import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
+import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.nfc.MemoryNotFoundCache;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
-import org.commonjava.maven.galley.spi.io.TransferDecorator;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.commonjava.maven.galley.spi.transport.TransportManager;
 import org.commonjava.maven.galley.transport.TransportManagerImpl;
@@ -54,7 +54,7 @@ public class GalleyFixture
 
     private final FileEventManager events;
 
-    private final TransferDecorator decorator;
+    private final TransferDecoratorManager decorator;
 
     private final ExecutorService executor;
 
@@ -69,7 +69,7 @@ public class GalleyFixture
         transports = new TransportManagerImpl( new HttpClientTransport( new HttpImpl(new MemoryPasswordManager()) ) );
 
         events = new IndyFileEventManager();
-        decorator = new NoOpTransferDecorator();
+        decorator = new TransferDecoratorManager( new NoOpTransferDecorator() );
         cache = new FileCacheProvider( repoRoot, new IndyPathGenerator(), events, decorator );
         executor = Executors.newFixedThreadPool( 2 );
         batchExecutor = Executors.newFixedThreadPool( 2 );
@@ -106,7 +106,7 @@ public class GalleyFixture
         return events;
     }
 
-    public TransferDecorator getDecorator()
+    public TransferDecoratorManager getDecorator()
     {
         return decorator;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.0.1</atlasVersion>
-    <galleyVersion>0.16.10</galleyVersion>
+    <galleyVersion>0.16.11-SNAPSHOT</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>2.0</partylineVersion>

--- a/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/TestProvider.java
+++ b/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/TestProvider.java
@@ -28,6 +28,7 @@ import org.commonjava.maven.galley.cache.FileCacheProvider;
 import org.commonjava.maven.galley.config.TransportManagerConfig;
 import org.commonjava.maven.galley.event.NoOpFileEventManager;
 import org.commonjava.maven.galley.io.NoOpTransferDecorator;
+import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.nfc.MemoryNotFoundCache;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.event.FileEventManager;
@@ -95,7 +96,7 @@ public class TestProvider
 
             cacheProvider =
                     new FileCacheProvider( temp.newFolder( "storage" ), indyPathGenerator, fileEventManager,
-                                           transferDecorator );
+                                           new TransferDecoratorManager( transferDecorator ) );
         }
         catch ( IOException e )
         {

--- a/test/fixtures-core/pom.xml
+++ b/test/fixtures-core/pom.xml
@@ -43,10 +43,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-pkg-maven-common</artifactId>
-    </dependency>
-    <dependency>
       <groupId>javax.enterprise</groupId>
       <artifactId>cdi-api</artifactId>
       <scope>compile</scope>

--- a/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/TestCacheProvider.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/TestCacheProvider.java
@@ -1,0 +1,302 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.test.fixture.core;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.commonjava.maven.galley.cache.SimpleLockingSupport;
+import org.commonjava.maven.galley.io.TransferDecoratorManager;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class TestCacheProvider
+    implements CacheProvider
+{
+
+    private final File dir;
+
+    private final FileEventManager events;
+
+    private final TransferDecoratorManager decorator;
+
+    private final SimpleLockingSupport lockingSupport = new SimpleLockingSupport();
+
+    public TestCacheProvider( final File dir, final FileEventManager events, final TransferDecoratorManager decorator )
+    {
+        this.dir = dir;
+        this.events = events;
+        this.decorator = decorator;
+    }
+
+    public Transfer writeClasspathResourceToCache( final ConcreteResource resource, final String cpResource )
+        throws IOException
+    {
+        final InputStream in = Thread.currentThread()
+                                     .getContextClassLoader()
+                                     .getResourceAsStream( cpResource );
+        if ( in == null )
+        {
+            throw new IOException( "Classpath resource not found: " + cpResource );
+        }
+
+        final Transfer tx = getTransfer( resource );
+        OutputStream out = null;
+        try
+        {
+            out = tx.openOutputStream( TransferOperation.UPLOAD, false );
+            IOUtils.copy( in, out );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( in );
+            IOUtils.closeQuietly( out );
+        }
+
+        return tx;
+    }
+
+    public Transfer writeToCache( final ConcreteResource resource, final String content )
+        throws IOException
+    {
+        if ( content == null )
+        {
+            throw new IOException( "Content is empty!" );
+        }
+
+        final Transfer tx = getTransfer( resource );
+        OutputStream out = null;
+        try
+        {
+            out = tx.openOutputStream( TransferOperation.UPLOAD, false );
+            out.write( content.getBytes() );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( out );
+        }
+
+        return tx;
+    }
+
+    @Override
+    public boolean isDirectory( final ConcreteResource resource )
+    {
+        return !getDetachedFile( resource ).isFile();
+    }
+
+    @Override
+    public boolean isFile( final ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).isFile();
+    }
+
+    @Override
+    public InputStream openInputStream( final ConcreteResource resource )
+        throws IOException
+    {
+        return new FileInputStream( getDetachedFile( resource ) );
+    }
+
+    @Override
+    public OutputStream openOutputStream( final ConcreteResource resource )
+        throws IOException
+    {
+        final File f = getDetachedFile( resource );
+        final File d = f.getParentFile();
+        if ( d != null )
+        {
+            d.mkdirs();
+        }
+
+        return new FileOutputStream( f );
+    }
+
+    @Override
+    public boolean exists( final ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).exists();
+    }
+
+    @Override
+    public void copy( final ConcreteResource from, final ConcreteResource to )
+        throws IOException
+    {
+        final File ff = getDetachedFile( from );
+        final File tf = getDetachedFile( to );
+        if ( ff.isDirectory() )
+        {
+            FileUtils.copyDirectory( ff, tf );
+        }
+        else
+        {
+            FileUtils.copyFile( ff, tf );
+        }
+    }
+
+    @Override
+    public String getFilePath( final ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).getPath();
+    }
+
+    @Override
+    public boolean delete( final ConcreteResource resource )
+        throws IOException
+    {
+        FileUtils.forceDelete( getDetachedFile( resource ) );
+        return true;
+    }
+
+    @Override
+    public String[] list( final ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).list();
+    }
+
+    public File getDetachedFile( final ConcreteResource resource )
+    {
+        return new File( new File( dir, resource.getLocationName() ), resource.getPath() );
+    }
+
+    @Override
+    public void mkdirs( final ConcreteResource resource )
+        throws IOException
+    {
+        getDetachedFile( resource ).mkdirs();
+    }
+
+    @Override
+    public void createFile( final ConcreteResource resource )
+        throws IOException
+    {
+        getDetachedFile( resource ).createNewFile();
+    }
+
+    @Override
+    public void createAlias( final ConcreteResource from, final ConcreteResource to )
+        throws IOException
+    {
+        final File fromFile = getDetachedFile( from );
+        final File toFile = getDetachedFile( to );
+        FileUtils.copyFile( fromFile, toFile );
+        //        Files.createLink( Paths.get( fromFile.toURI() ), Paths.get( toFile.toURI() ) );
+    }
+
+    @Override
+    public void clearTransferCache()
+    {
+    }
+
+    @Override
+    public Transfer getTransfer( final ConcreteResource resource )
+    {
+        return new Transfer( resource, this, events, decorator );
+    }
+
+    @Override
+    public long length( final ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).length();
+    }
+
+    @Override
+    public long lastModified( final ConcreteResource resource )
+    {
+        return getDetachedFile( resource ).lastModified();
+    }
+
+    @Override
+    public boolean isReadLocked( final ConcreteResource resource )
+    {
+        return lockingSupport.isLocked( resource );
+    }
+
+    @Override
+    public boolean isWriteLocked( final ConcreteResource resource )
+    {
+        return lockingSupport.isLocked( resource );
+    }
+
+    @Override
+    public void unlockRead( final ConcreteResource resource )
+    {
+        lockingSupport.unlock( resource );
+    }
+
+    @Override
+    public void unlockWrite( final ConcreteResource resource )
+    {
+        lockingSupport.unlock( resource );
+    }
+
+    @Override
+    public void lockRead( final ConcreteResource resource )
+    {
+        lockingSupport.lock( resource );
+    }
+
+    @Override
+    public void lockWrite( final ConcreteResource resource )
+    {
+        lockingSupport.lock( resource );
+    }
+
+    @Override
+    public void waitForWriteUnlock( final ConcreteResource resource )
+    {
+        lockingSupport.waitForUnlock( resource );
+    }
+
+    @Override
+    public void waitForReadUnlock( final ConcreteResource resource )
+    {
+        lockingSupport.waitForUnlock( resource );
+    }
+
+    @Override
+    public AdminView asAdminView()
+    {
+        throw new UnsupportedOperationException( "No support for AdminView" );
+    }
+
+    @Override
+    public void cleanupCurrentThread()
+    {
+        lockingSupport.cleanupCurrentThread();
+    }
+
+    @Override
+    public void startReporting()
+    {
+        lockingSupport.startReporting();
+    }
+
+    @Override
+    public void stopReporting()
+    {
+        lockingSupport.stopReporting();
+    }
+}

--- a/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/TestFileEventManager.java
+++ b/test/fixtures-core/src/main/java/org/commonjava/indy/test/fixture/core/TestFileEventManager.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc. (nos-devel@redhat.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.test.fixture.core;
+
+import org.commonjava.maven.galley.event.FileAccessEvent;
+import org.commonjava.maven.galley.event.FileDeletionEvent;
+import org.commonjava.maven.galley.event.FileErrorEvent;
+import org.commonjava.maven.galley.event.FileNotFoundEvent;
+import org.commonjava.maven.galley.event.FileStorageEvent;
+import org.commonjava.maven.galley.spi.event.FileEventManager;
+
+import javax.enterprise.inject.Alternative;
+import javax.inject.Named;
+
+@Named( "no-op-galley-events" )
+@Alternative
+public class TestFileEventManager
+    implements FileEventManager
+{
+
+    @Override
+    public void fire( final FileNotFoundEvent evt )
+    {
+    }
+
+    @Override
+    public void fire( final FileStorageEvent evt )
+    {
+    }
+
+    @Override
+    public void fire( final FileAccessEvent evt )
+    {
+    }
+
+    @Override
+    public void fire( final FileDeletionEvent evt )
+    {
+    }
+
+    @Override
+    public void fire( final FileErrorEvent evt )
+    {
+    }
+
+}


### PR DESCRIPTION
This is a fix for NPM support that should allow us to continue testing the new package type under real-world conditions. It was already merged to master.