### PR TITLE
Fix path parsing for metadata checking of sli filter

### DIFF
--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
@@ -85,6 +85,14 @@ public class GoldenSignalsFilter
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
+    // For Unit-testing
+    GoldenSignalsFilter(final GoldenSignalsMetricSet metricSet, final SpecialPathManager specialPathManager){
+        this.metricSet = metricSet;
+        this.specialPathManager = specialPathManager;
+    }
+
+    GoldenSignalsFilter() {}
+
     @Override
     public void init( final FilterConfig filterConfig )
     {
@@ -138,7 +146,7 @@ public class GoldenSignalsFilter
         }
     }
 
-    private List<String> getFunctions( String restPath, String method )
+    List<String> getFunctions( String restPath, String method )
     {
         String[] pathParts = restPath.split("/" );
         if ( pathParts.length < 2 )
@@ -170,7 +178,7 @@ public class GoldenSignalsFilter
             // this is a browse / list request
             return singletonList( FN_CONTENT_LISTING );
         }
-        else if ( ( "content".equals( classifierParts[0] ) && classifierParts.length > 4 && ( restPath.endsWith( "/" )
+        else if ( ( "content".equals( classifierParts[0] ) && classifierParts.length >= 4 && ( restPath.endsWith( "/" )
                 || restPath.endsWith( IndyRequestConstants.LISTING_HTML_FILE ) ) ) )
         {
             // this is an old version of the browse / list request
@@ -190,7 +198,7 @@ public class GoldenSignalsFilter
         else if ( restPrefix.startsWith( "folo/track/" ) && classifierParts.length > 6 )
         {
             String packageType = classifierParts[3];
-            boolean isMetadata = isMetadata( packageType, classifierParts[4], classifierParts[5], pathParts, 6 );
+            boolean isMetadata = isMetadata( packageType, classifierParts[4], classifierParts[5], pathParts, 7 );
 
             if ( PKG_TYPE_MAVEN.equals( packageType ) )
             {
@@ -224,12 +232,12 @@ public class GoldenSignalsFilter
         return emptyList();
     }
 
-    private boolean isMetadata( final String packageType, final String storeType, final String storeName, final String[] pathParts, final int realPathStartIdx )
+    boolean isMetadata( final String packageType, final String storeType, final String storeName, final String[] pathParts, final int realPathStartIdx )
     {
         Location location = getLightweightLocation( packageType, storeType, storeName );
 
-        String[] realPathParts = new String[pathParts.length-(realPathStartIdx+1)];
-        System.arraycopy( pathParts, 2, realPathParts, 0, realPathParts.length );
+        String[] realPathParts = new String[pathParts.length - realPathStartIdx];
+        System.arraycopy( pathParts, realPathStartIdx, realPathParts, 0, realPathParts.length );
 
         String realPath = join( realPathParts, '/' );
 

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilterMapper.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilterMapper.java
@@ -48,7 +48,10 @@ public class GoldenSignalsFilterMapper
           .addFilterUrlMapping( filterInfo.getName(), "/api/content/*", DispatcherType.REQUEST )
           .addFilterUrlMapping( filterInfo.getName(), "/api/promotion/*", DispatcherType.REQUEST )
           .addFilterUrlMapping( filterInfo.getName(), "/api/admin/stores/*", DispatcherType.REQUEST )
-          .addFilterUrlMapping( filterInfo.getName(), "/api/browse/*", DispatcherType.REQUEST );
+          .addFilterUrlMapping( filterInfo.getName(), "/api/browse/*", DispatcherType.REQUEST )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/remote/*", DispatcherType.REQUEST )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/hosted/*", DispatcherType.REQUEST )
+          .addFilterUrlMapping( filterInfo.getName(), "/api/group/*", DispatcherType.REQUEST );
 
         return di;
     }

--- a/addons/sli/jaxrs/src/test/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilterTest.java
+++ b/addons/sli/jaxrs/src/test/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilterTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.sli.jaxrs;
+
+import org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet;
+import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+public class GoldenSignalsFilterTest
+{
+    private final SpecialPathManagerImpl specialPathManager = new SpecialPathManagerImpl();
+
+    private final GoldenSignalsMetricSet metricSet = new GoldenSignalsMetricSet();
+
+    private final GoldenSignalsFilter filter = new GoldenSignalsFilter( metricSet, specialPathManager );
+
+    @Before
+    public void init()
+    {
+        specialPathManager.initPkgPathSets();
+    }
+
+    @Test
+    public void testIsMetadata()
+    {
+        final boolean isFoloMavenMetadata = filter.isMetadata( "maven", "group", "test",
+                                                               new String[] { "", "folo", "track", "test-1", "maven",
+                                                                       "group", "test", "io", "undertow",
+                                                                       "maven-metadata.xml" }, 7 );
+        assertThat( isFoloMavenMetadata, CoreMatchers.equalTo( true ) );
+
+        final boolean isContentMavenMetadata = filter.isMetadata( "maven", "group", "test",
+                                                                  new String[] { "", "content", "maven", "group",
+                                                                          "test", "io", "undertow",
+                                                                          "maven-metadata.xml" }, 5 );
+        assertThat( isContentMavenMetadata, CoreMatchers.equalTo( true ) );
+
+        final boolean isDeprecatedMavenMetadata = filter.isMetadata( "maven", "group", "test",
+                                                                     new String[] { "", "group", "test", "io",
+                                                                             "undertow", "maven-metadata.xml" }, 2 );
+        assertThat( isDeprecatedMavenMetadata, CoreMatchers.equalTo( true ) );
+
+        final boolean isFoloNPMMetadata = filter.isMetadata( "npm", "group", "test",
+                                                             new String[] { "", "folo", "track", "test-1", "maven",
+                                                                     "group", "test", "jquery", "package.json" }, 7 );
+        assertThat( isFoloNPMMetadata, CoreMatchers.equalTo( true ) );
+
+        final boolean isContentNPMMetadata = filter.isMetadata( "npm", "group", "test",
+                                                                new String[] { "", "content", "npm", "group", "test",
+                                                                        "jquery", "package.json" }, 5 );
+        assertThat( isContentNPMMetadata, CoreMatchers.equalTo( true ) );
+    }
+
+    @Test
+    public void testIsNormalPath()
+    {
+        final boolean isFoloMavenPath = filter.isMetadata( "maven", "group", "test",
+                                                           new String[] { "", "folo", "track", "test-1", "maven",
+                                                                   "group", "test", "io", "undertow", "1.0",
+                                                                   "undertow-1.0.pom" }, 7 );
+        assertThat( isFoloMavenPath, CoreMatchers.equalTo( false ) );
+
+        final boolean isContentMavenPath = filter.isMetadata( "maven", "group", "test",
+                                                              new String[] { "", "content", "maven", "group", "test",
+                                                                      "io", "undertow", "1.0", "undertow-1.0.pom" },
+                                                              5 );
+        assertThat( isContentMavenPath, CoreMatchers.equalTo( false ) );
+
+        final boolean isDeprecatedMavenPath = filter.isMetadata( "maven", "group", "test",
+                                                                 new String[] { "", "group", "test", "io", "undertow",
+                                                                         "maven-metadata.xml" }, 2 );
+        assertThat( isDeprecatedMavenPath, CoreMatchers.equalTo( true ) );
+
+        final boolean isFoloNPMPath = filter.isMetadata( "npm", "group", "test",
+                                                         new String[] { "", "folo", "track", "test-1", "maven", "group",
+                                                                 "test", "jquery", "-", "jquery.tar.gz" }, 7 );
+        assertThat( isFoloNPMPath, CoreMatchers.equalTo( false ) );
+
+        final boolean isContentNPMPath = filter.isMetadata( "npm", "group", "test",
+                                                            new String[] { "", "content", "npm", "group", "test",
+                                                                    "jquery", "-", "jquery.tar.gz" }, 5 );
+        assertThat( isContentNPMPath, CoreMatchers.equalTo( false ) );
+    }
+
+    @Test
+    public void testGetFunctions(){
+        List<String> groupPromoteFuncs= filter.getFunctions( "/promotion/groups/promote", "" );
+        assertThat( groupPromoteFuncs, hasItem( GoldenSignalsMetricSet.FN_PROMOTION ) );
+        List<String> pathsPromoteFuncs= filter.getFunctions( "/promotion/paths/promote", "" );
+        assertThat( groupPromoteFuncs, hasItem( GoldenSignalsMetricSet.FN_PROMOTION ) );
+
+        List<String> storesFuncs = filter.getFunctions( "/admin/stores/maven/group/test", "PUT" );
+        assertThat( storesFuncs, hasItem( GoldenSignalsMetricSet.FN_REPO_MGMT ) );
+        storesFuncs = filter.getFunctions( "/admin/stores/maven/remote/test2", "POST" );
+        assertThat( storesFuncs, hasItem( GoldenSignalsMetricSet.FN_REPO_MGMT ) );
+        storesFuncs = filter.getFunctions( "/admin/stores/maven/hosted/test3", "DELETE" );
+        assertThat( storesFuncs, hasItem( GoldenSignalsMetricSet.FN_REPO_MGMT ) );
+
+        List<String> listingFuncs = filter.getFunctions( "/browse/maven/group/test", "" );
+        assertThat( listingFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_LISTING ) );
+        listingFuncs = filter.getFunctions( "/content/maven/group/test/", "" );
+        assertThat( listingFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_LISTING ) );
+        listingFuncs = filter.getFunctions( "/content/maven/group/test", "" );
+        assertThat( listingFuncs, not(hasItem( GoldenSignalsMetricSet.FN_CONTENT_LISTING )) );
+        listingFuncs = filter.getFunctions( "/content/maven/group/test/index.html", "" );
+        assertThat( listingFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_LISTING ) );
+        listingFuncs = filter.getFunctions( "/group/test/", "" );
+        assertThat( listingFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_LISTING ) );
+        listingFuncs = filter.getFunctions( "/group/test/index.html", "" );
+        assertThat( listingFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_LISTING ) );
+
+        List<String> foloFuncs = filter.getFunctions( "/folo/admin/test-1/record", "" );
+        assertThat( foloFuncs, hasItem( GoldenSignalsMetricSet.FN_TRACKING_RECORD ) );
+        foloFuncs = filter.getFunctions( "/folo/admin/test-1/report", "" );
+        assertThat( foloFuncs, hasItem( GoldenSignalsMetricSet.FN_TRACKING_RECORD ) );
+
+        List<String> contentMavenFoloFuncs = filter.getFunctions( "/folo/track/test-1/maven/group/test/foo/bar/1.0/bar-1.0.pom", "" );
+        assertThat( contentMavenFoloFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_MAVEN ) );
+        List<String> contentMavenMetaFoloFuncs = filter.getFunctions( "/folo/track/test-1/maven/group/test/foo/bar/maven-metadata.xml", "" );
+        assertThat( contentMavenMetaFoloFuncs, hasItem( GoldenSignalsMetricSet.FN_METADATA_MAVEN ) );
+        List<String> contentNPMFoloFuncs = filter.getFunctions( "/folo/track/test-1/npm/group/test/foo/-/foo.tar.gz", "" );
+        assertThat( contentNPMFoloFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_NPM ) );
+        List<String> contentNPMMetaFoloFuncs = filter.getFunctions( "/folo/track/test-1/npm/group/test/foo/package.json", "" );
+        assertThat( contentNPMMetaFoloFuncs, hasItem( GoldenSignalsMetricSet.FN_METADATA_NPM ) );
+
+        List<String> contentMavenFuncs = filter.getFunctions( "/content/maven/group/test/foo/bar/1.0/bar-1.0.pom", "" );
+        assertThat( contentMavenFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_MAVEN ) );
+        List<String> contentMavenMetaFuncs = filter.getFunctions( "/content/maven/group/test/foo/bar/maven-metadata.xml", "" );
+        assertThat( contentMavenMetaFuncs, hasItem( GoldenSignalsMetricSet.FN_METADATA_MAVEN ) );
+        List<String> contentNPMFuncs = filter.getFunctions( "/content/npm/group/test/foo/-/foo.tar.gz", "" );
+        assertThat( contentNPMFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_NPM ) );
+        List<String> contentNPMMetaFuncs = filter.getFunctions( "/content/npm/group/test/foo/package.json", "" );
+        assertThat( contentNPMMetaFuncs, hasItem( GoldenSignalsMetricSet.FN_METADATA_NPM ) );
+
+        List<String> contentMavenDepFuncs = filter.getFunctions( "/group/test/foo/bar/1.0/bar-1.0.pom", "" );
+        assertThat( contentMavenDepFuncs, hasItem( GoldenSignalsMetricSet.FN_CONTENT_MAVEN ) );
+        List<String> contentMavenMetaDepFuncs = filter.getFunctions( "/group/test/foo/bar/maven-metadata.xml", "" );
+        assertThat( contentMavenMetaDepFuncs, hasItem( GoldenSignalsMetricSet.FN_METADATA_MAVEN ) );
+    }
+
+}


### PR DESCRIPTION
Today when I was doing testing with fake sli error endpoint of the new merged code, I found that all metadata sli is not reporting. After checking code I found some issues, so this PR is the fixing.