### PR TITLE
Fix NPE issue of kojiClient

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojijiProvider.java
@@ -83,6 +83,11 @@ public class KojijiProvider
     @Override
     public void start() throws IndyLifecycleException
     {
+    }
+
+    @PostConstruct
+    public void setUp() throws KojiClientException
+    {
         if ( !config.isEnabled() )
         {
             return;
@@ -99,20 +104,13 @@ public class KojijiProvider
             kojiPasswordManager.bind( config.getKeyPassword(), config.getKojiSiteId(), PasswordType.KEY );
         }
 
-        try
+        if ( indyMetricsConfig.isKojiMetricEnabled() )
         {
-            if ( indyMetricsConfig.isKojiMetricEnabled() )
-            {
-                kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor, metricRegistry );
-            }
-            else
-            {
-                kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor );
-            }
+            kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor, metricRegistry );
         }
-        catch ( KojiClientException e )
+        else
         {
-            throw new IndyLifecycleException( "Failed to initialize Koji client.", e );
+            kojiClient = new KojiClient( config, kojiPasswordManager, kojiExecutor );
         }
 
         versionMetadataLocks = new Locker<>();


### PR DESCRIPTION
Actually this should be part of the revert for the previous commit 424fbc51, that aims to fix the CDI @PostConstruct errors. But it caused the NPE failure that CDI expose the kojiClient first before running start() method based on the propulsor mechanism. So just make this revert first to let the failure gone and we can think how to fix the CDI error later. 