### PR TITLE
Fix: Metadata refreshing after promotion for readonly hosted target

### DIFF
--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/HostedMetadataRemergedOnPathPromoteToReadonlyHostedTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/HostedMetadataRemergedOnPathPromoteToReadonlyHostedTest.java
@@ -19,7 +19,6 @@ import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.IndyClientModule;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.ftest.core.category.EventDependent;
-import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.promote.client.IndyPromoteClientModule;
 import org.commonjava.indy.promote.model.PathsPromoteRequest;
@@ -37,12 +36,13 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /**
- * Check that metadata in a hosted repo is merged with content from a new hosted repository when it is promoted by path.
+ * Check that metadata in a hosted repo is merged with content from a new readonly hosted repository when it is promoted by path.
  * <br/>
  * GIVEN:
  * <ul>
  *     <li>HostedRepository A contains path for GA + V1</li>
  *     <li>HostedRepository B contains path for GA + V2</li>
+ *     <li>HostedRepository A is readonly</li>
  * </ul>
  * <br/>
  * WHEN:
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertThat;
  *     <li>HostedRepository A's metadata path P should reflect values in both V1 and V2</li>
  * </ul>
  */
-public class HostedMetadataRemergedOnPathPromoteWithOnlyArtifactTest
+public class HostedMetadataRemergedOnPathPromoteToReadonlyHostedTest
         extends AbstractContentManagementTest
 {
     private static final String HOSTED_A_NAME= "A";
@@ -160,6 +160,10 @@ public class HostedMetadataRemergedOnPathPromoteWithOnlyArtifactTest
         client.content()
               .store( b.getKey(), bPomPath, new ByteArrayInputStream(
                               bPomContent.getBytes() ) );
+
+        a.setReadonly( true );
+        client.stores().update( a, message );
+
     }
 
     @Test

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -970,7 +970,14 @@ public class DefaultDownloadManager
 
         if ( store.getKey().getType() == StoreType.group )
         {
-            return false;
+            // We should allow deletion of the group level mergeable metadata here, for supporting
+            // the cascading deletion from hosted member pom file deletion. See MetadataMergePomChangeListener.metaClear
+            // for details
+            final SpecialPathInfo pathInfo = specialPathManager.getSpecialPathInfo( path );
+            if ( pathInfo == null || !pathInfo.isMetadata() || !pathInfo.isMergable() )
+            {
+                return false;
+            }
         }
 
         if ( storeManager.isReadonly( store ) && !isIgnoreReadonly( eventMetadata ) )

--- a/embedder/src/it/resources/logback.xml
+++ b/embedder/src/it/resources/logback.xml
@@ -36,6 +36,7 @@
   <logger name="org.commonjava" level="TRACE" />
   <logger name="org.commonjava.indy.model.core.StoreKey" level="INFO" />
   <logger name="org.commonjava.indy.pkg.npm.content.NPMStoragePathCalculator" level="INFO" />
+  <logger name="org.commonjava.indy.metrics" level="INFO" />
   <!-- <logger name="org.commonjava.maven.galley.transport" level="DEBUG" /> -->
 
   <root level="INFO">

--- a/embedder/src/test/resources/logback-test.xml
+++ b/embedder/src/test/resources/logback-test.xml
@@ -46,6 +46,7 @@
   <logger name="org.commonjava.maven.galley" level="TRACE"/>
   <logger name="org.commonjava.indy.model.core.StoreKey" level="INFO" />
   <logger name="org.commonjava.indy.pkg.npm.content.NPMStoragePathCalculator" level="INFO" />
+  <logger name="org.commonjava.indy.metrics" level="INFO" />
 
   <root level="INFO">
     <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Found that the metadata not update issue happened on a readonly hosted target. It is caused by not set IGNORE_READONLY for this type of resource. And add a new ftest here to show the case.