### PR TITLE
Downgrade one logger for remote repo url parsing to WARN level

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -206,7 +206,7 @@ public class RemoteRepository
         }
         catch ( final MalformedURLException e )
         {
-            LOGGER.error( String.format( "Failed to parse repository URL: '%s'. Reason: %s", this.url, e.getMessage() ) );
+            LOGGER.warn( String.format( "Failed to parse repository URL: '%s'. Reason: %s", this.url, e.getMessage() ) );
         }
 
         if ( url == null )


### PR DESCRIPTION
Seems it is not a very critical problem which will break indy, so downgrade it for easy filter in Kibana