### PR TITLE
Add NATIVE AccessChannel, remove NPM, deprecate MAVEN

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloAdminController.java
@@ -456,7 +456,7 @@ public class FoloAdminController
         contentDigester.removeMetadata( transfer );
 
         TransferMetadata artifactData =
-                contentDigester.digest( affectedStore, path, new EventMetadata( channel.packageType() ) );
+                contentDigester.digest( affectedStore, path, new EventMetadata( affectedStore.getPackageType() ) );
 
         Map<ContentDigest, String> digests = artifactData.getDigests();
         return new TrackedContentEntry( entry.getTrackingKey(), affectedStore, channel, entry.getOriginUrl(), path,

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloMavenContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloMavenContentAccessResource.java
@@ -95,7 +95,7 @@ public class FoloMavenContentAccessResource
         final TrackingKey tk = new TrackingKey( id );
 
         EventMetadata metadata =
-                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO ).set(
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE ).set(
                         STORE_HTTP_HEADERS, RequestUtils.extractRequestHeadersToMap( request ) );
 
         Class cls = FoloMavenContentAccessResource.class;
@@ -122,7 +122,7 @@ public class FoloMavenContentAccessResource
         final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
 
         EventMetadata metadata =
-                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO );
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
         MDC.put( CONTENT_TRACKING_ID, id );
 
@@ -145,7 +145,7 @@ public class FoloMavenContentAccessResource
         final String baseUri = uriInfo.getBaseUriBuilder().path( BASE_PATH ).path( id ).build().toString();
 
         EventMetadata metadata =
-                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.MAVEN_REPO );
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
         MDC.put( CONTENT_TRACKING_ID, id );
 

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
@@ -96,7 +96,7 @@ public class FoloNPMContentAccessResource
         final TrackingKey tk = new TrackingKey( id );
 
         EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
-                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO )
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NATIVE )
                                                     .set( STORE_HTTP_HEADERS,
                                                           RequestUtils.extractRequestHeadersToMap( request ) );
 
@@ -124,7 +124,7 @@ public class FoloNPMContentAccessResource
     {
         final TrackingKey tk = new TrackingKey( id );
         EventMetadata metadata =
-                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
         final String path = Paths.get( packageName, versionTarball ).toString();
         Class cls = FoloNPMContentAccessResource.class;
         return handler.doCreate( NPM_PKG_KEY, type, name, path, request, metadata, () -> uriInfo.getBaseUriBuilder()
@@ -152,7 +152,7 @@ public class FoloNPMContentAccessResource
         final String baseUri = getBasePath( uriInfo, id );
 
         EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
-                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
         MDC.put( CONTENT_TRACKING_ID, id );
 
@@ -175,7 +175,7 @@ public class FoloNPMContentAccessResource
         final TrackingKey tk = new TrackingKey( id );
 
         EventMetadata metadata =
-                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
         MDC.put( CONTENT_TRACKING_ID, id );
 
@@ -202,7 +202,7 @@ public class FoloNPMContentAccessResource
         final String baseUri = getBasePath( uriInfo, id );
 
         EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
-                                                    .set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
+                                                    .set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
         MDC.put( CONTENT_TRACKING_ID, id );
 
@@ -225,7 +225,7 @@ public class FoloNPMContentAccessResource
     {
         final TrackingKey tk = new TrackingKey( id );
         EventMetadata metadata =
-                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NPM_REPO );
+                new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
         MDC.put( CONTENT_TRACKING_ID, id );
 
         final String path = Paths.get( packageName, versionTarball ).toString();

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/dto/TrackedContentEntryDTO.java
@@ -55,7 +55,7 @@ public class TrackedContentEntryDTO
     public TrackedContentEntryDTO( final StoreKey storeKey, final AccessChannel accessChannel, final String path )
     {
         this.storeKey = storeKey;
-        this.accessChannel = accessChannel;
+        setAccessChannel( accessChannel );
         this.path = path.startsWith( "/" ) ? path : "/" + path;
     }
 
@@ -125,7 +125,7 @@ public class TrackedContentEntryDTO
 
     public void setAccessChannel( final AccessChannel accessChannel )
     {
-        this.accessChannel = accessChannel;
+        this.accessChannel = accessChannel == AccessChannel.MAVEN_REPO ? AccessChannel.NATIVE : accessChannel;
     }
 
     public String getPath()
@@ -220,10 +220,14 @@ public class TrackedContentEntryDTO
                 return false;
             }
         }
-        else if ( !accessChannel.equals( other.accessChannel ) )
+        // this is complicated by the transition from using MAVEN_REPO to NATIVE for non-proxy access channels.
+        else if ( !accessChannel.equals( other.accessChannel ) && !( accessChannel == AccessChannel.NATIVE
+                && other.accessChannel == AccessChannel.MAVEN_REPO ) && !( accessChannel == AccessChannel.MAVEN_REPO
+                && other.accessChannel == AccessChannel.NATIVE ) )
         {
             return false;
         }
+
         return true;
     }
 

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyAcceptHandler.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyAcceptHandler.java
@@ -46,6 +46,7 @@ import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REQUEST_PHASE;
 import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.REQUEST_PHASE_START;
 import static org.commonjava.indy.bind.jaxrs.RequestContextHelper.setContext;
 import static org.commonjava.indy.httprox.util.HttpProxyConstants.PROXY_METRIC_LOGGER;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_GENERIC_HTTP;
 
 /**
  * Created by jdcasey on 8/13/15.
@@ -135,7 +136,7 @@ public class ProxyAcceptHandler
     {
         long start = System.nanoTime();
         MDC.put( RequestContextHelper.ACCESS_CHANNEL, AccessChannel.GENERIC_PROXY.toString() );
-        setContext( PACKAGE_TYPE, AccessChannel.GENERIC_PROXY.packageType() );
+        setContext( PACKAGE_TYPE, PKG_TYPE_GENERIC_HTTP );
 
         final Logger logger = LoggerFactory.getLogger( getClass() );
 

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AccessChannel.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AccessChannel.java
@@ -27,22 +27,14 @@ public enum AccessChannel
 {
 
     /** Used when the store is accessed via httprox addon. */
-    GENERIC_PROXY(PKG_TYPE_GENERIC_HTTP),
-    /** Used when the store is accessed via regular Maven repo. */
-    MAVEN_REPO(PKG_TYPE_MAVEN),
-    /** Used when the store is accessed via npm.*/
-    NPM_REPO( PKG_TYPE_NPM );
+    GENERIC_PROXY,
 
-    private final String packageType;
+    /** Used to signify content coming from normal repositories and groups. */
+    NATIVE,
 
-    AccessChannel(String packageType)
-    {
-        this.packageType = packageType;
-    }
-
-    public String packageType()
-    {
-        return packageType;
-    }
+    /** Used when the store is accessed via regular Maven repo.
+     *  NOTE: This has been changed to {@link #NATIVE} in our tracking code. It is included for historical purposes. */
+    @Deprecated
+    MAVEN_REPO;
 
 }


### PR DESCRIPTION
This switches usages of the new AccessChannel.NPM_REPO to use AccessChannel.NATIVE (to distinguish generic proxy use from 'native' REST interface use. It deprecates the old MAVEN_REPO value, and
switches the Maven tracking implementation to use NATIVE too...but it leaves MAVEN_REPO in place for historical reasons.

Automatically convert MAVEN_REPO AccessChannel to NATIVE in tracking report entry DTOs