### PR TITLE
Optimize logging for transfer getting

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -263,7 +263,14 @@ public class DefaultContentManager
             item = doRetrieve( store, path, eventMetadata );
         }
 
-        logger.info( "Returning transfer {} from {}", item, store.getKey() );
+        if ( item != null )
+        {
+            logger.info( "Returning transfer {} from {}", item, store.getKey() );
+        }
+        else
+        {
+            logger.trace( "Not found path {} from {}", path, store.getKey() );
+        }
 
         return item;
     }


### PR DESCRIPTION
Seems we have bunch of useless transfer getting log from hosted repo.
We need to reduce them by checking only hit transfer getting.