### PR TITLE
Update NPM support to do deeper metadata path mapping

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
@@ -1,0 +1,44 @@
+package org.commonjava.indy.pkg.npm.content;
+
+import org.commonjava.indy.content.StoragePathCalculator;
+import org.commonjava.indy.model.core.StoreKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
+
+/**
+ * We know that NPM requests to package-level resources, such as just "jquery" actually return package metadata, as
+ * you would find in a package.json file. Also, we know that NPM stores packages as binary tarballs UNDER A SUBPATH of
+ * the path used to access this metadata. Caching both requires us to map the actual storage location of metadata to
+ * a different subpath, so they both share a package-root directory and don't collide on the filesystem
+ * (as concrete file vs directory).
+ *
+ * This implementation looks for metadata paths when the package type is NPM, and maps them to a package.json filename
+ * under the package name, so we have a compatible file name for storage.
+ *
+ * NOTE: This does NOT affect the remote HTTP request path used to talk to upstream servers like npmjs.org.
+ */
+@ApplicationScoped
+@Named
+public class NPMStoragePathCalculator
+        implements StoragePathCalculator
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Override
+    public String calculateStoragePath( final StoreKey key, final String path )
+    {
+        if ( PKG_TYPE_NPM.equals( key.getPackageType() ) && path.split("/").length < 2 )
+        {
+            logger.debug( "Modifying target path: {}, appending 'package.json'", path );
+            return normalize( path, "package.json" );
+        }
+
+        return path;
+    }
+}

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataTimeoutTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataTimeoutTest.java
@@ -72,11 +72,11 @@ public class NPMMetadataTimeoutTest
         //FIXME: After using galley-0.16.8, I'm not sure the second retrieval of npm metadata will get path of
         //       "A/jquery/package.json" while the first retrieval is "A/jquery". So I add a new expectation here
         //       to let the second retrieval can work. Need further checking.
-        server.expect( "GET", server.formatUrl( REPO, PATH+"/package.json" ), (req, resp)->{
-            resp.setStatus( 200 );
-            mapper.writeValue( resp.getWriter(), src );
-            resp.getWriter().flush();
-        } );
+//        server.expect( "GET", server.formatUrl( REPO, PATH+"/package.json" ), (req, resp)->{
+//            resp.setStatus( 200 );
+//            mapper.writeValue( resp.getWriter(), src );
+//            resp.getWriter().flush();
+//        } );
 
         final RemoteRepository repo = new RemoteRepository( NPM_PKG_KEY, REPO, server.formatUrl( REPO ) );
         repo.setMetadataTimeoutSeconds( 1 );
@@ -90,6 +90,8 @@ public class NPMMetadataTimeoutTest
         Thread.sleep( 2000 );
 
         assertThat( "Metadata not cleaned up!", client.content().exists( repo.getKey(), PATH + "/package.json", true ), equalTo( false ) );
+
+        logger.info( "\n\n\n\nRE-REQUEST STARTS HERE\n\n\n\n" );
 
         // Second retrieval
         dts.setBeta( "2" );

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -68,7 +68,6 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponseFromMetadata;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.setInfoHeaders;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
-import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 
 @ApplicationScoped
 @NPMContentHandler
@@ -326,15 +325,18 @@ public class NPMContentAccessHandler
         {
             try
             {
-                if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.remote != st )
-                {
-                    // make sure the right mapping path for hosted and group when retrieve content
-                    path = PathUtils.storagePath( path, eventMetadata );
-                }
-                logger.info( "START: retrieval of content: {}:{}", sk, path );
+                // NOTE: We do NOT want to map this here. Instead, let's map it when we retrieve a Transfer instance as
+                // we access the file storage on this system...we do that via StoragePathCalculator, in pkg-npm/common.
+//                if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.remote != st )
+//                {
+//                    // make sure the right mapping path for hosted and group when retrieve content
+//                    path = PathUtils.storagePath( path, eventMetadata );
+//                }
+
+                logger.info( "START: retrieval of content: {}/{}", sk, path );
                 Transfer item = contentController.get( sk, path, eventMetadata );
 
-                logger.info( "HANDLE: retrieval of content: {}:{}", sk, path );
+                logger.info( "HANDLE: retrieval of content: {}/{}", sk, path );
                 if ( item == null )
                 {
                     return handleMissingContentQuery( sk, path, builderModifier );
@@ -386,13 +388,14 @@ public class NPMContentAccessHandler
                         setInfoHeaders( builder, item, sk, path, false, getNPMContentType( path ),
                                         contentController.getHttpMetadata( item ) );
                         response = responseWithBuilder( builder, builderModifier );
-                        // generating .http-metadata.json for npm group and remote retrieve to resolve header requirements
-                        // hosted .http-metadata.json will be generated when publish
-                        // only package.json file will generate this customized http meta to satisfy npm client header check
-                        if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.hosted != st )
-                        {
-                            generateHttpMetadataHeaders( item, request, response );
-                        }
+
+//                        // generating .http-metadata.json for npm group and remote retrieve to resolve header requirements
+//                        // hosted .http-metadata.json will be generated when publish
+//                        // only package.json file will generate this customized http meta to satisfy npm client header check
+//                        if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.hosted != st )
+//                        {
+//                            generateHttpMetadataHeaders( item, request, response );
+//                        }
                     }
                 }
                 finally

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
@@ -60,7 +60,7 @@ public class NPMContentAccessResource
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    private static final String PACKAGE_JSON = "/package.json";
+//    private static final String PACKAGE_JSON = "/package.json";
 
     @Inject
     @NPMContentHandler
@@ -87,8 +87,7 @@ public class NPMContentAccessResource
             final @Context HttpServletRequest request )
     {
         EventMetadata eventMetadata =
-                new EventMetadata().set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() )
-                                                         .set( STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
+                new EventMetadata().set( STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
 
         Class cls = NPMContentAccessResource.class;
         return handler.doCreate( NPM_PKG_KEY, type, name, packageName, request, eventMetadata,
@@ -134,8 +133,6 @@ public class NPMContentAccessResource
             final @PathParam( "packageName" ) String packageName,
             final @ApiParam( name = CHECK_CACHE_ONLY, value = "true or false" ) @QueryParam( CHECK_CACHE_ONLY ) Boolean cacheOnly )
     {
-        EventMetadata eventMetadata = new EventMetadata();
-        eventMetadata.set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() );
         return handler.doDelete( NPM_PKG_KEY, type, name, packageName, new EventMetadata() );
     }
 
@@ -167,8 +164,6 @@ public class NPMContentAccessResource
             @Context final UriInfo uriInfo, @Context final HttpServletRequest request )
     {
         EventMetadata eventMetadata = new EventMetadata();
-        eventMetadata.set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() );
-
         final String baseUri = uriInfo.getBaseUriBuilder().path( NPM_CONTENT_REST_BASE_PATH ).build().toString();
         return handler.doHead( NPM_PKG_KEY, type, name, packageName, cacheOnly, baseUri, request, eventMetadata );
     }
@@ -206,8 +201,6 @@ public class NPMContentAccessResource
             @Context final HttpServletRequest request )
     {
         EventMetadata eventMetadata = new EventMetadata();
-        eventMetadata.set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() );
-
         final String baseUri = uriInfo.getBaseUriBuilder().path( NPM_CONTENT_REST_BASE_PATH ).build().toString();
         return handler.doGet( NPM_PKG_KEY, type, name, packageName, baseUri, request, eventMetadata );
     }

--- a/api/src/main/java/org/commonjava/indy/content/StoragePathCalculator.java
+++ b/api/src/main/java/org/commonjava/indy/content/StoragePathCalculator.java
@@ -1,0 +1,13 @@
+package org.commonjava.indy.content;
+
+import org.commonjava.indy.model.core.StoreKey;
+
+/**
+ * Support separation between logical path and storage path, usually for package metadata. This allows package-specific
+ * path manipulations for how Indy stores content on the filesystem, without affecting the path used to transfer the
+ * content.
+ */
+public interface StoragePathCalculator
+{
+    String calculateStoragePath( StoreKey storeKey, String path );
+}


### PR DESCRIPTION
When accessing package metadata for NPM, we need separation between storage location and logical / upstream path. This allows us to avoid colliding between the metadata's requested path and the directory structure used to access tarballs. We had been doing this mapping in certain cases, in the NPMContentAccessHandler.

However, this resulted in weird behavior when the metadata files expired, and the directory structure was left in place, but empty.

This reimplementation provides a new interface for calculating storage paths, used by Indy's custom path generator (which in turn is used in the CacheProvider from Galley). Then, we implement this interface in pkg-npm/common, in order to handle the NPM specific case.

Finally, an upstream-server expectation was commented out of the NPMMetadataTimeoutTest in order to simulate real-world usage.