### PR TITLE
use new shutdownNow() method when Indy client API is closed

### DIFF
--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
@@ -30,12 +30,9 @@ import org.commonjava.util.jhttpc.auth.PasswordManager;
 import org.commonjava.util.jhttpc.model.SiteConfig;
 
 import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Properties;
 import java.util.Set;
 
 import static org.commonjava.indy.IndyRequestConstants.HEADER_COMPONENT_ID;
@@ -124,6 +121,7 @@ public class Indy
         loadApiVersion();
         this.http = new IndyClientHttp( authenticator, mapper == null ? new IndyObjectMapper( true ) : mapper, location,
                                         getApiVersion() );
+
         this.moduleRegistry = new HashSet<>();
 
         setupStandardModules();
@@ -139,7 +137,6 @@ public class Indy
     {
         this( location, passwordManager, null, modules );
     }
-
 
     public Indy( SiteConfig location, PasswordManager passwordManager, IndyObjectMapper objectMapper, IndyClientModule... modules )
             throws IndyClientException

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
@@ -624,14 +624,7 @@ public class IndyClientHttp
     public void close()
     {
         logger.debug( "Shutting down indy client HTTP manager" );
-        try
-        {
-            factory.close();
-        }
-        catch ( IOException e )
-        {
-            logger.debug( "Shutting down indy client HTTP factory error", e ); // log and return quietly
-        }
+        factory.shutdownNow();
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <partylineVersion>2.0</partylineVersion>
     <kojijiVersion>2.7</kojijiVersion>
     <rwxVersion>2.3</rwxVersion>
-    <jhttpcVersion>1.9</jhttpcVersion>
+    <jhttpcVersion>1.10-SNAPSHOT</jhttpcVersion>
     <weftVersion>1.14</weftVersion>
     <httpTestserverVersion>1.4</httpTestserverVersion>
     <propulsorVersion>1.4</propulsorVersion>

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpProvider.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpProvider.java
@@ -63,6 +63,7 @@ public class IndyHttpProvider
     {
         passwordManager = new org.commonjava.maven.galley.auth.AttributePasswordManager();
         http = new HttpImpl( passwordManager );
+
         httpFactory = new HttpFactory( new AttributePasswordManager( siteConfigLookup ) );
     }
 


### PR DESCRIPTION
This will forcibly close the connection manager and all connections when the client is closed.

This depends on https://github.com/Commonjava/jhttpc/pull/38.