### PR TITLE
Record load metric up front when request starts

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
@@ -98,7 +98,7 @@ public class HttpConduitWrapper
     public void writeStatus( final ApplicationStatus status )
             throws IOException
     {
-        setContext( HTTP_STATUS, String.valueOf( status.code() ) );
+        setContext( HTTP_STATUS, status.code() );
 
         final ByteBuffer b =
                 ByteBuffer.wrap( String.format( "HTTP/1.1 %d %s\r\n", status.code(), status.message() ).getBytes() );
@@ -109,7 +109,7 @@ public class HttpConduitWrapper
     public void writeStatus( final int code, final String message )
             throws IOException
     {
-        setContext( HTTP_STATUS, String.valueOf( code ) );
+        setContext( HTTP_STATUS, code );
 
         final ByteBuffer b = ByteBuffer.wrap( String.format( "HTTP/1.1 %d %s\r\n", code, message ).getBytes() );
         sinkChannel.write( b );

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyMeter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyMeter.java
@@ -68,7 +68,7 @@ public class ProxyMeter
                 sliMetricSet.function( GoldenSignalsMetricSet.FN_CONTENT_GENERIC ).ifPresent( ms ->{
                     ms.latency( latency ).call();
 
-                    if ( parseInt( getContext( HTTP_STATUS, "200" ) ) > 499 )
+                    if ( getContext( HTTP_STATUS, 200 ) > 499 )
                     {
                         ms.error();
                     }

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsFunctionMetrics.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/metrics/GoldenSignalsFunctionMetrics.java
@@ -22,13 +22,14 @@ import com.codahale.metrics.health.HealthCheck;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class GoldenSignalsFunctionMetrics
 {
     private String name;
+
+    private Meter load = new Meter();
 
     private Timer latency = new Timer();
 
@@ -47,6 +48,7 @@ public class GoldenSignalsFunctionMetrics
         metrics.put( name + ".latency", latency );
         metrics.put( name + ".errors", errors );
         metrics.put( name + ".throughput", throughput );
+        metrics.put( name + ".load", load );
 
         return metrics;
     }
@@ -74,6 +76,12 @@ public class GoldenSignalsFunctionMetrics
         return new GSFunctionHealthCheck();
     }
 
+    public GoldenSignalsFunctionMetrics started()
+    {
+        load.mark();
+        return this;
+    }
+
     final class GSFunctionHealthCheck
             extends HealthCheck
     {
@@ -86,6 +94,7 @@ public class GoldenSignalsFunctionMetrics
                          .withDetail( "latency", latency.getSnapshot().get99thPercentile() )
                          .withDetail( "errors", errors.getOneMinuteRate() )
                          .withDetail( "throughput", throughput.getOneMinuteRate() )
+                         .withDetail( "load", load.getOneMinuteRate() )
                          .healthy()
                          .build();
         }

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.core.ctl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.commonjava.indy.IndyRequestConstants;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.content.StoreResource;
@@ -69,7 +70,8 @@ public class ContentController
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    public static final String LISTING_HTML_FILE = "index.html";
+    @Deprecated
+    public static final String LISTING_HTML_FILE = IndyRequestConstants.LISTING_HTML_FILE;
 
     public static final String CONTENT_BROWSE_ROOT = "/browse";
 

--- a/models/core-java/src/main/java/org/commonjava/indy/IndyRequestConstants.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/IndyRequestConstants.java
@@ -18,6 +18,8 @@ package org.commonjava.indy;
 public final class IndyRequestConstants
 {
 
+    public static final String LISTING_HTML_FILE = "index.html";
+
     public static final String HEADER_COMPONENT_ID = "component-id";
 
 }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RequestContextHelper.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/RequestContextHelper.java
@@ -31,24 +31,24 @@ import static org.commonjava.indy.IndyRequestConstants.HEADER_COMPONENT_ID;
  */
 public class RequestContextHelper
 {
-    public static void setContext( final String key, final String value )
+    public static void setContext( final String key, final Object value )
     {
-        org.slf4j.MDC.put( key, value );
+        org.slf4j.MDC.put( key, String.valueOf( value ) );
         ThreadContext.getContext( true ).computeIfAbsent( key, k -> value );
     }
 
-    public static String getContext( final String key )
+    public static <T> T getContext( final String key )
     {
         return getContext( key, null );
     }
 
-    public static String getContext( final String key, final String defaultValue )
+    public static <T> T getContext( final String key, final T defaultValue )
     {
         ThreadContext ctx = ThreadContext.getContext( false );
         if ( ctx != null )
         {
             Object v = ctx.get( key );
-            return v == null ? defaultValue : String.valueOf( v );
+            return v == null ? defaultValue : (T) v;
         }
 
         return defaultValue;
@@ -63,6 +63,11 @@ public class RequestContextHelper
         {
             ctx.remove( key );
         }
+    }
+
+    public static long getRequestEndNanos()
+    {
+        return getContext( END_NANOS, System.nanoTime() );
     }
 
     // Scope annotations
@@ -80,6 +85,9 @@ public class RequestContextHelper
     private @interface Thread{}
 
     //
+
+    @Thread
+    public static final String END_NANOS = "latency-end-nanos";
 
     @Thread @MDC
     public static final String REST_CLASS_PATH = "REST-class-path";


### PR DESCRIPTION
This also means that we have to classify traffic without the benefit of ThreadContext
variables, or the path parameters we would normally get from the REST endpoint classes.