### PR TITLE
Fix wrong handling of npm content retrieving through folo service

### DIFF
--- a/addons/folo/client-java/src/main/java/org/commonjava/indy/folo/client/IndyFoloContentClientModule.java
+++ b/addons/folo/client-java/src/main/java/org/commonjava/indy/folo/client/IndyFoloContentClientModule.java
@@ -96,6 +96,7 @@ public class IndyFoloContentClientModule
         return getInfo( trackingId, new StoreKey( MAVEN_PKG_KEY, type, name ), path );
     }
 
+    @Deprecated
     public InputStream get( final String trackingId, final StoreType type, final String name, final String path )
             throws IndyClientException
     {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
@@ -114,11 +114,10 @@ public class FoloTrackingListener
             logger.trace( "Tracking report: {} += {} in {} (DOWNLOAD)", trackingKey, transfer.getPath(),
                           keyedLocation.getKey() );
 
-            //FIXME: Here we need to think about npm metadata retrieving case. As almost all npm metadata retrieving is through
-            //      /$pkg from remote, but we use STORAGE_PATH in EventMetadata with /$pkg/package.json to store this metadata,
-            //      so the real path for this transfer should be /$pkg but its current path is /$pkg/package.json. We need to
-            //      think about to do replacement here for this case.
-
+            //Here we need to think about npm metadata retrieving case. As almost all npm metadata retrieving is through
+            // /$pkg from remote, but we use STORAGE_PATH in EventMetadata with /$pkg/package.json to store this metadata,
+            //so the real path for this transfer should be /$pkg but its current path is /$pkg/package.json. We need to
+            //think about if need to do the replacement here, especially for the originalUrl.
             recordManager.recordArtifact(
                     createEntry( trackingKey, keyedLocation.getKey(), accessChannel, transfer.getPath(),
                                  StoreEffect.DOWNLOAD, event.getEventMetadata() ) );

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
@@ -114,6 +114,11 @@ public class FoloTrackingListener
             logger.trace( "Tracking report: {} += {} in {} (DOWNLOAD)", trackingKey, transfer.getPath(),
                           keyedLocation.getKey() );
 
+            //FIXME: Here we need to think about npm metadata retrieving case. As almost all npm metadata retrieving is through
+            //      /$pkg from remote, but we use STORAGE_PATH in EventMetadata with /$pkg/package.json to store this metadata,
+            //      so the real path for this transfer should be /$pkg but its current path is /$pkg/package.json. We need to
+            //      think about to do replacement here for this case.
+
             recordManager.recordArtifact(
                     createEntry( trackingKey, keyedLocation.getKey(), accessChannel, transfer.getPath(),
                                  StoreEffect.DOWNLOAD, event.getEventMetadata() ) );

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/AbstractNPMFoloContentManagementTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/AbstractNPMFoloContentManagementTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.folo.ftest.content;
+
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.folo.client.IndyFoloAdminClientModule;
+import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.experimental.categories.Category;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.commonjava.indy.model.core.StoreType.group;
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+
+@Category( EventDependent.class )
+public class AbstractNPMFoloContentManagementTest
+        extends AbstractIndyFunctionalTest
+{
+
+    protected static final String STORE = "test";
+
+    protected static final String NPMJS = "npmjs";
+
+    protected static final String PUBLIC = "public";
+
+    @Rule
+    public ExpectationServer npmjsServer = new ExpectationServer();
+
+    @Before
+    public void before()
+            throws Exception
+    {
+        final String changelog = "Setup: " + name.getMethodName();
+        final HostedRepository hosted = this.client.stores()
+                                                   .create( new HostedRepository( PKG_TYPE_NPM, STORE ), changelog,
+                                                            HostedRepository.class );
+
+        RemoteRepository npmjs = null;
+        final StoreKey npmjsKey = new StoreKey( PKG_TYPE_NPM, remote, NPMJS );
+        if ( client.stores().exists( npmjsKey ) )
+        {
+            client.stores().delete( npmjsKey, "removing existing remote:npmjs definition" );
+        }
+
+        npmjs = client.stores()
+                      .create( new RemoteRepository( PKG_TYPE_NPM, NPMJS, npmjsServer.getBaseUri() ), changelog,
+                               RemoteRepository.class );
+
+        Group g;
+        final StoreKey publicGrpKey = new StoreKey( PKG_TYPE_NPM, group, PUBLIC );
+        if ( client.stores().exists( publicGrpKey ) )
+        {
+            g = client.stores().load( publicGrpKey, Group.class );
+        }
+        else
+        {
+            g = client.stores().create( new Group( PKG_TYPE_NPM, PUBLIC ), changelog, Group.class );
+        }
+
+        g.setConstituents( Arrays.asList( hosted.getKey(), npmjs.getKey() ) );
+        client.stores().update( g, changelog );
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Arrays.asList( new IndyFoloContentClientModule(), new IndyFoloAdminClientModule() );
+    }
+
+}

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DownloadFromTrackedNPMRemoteRepoTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DownloadFromTrackedNPMRemoteRepoTest.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.folo.ftest.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>RemoteRepository for npm and path</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Access path through folo track</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>The path can be got correctly</li>
+ * </ul>
+ */
+public class DownloadFromTrackedNPMRemoteRepoTest
+        extends AbstractNPMFoloContentManagementTest
+{
+
+    @Test
+    public void downloadFileFromRemoteRepository()
+            throws Exception
+    {
+        final String packageContent =
+                "{\"name\": \"jquery\",\n" + "\"description\": \"JavaScript library for DOM operations\",\n" + "\"license\": \"MIT\"}";
+        final String versionContent = "{\"name\": \"jquery\",\n" + "\"url\": \"jquery.com\",\n" + "\"version\": \"1.1.0\"}";
+
+        final String packagePath = "jquery";
+        final String versionPath = "jquery/1.1.0";
+
+        final String trackingId = newName();
+
+        npmjsServer.expect( npmjsServer.formatUrl( packagePath ), 200, new ByteArrayInputStream( packageContent.getBytes() ) );
+        npmjsServer.expect( npmjsServer.formatUrl( versionPath ), 200, new ByteArrayInputStream( versionContent.getBytes() ) );
+
+        final StoreKey storeKey = new StoreKey( NPM_PKG_KEY, remote, NPMJS );
+
+        IndyFoloContentClientModule folo = client.module( IndyFoloContentClientModule.class );
+
+        final InputStream packageStream = folo.get( trackingId, storeKey,  packagePath );
+        final InputStream versionStream = folo.get( trackingId, storeKey, versionPath );
+
+        assertThat( packageStream, notNullValue() );
+        assertThat( versionStream, notNullValue() );
+
+        assertThat( IOUtils.toString( packageStream ), equalTo( packageContent ) );
+        assertThat( IOUtils.toString( versionStream ), equalTo( versionContent ) );
+
+        packageStream.close();
+        versionStream.close();
+    }
+
+}

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DownloadFromTrackedNPMRemoteRepoTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DownloadFromTrackedNPMRemoteRepoTest.java
@@ -17,16 +17,13 @@ package org.commonjava.indy.folo.ftest.content;
 
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
-import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.model.core.StoreType;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 import static org.commonjava.indy.model.core.StoreType.remote;
-import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DownloadFromTrackedRemoteRepoTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/DownloadFromTrackedRemoteRepoTest.java
@@ -26,6 +26,24 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
 import org.junit.Test;
 
+/**
+ * <b>GIVEN:</b>
+ * <ul>
+ *     <li>RemoteRepository for maven and path</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>WHEN:</b>
+ * <ul>
+ *     <li>Access path through folo track</li>
+ * </ul>
+ *
+ * <br/>
+ * <b>THEN:</b>
+ * <ul>
+ *     <li>The path can be got correctly</li>
+ * </ul>
+ */
 public class DownloadFromTrackedRemoteRepoTest
     extends AbstractFoloContentManagementTest
 {

--- a/addons/folo/ftests/src/main/resources/folo-content/simple.json
+++ b/addons/folo/ftests/src/main/resources/folo-content/simple.json
@@ -1,0 +1,124 @@
+{
+  "_id": "simple",
+  "_rev": "9-dac331b3e187a16cf7583e97467992bb",
+  "name": "simple",
+  "description": "A naive Node.js clone of Python's simpleHttpServer",
+  "dist-tags": {
+    "latest": "0.2.0"
+  },
+  "versions": {
+    "0.1.0": {
+      "author": "",
+      "name": "simple",
+      "description": "A naive Node.js clone of Python's simpleHttpServer",
+      "version": "0.1.0",
+      "repository": {
+        "url": "https://github.com/thisandagain/simple.git"
+      },
+      "main": "./bin/index.js",
+      "scripts": {},
+      "preferGlobal": "true",
+      "bin": {
+        "simple": "./bin/index.js"
+      },
+      "dependencies": {
+        "commander": "~1.0.0",
+        "mime": "~1.2.6"
+      },
+      "devDependencies": {
+        "vows": "0.6.3"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "_npmUser": {
+        "name": "diy",
+        "email": "help@diy.org"
+      },
+      "_id": "simple@0.1.0",
+      "_engineSupported": true,
+      "_npmVersion": "1.1.21",
+      "_nodeVersion": "v0.6.17",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "224dead7842d56bf4ba8ec9fcbce2ae420a71c0b",
+        "tarball": "https://registry.npmjs.org/simple/-/simple-0.1.0.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "diy",
+          "email": "help@diy.org"
+        }
+      ],
+      "directories": {}
+    },
+    "0.2.0": {
+      "author": "",
+      "name": "simple",
+      "description": "A naive Node.js clone of Python's simpleHttpServer",
+      "version": "0.2.0",
+      "repository": {
+        "url": "https://github.com/thisandagain/simple.git"
+      },
+      "main": "./bin/index.js",
+      "scripts": {},
+      "preferGlobal": "true",
+      "bin": {
+        "simple": "./bin/index.js"
+      },
+      "dependencies": {
+        "commander": "~1.0.0",
+        "mime": "~1.2.6"
+      },
+      "devDependencies": {
+        "vows": "0.6.3"
+      },
+      "optionalDependencies": {},
+      "engines": {
+        "node": "*"
+      },
+      "readme": "# Simple\n### HTTP all the things!\n\nSimple is a binary created using Node.js that clones some of the functionality of Python's `simpleHttpServer`. It's a rather naive and simple static HTTP server, but it gets the job done in a pinch. Please don't use this in production... it's a development tool. Really.\n\n#### Installation\n```bash\nnpm install -g simple\n```\n\n#### Basic Use\n```bash\ncd /my/awesome/website\nsimple\n```\n```bash\nServing HTTP on 0.0.0.0 port 8000 ...\n```\n\n#### Options\n`-p` Port to listen on (defaults to 8000)\n\n`-h` Hostname to listen on (defaults to 127.0.0.1)\n\n`-d` Default index (defaults to `index.html`)\n\n`-s` Silent mode\n\n`-h` Help",
+      "readmeFilename": "README.md",
+      "_id": "simple@0.2.0",
+      "dist": {
+        "shasum": "1e74ccf707f243ba74f1cbedc7c49c51899653f1",
+        "tarball": "https://registry.npmjs.org/simple/-/simple-0.2.0.tgz"
+      },
+      "_from": ".",
+      "_npmVersion": "1.2.11",
+      "_npmUser": {
+        "name": "diy",
+        "email": "help@diy.org"
+      },
+      "maintainers": [
+        {
+          "name": "diy",
+          "email": "help@diy.org"
+        }
+      ],
+      "directories": {}
+    }
+  },
+  "readme": "# Simple\n### HTTP all the things!\n\nSimple is a binary created using Node.js that clones some of the functionality of Python's `simpleHttpServer`. It's a rather naive and simple static HTTP server, but it gets the job done in a pinch. Please don't use this in production... it's a development tool. Really.\n\n#### Installation\n```bash\nnpm install -g simple\n```\n\n#### Basic Use\n```bash\ncd /my/awesome/website\nsimple\n```\n```bash\nServing HTTP on 0.0.0.0 port 8000 ...\n```\n\n#### Options\n`-p` Port to listen on (defaults to 8000)\n\n`-d` Default index (defaults to `index.html`)\n\n`-s` Silent mode\n\n`-h` Help",
+  "maintainers": [
+    {
+      "name": "diy",
+      "email": "help@diy.org"
+    }
+  ],
+  "time": {
+    "modified": "2013-10-17T16:14:23.069Z",
+    "created": "2012-07-11T01:35:20.393Z",
+    "0.1.0": "2012-07-11T01:35:21.822Z",
+    "0.2.0": "2013-10-17T16:14:23.069Z"
+  },
+  "repository": {
+    "url": "https://github.com/thisandagain/simple.git"
+  },
+  "users": {
+    "vlad1988": true,
+    "pgilad": true
+  },
+  "_attachments": {}
+}

--- a/addons/folo/jaxrs/pom.xml
+++ b/addons/folo/jaxrs/pom.xml
@@ -42,6 +42,14 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-bindings-jaxrs</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-pkg-npm-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-pkg-npm-jaxrs</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>javax.enterprise</groupId>

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloContentAccessResource.java
@@ -59,7 +59,7 @@ import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEA
  */
 @Api( value = "FOLO Tracked Content Access and Storage",
       description = "Tracks retrieval and management of file/artifact content." )
-@Path( "/api/folo/track/{id}/{packageType}/{type: (hosted|group|remote)}/{name}" )
+@Path( "/api/folo/track/{id}/{packageType: (maven|generic)}/{type: (hosted|group|remote)}/{name}" )
 @REST
 public class FoloContentAccessResource
         implements IndyResources
@@ -87,7 +87,7 @@ public class FoloContentAccessResource
     @PUT
     @Path( "/{path: (.*)}" )
     public Response doCreate( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
-                              @ApiParam( "Package type (eg. maven, npm)" ) @PathParam( "packageType" )
+                              @ApiParam( "Package type (eg. maven, generic)" ) @PathParam( "packageType" )
                               final String packageType,
                               @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
                               final String type, @PathParam( "name" ) final String name,
@@ -113,7 +113,7 @@ public class FoloContentAccessResource
     @HEAD
     @Path( "/{path: (.*)}" )
     public Response doHead( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
-                            @ApiParam( "Package type (eg. maven, npm)" ) @PathParam( "packageType" )
+                            @ApiParam( "Package type (eg. maven, generic)" ) @PathParam( "packageType" )
                             final String packageType,
                             @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
                             final String type, @PathParam( "name" ) final String name,
@@ -140,7 +140,7 @@ public class FoloContentAccessResource
     @GET
     @Path( "/{path: (.*)}" )
     public Response doGet( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
-                           @ApiParam( "Package type (eg. maven, npm)" ) @PathParam( "packageType" )
+                           @ApiParam( "Package type (eg. maven, generic)" ) @PathParam( "packageType" )
                            final String packageType,
                            @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
                            final String type, @PathParam( "name" ) final String name,

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloMavenContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloMavenContentAccessResource.java
@@ -49,6 +49,7 @@ import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.CONTENT_TRACKING_ID;
 import static org.commonjava.indy.folo.ctl.FoloConstants.ACCESS_CHANNEL;
 import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_KEY;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
 
 /**
@@ -57,11 +58,10 @@ import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEA
  *
  * @author jdcasey
  */
-@Api( value = "FOLO Tracked Content Access and Storage",
-      description = "Tracks retrieval and management of file/artifact content." )
-@Path( "/api/folo/track/{id}/{packageType: (maven|generic)}/{type: (hosted|group|remote)}/{name}" )
+@Api( value = "FOLO Tracked Content Access and Storage. Tracks retrieval and management of file/artifact content." )
+@Path( "/api/folo/track/{id}/maven/{type: (hosted|group|remote)}/{name}" )
 @REST
-public class FoloContentAccessResource
+public class FoloMavenContentAccessResource
         implements IndyResources
 {
 
@@ -72,11 +72,11 @@ public class FoloContentAccessResource
     @Inject
     private ContentAccessHandler handler;
 
-    public FoloContentAccessResource()
+    public FoloMavenContentAccessResource()
     {
     }
 
-    public FoloContentAccessResource( final ContentAccessHandler handler )
+    public FoloMavenContentAccessResource( final ContentAccessHandler handler )
     {
         this.handler = handler;
     }
@@ -87,8 +87,6 @@ public class FoloContentAccessResource
     @PUT
     @Path( "/{path: (.*)}" )
     public Response doCreate( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
-                              @ApiParam( "Package type (eg. maven, generic)" ) @PathParam( "packageType" )
-                              final String packageType,
                               @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
                               final String type, @PathParam( "name" ) final String name,
                               @PathParam( "path" ) final String path, @Context final HttpServletRequest request,
@@ -100,11 +98,11 @@ public class FoloContentAccessResource
                 new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO ).set(
                         STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
 
-        Class cls = FoloContentAccessResource.class;
-        return handler.doCreate( packageType, type, name, path, request, metadata, () -> uriInfo.getBaseUriBuilder()
-                                                                                   .path( cls )
-                                                                                   .path( path )
-                                                                                   .build( id, packageType, type, name ) );
+        Class cls = FoloMavenContentAccessResource.class;
+        return handler.doCreate( PKG_TYPE_MAVEN, type, name, path, request, metadata, () -> uriInfo.getBaseUriBuilder()
+                                                                                                         .path( cls )
+                                                                                                         .path( path )
+                                                                                                         .build( id, PKG_TYPE_MAVEN, type, name ) );
     }
 
     @ApiOperation( "Store and track file/artifact content under the given artifact store (type/name) and path." )
@@ -113,8 +111,6 @@ public class FoloContentAccessResource
     @HEAD
     @Path( "/{path: (.*)}" )
     public Response doHead( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
-                            @ApiParam( "Package type (eg. maven, generic)" ) @PathParam( "packageType" )
-                            final String packageType,
                             @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
                             final String type, @PathParam( "name" ) final String name,
                             @PathParam( "path" ) final String path,
@@ -130,7 +126,7 @@ public class FoloContentAccessResource
 
         MDC.put( CONTENT_TRACKING_ID, id );
 
-        return handler.doHead( packageType, type, name, path, cacheOnly, baseUri, request, metadata );
+        return handler.doHead( PKG_TYPE_MAVEN, type, name, path, cacheOnly, baseUri, request, metadata );
     }
 
     @ApiOperation( "Retrieve and track file/artifact content under the given artifact store (type/name) and path." )
@@ -140,8 +136,6 @@ public class FoloContentAccessResource
     @GET
     @Path( "/{path: (.*)}" )
     public Response doGet( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
-                           @ApiParam( "Package type (eg. maven, generic)" ) @PathParam( "packageType" )
-                           final String packageType,
                            @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
                            final String type, @PathParam( "name" ) final String name,
                            @PathParam( "path" ) final String path, @Context final HttpServletRequest request,
@@ -155,7 +149,7 @@ public class FoloContentAccessResource
 
         MDC.put( CONTENT_TRACKING_ID, id );
 
-        return handler.doGet( packageType, type, name, path, baseUri, request, metadata );
+        return handler.doGet( PKG_TYPE_MAVEN, type, name, path, baseUri, request, metadata );
     }
 
 }

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
@@ -55,8 +55,7 @@ import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
 
-@Api( value = "FOLO Tracked Content Access and Storage For NPM related artifacts",
-      description = "Tracks retrieval and management of file/artifact content." )
+@Api( value = "FOLO Tracked Content Access and Storage For NPM related artifacts. Tracks retrieval and management of file/artifact content." )
 @Path( "/api/folo/track/{id}/npm/{type: (hosted|group|remote)}/{name}" )
 @REST
 public class FoloNPMContentAccessResource
@@ -238,29 +237,6 @@ public class FoloNPMContentAccessResource
         final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
 
         return handler.doGet( NPM_PKG_KEY, type, name, path, baseUri, request, metadata );
-    }
-
-    @ApiOperation( "Retrieve and track NPM root listing under the given artifact store (type/name)" )
-    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
-                           @ApiResponse( code = 200, response = String.class,
-                                         message = "Rendered root content listing" ),
-                           @ApiResponse( code = 200, response = StreamingOutput.class, message = "Content stream" ), } )
-    @GET
-    @Path( "/" )
-    public Response doGet( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
-                           @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
-                           final String type, @PathParam( "name" ) final String name,
-                           @Context final HttpServletRequest request, @Context final UriInfo uriInfo )
-    {
-        final TrackingKey tk = new TrackingKey( id );
-        EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
-                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
-                                                    .set( STORAGE_PATH, "" );
-        MDC.put( CONTENT_TRACKING_ID, id );
-
-        final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
-
-        return handler.doGet( NPM_PKG_KEY, type, name, "", baseUri, request, metadata );
     }
 
 }

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
@@ -1,0 +1,266 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.folo.bind.jaxrs;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.commonjava.indy.bind.jaxrs.IndyDeployment;
+import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
+import org.commonjava.indy.folo.model.TrackingKey;
+import org.commonjava.indy.model.core.AccessChannel;
+import org.commonjava.indy.pkg.npm.inject.NPMContentHandler;
+import org.commonjava.indy.pkg.npm.jaxrs.NPMContentAccessHandler;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.HEAD;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+import javax.ws.rs.core.UriInfo;
+import java.nio.file.Paths;
+
+import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
+import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.CONTENT_TRACKING_ID;
+import static org.commonjava.indy.folo.ctl.FoloConstants.ACCESS_CHANNEL;
+import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_KEY;
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
+import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
+
+@Api( value = "FOLO Tracked Content Access and Storage For NPM related artifacts",
+      description = "Tracks retrieval and management of file/artifact content." )
+@Path( "/api/folo/track/{id}/npm/{type: (hosted|group|remote)}/{name}" )
+@REST
+public class FoloNPMContentAccessResource
+        implements IndyResources
+{
+
+    private static final String BASE_PATH = IndyDeployment.API_PREFIX + "/folo/track";
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final String PACKAGE_JSON = "/package.json";
+
+    @Inject
+    @NPMContentHandler
+    private NPMContentAccessHandler handler;
+
+    public FoloNPMContentAccessResource()
+    {
+    }
+
+    public FoloNPMContentAccessResource( final NPMContentAccessHandler handler )
+    {
+        this.handler = handler;
+    }
+
+    @ApiOperation( "Store and track NPM file/artifact content under the given artifact store (type/name) and path." )
+    @ApiResponses( { @ApiResponse( code = 201, message = "Content was stored successfully" ), @ApiResponse( code = 400,
+                                                                                                            message = "No appropriate storage location was found in the specified store (this store, or a member if a group is specified)." ) } )
+    @PUT
+    @Path( "/{packageName}" )
+    public Response doCreate( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
+                              @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
+                              final String type, @PathParam( "name" ) final String name,
+                              @PathParam( "packageName" ) final String packageName,
+                              @Context final HttpServletRequest request, @Context final UriInfo uriInfo )
+    {
+        final TrackingKey tk = new TrackingKey( id );
+
+        EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
+                                                    .set( STORE_HTTP_HEADERS,
+                                                          RequestUtils.extractRequestHeadersToMap( request ) )
+                                                    .set( STORAGE_PATH,
+                                                          Paths.get( packageName, PACKAGE_JSON ).toString() );
+
+        Class cls = FoloNPMContentAccessResource.class;
+        return handler.doCreate( NPM_PKG_KEY, type, name, packageName, request, metadata,
+                                 () -> uriInfo.getBaseUriBuilder()
+                                              .path( cls )
+                                              .path( packageName )
+                                              .build( id, NPM_PKG_KEY, type, name ) );
+    }
+
+    @ApiOperation(
+            "Store NPM artifact content under the given artifact store (type/name), packageName and versionTarball (/version or /-/tarball)." )
+    @ApiResponses( { @ApiResponse( code = 201, message = "Content was stored successfully" ), @ApiResponse( code = 400,
+                                                                                                            message = "No appropriate storage location was found in the specified store (this store, or a member if a group is specified)." ) } )
+    @PUT
+    @Path( "/{packageName}/{versionTarball: (.*)}" )
+    public Response doCreate( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
+                              final @ApiParam( allowableValues = "hosted,group,remote", required = true )
+                              @PathParam( "type" ) String type,
+                              final @ApiParam( required = true ) @PathParam( "name" ) String name,
+                              final @PathParam( "packageName" ) String packageName,
+                              final @PathParam( "versionTarball" ) String versionTarball,
+                              final @Context UriInfo uriInfo, final @Context HttpServletRequest request )
+    {
+        final TrackingKey tk = new TrackingKey( id );
+        EventMetadata metadata =
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
+        final String path = Paths.get( packageName, versionTarball ).toString();
+        Class cls = FoloNPMContentAccessResource.class;
+        return handler.doCreate( NPM_PKG_KEY, type, name, path, request, metadata, () -> uriInfo.getBaseUriBuilder()
+                                                                                                .path( cls )
+                                                                                                .path( path )
+                                                                                                .build( NPM_PKG_KEY,
+                                                                                                        type, name ) );
+    }
+
+    @ApiOperation( "Store and track file/artifact content under the given artifact store (type/name) and path." )
+    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ), @ApiResponse( code = 200,
+                                                                                                     message = "Header metadata for content (or rendered listing when path ends with '/index.html' or '/'" ), } )
+    @HEAD
+    @Path( "/{packageName}" )
+    public Response doHead( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
+                            final @ApiParam( allowableValues = "hosted,group,remote", required = true )
+                            @PathParam( "type" ) String type,
+                            final @ApiParam( required = true ) @PathParam( "name" ) String name,
+                            final @PathParam( "packageName" ) String packageName,
+                            final @QueryParam( CHECK_CACHE_ONLY ) Boolean cacheOnly, final @Context UriInfo uriInfo,
+                            final @Context HttpServletRequest request )
+    {
+        final TrackingKey tk = new TrackingKey( id );
+
+        final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
+
+        EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
+                                                    .set( STORAGE_PATH,
+                                                          Paths.get( packageName, PACKAGE_JSON ).toString() );
+
+        MDC.put( CONTENT_TRACKING_ID, id );
+
+        return handler.doHead( NPM_PKG_KEY, type, name, packageName, cacheOnly, baseUri, request, metadata );
+    }
+
+    @ApiOperation( "Store and track file/artifact content under the given artifact store (type/name) and path." )
+    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ), @ApiResponse( code = 200,
+                                                                                                     message = "Header metadata for content (or rendered listing when path ends with '/index.html' or '/'" ), } )
+    @HEAD
+    @Path( "/{packageName}/{versionTarball: (.*)}" )
+    public Response doHead( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
+                            @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
+                            final String type, @PathParam( "name" ) final String name,
+                            final @PathParam( "packageName" ) String packageName,
+                            final @PathParam( "versionTarball" ) String versionTarball,
+                            final @QueryParam( CHECK_CACHE_ONLY ) Boolean cacheOnly,
+                            @Context final HttpServletRequest request, @Context final UriInfo uriInfo )
+    {
+        final TrackingKey tk = new TrackingKey( id );
+
+        EventMetadata metadata =
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
+
+        MDC.put( CONTENT_TRACKING_ID, id );
+
+        final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
+        final String path = Paths.get( packageName, versionTarball ).toString();
+
+        return handler.doHead( NPM_PKG_KEY, type, name, path, cacheOnly, baseUri, request, metadata );
+    }
+
+    @ApiOperation( "Retrieve and track NPM file/artifact content under the given artifact store (type/name) and path." )
+    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
+                           @ApiResponse( code = 200, response = String.class,
+                                         message = "Rendered content listing (when path ends with '/index.html' or '/')" ),
+                           @ApiResponse( code = 200, response = StreamingOutput.class, message = "Content stream" ), } )
+    @GET
+    @Path( "/{packageName}" )
+    public Response doGet( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
+                           @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
+                           final String type, @PathParam( "name" ) final String name,
+                           final @PathParam( "packageName" ) String packageName,
+                           @Context final HttpServletRequest request, @Context final UriInfo uriInfo )
+    {
+        final TrackingKey tk = new TrackingKey( id );
+        final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
+
+        EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
+                                                    .set( STORAGE_PATH,
+                                                          Paths.get( packageName, PACKAGE_JSON ).toString() );
+
+        MDC.put( CONTENT_TRACKING_ID, id );
+
+        return handler.doGet( NPM_PKG_KEY, type, name, packageName, baseUri, request, metadata );
+    }
+
+    @ApiOperation( "Retrieve and track NPM file/artifact content under the given artifact store (type/name) and path." )
+    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
+                           @ApiResponse( code = 200, response = String.class,
+                                         message = "Rendered content listing (when path ends with '/index.html' or '/')" ),
+                           @ApiResponse( code = 200, response = StreamingOutput.class, message = "Content stream" ), } )
+    @GET
+    @Path( "/{packageName}/{versionTarball: (.*)}" )
+    public Response doGet( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
+                           @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
+                           final String type, @PathParam( "name" ) final String name,
+                           final @PathParam( "packageName" ) String packageName,
+                           final @PathParam( "versionTarball" ) String versionTarball,
+                           @Context final HttpServletRequest request, @Context final UriInfo uriInfo )
+    {
+        final TrackingKey tk = new TrackingKey( id );
+        EventMetadata metadata =
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
+        MDC.put( CONTENT_TRACKING_ID, id );
+
+        final String path = Paths.get( packageName, versionTarball ).toString();
+        final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
+
+        return handler.doGet( NPM_PKG_KEY, type, name, path, baseUri, request, metadata );
+    }
+
+    @ApiOperation( "Retrieve and track NPM root listing under the given artifact store (type/name)" )
+    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
+                           @ApiResponse( code = 200, response = String.class,
+                                         message = "Rendered root content listing" ),
+                           @ApiResponse( code = 200, response = StreamingOutput.class, message = "Content stream" ), } )
+    @GET
+    @Path( "/" )
+    public Response doGet( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
+                           @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" )
+                           final String type, @PathParam( "name" ) final String name,
+                           @Context final HttpServletRequest request, @Context final UriInfo uriInfo )
+    {
+        final TrackingKey tk = new TrackingKey( id );
+        EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
+                                                    .set( STORAGE_PATH, "" );
+        MDC.put( CONTENT_TRACKING_ID, id );
+
+        final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
+
+        return handler.doGet( NPM_PKG_KEY, type, name, "", baseUri, request, metadata );
+    }
+
+}

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AccessChannel.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AccessChannel.java
@@ -15,8 +15,8 @@
  */
 package org.commonjava.indy.model.core;
 
-import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_GENERIC_HTTP;
-import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.*;
 
 /**
  * Enumeration to distinguish between different access channels to stores.
@@ -29,7 +29,9 @@ public enum AccessChannel
     /** Used when the store is accessed via httprox addon. */
     GENERIC_PROXY(PKG_TYPE_GENERIC_HTTP),
     /** Used when the store is accessed via regular Maven repo. */
-    MAVEN_REPO(PKG_TYPE_MAVEN);
+    MAVEN_REPO(PKG_TYPE_MAVEN),
+    /** Used when the store is accessed via npm.*/
+    NPM_REPO( PKG_TYPE_NPM );
 
     private final String packageType;
 


### PR DESCRIPTION
NPM content retrieving has its own logic now, but current folo service does not use it yet for npm cases. So this pr fix it by adding a new folo resource for npm cases.