### PR TITLE
Add a log warning when folo-in-progress expires an entry

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloExpirationWarningListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloExpirationWarningListener.java
@@ -1,0 +1,34 @@
+package org.commonjava.indy.folo.change;
+
+import org.commonjava.indy.folo.model.TrackedContent;
+import org.commonjava.indy.folo.model.TrackedContentEntry;
+import org.commonjava.indy.folo.model.TrackingKey;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.IOException;
+
+@Listener
+@ApplicationScoped
+public class FoloExpirationWarningListener
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @CacheEntryExpired
+    public void onCacheEntryExpired( final CacheEntryExpiredEvent<TrackedContentEntry, TrackedContentEntry> event )
+    {
+        if ( event.isPre() )
+        {
+            return;
+        }
+
+        TrackedContentEntry entry = event.getKey();
+        logger.warn( "Tracking record entry {}:{}:{} was expired by Infinispan!", entry.getTrackingKey(), entry.getStoreKey(), entry.getPath() );
+    }
+}

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.folo.data;
 
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.folo.change.FoloBackupListener;
+import org.commonjava.indy.folo.change.FoloExpirationWarningListener;
 import org.commonjava.indy.folo.model.StoreEffect;
 import org.commonjava.indy.folo.model.TrackedContent;
 import org.commonjava.indy.folo.model.TrackedContentEntry;
@@ -65,11 +66,19 @@ public class FoloRecordCache
     @Inject
     private FoloBackupListener foloBackupListener;
 
+    @Inject
+    private FoloExpirationWarningListener expirationWarningListener;
+
     @PostConstruct
     private void init()
     {
         sealedRecordCache.executeCache( (cache) -> {
             cache.addListener( foloBackupListener );
+            return null;
+        } );
+
+        inProgressRecordCache.executeCache( (cache) ->{
+            cache.addListener( expirationWarningListener );
             return null;
         } );
     }

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -32,6 +32,7 @@
   <modules>
     <module>launcher</module>
     <module>cache-migrator</module>
+    <module>record-extractor</module>
   </modules>
 
   <profiles>

--- a/deployments/record-extractor/pom.xml
+++ b/deployments/record-extractor/pom.xml
@@ -1,0 +1,131 @@
+<!--
+
+    Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-deployments</artifactId>
+    <version>1.9.0-SNAPSHOT</version>
+  </parent>
+  
+  <groupId>org.commonjava.indy.launch</groupId>
+  <artifactId>indy-record-extractor</artifactId>
+
+  <name>Indy :: Tracking Record Extractor</name>
+  
+  <properties>
+    <!-- defaults for assembly -->
+    <distName>${project.artifactId}</distName>
+    <disableLauncher>false</disableLauncher>
+    <enforcer.skip>true</enforcer.skip>
+  </properties>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-folo-model-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.11</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>executable-jar</id>
+              <goals>
+                <goal>single</goal>
+              </goals>
+              <phase>package</phase>
+              <configuration>
+                <descriptorRefs>
+                  <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+                <appendAssemblyId>false</appendAssemblyId>
+                <archive>
+                  <manifest>
+                    <mainClass>org.commonjava.indy.tools.folo.record.Main</mainClass>
+                  </manifest>
+                </archive>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/deployments/record-extractor/src/main/java/org/commonjava/indy/tools/folo/record/ExtractOptions.java
+++ b/deployments/record-extractor/src/main/java/org/commonjava/indy/tools/folo/record/ExtractOptions.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.tools.folo.record;
+
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import java.io.File;
+
+public class ExtractOptions
+{
+    @Option( name = "-h", aliases = { "--help" }, usage = "Print this and exit" )
+    private boolean help;
+
+    @Argument( index = 0, metaVar = "data-file", required = false, usage = "Record file to read")
+    private File dataFile;
+
+    @Argument( index = 1, metaVar = "out-file", required = false, usage = "JSON file to write")
+    private File outFile;
+
+    public boolean isHelp()
+    {
+        return help;
+    }
+
+    public void setHelp( final boolean help )
+    {
+        this.help = help;
+    }
+
+    public File getDataFile()
+    {
+        return dataFile;
+    }
+
+    public void setDataFile( final File dataFile )
+    {
+        this.dataFile = dataFile;
+    }
+
+    public File getOutFile()
+    {
+        return outFile;
+    }
+
+    public void setOutFile( final File outFile )
+    {
+        this.outFile = outFile;
+    }
+
+    public boolean parseArgs( final String[] args )
+            throws CmdLineException
+    {
+        final CmdLineParser parser = new CmdLineParser( this );
+        boolean canStart = true;
+        parser.parseArgument( args );
+
+        if ( isHelp() )
+        {
+            printUsage( parser, null );
+            canStart = false;
+        }
+        else if ( getDataFile() == null )
+        {
+            System.err.println("You must provide 'action', 'cache-name', and 'data-file' arguments!");
+            printUsage( parser, null );
+
+            canStart = false;
+        }
+
+        return canStart;
+    }
+
+    public static void printUsage( final CmdLineParser parser, final CmdLineException error )
+    {
+        if ( error != null )
+        {
+            System.err.println( "Invalid option(s): " + error.getMessage() );
+            System.err.println();
+        }
+
+        System.err.println( "Usage: $0 [OPTIONS] [<target-path>]" );
+        System.err.println();
+        System.err.println();
+        // If we are running under a Linux shell COLUMNS might be available for the width
+        // of the terminal.
+        parser.setUsageWidth( ( System.getenv( "COLUMNS" ) == null ? 100 : Integer.valueOf( System.getenv( "COLUMNS" ) ) ) );
+        parser.printUsage( System.err );
+        System.err.println();
+    }
+}

--- a/deployments/record-extractor/src/main/java/org/commonjava/indy/tools/folo/record/Main.java
+++ b/deployments/record-extractor/src/main/java/org/commonjava/indy/tools/folo/record/Main.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (C) 2011-2018 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.tools.folo.record;
+
+import org.commonjava.indy.folo.model.TrackedContent;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.kohsuke.args4j.CmdLineException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.ObjectInputStream;
+import java.lang.reflect.InvocationTargetException;
+
+public class Main
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final int ERR_INIT = 1;
+    private static final int ERR_PARSE_ARGS = 2;
+
+    public static void main( String[] args )
+    {
+        Thread.currentThread()
+              .setUncaughtExceptionHandler( ( thread, error ) -> {
+                  if ( error instanceof InvocationTargetException )
+                  {
+                      final InvocationTargetException ite = (InvocationTargetException) error;
+                      System.err.println( "In: " + thread.getName() + "(" + thread.getId()
+                                                  + "), caught InvocationTargetException:" );
+                      ite.getTargetException()
+                         .printStackTrace();
+
+                      System.err.println( "...via:" );
+                      error.printStackTrace();
+                  }
+                  else
+                  {
+                      System.err.println( "In: " + thread.getName() + "(" + thread.getId() + ") Uncaught error:" );
+                      error.printStackTrace();
+                  }
+              } );
+
+        ExtractOptions options = new ExtractOptions();
+        try
+        {
+            if ( options.parseArgs( args ) )
+            {
+                try
+                {
+                    int result = new Main().run( options );
+                    if ( result != 0 )
+                    {
+                        System.exit( result );
+                    }
+                }
+                catch ( final Exception e )
+                {
+                    System.err.printf( "ERROR INITIALIZING BOOTER: %s", e.getMessage() );
+                    System.exit( ERR_INIT );
+                }
+            }
+        }
+        catch ( final CmdLineException e )
+        {
+            System.err.printf( "ERROR: %s", e.getMessage() );
+            System.exit( ERR_PARSE_ARGS );
+        }
+    }
+
+    private int run( final ExtractOptions options )
+            throws Exception
+    {
+        try
+        {
+            File dataFile = options.getDataFile();
+            File outFile = options.getOutFile();
+            try (ObjectInputStream ion = new ObjectInputStream( new FileInputStream( dataFile ) );
+                 FileOutputStream fos = new FileOutputStream( outFile ) )
+            {
+                TrackedContent content = (TrackedContent) ion.readObject();
+                new IndyObjectMapper( true ).writeValue( fos, content );
+            }
+        }
+        catch ( final Throwable e )
+        {
+            if ( e instanceof Exception )
+                throw (Exception)e;
+
+            logger.error( "Failed to initialize Booter: " + e.getMessage(), e );
+            return ERR_INIT;
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
This will help us debug problems where really long-running builds end up with content missing from their sealed tracking record.

Also, adding a very small client that can deserialize and export a tracking record backup file to JSON.