### PR TITLE
[Not merge]Fix npm metadata expiration not working with new pathCalculator way

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
@@ -52,7 +52,6 @@ import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.CONTENT_TRACKI
 import static org.commonjava.indy.folo.ctl.FoloConstants.ACCESS_CHANNEL;
 import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_KEY;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
-import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
 
 @Api( value = "FOLO Tracked Content Access and Storage For NPM related artifacts. Tracks retrieval and management of file/artifact content." )
@@ -97,9 +96,7 @@ public class FoloNPMContentAccessResource
         EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
                                                     .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
                                                     .set( STORE_HTTP_HEADERS,
-                                                          RequestUtils.extractRequestHeadersToMap( request ) )
-                                                    .set( STORAGE_PATH,
-                                                          Paths.get( packageName, PACKAGE_JSON ).toString() );
+                                                          RequestUtils.extractRequestHeadersToMap( request ) );
 
         Class cls = FoloNPMContentAccessResource.class;
         return handler.doCreate( NPM_PKG_KEY, type, name, packageName, request, metadata,
@@ -153,9 +150,7 @@ public class FoloNPMContentAccessResource
         final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
 
         EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
-                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
-                                                    .set( STORAGE_PATH,
-                                                          Paths.get( packageName, PACKAGE_JSON ).toString() );
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
 
         MDC.put( CONTENT_TRACKING_ID, id );
 
@@ -205,9 +200,7 @@ public class FoloNPMContentAccessResource
         final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
 
         EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
-                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
-                                                    .set( STORAGE_PATH,
-                                                          Paths.get( packageName, PACKAGE_JSON ).toString() );
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
 
         MDC.put( CONTENT_TRACKING_ID, id );
 

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
@@ -9,6 +9,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.indy.pkg.npm.content.group.PackageMetadataMerger.METADATA_NAME;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 
 /**
@@ -35,8 +36,8 @@ public class NPMStoragePathCalculator
     {
         if ( PKG_TYPE_NPM.equals( key.getPackageType() ) && path.split("/").length < 2 )
         {
-            logger.debug( "Modifying target path: {}, appending 'package.json'", path );
-            return normalize( path, "package.json" );
+            logger.debug( "Modifying target path: {}, appending '{}'", path, METADATA_NAME );
+            return normalize( path, METADATA_NAME );
         }
 
         return path;

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
@@ -1,0 +1,44 @@
+package org.commonjava.indy.pkg.npm.content;
+
+import org.commonjava.indy.content.StoragePathCalculator;
+import org.commonjava.indy.model.core.StoreKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
+
+/**
+ * We know that NPM requests to package-level resources, such as just "jquery" actually return package metadata, as
+ * you would find in a package.json file. Also, we know that NPM stores packages as binary tarballs UNDER A SUBPATH of
+ * the path used to access this metadata. Caching both requires us to map the actual storage location of metadata to
+ * a different subpath, so they both share a package-root directory and don't collide on the filesystem
+ * (as concrete file vs directory).
+ *
+ * This implementation looks for metadata paths when the package type is NPM, and maps them to a package.json filename
+ * under the package name, so we have a compatible file name for storage.
+ *
+ * NOTE: This does NOT affect the remote HTTP request path used to talk to upstream servers like npmjs.org.
+ */
+@ApplicationScoped
+@Named
+public class NPMStoragePathCalculator
+        implements StoragePathCalculator
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Override
+    public String calculateStoragePath( final StoreKey key, final String path )
+    {
+        if ( PKG_TYPE_NPM.equals( key.getPackageType() ) && path.split("/").length < 2 )
+        {
+            logger.debug( "Modifying target path: {}, appending 'package.json'", path );
+            return normalize( path, "package.json" );
+        }
+
+        return path;
+    }
+}

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataTimeoutTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataTimeoutTest.java
@@ -72,11 +72,11 @@ public class NPMMetadataTimeoutTest
         //FIXME: After using galley-0.16.8, I'm not sure the second retrieval of npm metadata will get path of
         //       "A/jquery/package.json" while the first retrieval is "A/jquery". So I add a new expectation here
         //       to let the second retrieval can work. Need further checking.
-        server.expect( "GET", server.formatUrl( REPO, PATH+"/package.json" ), (req, resp)->{
-            resp.setStatus( 200 );
-            mapper.writeValue( resp.getWriter(), src );
-            resp.getWriter().flush();
-        } );
+//        server.expect( "GET", server.formatUrl( REPO, PATH+"/package.json" ), (req, resp)->{
+//            resp.setStatus( 200 );
+//            mapper.writeValue( resp.getWriter(), src );
+//            resp.getWriter().flush();
+//        } );
 
         final RemoteRepository repo = new RemoteRepository( NPM_PKG_KEY, REPO, server.formatUrl( REPO ) );
         repo.setMetadataTimeoutSeconds( 1 );
@@ -90,6 +90,8 @@ public class NPMMetadataTimeoutTest
         Thread.sleep( 2000 );
 
         assertThat( "Metadata not cleaned up!", client.content().exists( repo.getKey(), PATH + "/package.json", true ), equalTo( false ) );
+
+        logger.info( "\n\n\n\nRE-REQUEST STARTS HERE\n\n\n\n" );
 
         // Second retrieval
         dts.setBeta( "2" );

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -68,7 +68,6 @@ import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponseFromMetadata;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.setInfoHeaders;
 import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
-import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORAGE_PATH;
 
 @ApplicationScoped
 @NPMContentHandler
@@ -326,15 +325,18 @@ public class NPMContentAccessHandler
         {
             try
             {
-                if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.remote != st )
-                {
-                    // make sure the right mapping path for hosted and group when retrieve content
-                    path = PathUtils.storagePath( path, eventMetadata );
-                }
-                logger.info( "START: retrieval of content: {}:{}", sk, path );
+                // NOTE: We do NOT want to map this here. Instead, let's map it when we retrieve a Transfer instance as
+                // we access the file storage on this system...we do that via StoragePathCalculator, in pkg-npm/common.
+//                if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.remote != st )
+//                {
+//                    // make sure the right mapping path for hosted and group when retrieve content
+//                    path = PathUtils.storagePath( path, eventMetadata );
+//                }
+
+                logger.info( "START: retrieval of content: {}/{}", sk, path );
                 Transfer item = contentController.get( sk, path, eventMetadata );
 
-                logger.info( "HANDLE: retrieval of content: {}:{}", sk, path );
+                logger.info( "HANDLE: retrieval of content: {}/{}", sk, path );
                 if ( item == null )
                 {
                     return handleMissingContentQuery( sk, path, builderModifier );
@@ -386,13 +388,14 @@ public class NPMContentAccessHandler
                         setInfoHeaders( builder, item, sk, path, false, getNPMContentType( path ),
                                         contentController.getHttpMetadata( item ) );
                         response = responseWithBuilder( builder, builderModifier );
-                        // generating .http-metadata.json for npm group and remote retrieve to resolve header requirements
-                        // hosted .http-metadata.json will be generated when publish
-                        // only package.json file will generate this customized http meta to satisfy npm client header check
-                        if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.hosted != st )
-                        {
-                            generateHttpMetadataHeaders( item, request, response );
-                        }
+
+//                        // generating .http-metadata.json for npm group and remote retrieve to resolve header requirements
+//                        // hosted .http-metadata.json will be generated when publish
+//                        // only package.json file will generate this customized http meta to satisfy npm client header check
+//                        if ( eventMetadata.get( STORAGE_PATH ) != null && StoreType.hosted != st )
+//                        {
+//                            generateHttpMetadataHeaders( item, request, response );
+//                        }
                     }
                 }
                 finally

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
@@ -60,7 +60,7 @@ public class NPMContentAccessResource
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    private static final String PACKAGE_JSON = "/package.json";
+//    private static final String PACKAGE_JSON = "/package.json";
 
     @Inject
     @NPMContentHandler
@@ -87,8 +87,7 @@ public class NPMContentAccessResource
             final @Context HttpServletRequest request )
     {
         EventMetadata eventMetadata =
-                new EventMetadata().set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() )
-                                                         .set( STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
+                new EventMetadata().set( STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
 
         Class cls = NPMContentAccessResource.class;
         return handler.doCreate( NPM_PKG_KEY, type, name, packageName, request, eventMetadata,
@@ -134,8 +133,6 @@ public class NPMContentAccessResource
             final @PathParam( "packageName" ) String packageName,
             final @ApiParam( name = CHECK_CACHE_ONLY, value = "true or false" ) @QueryParam( CHECK_CACHE_ONLY ) Boolean cacheOnly )
     {
-        EventMetadata eventMetadata = new EventMetadata();
-        eventMetadata.set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() );
         return handler.doDelete( NPM_PKG_KEY, type, name, packageName, new EventMetadata() );
     }
 
@@ -167,8 +164,6 @@ public class NPMContentAccessResource
             @Context final UriInfo uriInfo, @Context final HttpServletRequest request )
     {
         EventMetadata eventMetadata = new EventMetadata();
-        eventMetadata.set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() );
-
         final String baseUri = uriInfo.getBaseUriBuilder().path( NPM_CONTENT_REST_BASE_PATH ).build().toString();
         return handler.doHead( NPM_PKG_KEY, type, name, packageName, cacheOnly, baseUri, request, eventMetadata );
     }
@@ -206,8 +201,6 @@ public class NPMContentAccessResource
             @Context final HttpServletRequest request )
     {
         EventMetadata eventMetadata = new EventMetadata();
-        eventMetadata.set( STORAGE_PATH, Paths.get( packageName, PACKAGE_JSON ).toString() );
-
         final String baseUri = uriInfo.getBaseUriBuilder().path( NPM_CONTENT_REST_BASE_PATH ).build().toString();
         return handler.doGet( NPM_PKG_KEY, type, name, packageName, baseUri, request, eventMetadata );
     }

--- a/api/src/main/java/org/commonjava/indy/content/IndyPathGenerator.java
+++ b/api/src/main/java/org/commonjava/indy/content/IndyPathGenerator.java
@@ -37,8 +37,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.commonjava.indy.model.core.PathStyle.hashed;
-import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
-import static org.commonjava.maven.galley.util.PathUtils.normalize;
 
 /**
  * {@link PathGenerator} implementation that assumes the locations it sees will be {@link KeyedLocation}, and translates them into storage locations
@@ -47,7 +45,7 @@ import static org.commonjava.maven.galley.util.PathUtils.normalize;
 @Default
 @ApplicationScoped
 public class IndyPathGenerator
-    implements PathGenerator
+        implements PathGenerator
 {
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
@@ -83,6 +81,14 @@ public class IndyPathGenerator
         final String name = key.getPackageType() + "/" + key.getType()
                                .name() + "-" + key.getName();
 
+        return PathUtils.join( name, getPath( resource ) );
+    }
+
+    @Override
+    public String getPath( final ConcreteResource resource )
+    {
+        final KeyedLocation kl = (KeyedLocation) resource.getLocation();
+        final StoreKey key = kl.getKey();
         String path = resource.getPath();
         if ( hashed == kl.getAttribute( LocationUtils.PATH_STYLE, PathStyle.class ) )
         {
@@ -116,7 +122,7 @@ public class IndyPathGenerator
             path = pathref.get();
         }
 
-        return PathUtils.join( name, path );
+        return path;
     }
 
 }

--- a/api/src/main/java/org/commonjava/indy/content/StoragePathCalculator.java
+++ b/api/src/main/java/org/commonjava/indy/content/StoragePathCalculator.java
@@ -1,0 +1,13 @@
+package org.commonjava.indy.content;
+
+import org.commonjava.indy.model.core.StoreKey;
+
+/**
+ * Support separation between logical path and storage path, usually for package metadata. This allows package-specific
+ * path manipulations for how Indy stores content on the filesystem, without affecting the path used to transfer the
+ * content.
+ */
+public interface StoragePathCalculator
+{
+    String calculateStoragePath( StoreKey storeKey, String path );
+}

--- a/core/src/main/java/org/commonjava/indy/core/content/ContentGeneratorManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/ContentGeneratorManager.java
@@ -20,8 +20,11 @@ import org.commonjava.indy.content.ContentGenerator;
 import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.spi.io.PathGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +46,9 @@ public class ContentGeneratorManager
     private Instance<ContentGenerator> contentGeneratorInstance;
 
     private Set<ContentGenerator> contentGenerators;
+
+    @Inject
+    private PathGenerator pathGenerator;
 
     public ContentGeneratorManager()
     {
@@ -85,7 +91,10 @@ public class ContentGeneratorManager
         Transfer item = null;
         for ( final ContentGenerator generator : contentGenerators )
         {
-            if ( generator.canProcess( path ) )
+            String storagePath =
+                    pathGenerator.getPath( new ConcreteResource( LocationUtils.toLocation( group ), path ) );
+            final boolean canProcess =  generator.canProcess( path ) || generator.canProcess( storagePath );
+            if ( canProcess )
             {
                 item = generator.generateGroupFileContent( group, members, path, eventMetadata );
                 logger.trace( "From content {}.generateGroupFileContent: {} (exists? {})",

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.0.1</atlasVersion>
-    <galleyVersion>0.16.11</galleyVersion>
+    <galleyVersion>0.16.12-SNAPSHOT</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>2.0</partylineVersion>


### PR DESCRIPTION
We should also use this new calculator in ScheduleManager to decide real metadata to expire. 
BTW, this commit also includes a fix for the sibling http-metadata generation problem for npm package.json, but it depends on a galley fix here: https://github.com/Commonjava/galley/pull/285

But it still fails because of the group metadata generation problem now. Will continue on investigation.