### PR TITLE
Add missing @REST annotation for folo content rest endpoint

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.folo.model.TrackingKey;
@@ -59,6 +60,7 @@ import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEA
 @Api( value = "FOLO Tracked Content Access and Storage",
       description = "Tracks retrieval and management of file/artifact content." )
 @Path( "/api/folo/track/{id}/{packageType}/{type: (hosted|group|remote)}/{name}" )
+@REST
 public class FoloContentAccessResource
         implements IndyResources
 {


### PR DESCRIPTION
Because of this missing, seems that all folo content rest access is not processed by the RestInterceptor, which means that the needed mdc info for sli tracing is missed now.