### PR TITLE
Switch to StreamingOutput impl for DTO rendering

### DIFF
--- a/addons/content-browse/jaxrs/src/main/java/org/commonjava/indy/content/browse/bind/jaxrs/ContentBrowseResource.java
+++ b/addons/content-browse/jaxrs/src/main/java/org/commonjava/indy/content/browse/bind/jaxrs/ContentBrowseResource.java
@@ -27,7 +27,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.JaxRsRequestHelper;
 import org.commonjava.indy.bind.jaxrs.util.REST;
-import org.commonjava.indy.bind.jaxrs.util.ResponseUtils;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.content.browse.ContentBrowseController;
 import org.commonjava.indy.content.browse.model.ContentBrowseResult;
 import org.commonjava.indy.model.core.PackageTypes;
@@ -56,8 +56,6 @@ import javax.ws.rs.core.UriInfo;
 
 import java.util.Date;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-
 @Api( value = "Indy Directory Content Browse", description = "Browse directory content in indy repository" )
 @Path( "/api/browse/{packageType}/{type: (hosted|group|remote)}/{name}" )
 @ApplicationScoped
@@ -82,6 +80,9 @@ public class ContentBrowseResource
 
     @Inject
     protected JaxRsRequestHelper jaxRsRequestHelper;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @ApiOperation( "Retrieve directory content under the given artifact store (type/name) and directory path." )
     @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
@@ -145,11 +146,11 @@ public class ContentBrowseResource
         {
             logger.error( String.format( "Failed to list content: %s from: %s. Reason: %s",
                                          StringUtils.isBlank( path ) ? "/" : path, name, e.getMessage() ), e );
-            response = ResponseUtils.formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
         catch ( JsonProcessingException e )
         {
-            response = ResponseUtils.formatResponse( e, "Failed to serialize DTO to JSON: " + result );
+            response = responseHelper.formatResponse( e, "Failed to serialize DTO to JSON: " + result );
         }
 
         return response;
@@ -202,13 +203,13 @@ public class ContentBrowseResource
         {
             result = getBrowseResult( packageType, type, name, path, uriInfo );
 
-            response = formatOkResponseWithJsonEntity( result, mapper );
+            response = responseHelper.formatOkResponseWithJsonEntity( result );
         }
         catch ( IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to list content: %s from: %s. Reason: %s",
                                          StringUtils.isBlank( path ) ? "/" : path, name, e.getMessage() ), e );
-            response = ResponseUtils.formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/DeprecatedFoloContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/DeprecatedFoloContentAccessResource.java
@@ -23,8 +23,8 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
-import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.folo.model.TrackingKey;
 import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -43,14 +43,12 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriInfo;
-
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.markDeprecated;
 import static org.commonjava.indy.folo.ctl.FoloConstants.ACCESS_CHANNEL;
 import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_KEY;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
@@ -75,6 +73,9 @@ public class DeprecatedFoloContentAccessResource
 
     @Inject
     private ContentAccessHandler handler;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     public DeprecatedFoloContentAccessResource()
     {
@@ -107,7 +108,7 @@ public class DeprecatedFoloContentAccessResource
 
         final Consumer<Response.ResponseBuilder> deprecation = builder -> {
             String alt = Paths.get( "/api/folo/track/", id, MAVEN_PKG_KEY, type, name, path ).toString();
-            markDeprecated( builder, alt );
+            responseHelper.markDeprecated( builder, alt );
         };
 
         return handler.doCreate( MAVEN_PKG_KEY, type, name, path, request, metadata, uriSupplier, deprecation );
@@ -134,7 +135,7 @@ public class DeprecatedFoloContentAccessResource
 
         final Consumer<Response.ResponseBuilder> deprecation = builder -> {
             String alt = Paths.get( "/api/folo/track/", id, MAVEN_PKG_KEY, type, name, path ).toString();
-            markDeprecated( builder, alt );
+            responseHelper.markDeprecated( builder, alt );
         };
 
         return handler.doHead( MAVEN_PKG_KEY, type, name, path, cacheOnly, baseUri, request, metadata, deprecation );
@@ -160,7 +161,7 @@ public class DeprecatedFoloContentAccessResource
 
         final Consumer<Response.ResponseBuilder> deprecation = builder -> {
             String alt = Paths.get( "/api/folo/track/", id, MAVEN_PKG_KEY, type, name, path ).toString();
-            markDeprecated( builder, alt );
+            responseHelper.markDeprecated( builder, alt );
         };
 
         return handler.doGet( MAVEN_PKG_KEY, type, name, path, baseUri, request, metadata, deprecation );

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.folo.ctl.FoloAdminController;
 import org.commonjava.indy.folo.ctl.FoloConstants;
@@ -53,9 +54,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
 import static org.commonjava.indy.folo.ctl.FoloConstants.ALL;
 import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_TYPE.IN_PROGRESS;
 import static org.commonjava.indy.folo.ctl.FoloConstants.TRACKING_TYPE.SEALED;
@@ -80,6 +78,9 @@ public class FoloAdminResource
     @Inject
     private ContentController contentController;
 
+    @Inject
+    private ResponseHelper responseHelper;
+
     @ApiOperation( "Recalculate sizes and checksums for every file listed in a tracking record." )
     @ApiResponses(
             { @ApiResponse( code = 200, response = TrackedContentDTO.class, message = "Recalculated tracking report" ),
@@ -101,7 +102,7 @@ public class FoloAdminResource
             }
             else
             {
-                response = formatOkResponseWithJsonEntity( report, objectMapper );
+                response = responseHelper.formatOkResponseWithJsonEntity( report );
             }
         }
         catch ( final IndyWorkflowException e )
@@ -109,7 +110,7 @@ public class FoloAdminResource
             logger.error(
                     String.format( "Failed to serialize tracking report for: %s. Reason: %s", id, e.getMessage() ), e );
 
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;
@@ -134,7 +135,7 @@ public class FoloAdminResource
         }
         catch ( IndyWorkflowException e )
         {
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;
@@ -162,7 +163,7 @@ public class FoloAdminResource
             }
             else
             {
-                response = formatOkResponseWithJsonEntity( report, objectMapper );
+                response = responseHelper.formatOkResponseWithJsonEntity( report );
             }
         }
         catch ( final IndyWorkflowException e )
@@ -170,7 +171,7 @@ public class FoloAdminResource
             logger.error(
                     String.format( "Failed to serialize tracking report for: %s. Reason: %s", id, e.getMessage() ), e );
 
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;
@@ -230,7 +231,7 @@ public class FoloAdminResource
             }
             else
             {
-                response = formatOkResponseWithJsonEntity( record, objectMapper );
+                response = responseHelper.formatOkResponseWithJsonEntity( record );
             }
         }
         catch ( final IndyWorkflowException e )
@@ -238,7 +239,7 @@ public class FoloAdminResource
             logger.error( String.format( "Failed to retrieve tracking report for: %s. Reason: %s", id, e.getMessage() ),
                           e );
 
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;
@@ -256,7 +257,7 @@ public class FoloAdminResource
         }
         catch ( FoloContentException e )
         {
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;
@@ -277,7 +278,7 @@ public class FoloAdminResource
         TrackingIdsDTO ids = controller.getTrackingIds( types );
         if ( ids != null )
         {
-            response = formatOkResponseWithJsonEntity( ids, objectMapper );
+            response = responseHelper.formatOkResponseWithJsonEntity( ids );
         }
         else
         {
@@ -301,7 +302,7 @@ public class FoloAdminResource
         }
         catch ( IndyWorkflowException e )
         {
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;
@@ -319,11 +320,11 @@ public class FoloAdminResource
         }
         catch ( IndyWorkflowException e )
         {
-            throwError( e );
+            responseHelper.throwError( e );
         }
         catch ( IOException e )
         {
-            throwError( new IndyWorkflowException( "IO error", e ) );
+            responseHelper.throwError( new IndyWorkflowException( "IO error", e ) );
         }
 
         return Response.created( uriInfo.getRequestUri() ).build();

--- a/addons/hosted-by-archive/jaxrs/src/main/java/org/commonjava/indy/hostedbyarc/bind/jaxrs/IndyHostedByArchiveResource.java
+++ b/addons/hosted-by-archive/jaxrs/src/main/java/org/commonjava/indy/hostedbyarc/bind/jaxrs/IndyHostedByArchiveResource.java
@@ -27,6 +27,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.AdminController;
 import org.commonjava.indy.hostedbyarc.HostedByArchiveManager;
 import org.commonjava.indy.hostedbyarc.config.HostedByArchiveConfig;
@@ -54,12 +55,9 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URI;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatCreatedResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
 
 @Api( value = "Hosted by archive", description = "Create a new maven hosted store by zip file" )
@@ -85,6 +83,9 @@ public class IndyHostedByArchiveResource
 
     @Inject
     private IndyObjectMapper objectMapper;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @ApiOperation( "Create a new maven hosted store by a zip file" )
     @ApiResponses( { @ApiResponse( code = 201, response = ArtifactStore.class, message = "The store was created" ),
@@ -128,7 +129,7 @@ public class IndyHostedByArchiveResource
     {
         if ( !config.isEnabled() )
         {
-            return formatResponse( ApplicationStatus.METHOD_NOT_ALLOWED,
+            return responseHelper.formatResponse( ApplicationStatus.METHOD_NOT_ALLOWED,
                                    "This REST end point is disabled, please enable it first to use" );
         }
 
@@ -136,7 +137,7 @@ public class IndyHostedByArchiveResource
         StoreKey storeKey = new StoreKey( MAVEN_PKG_KEY, StoreType.hosted, name );
         if ( adminController.exists( storeKey ) )
         {
-            return formatResponse( ApplicationStatus.CONFLICT,
+            return responseHelper.formatResponse( ApplicationStatus.CONFLICT,
                                    String.format( "Hosted repository %s already exists, can not create it again.",
                                                   name ) );
         }
@@ -161,7 +162,7 @@ public class IndyHostedByArchiveResource
         catch ( IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            return formatResponse( e );
+            return responseHelper.formatResponse( e );
         }
         finally
         {
@@ -176,11 +177,11 @@ public class IndyHostedByArchiveResource
                                    .path( repo.getType().singularEndpointName() )
                                    .build( repo.getName() );
 
-            return formatCreatedResponseWithJsonEntity( uri, repo, objectMapper );
+            return responseHelper.formatCreatedResponseWithJsonEntity( uri, repo );
         }
         else
         {
-            return formatResponse( new IndyWorkflowException( "Hosted creation failed with some unknown error!" ) );
+            return responseHelper.formatResponse( new IndyWorkflowException( "Hosted creation failed with some unknown error!" ) );
         }
 
     }

--- a/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
+++ b/addons/koji/jaxrs/src/main/java/org/commonjava/indy/koji/bind/jaxrs/KojiRepairResource.java
@@ -25,13 +25,12 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.koji.data.KojiRepairException;
 import org.commonjava.indy.koji.data.KojiRepairManager;
 import org.commonjava.indy.koji.model.KojiMultiRepairResult;
 import org.commonjava.indy.koji.model.KojiRepairRequest;
 import org.commonjava.indy.koji.model.KojiRepairResult;
-import org.commonjava.indy.model.core.PackageTypeDescriptor;
-import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.util.ApplicationContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +47,6 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 
 import static org.commonjava.indy.bind.jaxrs.util.JaxRsUriFormatter.getBaseUrlByStoreKey;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.ALL_MASKS;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.MASK;
 import static org.commonjava.indy.koji.model.IndyKojiConstants.META_TIMEOUT;
@@ -75,6 +73,9 @@ public class KojiRepairResource
     @Inject
     private KojiRepairManager repairManager;
 
+    @Inject
+    private ResponseHelper responseHelper;
+
     @ApiOperation( "Repair koji repository remote url /vol." )
     @ApiResponse( code = 200, message = "Operation finished (consult response content for success/failure).",
                     response = KojiRepairResult.class )
@@ -96,7 +97,7 @@ public class KojiRepairResource
         catch ( KojiRepairException | KojiClientException e )
         {
             logger.error( e.getMessage(), e );
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;
@@ -122,7 +123,7 @@ public class KojiRepairResource
         catch ( KojiRepairException e )
         {
             logger.error( e.getMessage(), e );
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;
@@ -145,7 +146,7 @@ public class KojiRepairResource
         catch ( KojiRepairException | IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;
@@ -171,7 +172,7 @@ public class KojiRepairResource
         catch ( KojiRepairException e )
         {
             logger.error( e.getMessage(), e );
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;
@@ -201,7 +202,7 @@ public class KojiRepairResource
         catch ( KojiRepairException | IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.binary.Base64;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
@@ -61,9 +62,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponseFromMetadata;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.setInfoHeaders;
 
 @ApplicationScoped
 @NPMContentHandler
@@ -80,6 +78,9 @@ public class NPMContentAccessHandler
 
     @Inject
     private ObjectMapper mapper;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @Override
     public Response doCreate( String packageType, String type, String name, String path, HttpServletRequest request,
@@ -145,7 +146,7 @@ public class NPMContentAccessHandler
         {
             logger.error( String.format( "Failed to upload: %s to: %s. Reason: %s", path, name, e.getMessage() ), e );
 
-            response = formatResponse( e, builderModifier );
+            response = responseHelper.formatResponse( e, builderModifier );
         }
         finally
         {
@@ -229,7 +230,7 @@ public class NPMContentAccessHandler
 
                     final Response.ResponseBuilder builder = Response.ok();
 
-                    setInfoHeaders( builder, item, sk, path, true, getNPMContentType( path ),
+                    responseHelper.setInfoHeaders( builder, item, sk, path, true, getNPMContentType( path ),
                                     httpMetadata );
                     if ( builderModifier != null )
                     {
@@ -246,7 +247,7 @@ public class NPMContentAccessHandler
                         if ( metadata != null )
                         {
                             logger.debug( "Using HTTP metadata to build negative response." );
-                            response = formatResponseFromMetadata( metadata );
+                            response = responseHelper.formatResponseFromMetadata( metadata );
                         }
                     }
 
@@ -266,7 +267,7 @@ public class NPMContentAccessHandler
             {
                 logger.error( String.format( "Failed to download artifact: %s from: %s. Reason: %s", path, name,
                                              e.getMessage() ), e );
-                response = formatResponse( e, builderModifier );
+                response = responseHelper.formatResponse( e, builderModifier );
             }
         }
         return response;
@@ -370,7 +371,7 @@ public class NPMContentAccessHandler
 //                        if ( item == null )
 //                        {
 //                            logger.error( "Retrieval of actual storage path: {} FAILED!", path );
-//                            throwError( ApplicationStatus.SERVER_ERROR, new NullPointerException( path ), "Retrieval of mapped file from storage failed." );
+//                            responseHelper.throwError( ApplicationStatus.SERVER_ERROR, new NullPointerException( path ), "Retrieval of mapped file from storage failed." );
 //                        }
 
                         logger.info( "RETURNING: retrieval of content: {}:{}", sk, path );
@@ -380,7 +381,7 @@ public class NPMContentAccessHandler
                         final Response.ResponseBuilder builder =
                                 Response.ok( new TransferStreamingOutput( in, metricsManager, metricsConfig ) );
 
-                        setInfoHeaders( builder, item, sk, path, false, getNPMContentType( path ),
+                        responseHelper.setInfoHeaders( builder, item, sk, path, false, getNPMContentType( path ),
                                         contentController.getHttpMetadata( item ) );
                         response = responseWithBuilder( builder, builderModifier );
 
@@ -405,7 +406,7 @@ public class NPMContentAccessHandler
             {
                 logger.error( String.format( "Failed to download artifact: %s from: %s. Reason: %s", path, name,
                                              e.getMessage() ), e );
-                response = formatResponse( e, builderModifier );
+                response = responseHelper.formatResponse( e, builderModifier );
             }
         }
 

--- a/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteResource.java
+++ b/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteResource.java
@@ -28,6 +28,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.promote.data.PromotionException;
 import org.commonjava.indy.promote.data.PromotionManager;
 import org.commonjava.indy.promote.model.GroupPromoteRequest;
@@ -50,10 +51,6 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
-
 @Api( value="Content Promotion", description = "Promote content from a source repository to a target repository or group." )
 @Path( "/api/promotion" )
 @Produces( { application_json } )
@@ -72,6 +69,9 @@ public class PromoteResource
 
     @Inject
     private SecurityManager securityManager;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @ApiOperation( "Promote a source repository into the membership of a target group (subject to validation)." )
     @ApiResponse( code = 200, message = "Promotion operation finished (consult response content for success/failure).",
@@ -99,7 +99,7 @@ public class PromoteResource
         catch ( PromotionException | IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;
@@ -126,7 +126,7 @@ public class PromoteResource
         catch ( PromotionException | IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         return null;
@@ -153,7 +153,7 @@ public class PromoteResource
         }
         catch ( final IOException e )
         {
-            response = formatResponse( e, "Failed to read DTO from request body." );
+            response = responseHelper.formatResponse( e, "Failed to read DTO from request body." );
             return response;
         }
 
@@ -162,13 +162,13 @@ public class PromoteResource
             final String baseUrl = getBaseUrlByStoreKey( uriInfo, req.getSource() );
             final PathsPromoteResult result = manager.promotePaths( req, baseUrl );
 
-            response = formatOkResponseWithJsonEntity( result, mapper );
+            response = responseHelper.formatOkResponseWithJsonEntity( result );
             logger.info( "Send promotion result:\n{}", response.getEntity() );
         }
         catch ( PromotionException | IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;
@@ -193,19 +193,19 @@ public class PromoteResource
         }
         catch ( final IOException e )
         {
-            response = formatResponse( e, "Failed to read DTO from request body." );
+            response = responseHelper.formatResponse( e, "Failed to read DTO from request body." );
             return response;
         }
 
         try
         {
             result = manager.rollbackPathsPromote( result );
-            response = formatOkResponseWithJsonEntity( result, mapper );
+            response = responseHelper.formatOkResponseWithJsonEntity( result );
         }
         catch ( PromotionException | IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;

--- a/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/ChangelogResource.java
+++ b/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/ChangelogResource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.revisions.RevisionsManager;
@@ -40,9 +41,6 @@ import javax.ws.rs.core.Response.Status;
 import java.util.Date;
 import java.util.List;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-
 @Path( "/api/revisions/changelog" )
 @REST
 public class ChangelogResource
@@ -58,6 +56,9 @@ public class ChangelogResource
 
     @Inject
     private ObjectMapper objectMapper;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @ApiOperation(
             "Retrieve the changelog for the Indy group/repository definition with the start-index and number of results" )
@@ -92,7 +93,7 @@ public class ChangelogResource
         try
         {
             final List<ChangeSummary> dataChangeLog = revisions.getDataChangeLog( key, start, count );
-            response = formatOkResponseWithJsonEntity( new ChangeSummaryDTO( dataChangeLog ), objectMapper );
+            response = responseHelper.formatOkResponseWithJsonEntity( new ChangeSummaryDTO( dataChangeLog ) );
 
             logger.info( "\n\n\n\n\n\n{} Sent changelog for: {}\n\n{}\n\n\n\n\n\n\n", new Date(), key, dataChangeLog );
         }
@@ -102,7 +103,7 @@ public class ChangelogResource
                     String.format( "Failed to lookup changelog for: %s. Reason: %s", key, e.getMessage() );
             logger.error( message, e );
 
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;

--- a/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/RevisionsAdminResource.java
+++ b/addons/revisions/jaxrs/src/main/java/org/commonjava/indy/revisions/jaxrs/RevisionsAdminResource.java
@@ -22,7 +22,7 @@ import io.swagger.annotations.ApiResponse;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
-import org.commonjava.indy.bind.jaxrs.util.ResponseUtils;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.revisions.RevisionsManager;
 import org.commonjava.indy.revisions.jaxrs.dto.ChangeSummaryDTO;
 import org.commonjava.indy.subsys.git.GitSubsystemException;
@@ -40,9 +40,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-
 @Api( "Data-Directory Revisions" )
 @Path( "/api/admin/revisions" )
 @ApplicationScoped
@@ -58,6 +55,9 @@ public class RevisionsAdminResource
 
     @Inject
     private ObjectMapper objectMapper;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @ApiOperation(
             "Pull from the configured remote Git repository, updating the Indy data directory with files (merged according to configuration in the [revisions] section)" )
@@ -77,7 +77,7 @@ public class RevisionsAdminResource
         catch ( final GitSubsystemException e )
         {
             logger.error( "Failed to pull git updates for data dir: " + e.getMessage(), e );
-            response = ResponseUtils.formatResponse( e, "Failed to pull git updates for data dir: " + e.getMessage() );
+            response = responseHelper.formatResponse( e, "Failed to pull git updates for data dir: " + e.getMessage() );
         }
 
         return response;
@@ -101,7 +101,7 @@ public class RevisionsAdminResource
         catch ( final GitSubsystemException e )
         {
             logger.error( "Failed to push git updates for data dir: " + e.getMessage(), e );
-            response = ResponseUtils.formatResponse( e, "Failed to push git updates for data dir: " + e.getMessage() );
+            response = responseHelper.formatResponse( e, "Failed to push git updates for data dir: " + e.getMessage() );
         }
 
         return response;
@@ -121,12 +121,12 @@ public class RevisionsAdminResource
         {
             final List<ChangeSummary> listing = revisionsManager.getDataChangeLog( path, start, count );
 
-            response = formatOkResponseWithJsonEntity( new ChangeSummaryDTO( listing ), objectMapper );
+            response = responseHelper.formatOkResponseWithJsonEntity( new ChangeSummaryDTO( listing ) );
         }
         catch ( final GitSubsystemException e )
         {
             logger.error( "Failed to read git changelog from data dir: " + e.getMessage(), e );
-            response = formatResponse( e, "Failed to read git changelog from data dir." );
+            response = responseHelper.formatResponse( e, "Failed to read git changelog from data dir." );
         }
 
         return response;

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -19,6 +19,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.JaxRsRequestHelper;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.content.ContentManager;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.core.bind.jaxrs.util.TransferStreamingOutput;
@@ -62,9 +63,6 @@ import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.METADATA_CONTE
 import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PACKAGE_TYPE;
 import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.PATH;
 import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.setContext;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponseFromMetadata;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.setInfoHeaders;
 import static org.commonjava.indy.core.ctl.ContentController.LISTING_HTML_FILE;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
 
@@ -93,6 +91,9 @@ public class ContentAccessHandler
 
     @Inject
     protected SpecialPathManager specialPathManager;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
 
     protected ContentAccessHandler()
@@ -151,7 +152,7 @@ public class ContentAccessHandler
         {
             logger.error( String.format( "Failed to upload: %s to: %s. Reason: %s", path, name, e.getMessage() ), e );
 
-            response = formatResponse( e, builderModifier );
+            response = responseHelper.formatResponse( e, builderModifier );
         }
 
         return response;
@@ -202,7 +203,7 @@ public class ContentAccessHandler
         {
             logger.error( String.format( "Failed to tryDelete artifact: %s from: %s. Reason: %s", path, name,
                                          e.getMessage() ), e );
-            response = formatResponse( e, builderModifier );
+            response = responseHelper.formatResponse( e, builderModifier );
         }
         return response;
     }
@@ -302,7 +303,7 @@ public class ContentAccessHandler
                             MediaType.APPLICATION_JSON :
                             contentController.getContentType( path );
 
-                    setInfoHeaders( builder, item, sk, path, true, contentType,
+                    responseHelper.setInfoHeaders( builder, item, sk, path, true, contentType,
                                     httpMetadata );
                     if ( builderModifier != null )
                     {
@@ -319,7 +320,7 @@ public class ContentAccessHandler
                         if ( metadata != null )
                         {
                             logger.trace( "Using HTTP metadata to build negative response." );
-                            response = formatResponseFromMetadata( metadata );
+                            response = responseHelper.formatResponseFromMetadata( metadata );
                         }
                     }
 
@@ -340,7 +341,7 @@ public class ContentAccessHandler
             {
                 logger.error( String.format( "Failed to download artifact: %s from: %s. Reason: %s", path, name,
                                              e.getMessage() ), e );
-                response = formatResponse( e, builderModifier );
+                response = responseHelper.formatResponse( e, builderModifier );
             }
         }
         return response;
@@ -431,7 +432,7 @@ public class ContentAccessHandler
                         final ResponseBuilder builder = Response.ok(
                                 new TransferStreamingOutput( in, metricsManager, metricsConfig ) );
 
-                        setInfoHeaders( builder, item, sk, path, true, contentController.getContentType( path ),
+                        responseHelper.setInfoHeaders( builder, item, sk, path, true, contentController.getContentType( path ),
                                         contentController.getHttpMetadata( item ) );
                         if ( builderModifier != null )
                         {
@@ -452,7 +453,7 @@ public class ContentAccessHandler
             {
                 logger.error( String.format( "Failed to download artifact: %s from: %s. Reason: %s", path, name,
                                              e.getMessage() ), e );
-                response = formatResponse( e, builderModifier );
+                response = responseHelper.formatResponse( e, builderModifier );
             }
         }
 
@@ -475,7 +476,7 @@ public class ContentAccessHandler
                 if ( metadata != null )
                 {
                     logger.trace( "Using HTTP metadata to formulate response status for: {}/{}", sk, path );
-                    response = formatResponseFromMetadata( metadata, builderModifier );
+                    response = responseHelper.formatResponseFromMetadata( metadata, builderModifier );
                 }
                 else
                 {
@@ -486,13 +487,13 @@ public class ContentAccessHandler
             {
                 logger.error( String.format( "Error retrieving status metadata for: %s from: %s. Reason: %s", path,
                                              sk.getName(), e.getMessage() ), e );
-                response = formatResponse( e, builderModifier );
+                response = responseHelper.formatResponse( e, builderModifier );
             }
         }
 
         if ( response == null )
         {
-            response = formatResponse( ApplicationStatus.NOT_FOUND, null,
+            response = responseHelper.formatResponse( ApplicationStatus.NOT_FOUND, null,
                                        "Path " + path + " is not available in store " + sk + ".", builderModifier );
         }
 

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/DeprecatedContentAccessResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/DeprecatedContentAccessResource.java
@@ -23,6 +23,7 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -47,7 +48,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.markDeprecated;
 import static org.commonjava.maven.galley.spi.cache.CacheProvider.STORE_HTTP_HEADERS;
 
 @Api( value = "DEPRECATED: Content Access and Storage",
@@ -60,6 +60,9 @@ public class DeprecatedContentAccessResource
 {
     @Inject
     private ContentAccessHandler handler;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     public DeprecatedContentAccessResource()
     {
@@ -89,7 +92,7 @@ public class DeprecatedContentAccessResource
 
         final Consumer<Response.ResponseBuilder> deprecated = builder -> {
             String alt = Paths.get( "/api/maven", type, name, path ).toString();
-            markDeprecated( builder, alt );
+            responseHelper.markDeprecated( builder, alt );
         };
 
         final EventMetadata metadata = new EventMetadata().set( STORE_HTTP_HEADERS,
@@ -110,7 +113,7 @@ public class DeprecatedContentAccessResource
         String packageType = MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
         final Consumer<Response.ResponseBuilder> deprecated = builder -> {
             String alt = Paths.get( "/api/maven", type, name, path ).toString();
-            markDeprecated( builder, alt );
+            responseHelper.markDeprecated( builder, alt );
         };
 
         return handler.doDelete( packageType, type, name, path, new EventMetadata(), deprecated );
@@ -135,7 +138,7 @@ public class DeprecatedContentAccessResource
 
         final Consumer<Response.ResponseBuilder> deprecated = builder -> {
             String alt = Paths.get( "/api/maven", type, name, path ).toString();
-            markDeprecated( builder, alt );
+            responseHelper.markDeprecated( builder, alt );
         };
 
         return handler.doHead( packageType, type, name, path, cacheOnly, baseUri, request, new EventMetadata(), deprecated );
@@ -161,7 +164,7 @@ public class DeprecatedContentAccessResource
 
         final Consumer<Response.ResponseBuilder> deprecated = builder -> {
             String alt = Paths.get( "/api/maven", type, name, path ).toString();
-            markDeprecated( builder, alt );
+            responseHelper.markDeprecated( builder, alt );
         };
 
         return handler.doGet( packageType, type, name, path, baseUri, request, new EventMetadata(), deprecated );
@@ -186,7 +189,7 @@ public class DeprecatedContentAccessResource
 
         final Consumer<Response.ResponseBuilder> deprecated = builder -> {
             String alt = Paths.get( "/api/maven", type, name ).toString();
-            markDeprecated( builder, alt );
+            responseHelper.markDeprecated( builder, alt );
         };
 
         return handler.doGet( packageType, type, name, "", baseUri, request, new EventMetadata(), deprecated );

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/NfcResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/NfcResource.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.NfcController;
 import org.commonjava.indy.core.model.Page;
 import org.commonjava.indy.model.core.StoreKey;
@@ -46,9 +47,6 @@ import javax.ws.rs.core.Response;
 import java.nio.file.Paths;
 
 import static org.apache.commons.lang.StringUtils.isBlank;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.markDeprecated;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
 
 @Api( description = "REST resource that manages the not-found cache", value = "Not-Found Cache" )
@@ -63,6 +61,9 @@ public class NfcResource
 
     @Inject
     private ObjectMapper serializer;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -105,11 +106,11 @@ public class NfcResource
                 controller.clear( key, p );
             }
 
-            response = markDeprecated( Response.ok(), altPath ).build();
+            response = responseHelper.markDeprecated( Response.ok(), altPath ).build();
         }
         catch ( final IndyWorkflowException e )
         {
-            response = formatResponse( e, ( rb ) -> markDeprecated( rb, altPath ) );
+            response = responseHelper.formatResponse( e, ( rb ) -> responseHelper.markDeprecated( rb, altPath ) );
         }
 
         return response;
@@ -148,7 +149,7 @@ public class NfcResource
         }
         catch ( final IndyWorkflowException e )
         {
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;
@@ -175,7 +176,7 @@ public class NfcResource
         else {
             dto = controller.getAllMissing();
         }
-        return formatOkResponseWithJsonEntity( dto, serializer );
+        return responseHelper.formatOkResponseWithJsonEntity( dto );
     }
 
     @GET
@@ -187,7 +188,7 @@ public class NfcResource
     public Response getInfo( )
     {
         NotFoundCacheInfoDTO dto = controller.getInfo();
-        return formatOkResponseWithJsonEntity( dto, serializer );
+        return responseHelper.formatOkResponseWithJsonEntity( dto );
     }
 
     @Path( "/{type: (hosted|group|remote)}/{name}" )
@@ -225,11 +226,12 @@ public class NfcResource
             {
                 dto = controller.getMissing( key );
             }
-            response = formatOkResponseWithJsonEntity( dto, serializer, rb->markDeprecated( rb, altPath ) );
+            response = responseHelper.formatOkResponseWithJsonEntity( dto,
+                                                                      rb->responseHelper.markDeprecated( rb, altPath ) );
         }
         catch ( final IndyWorkflowException e )
         {
-            response = formatResponse( e, ( rb ) -> markDeprecated( rb, altPath ) );
+            response = responseHelper.formatResponse( e, ( rb ) -> responseHelper.markDeprecated( rb, altPath ) );
         }
 
         return response;
@@ -255,11 +257,11 @@ public class NfcResource
         try
         {
             NotFoundCacheInfoDTO dto = controller.getInfo( key );
-            response = formatOkResponseWithJsonEntity( dto, serializer );
+            response = responseHelper.formatOkResponseWithJsonEntity( dto );
         }
         catch ( final IndyWorkflowException e )
         {
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }
@@ -299,11 +301,11 @@ public class NfcResource
             {
                 dto = controller.getMissing( key );
             }
-            response = formatOkResponseWithJsonEntity( dto, serializer );
+            response = responseHelper.formatOkResponseWithJsonEntity( dto );
         }
         catch ( final IndyWorkflowException e )
         {
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/RootResource.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/RootResource.java
@@ -15,11 +15,10 @@
  */
 package org.commonjava.indy.core.bind.jaxrs;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatRedirect;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-
 import java.net.URISyntaxException;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
@@ -28,12 +27,17 @@ import javax.ws.rs.core.UriInfo;
 
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 
 //@Path( "/" )
 @REST
+@ApplicationScoped
 public class RootResource
     implements IndyResources
 {
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @GET
     public Response rootStats( @Context final UriInfo uriInfo )
@@ -41,13 +45,13 @@ public class RootResource
         Response response;
         try
         {
-            response = formatRedirect( uriInfo.getBaseUriBuilder()
+            response = responseHelper.formatRedirect( uriInfo.getBaseUriBuilder()
                                               .path( "stats/version-info" )
                                               .build() );
         }
-        catch ( UriBuilderException | URISyntaxException e )
+        catch ( UriBuilderException e )
         {
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/DeprecatedStoreAdminHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/DeprecatedStoreAdminHandler.java
@@ -27,6 +27,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.AdminController;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
@@ -68,10 +69,6 @@ import static javax.ws.rs.core.Response.notModified;
 import static javax.ws.rs.core.Response.ok;
 import static javax.ws.rs.core.Response.status;
 import static org.apache.commons.lang.StringUtils.isEmpty;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatCreatedResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.markDeprecated;
 import static org.commonjava.indy.model.core.ArtifactStore.METADATA_CHANGELOG;
 import static org.commonjava.indy.util.ApplicationContent.application_json;
 
@@ -93,6 +90,9 @@ public class DeprecatedStoreAdminHandler
 
     @Inject
     private SecurityManager securityManager;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     public DeprecatedStoreAdminHandler()
     {
@@ -124,13 +124,13 @@ public class DeprecatedStoreAdminHandler
         {
 
             logger.info( "returning OK" );
-            response = markDeprecated( Response.ok(), altPath )
+            response = responseHelper.markDeprecated( Response.ok(), altPath )
                                .build();
         }
         else
         {
             logger.info( "Returning NOT FOUND" );
-            response = markDeprecated( Response.status( Status.NOT_FOUND ), altPath )
+            response = responseHelper.markDeprecated( Response.status( Status.NOT_FOUND ), altPath )
                                .build();
         }
         return response;
@@ -149,7 +149,7 @@ public class DeprecatedStoreAdminHandler
                             final @Context SecurityContext securityContext )
     {
         String altPath = Paths.get(MavenPackageTypeDescriptor.MAVEN_ADMIN_REST_BASE_PATH, type).toString();
-        Consumer<Response.ResponseBuilder> modifier = ( rb)->markDeprecated( rb, altPath);
+        Consumer<Response.ResponseBuilder> modifier = ( rb)->responseHelper.markDeprecated( rb, altPath);
 
         final StoreType st = StoreType.get( type );
 
@@ -166,7 +166,7 @@ public class DeprecatedStoreAdminHandler
                                                          .getSimpleName() + " from request body.";
 
             logger.error( message, e );
-            response = formatResponse( e, message, modifier );
+            response = responseHelper.formatResponse( e, message, modifier );
         }
 
         if ( response != null )
@@ -185,7 +185,7 @@ public class DeprecatedStoreAdminHandler
                                                          .getSimpleName() + " from request body.";
 
             logger.error( message, e );
-            response = formatResponse( e, message, modifier );
+            response = responseHelper.formatResponse( e, message, modifier );
         }
 
         if ( response != null )
@@ -206,11 +206,11 @@ public class DeprecatedStoreAdminHandler
                                        .path( store.getName() )
                                        .build( store.getKey().getType().singularEndpointName() );
 
-                response = formatCreatedResponseWithJsonEntity( uri, store, objectMapper, modifier );
+                response = responseHelper.formatCreatedResponseWithJsonEntity( uri, store, modifier );
             }
             else
             {
-                response = markDeprecated( status( CONFLICT )
+                response = responseHelper.markDeprecated( status( CONFLICT )
                                    .entity( "{\"error\": \"Store already exists.\"}" )
                                    .type( application_json ), altPath )
                                    .build();
@@ -219,7 +219,7 @@ public class DeprecatedStoreAdminHandler
         catch ( final IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e, modifier );
+            response = responseHelper.formatResponse( e, modifier );
         }
         return response;
     }
@@ -241,7 +241,7 @@ public class DeprecatedStoreAdminHandler
                            final @Context SecurityContext securityContext )
     {
         String altPath = Paths.get(MavenPackageTypeDescriptor.MAVEN_ADMIN_REST_BASE_PATH, type, name).toString();
-        Consumer<Response.ResponseBuilder> modifier = ( rb)->markDeprecated( rb, altPath);
+        Consumer<Response.ResponseBuilder> modifier = ( rb)->responseHelper.markDeprecated( rb, altPath);
 
         final StoreType st = StoreType.get( type );
 
@@ -258,7 +258,7 @@ public class DeprecatedStoreAdminHandler
                                                          .getSimpleName() + " from request body.";
 
             logger.error( message, e );
-            response = formatResponse( e, message, modifier );
+            response = responseHelper.formatResponse( e, message, modifier );
         }
 
         if ( response != null )
@@ -277,7 +277,7 @@ public class DeprecatedStoreAdminHandler
                                                           .getSimpleName() + " from request body.";
 
             logger.error( message, e );
-            response = formatResponse( e, message, modifier );
+            response = responseHelper.formatResponse( e, message, modifier );
         }
 
         if ( response != null )
@@ -288,7 +288,7 @@ public class DeprecatedStoreAdminHandler
         if ( !name.equals( store.getName() ) )
         {
             response =
-                markDeprecated( Response.status( Status.BAD_REQUEST )
+                    responseHelper.markDeprecated( Response.status( Status.BAD_REQUEST )
                         .entity( String.format( "Store in URL path is: '%s' but in JSON it is: '%s'", name,
                                                 store.getName() ) ), altPath )
                         .build();
@@ -301,18 +301,18 @@ public class DeprecatedStoreAdminHandler
             logger.info( "Storing: {}", store );
             if ( adminController.store( store, user, false ) )
             {
-                response = markDeprecated( ok(), altPath ).build();
+                response = responseHelper.markDeprecated( ok(), altPath ).build();
             }
             else
             {
                 logger.warn( "{} NOT modified!", store );
-                response = markDeprecated( notModified(), altPath ).build();
+                response = responseHelper.markDeprecated( notModified(), altPath ).build();
             }
         }
         catch ( final IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e, modifier );
+            response = responseHelper.formatResponse( e, modifier );
         }
 
         return response;
@@ -325,7 +325,7 @@ public class DeprecatedStoreAdminHandler
     public Response getAll( final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" ) String type )
     {
         String altPath = Paths.get(MavenPackageTypeDescriptor.MAVEN_ADMIN_REST_BASE_PATH, type).toString();
-        Consumer<Response.ResponseBuilder> modifier = ( rb)->markDeprecated( rb, altPath);
+        Consumer<Response.ResponseBuilder> modifier = ( rb)->responseHelper.markDeprecated( rb, altPath);
 
         final StoreType st = StoreType.get( type );
 
@@ -338,12 +338,12 @@ public class DeprecatedStoreAdminHandler
 
             final StoreListingDTO<ArtifactStore> dto = new StoreListingDTO<>( stores );
 
-            response = formatOkResponseWithJsonEntity( dto, objectMapper, modifier );
+            response = responseHelper.formatOkResponseWithJsonEntity( dto, modifier );
         }
         catch ( final IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e, modifier );
+            response = responseHelper.formatResponse( e, modifier );
         }
 
         return response;
@@ -359,7 +359,7 @@ public class DeprecatedStoreAdminHandler
                          final @ApiParam( required = true ) @PathParam( "name" ) String name )
     {
         String altPath = Paths.get(MavenPackageTypeDescriptor.MAVEN_ADMIN_REST_BASE_PATH, type, name).toString();
-        Consumer<Response.ResponseBuilder> modifier = ( rb)->markDeprecated( rb, altPath);
+        Consumer<Response.ResponseBuilder> modifier = ( rb)->responseHelper.markDeprecated( rb, altPath);
 
         final StoreType st = StoreType.get( type );
         final StoreKey key = new StoreKey( st, name );
@@ -372,18 +372,18 @@ public class DeprecatedStoreAdminHandler
 
             if ( store == null )
             {
-                response = markDeprecated( Response.status( Status.NOT_FOUND ), altPath )
+                response = responseHelper.markDeprecated( Response.status( Status.NOT_FOUND ), altPath )
                                    .build();
             }
             else
             {
-                response = formatOkResponseWithJsonEntity( store, objectMapper, modifier );
+                response = responseHelper.formatOkResponseWithJsonEntity( store, modifier );
             }
         }
         catch ( final IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e, modifier );
+            response = responseHelper.formatResponse( e, modifier );
         }
         return response;
     }
@@ -398,7 +398,7 @@ public class DeprecatedStoreAdminHandler
                             final @Context SecurityContext securityContext )
     {
         String altPath = Paths.get(MavenPackageTypeDescriptor.MAVEN_ADMIN_REST_BASE_PATH, type, name).toString();
-        Consumer<Response.ResponseBuilder> modifier = ( rb)->markDeprecated( rb, altPath);
+        Consumer<Response.ResponseBuilder> modifier = ( rb)->responseHelper.markDeprecated( rb, altPath);
 
         final StoreType st = StoreType.get( type );
         final StoreKey key = new StoreKey( st, name );
@@ -432,12 +432,12 @@ public class DeprecatedStoreAdminHandler
 
             adminController.delete( key, user, summary );
 
-            response = markDeprecated( noContent(), altPath ).build();
+            response = responseHelper.markDeprecated( noContent(), altPath ).build();
         }
         catch ( final IndyWorkflowException e )
         {
             logger.error( e.getMessage(), e );
-            response = formatResponse( e, modifier );
+            response = responseHelper.formatResponse( e, modifier );
         }
         return response;
     }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
@@ -15,14 +15,11 @@
  */
 package org.commonjava.indy.core.bind.jaxrs.admin;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.markDeprecated;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
 
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Response;
@@ -31,10 +28,10 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.core.ctl.IspnCacheController;
 import org.commonjava.indy.model.core.StoreKey;
@@ -56,6 +53,9 @@ public class MaintenanceHandler
     @Inject
     private ContentController contentController;
 
+    @Inject
+    private ResponseHelper responseHelper;
+
     @ApiOperation( "[Deprecated] Rescan all content in the specified repository to re-initialize metadata, capture missing index keys, etc." )
     @ApiResponse( code = 200, message = "Rescan was started successfully. (NOTE: There currently is no way to determine when rescanning is complete.)" )
     @Path( "/rescan/{type: (hosted|group|remote)}/{name}" )
@@ -73,13 +73,13 @@ public class MaintenanceHandler
         try
         {
             contentController.rescan( key );
-            response = markDeprecated( Response.ok(), altPath )
+            response = responseHelper.markDeprecated( Response.ok(), altPath )
                                .build();
         }
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to rescan: %s. Reason: %s", key, e.getMessage() ), e );
-            response = formatResponse( e, rb->markDeprecated( rb, altPath ) );
+            response = responseHelper.formatResponse( e, rb->responseHelper.markDeprecated( rb, altPath ) );
         }
         return response;
     }
@@ -108,7 +108,7 @@ public class MaintenanceHandler
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to rescan: %s. Reason: %s", key, e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }
@@ -129,7 +129,7 @@ public class MaintenanceHandler
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to rescan: ALL. Reason: %s", e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }
@@ -150,7 +150,7 @@ public class MaintenanceHandler
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to delete: %s in: ALL. Reason: %s", e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }
@@ -171,7 +171,7 @@ public class MaintenanceHandler
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to delete: %s in: ALL. Reason: %s", e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }
@@ -195,7 +195,7 @@ public class MaintenanceHandler
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to clean: %s. Reason: %s", name, e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/ReplicationHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/ReplicationHandler.java
@@ -15,9 +15,6 @@
  */
 package org.commonjava.indy.core.bind.jaxrs.admin;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -40,6 +37,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.SecurityManager;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.ReplicationController;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.dto.ReplicationDTO;
@@ -68,6 +66,9 @@ public class ReplicationHandler
     @Inject
     private SecurityManager securityManager;
 
+    @Inject
+    private ResponseHelper responseHelper;
+
     @ApiOperation( "Replicate the stores of a remote Indy" )
     @ApiImplicitParams( { @ApiImplicitParam( paramType = "body", name = "body",
                                              dataType = "org.commonjava.indy.model.core.dto.ReplicationDTO",
@@ -90,12 +91,12 @@ public class ReplicationHandler
             params.put( "replicationCount", replicated.size() );
             params.put( "items", replicated );
 
-            response = formatOkResponseWithJsonEntity( params, serializer );
+            response = responseHelper.formatOkResponseWithJsonEntity( params );
         }
         catch ( final IndyWorkflowException | IOException e )
         {
             logger.error( String.format( "Replication failed: %s", e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/SchedulerHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/SchedulerHandler.java
@@ -24,7 +24,7 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
-import org.commonjava.indy.bind.jaxrs.util.ResponseUtils;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.SchedulerController;
 import org.commonjava.indy.core.expire.Expiration;
 import org.commonjava.indy.core.expire.ExpirationSet;
@@ -42,9 +42,6 @@ import javax.ws.rs.core.Response;
 
 import java.nio.file.Paths;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.markDeprecated;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.throwError;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
 
 @Api( value = "Schedules and Expirations",
@@ -60,6 +57,9 @@ public class SchedulerHandler
 
     @Inject
     private ObjectMapper objectMapper;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @ApiOperation( "[Deprecated] Retrieve the expiration information related to re-enablement of a repository" )
     @ApiResponses( { @ApiResponse( code = 200, message = "Expiration information retrieved successfully.", response = Expiration.class ),
@@ -83,11 +83,12 @@ public class SchedulerHandler
                 throw new WebApplicationException( Response.Status.NOT_FOUND );
             }
 
-            return formatOkResponseWithJsonEntity( timeout, objectMapper, rb -> markDeprecated( rb, altPath ) );
+            return responseHelper.formatOkResponseWithJsonEntity( timeout,
+                                                                  rb -> responseHelper.markDeprecated( rb, altPath ) );
         }
         catch ( IndyWorkflowException e )
         {
-            throwError( e, rb->markDeprecated( rb, altPath ) );
+            responseHelper.throwError( e, rb->responseHelper.markDeprecated( rb, altPath ) );
         }
 
         return null;
@@ -113,7 +114,7 @@ public class SchedulerHandler
         }
         catch ( IndyWorkflowException e )
         {
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         if ( timeout == null )
@@ -136,7 +137,7 @@ public class SchedulerHandler
         }
         catch ( IndyWorkflowException e )
         {
-            throwError( e );
+            responseHelper.throwError( e );
         }
 
         throw new WebApplicationException( "Impossible Error", 500 );

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/stats/StatsHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/stats/StatsHandler.java
@@ -15,12 +15,6 @@
  */
 package org.commonjava.indy.core.bind.jaxrs.stats;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
-
-import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.TreeSet;
@@ -40,6 +34,7 @@ import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.StatsController;
 import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.dto.EndpointViewListing;
@@ -70,6 +65,9 @@ public class StatsHandler
     @Inject
     private ObjectMapper objectMapper;
 
+    @Inject
+    private ResponseHelper responseHelper;
+
     @ApiOperation( "Retrieve JSON describing the add-ons that are available on the system" )
     @ApiResponse( code = 200, response = AddOnListing.class, message = "The description object" )
     @Path( "/addons/active" )
@@ -77,7 +75,7 @@ public class StatsHandler
     @Produces( ApplicationContent.application_json )
     public Response getAddonList()
     {
-        return formatOkResponseWithJsonEntity( statsController.getActiveAddOns(), objectMapper );
+        return responseHelper.formatOkResponseWithJsonEntity( statsController.getActiveAddOns() );
     }
 
     @ApiOperation( "Aggregate javascript content for all add-ons and format as a single Javascript stream (this gives the UI a static URL to load add-on logic)" )
@@ -91,13 +89,13 @@ public class StatsHandler
         try
         {
             response =
-                formatOkResponseWithEntity( statsController.getActiveAddOnsJavascript(),
+                    responseHelper.formatOkResponseWithEntity( statsController.getActiveAddOnsJavascript(),
                                             ApplicationContent.application_json );
         }
         catch ( final IndyWorkflowException e )
         {
-            logger.error( String.format( "Failed to format active-addons javascript: %s", formatEntity( e ) ), e );
-            response = formatResponse( e );
+            logger.error( String.format( "Failed to format active-addons javascript: %s", responseHelper.formatEntity( e ) ), e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }
@@ -109,7 +107,7 @@ public class StatsHandler
     @Produces( ApplicationContent.application_json )
     public Response getIndyVersion()
     {
-        return formatOkResponseWithJsonEntity( statsController.getVersionInfo(), objectMapper );
+        return responseHelper.formatOkResponseWithJsonEntity( statsController.getVersionInfo() );
     }
 
     @ApiOperation( "Retrieve a mapping of the package type names to descriptors (eg. maven, npm, generic-http, etc) available on the system." )
@@ -148,14 +146,14 @@ public class StatsHandler
                                           .toString();
 
             final EndpointViewListing listing = statsController.getEndpointsListing( baseUri, uriFormatter );
-            response = formatOkResponseWithJsonEntity( listing, objectMapper );
+            response = responseHelper.formatOkResponseWithJsonEntity( listing );
 
             logger.info( "\n\n\n\n\n\n{} Sent all-endpoints:\n\n{}\n\n\n\n\n\n\n", new Date(), listing );
         }
         catch ( final IndyWorkflowException e )
         {
-            logger.error( String.format( "Failed to retrieve endpoint listing: %s", formatEntity( e ) ), e );
-            response = formatResponse( e );
+            logger.error( String.format( "Failed to retrieve endpoint listing: %s", responseHelper.formatEntity( e ) ), e );
+            response = responseHelper.formatResponse( e );
         }
         return response;
     }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/jaxrs/VersioningTestHandler.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/jaxrs/VersioningTestHandler.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.ftest.core.jaxrs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.util.ApplicationContent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,8 +27,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
-
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
 
 @Path( "/api/test" )
 public class VersioningTestHandler
@@ -39,6 +38,9 @@ public class VersioningTestHandler
     @Inject
     private ObjectMapper objectMapper;
 
+    @Inject
+    private ResponseHelper responseHelper;
+
     /**
      * Assuming we want to upgrade this to a new version, we will deprecate old impl by moving old code to somewhere
      * like VersioningTestHandlerDeprecated and keep working on the new impl here.
@@ -49,7 +51,7 @@ public class VersioningTestHandler
     public Response getTestInfo()
     {
         logger.debug( "Accessing getTestInfo..." );
-        return formatOkResponseWithJsonEntity( new TestInfo( "001", "This is a test." ), objectMapper );
+        return responseHelper.formatOkResponseWithJsonEntity( new TestInfo( "001", "This is a test." ) );
     }
 
     @Path( "/another" )
@@ -57,7 +59,7 @@ public class VersioningTestHandler
     @Produces( ApplicationContent.application_json )
     public Response getAnotherInfo()
     {
-        return formatOkResponseWithJsonEntity( new AnotherInfo( "This is another info." ), objectMapper );
+        return responseHelper.formatOkResponseWithJsonEntity( new AnotherInfo( "This is another info." ) );
     }
 
     /** this class changed in new version */

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/jaxrs/VersioningTestHandlerDeprecated.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/jaxrs/VersioningTestHandlerDeprecated.java
@@ -15,8 +15,8 @@
  */
 package org.commonjava.indy.ftest.core.jaxrs;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,8 +26,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatOkResponseWithJsonEntity;
-
 @Path( "/api/test" )
 public class VersioningTestHandlerDeprecated
                 implements IndyResources
@@ -36,7 +34,7 @@ public class VersioningTestHandlerDeprecated
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     @Inject
-    private ObjectMapper objectMapper;
+    private ResponseHelper responseHelper;
 
     @Path( "/info" )
     @GET
@@ -44,7 +42,7 @@ public class VersioningTestHandlerDeprecated
     public Response getTestInfo()
     {
         logger.debug( "Accessing deprecated getTestInfo..." );
-        return formatOkResponseWithJsonEntity( new TestInfo( "This is a test." ), objectMapper );
+        return responseHelper.formatOkResponseWithJsonEntity( new TestInfo( "This is a test." ) );
     }
 
     static class TestInfo

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/SecurityResource.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/SecurityResource.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.subsys.keycloak.rest.SecurityController;
 import org.commonjava.indy.util.ApplicationHeader;
 import org.slf4j.Logger;
@@ -35,8 +36,6 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.net.URI;
 import java.net.URISyntaxException;
-
-import static org.commonjava.indy.bind.jaxrs.util.ResponseUtils.formatResponse;
 
 @Api( "Security Infrastructure" )
 @Path( "/api/security" )
@@ -53,6 +52,9 @@ public class SecurityResource
 
     @Inject
     private SecurityController controller;
+
+    @Inject
+    private ResponseHelper responseHelper;
 
     @ApiOperation( "Retrieve the keycloak JSON configuration (for use by the UI)" )
     @ApiResponses( { @ApiResponse( code = 400, message = "Keycloak is disabled" ),
@@ -82,7 +84,7 @@ public class SecurityResource
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to load client-side keycloak.json. Reason: %s", e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;
@@ -106,7 +108,7 @@ public class SecurityResource
         catch ( final IndyWorkflowException e )
         {
             logger.error( String.format( "Failed to load keycloak-init.js. Reason: %s", e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;
@@ -140,7 +142,7 @@ public class SecurityResource
         catch ( final IndyWorkflowException | URISyntaxException e )
         {
             logger.error( String.format( "Failed to load keycloak.js. Reason: %s", e.getMessage() ), e );
-            response = formatResponse( e );
+            response = responseHelper.formatResponse( e );
         }
 
         return response;

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/DTOStreamingOutput.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/DTOStreamingOutput.java
@@ -1,0 +1,82 @@
+package org.commonjava.indy.bind.jaxrs.util;
+
+import com.codahale.metrics.Meter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.output.CountingOutputStream;
+import org.commonjava.indy.measure.annotation.Measure;
+import org.commonjava.indy.measure.annotation.MetricNamed;
+import org.commonjava.indy.metrics.IndyMetricsManager;
+import org.commonjava.indy.metrics.conf.IndyMetricsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.StreamingOutput;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.commonjava.indy.measure.annotation.MetricNamed.DEFAULT;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.METER;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.getDefaultName;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.getName;
+
+public class DTOStreamingOutput
+        implements StreamingOutput
+{
+    private static final String TRANSFER_METRIC_NAME = "indy.dto";
+
+    private final ObjectMapper mapper;
+
+    private final Object dto;
+
+    private final IndyMetricsManager metricsManager;
+
+    private final IndyMetricsConfig metricsConfig;
+
+    public DTOStreamingOutput( final ObjectMapper mapper, final Object dto, final IndyMetricsManager metricsManager,
+                               final IndyMetricsConfig metricsConfig )
+    {
+        this.mapper = mapper;
+        this.dto = dto;
+        this.metricsManager = metricsManager;
+        this.metricsConfig = metricsConfig;
+    }
+
+    @Override
+    public void write( final OutputStream outputStream )
+            throws IOException, WebApplicationException
+    {
+        AtomicReference<IOException> ioe = new AtomicReference<>();
+        metricsManager.wrapWithStandardMetrics( () -> {
+            CountingOutputStream cout = new CountingOutputStream( outputStream );
+            try
+            {
+                mapper.writeValue( cout, dto );
+            }
+            catch ( IOException e )
+            {
+                ioe.set( e );
+            }
+            finally
+            {
+                Logger logger = LoggerFactory.getLogger( getClass() );
+                logger.trace( "Wrote: {} bytes", cout.getByteCount() );
+
+                String name = getName( metricsConfig.getNodePrefix(), TRANSFER_METRIC_NAME,
+                                       getDefaultName( dto.getClass().getSimpleName(), "write" ), METER );
+
+                Meter meter = metricsManager.getMeter( name );
+                meter.mark( cout.getByteCount() );
+            }
+
+            return null;
+
+        }, () -> null );
+
+        if ( ioe.get() != null )
+        {
+            throw ioe.get();
+        }
+    }
+}


### PR DESCRIPTION
This uses a form of StreamingOutput as a response entity in order to avoid measuring rendering / transfer times for DTOs in with latency, since these are not logical functions.

In the process, I've added logic to wrap DTO rendering / streaming with metrics for this process as well, in case we need it for diagnosis. This required switching ResponseUtils to a helper class, ResponseHelper, which is CDI injected into REST resources.