### PR TITLE
Fix npm metadata download error when it is removed from npm repo

### DIFF
--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataTimeoutTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataTimeoutTest.java
@@ -69,15 +69,6 @@ public class NPMMetadataTimeoutTest
             resp.getWriter().flush();
         } );
 
-        //FIXME: After using galley-0.16.8, I'm not sure the second retrieval of npm metadata will get path of
-        //       "A/jquery/package.json" while the first retrieval is "A/jquery". So I add a new expectation here
-        //       to let the second retrieval can work. Need further checking.
-        server.expect( "GET", server.formatUrl( REPO, PATH+"/package.json" ), (req, resp)->{
-            resp.setStatus( 200 );
-            mapper.writeValue( resp.getWriter(), src );
-            resp.getWriter().flush();
-        } );
-
         final RemoteRepository repo = new RemoteRepository( NPM_PKG_KEY, REPO, server.formatUrl( REPO ) );
         repo.setMetadataTimeoutSeconds( 1 );
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.0.1</atlasVersion>
-    <galleyVersion>0.16.11</galleyVersion>
+    <galleyVersion>0.16.12-SNAPSHOT</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>2.0</partylineVersion>


### PR DESCRIPTION
Seems for remote npm repo, after package.json has been swept from
cache, the second trying for retrieving of it will fail. So in this case
we need to trigger the re-download from remote.

This pr depends on https://github.com/Commonjava/galley/pull/283