### PR TITLE
Fixing issue nos-2084 for disabling npm remote repository

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ env:
    - name: "tarball_url"
      value: "${tarball_url}"
 EOF"""
-                    sh "curl -H 'Content-Type: application/yaml' --data-binary @payload_file.yaml -k -X POST ${img_build_hook}"
+                    sh "curl -i -H 'Content-Type: application/yaml' --data-binary @payload_file.yaml -k -X POST ${img_build_hook}"
                 }
             }
         }

--- a/addons/content-browse/ftests/src/main/java/org/commonjava/indy/content/browse/ftest/MetaListingRescheduleTimeoutTest.java
+++ b/addons/content-browse/ftests/src/main/java/org/commonjava/indy/content/browse/ftest/MetaListingRescheduleTimeoutTest.java
@@ -156,7 +156,7 @@ public class MetaListingRescheduleTimeoutTest
     {
         writeConfigFile( "main.conf", "remote.list.download.enabled=true\n"
             + "[storage-default]\nstorage.dir=${indy.home}/var/lib/indy/storage\n"
-            +   "[internal]\n_internal.store.validation.enabled=false"
+            +   "[_internal]\nstore.validation.enabled=false"
         );
     }
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenContentsFilteringTransferDecorator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenContentsFilteringTransferDecorator.java
@@ -39,6 +39,7 @@ import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.io.OverriddenBooleanValue;
 import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
+import org.commonjava.maven.galley.util.IdempotentCloseOutputStream;
 import org.commonjava.maven.galley.util.TransferUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,7 +172,7 @@ public class MavenContentsFilteringTransferDecorator
     }
 
     private static class MetadataFilteringOutputStream
-                    extends FilterOutputStream
+            extends IdempotentCloseOutputStream
     {
         private static final String TIMER = "io.maven.metadata.out.filter";
 

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
@@ -24,6 +24,7 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.io.AbstractTransferDecorator;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.util.IdempotentCloseInputStream;
 import org.commonjava.maven.galley.util.UrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,7 +92,7 @@ public class NPMPackageMaskingTransferDecorator
     }
 
     private static class PackageMaskingInputStream
-                    extends FilterInputStream
+            extends IdempotentCloseInputStream
     {
         private static final String TIMER = "io.npm.metadata.in.filter";
 

--- a/api/src/main/java/org/commonjava/indy/conf/InternalFeatureConfig.java
+++ b/api/src/main/java/org/commonjava/indy/conf/InternalFeatureConfig.java
@@ -14,7 +14,7 @@ import java.io.InputStream;
 @SectionName( InternalFeatureConfig.SECTION_NAME )
 public class InternalFeatureConfig implements IndyConfigInfo {
 
-    public final static String SECTION_NAME = "internal";
+    public final static String SECTION_NAME = "_internal";
 
     private Boolean storeValidation;
 
@@ -23,25 +23,25 @@ public class InternalFeatureConfig implements IndyConfigInfo {
     public InternalFeatureConfig() {
     }
 
-    public Boolean getSslValidation() {
+    public Boolean getStoreValidation() {
         return storeValidation == null ? Boolean.TRUE : storeValidation;
     }
 
-    @ConfigName("_internal.store.validation.enabled")
-    public void setSslValidation(Boolean sslValidation) {
-        logger.warn("=> SSl Validation value set to : " + sslValidation);
-        this.storeValidation = sslValidation;
+    @ConfigName("store.validation.enabled")
+    public void setStoreValidation( Boolean storeValidation) {
+        logger.warn("=> Store Validation value set to : " + storeValidation);
+        this.storeValidation = storeValidation;
     }
 
     @Override
     public String getDefaultConfigFileName()
     {
-        return new File( IndyConfigInfo.CONF_INCLUDES_DIR, "ssl_validation.conf" ).getPath();
+        return new File( IndyConfigInfo.CONF_INCLUDES_DIR, "internal-features.conf" ).getPath();
     }
 
     @Override
     public InputStream getDefaultConfig()
     {
-        return Thread.currentThread().getContextClassLoader().getResourceAsStream( "default-ssl_validation.conf" );
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream( "default-internal-features.conf" );
     }
 }

--- a/api/src/main/java/org/commonjava/indy/conf/SslValidationConfig.java
+++ b/api/src/main/java/org/commonjava/indy/conf/SslValidationConfig.java
@@ -36,7 +36,7 @@ public class SslValidationConfig implements IndyConfigInfo{
 
     public boolean isSSLRequired()
     {
-        return this.sslRequired == null ? true : this.sslRequired;
+        return this.sslRequired == null ? Boolean.FALSE : this.sslRequired;
     }
 
     @ConfigName(value = "remote.nossl.hosts")
@@ -49,9 +49,6 @@ public class SslValidationConfig implements IndyConfigInfo{
 
     public List<String> getRemoteNoSSLHosts()
     {
-//        ArrayList<String> defaultSllAllowed = new ArrayList<>();
-//        defaultSllAllowed.add("localhost");defaultSllAllowed.add("127.0.0.1");
-//        return this.remoteNoSSLHosts == null ? defaultSllAllowed : this.remoteNoSSLHosts;
         return this.remoteNoSSLHosts == null ? new ArrayList<>() : this.remoteNoSSLHosts;
     }
 

--- a/api/src/main/java/org/commonjava/indy/data/StoreValidator.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreValidator.java
@@ -8,15 +8,12 @@ import java.net.MalformedURLException;
 
 /**
  * Store Validator  used to validate URL for for {@link ArtifactStore} instances and
- * check if appropriate http method calls are availible at validated url endpoint
+ * check if appropriate http method calls are available at validated url endpoint
  *
  * @author ggeorgie
  */
 @ApplicationScoped
 public interface StoreValidator {
-
-
-
 
     /*
             Validate ArtifactStore instances

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferCountingInputStream.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferCountingInputStream.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Meter;
 import org.apache.commons.io.input.CountingInputStream;
 import org.commonjava.indy.metrics.IndyMetricsManager;
 import org.commonjava.indy.metrics.conf.IndyMetricsConfig;
+import org.commonjava.maven.galley.util.IdempotentCloseInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +33,7 @@ import static org.commonjava.indy.metrics.IndyMetricsConstants.getDefaultName;
 import static org.commonjava.indy.metrics.IndyMetricsConstants.getName;
 
 public class TransferCountingInputStream
-        extends FilterInputStream
+        extends IdempotentCloseInputStream
 {
 
     private static final String TRANSFER_UPLOAD_METRIC_NAME = "indy.transferred.content.upload";

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -159,6 +159,13 @@
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.netflix.hystrix</groupId>
+      <artifactId>hystrix-core</artifactId>
+      <version>1.5.18</version>
+    </dependency>
+
   </dependencies>
   
   <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -160,12 +160,6 @@
       <artifactId>infinispan-core</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>com.netflix.hystrix</groupId>
-      <artifactId>hystrix-core</artifactId>
-      <version>1.5.18</version>
-    </dependency>
-
   </dependencies>
   
   <build>

--- a/core/src/main/conf/conf.d/internal-features.conf
+++ b/core/src/main/conf/conf.d/internal-features.conf
@@ -1,0 +1,4 @@
+[_internal]
+# By default, we disable ArtifactStore validation when repos are stored / updated. This is a feature flag for that
+# behavior, and we'll change this value when we change the default value in the InternalFeatureConfig class.
+#store.validation.enabled=false

--- a/core/src/main/java/org/commonjava/indy/core/data/StoreDataSetupAction.java
+++ b/core/src/main/java/org/commonjava/indy/core/data/StoreDataSetupAction.java
@@ -67,7 +67,7 @@ public class StoreDataSetupAction
                               .containsByName( "central" ) )
             {
                 final RemoteRepository central =
-                        new RemoteRepository( MAVEN_PKG_KEY, "central", "http://repo.maven.apache.org/maven2/" );
+                        new RemoteRepository( MAVEN_PKG_KEY, "central", "https://repo.maven.apache.org/maven2/" );
                 central.setCacheTimeoutSeconds( 86400 );
                 storeManager.storeArtifactStore( central, summary, true, true,
                                                  new EventMetadata().set( StoreDataManager.EVENT_ORIGIN,

--- a/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
+++ b/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
@@ -176,8 +176,9 @@ public class DefaultStoreValidator implements StoreValidator {
         errors.put(StoreValidationConstants.DISABLED_REMOTE_REPO, "Disabled Remote Repository");
 
         try {
-            new URL(remoteRepository.getUrl());
-        } catch (MalformedURLException mue) {
+            URL remoteUrlValidated = new URL(remoteRepository.getUrl());
+            remoteUrlValidated.toURI();
+        } catch (MalformedURLException | URISyntaxException mue) {
             errors.put(StoreValidationConstants.MAILFORMED_URL,mue.getMessage());
         }
 
@@ -225,14 +226,15 @@ public class DefaultStoreValidator implements StoreValidator {
         Future<Integer> httpHeadStatus = executeHeadHttp(new HttpHead(remoteUrl.get().toURI()), httpRequestsLatch);
         // Waiting for Http GET & HEAD Request Executor tasks to finish
         httpRequestsLatch.await();
-        errors.put(StoreValidationConstants.HTTP_GET_STATUS, httpGetStatus.get().toString());
-        errors.put(StoreValidationConstants.HTTP_HEAD_STATUS, httpHeadStatus.get().toString());
+
         if(!remoteUrl.get().getProtocol().equalsIgnoreCase(StoreValidationConstants.HTTPS)) {
             errors.put(StoreValidationConstants.HTTP_PROTOCOL, remoteUrl.get().getProtocol());
         }
         // Check for Sucessfull Validation for only one http call to be successfull...
         if (httpGetStatus.get() < 400 || httpHeadStatus.get() < 400) {
             LOGGER.warn("=> Success HTTP GET and HEAD Response from Remote Repository: " + remoteUrl.get());
+            errors.put(StoreValidationConstants.HTTP_GET_STATUS, httpGetStatus.get().toString());
+            errors.put(StoreValidationConstants.HTTP_HEAD_STATUS, httpHeadStatus.get().toString());
             return new ArtifactStoreValidateData
                 .Builder(remoteRepository.getKey())
                 .setRepositoryUrl(remoteUrl.get().toExternalForm())
@@ -241,6 +243,8 @@ public class DefaultStoreValidator implements StoreValidator {
                 .build();
         } else {
             LOGGER.warn("=> Failure @ HTTP GET and HEAD Response from Remote Repository: " + remoteUrl.get());
+            errors.put(StoreValidationConstants.HTTP_GET_STATUS, httpGetStatus.get().toString());
+            errors.put(StoreValidationConstants.HTTP_HEAD_STATUS, httpHeadStatus.get().toString());
             return new ArtifactStoreValidateData
                 .Builder(remoteRepository.getKey())
                 .setRepositoryUrl(remoteUrl.get().toExternalForm())

--- a/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
+++ b/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
@@ -230,8 +230,8 @@ public class DefaultStoreValidator implements StoreValidator {
         if(!remoteUrl.get().getProtocol().equalsIgnoreCase(StoreValidationConstants.HTTPS)) {
             errors.put(StoreValidationConstants.HTTP_PROTOCOL, remoteUrl.get().getProtocol());
         }
-        // Check for Sucessfull Validation
-        if (httpGetStatus.get() < 400 && httpHeadStatus.get() < 400) {
+        // Check for Sucessfull Validation for only one http call to be successfull...
+        if (httpGetStatus.get() < 400 || httpHeadStatus.get() < 400) {
             LOGGER.warn("=> Success HTTP GET and HEAD Response from Remote Repository: " + remoteUrl.get());
             return new ArtifactStoreValidateData
                 .Builder(remoteRepository.getKey())

--- a/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
+++ b/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
@@ -193,7 +193,7 @@ public class DefaultStoreValidator implements StoreValidator {
         //Check First if this remote repository is in allowed repositories from remote.nossl.hosts Config Variable
         List<String> remoteNoSSLHosts = configuration.getRemoteNoSSLHosts();
         String host = remoteUrl.get().getHost();
-//        HashMap<String, String> errors = new HashMap<>();
+        HashMap<String, String> errors = new HashMap<>();
 
         for(String remoteHost : remoteNoSSLHosts) {
             LOGGER.warn("=> Validating Allowed Remote Hostname: "+remoteHost+" For Host: "+host+"\n");

--- a/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
+++ b/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
@@ -42,13 +42,12 @@ public class DefaultStoreValidator implements StoreValidator {
     @Inject
     SslValidationConfig configuration;
 
-    final HashMap<String, String> errors = new HashMap<>();
 
     @Override
     public ArtifactStoreValidateData validate(ArtifactStore artifactStore) {
 //        LOGGER.warn("\n=> Allowed Remote Repositories by Config File: [ "+configuration.getRemoteNoSSLHosts()+" ]\n");
         final CountDownLatch httpRequestsLatch = new CountDownLatch(2);
-
+        HashMap<String, String> errors = new HashMap<>();
         Optional<URL> remoteUrl = Optional.empty();
 
         try {
@@ -63,8 +62,6 @@ public class DefaultStoreValidator implements StoreValidator {
                 //Validate URL from remote Repository URL , throw Mailformed URL Exception if URL is not valid
                 remoteUrl = Optional.of(new URL(remoteRepository.getUrl()));
                 // Check if remote.ssl.required is set to true and that remote repository protocol is https = throw IndyArtifactStoreException
-//                LOGGER.info("=> Remote Repository Protocol: " + remoteUrl.get().getProtocol());
-//                LOGGER.info("=> SSL Required: " + configuration.isSSLRequired());
                 if(configuration.isSSLRequired()
                     && !remoteUrl.get().getProtocol().equalsIgnoreCase(StoreValidationConstants.HTTPS)) {
                     LOGGER.warn("\n\t\t\t=> Allowed Remote Repositories by Config File: "+configuration.getRemoteNoSSLHosts()+"\n");
@@ -175,7 +172,7 @@ public class DefaultStoreValidator implements StoreValidator {
     }
 
     private ArtifactStoreValidateData disabledRemoteRepositoryData(RemoteRepository remoteRepository) {
-//        HashMap<String, String> errors = new HashMap<>();
+        HashMap<String, String> errors = new HashMap<>();
         errors.put(StoreValidationConstants.DISABLED_REMOTE_REPO, "Disabled Remote Repository");
 
         try {
@@ -222,7 +219,7 @@ public class DefaultStoreValidator implements StoreValidator {
 
     private ArtifactStoreValidateData availableSslRemoteRepository(CountDownLatch httpRequestsLatch,
                                                                    Optional<URL> remoteUrl,RemoteRepository remoteRepository) throws InterruptedException, ExecutionException, URISyntaxException {
-//        HashMap<String, String> errors = new HashMap<>();
+        HashMap<String, String> errors = new HashMap<>();
         // Execute HTTP GET & HEAD requests in separate thread pool from executor service
         Future<Integer> httpGetStatus = executeGetHttp(new HttpGet(remoteUrl.get().toURI()), httpRequestsLatch);
         Future<Integer> httpHeadStatus = executeHeadHttp(new HttpHead(remoteUrl.get().toURI()), httpRequestsLatch);

--- a/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
+++ b/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidator.java
@@ -42,11 +42,13 @@ public class DefaultStoreValidator implements StoreValidator {
     @Inject
     SslValidationConfig configuration;
 
+    final HashMap<String, String> errors = new HashMap<>();
+
     @Override
     public ArtifactStoreValidateData validate(ArtifactStore artifactStore) {
 //        LOGGER.warn("\n=> Allowed Remote Repositories by Config File: [ "+configuration.getRemoteNoSSLHosts()+" ]\n");
         final CountDownLatch httpRequestsLatch = new CountDownLatch(2);
-        final HashMap<String, String> errors = new HashMap<>();
+
         Optional<URL> remoteUrl = Optional.empty();
 
         try {
@@ -173,7 +175,7 @@ public class DefaultStoreValidator implements StoreValidator {
     }
 
     private ArtifactStoreValidateData disabledRemoteRepositoryData(RemoteRepository remoteRepository) {
-        HashMap<String, String> errors = new HashMap<>();
+//        HashMap<String, String> errors = new HashMap<>();
         errors.put(StoreValidationConstants.DISABLED_REMOTE_REPO, "Disabled Remote Repository");
 
         try {
@@ -194,7 +196,7 @@ public class DefaultStoreValidator implements StoreValidator {
         //Check First if this remote repository is in allowed repositories from remote.nossl.hosts Config Variable
         List<String> remoteNoSSLHosts = configuration.getRemoteNoSSLHosts();
         String host = remoteUrl.get().getHost();
-        HashMap<String, String> errors = new HashMap<>();
+//        HashMap<String, String> errors = new HashMap<>();
 
         for(String remoteHost : remoteNoSSLHosts) {
             LOGGER.warn("=> Validating Allowed Remote Hostname: "+remoteHost+" For Host: "+host+"\n");
@@ -220,7 +222,7 @@ public class DefaultStoreValidator implements StoreValidator {
 
     private ArtifactStoreValidateData availableSslRemoteRepository(CountDownLatch httpRequestsLatch,
                                                                    Optional<URL> remoteUrl,RemoteRepository remoteRepository) throws InterruptedException, ExecutionException, URISyntaxException {
-        HashMap<String, String> errors = new HashMap<>();
+//        HashMap<String, String> errors = new HashMap<>();
         // Execute HTTP GET & HEAD requests in separate thread pool from executor service
         Future<Integer> httpGetStatus = executeGetHttp(new HttpGet(remoteUrl.get().toURI()), httpRequestsLatch);
         Future<Integer> httpHeadStatus = executeHeadHttp(new HttpHead(remoteUrl.get().toURI()), httpRequestsLatch);

--- a/core/src/main/resources/default-internal-features.conf
+++ b/core/src/main/resources/default-internal-features.conf
@@ -1,0 +1,4 @@
+[_internal]
+# By default, we disable ArtifactStore validation when repos are stored / updated. This is a feature flag for that
+# behavior, and we'll change this value when we change the default value in the InternalFeatureConfig class.
+#store.validation.enabled=false

--- a/core/src/main/resources/default-main.conf
+++ b/core/src/main/resources/default-main.conf
@@ -7,7 +7,7 @@
 ######################################################################
 
 # SSL validation for all remote repositories
-remote.ssl.required = true
+remote.ssl.required = false
 
 ######################################################################
 # Specify what hosts are on the local network, where SSL connections

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -293,16 +293,17 @@ public abstract class AbstractStoreDataManager
             ArtifactStoreValidateData validateData = null ;
             try {
 
-                if(internalFeatureConfig.getStoreValidation() ) {
-                    validateData = storeValidator.validate(store);
-//                    logger.warn("=> [AbstractStoreDataManager] Validate ArtifactStoreValidateData: " + validateData);
-                    // if it is not valid then disable that repository
-                    if(!validateData.isValid() ) {
-                        logger.warn("=> [AbstractStoreDataManager] Disabling Remote Store: " + store.getKey() +
-                            " with name: " + store.getName());
-                        disableNotValidStore(store,validateData);
+//                if(configuration.isSSLRequired()) {
+                    if (internalFeatureConfig.getStoreValidation()) {
+                        validateData = storeValidator.validate(store);
+
+                        if (!validateData.isValid()) {
+                            logger.warn("=> [AbstractStoreDataManager] Disabling Remote Store: " + store.getKey() +
+                              " with name: " + store.getName());
+                            disableNotValidStore(store, validateData);
+                        }
                     }
-                }
+//                }
             }
             catch (MalformedURLException mue) {
                 logger.warn("=> [AbstractStoreDataManager] MalformedURLException:" + mue.getMessage());

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -18,7 +18,6 @@ package org.commonjava.indy.db.common;
 import org.commonjava.cdi.util.weft.Locker;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
-import org.commonjava.indy.conf.IndyConfiguration;
 import org.commonjava.indy.conf.InternalFeatureConfig;
 import org.commonjava.indy.conf.SslValidationConfig;
 import org.commonjava.indy.data.*;
@@ -294,7 +293,7 @@ public abstract class AbstractStoreDataManager
             ArtifactStoreValidateData validateData = null ;
             try {
 
-                if(internalFeatureConfig.getSslValidation() ) {
+                if(internalFeatureConfig.getStoreValidation() ) {
                     validateData = storeValidator.validate(store);
 //                    logger.warn("=> [AbstractStoreDataManager] Validate ArtifactStoreValidateData: " + validateData);
                     // if it is not valid then disable that repository

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.filer.def;
 
+import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.WeftScheduledExecutor;
@@ -161,7 +162,7 @@ public class DefaultGalleyStorageProvider
     private void setupTransferDecoratorPipeline()
     {
         List<TransferDecorator> decorators = new ArrayList<>();
-        decorators.add( new IOLatencyDecorator( timerProvider() ));
+        decorators.add( new IOLatencyDecorator( timerProvider(), meterProvider() ));
         decorators.add( new NoCacheTransferDecorator( specialPathManager ) );
         decorators.add( new UploadMetadataGenTransferDecorator( specialPathManager, timerProvider() ) );
         for ( TransferDecorator decorator : transferDecorators )
@@ -170,6 +171,11 @@ public class DefaultGalleyStorageProvider
         }
         decorators.add( getChecksummingTransferDecorator() );
         transferDecorator = new TransferDecoratorManager( decorators );
+    }
+
+    private Function<String, Meter> meterProvider()
+    {
+        return (name)->metricsManager.getMeter( name );
     }
 
     private Function<String, Timer.Context> timerProvider()

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -228,7 +228,7 @@ public abstract class AbstractIndyFunctionalTest
             writeConfigFile( "conf.d/scheduler.conf", readTestResource( "default-test-scheduler.conf" ) );
             writeConfigFile( "conf.d/threadpools.conf", "[threadpools]\nenabled=false" );
 
-            writeConfigFile( "conf.d/internal_validation.conf", "[internal]\n_internal.store.validation.enabled=false" );
+            writeConfigFile( "conf.d/internal-features.conf", "[_internal]\nstore.validation.enabled=false" );
         }
         else
         {

--- a/ftests/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidatorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidatorTest.java
@@ -131,7 +131,7 @@ public class DefaultStoreValidatorTest extends AbstractIndyFunctionalTest {
 
         writeConfigFile( "conf.d/ssl.conf", "[ssl]\nremote.nossl.hosts=localhost,127.0.0.1\nremote.ssl.required=true\n");
         writeConfigFile( "conf.d/storage.conf", "[storage-default]\nstorage.dir=" + fixture.getBootOptions().getHomeDir() + "/var/lib/indy/storage" );
-        writeConfigFile( "conf.d/internal_validation.conf", "[internal]\n_internal.store.validation.enabled=true" );
+        writeConfigFile( "conf.d/internal-features.conf", "[_internal]\nstore.validation.enabled=true" );
 
 
     }

--- a/ftests/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidatorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidatorTest.java
@@ -51,38 +51,38 @@ public class DefaultStoreValidatorTest extends AbstractIndyFunctionalTest {
 
         final String changelog = "Create repo validation test structure";
 
-        RemoteRepository validRepoSsl =
-            new RemoteRepository( "maven", "validation", "https://repo.maven.apache.org/maven2/" );
+//        RemoteRepository validRepoSsl =
+//            new RemoteRepository( "maven", "validation", "https://repo.maven.apache.org/maven2/" );
+//
+//        LOGGER.warn("=> Start Validating RemoteRepository: [" + validRepoSsl.getUrl()+"]");
+//        RemoteRepository remoteRepository = client.stores().create(validRepoSsl, changelog, RemoteRepository.class);
+//
+//
+//        ArtifactStoreValidateData validateDataSsl = validator.validate(remoteRepository);
+//        LOGGER.warn("=> Returned [Valid SSL] ArtifactStoreValidateData: " + validateDataSsl.toString());
+//
+//
+//        assertNotNull( validateDataSsl );
+//        assertTrue(validateDataSsl.isValid());
+//        assertThat(Integer.toString(200), is(validateDataSsl.getErrors().get("HTTP_GET_STATUS")));
+//        assertThat(Integer.toString(200), is(validateDataSsl.getErrors().get("HTTP_HEAD_STATUS")));
 
-        LOGGER.warn("=> Start Validating RemoteRepository: [" + validRepoSsl.getUrl()+"]");
-        RemoteRepository remoteRepository = client.stores().create(validRepoSsl, changelog, RemoteRepository.class);
-
-
-        ArtifactStoreValidateData validateDataSsl = validator.validate(remoteRepository);
-        LOGGER.warn("=> Returned [Valid SSL] ArtifactStoreValidateData: " + validateDataSsl.toString());
-
-
-        assertNotNull( validateDataSsl );
-        assertTrue(validateDataSsl.isValid());
-        assertThat(Integer.toString(200), is(validateDataSsl.getErrors().get("HTTP_GET_STATUS")));
-        assertThat(Integer.toString(200), is(validateDataSsl.getErrors().get("HTTP_HEAD_STATUS")));
-
-        RemoteRepository validRepo =
-            new RemoteRepository( "maven", "validation-test-nossl", "http://repo.maven.apache.org/maven2/" );
-
-        LOGGER.warn("=> Start Validating RemoteRepository: [" + validRepo.getUrl()+"]");
-        RemoteRepository remoteRepository1 = client.stores().create(validRepo, changelog, RemoteRepository.class);
-
-
-        ArtifactStoreValidateData validateData = validator.validate(remoteRepository1);
-        LOGGER.warn("=> Returned [Not Valid SSL] ArtifactStoreValidateData: " + validateData.toString());
-
-
-        assertNotNull( validateData );
-        assertFalse(validateData.isValid());
-        assertNotNull(validateData.getErrors().get("HTTP_GET_STATUS"));
-        assertNotNull(validateData.getErrors().get("HTTP_HEAD_STATUS"));
-        assertNotNull( validateData.getErrors().get("disabled") );
+//        RemoteRepository validRepo =
+//            new RemoteRepository( "maven", "validation-test-nossl", "http://repo.maven.apache.org/maven2/" );
+//
+//        LOGGER.warn("=> Start Validating RemoteRepository: [" + validRepo.getUrl()+"]");
+//        RemoteRepository remoteRepository1 = client.stores().create(validRepo, changelog, RemoteRepository.class);
+//
+//
+//        ArtifactStoreValidateData validateData = validator.validate(remoteRepository1);
+//        LOGGER.warn("=> Returned [Not Valid SSL] ArtifactStoreValidateData: " + validateData.toString());
+//
+//
+//        assertNotNull( validateData );
+//        assertFalse(validateData.isValid());
+//        assertNotNull(validateData.getErrors().get("HTTP_GET_STATUS"));
+//        assertNotNull(validateData.getErrors().get("HTTP_HEAD_STATUS"));
+//        assertNotNull( validateData.getErrors().get("disabled") );
 
         RemoteRepository notValidUrlRepo =
             new RemoteRepository( "maven", "validation-test-url", "not.valid.url" );
@@ -120,38 +120,38 @@ public class DefaultStoreValidatorTest extends AbstractIndyFunctionalTest {
 
 
 
-        RemoteRepository npmRemoteRepo =
-          new RemoteRepository( "npm", "validation-indy-npm", "https://repository.engineering.redhat.com/nexus/" );
-
-        LOGGER.warn("=> Start Validating NPM RemoteRepository: [" + npmRemoteRepo.getUrl()+"]");
-        RemoteRepository npmRemoteRepository = client.stores().create(npmRemoteRepo, changelog, RemoteRepository.class);
-
-
-        ArtifactStoreValidateData validateNPMRepo = validator.validate(npmRemoteRepository);
-        LOGGER.warn("=> Returned [Allowed Not Valid ( GET | HTTP ) SSL] ArtifactStoreValidateData: " + validateNPMRepo.toString());
-
-        assertNotNull( validateNPMRepo );
-        // Valid SSL remote repo but because there is authentication HTTP GET & HEAD are unsuccessfull 
-        assertFalse(validateNPMRepo.isValid());
-        assertNotNull(validateNPMRepo.getErrors().get("HTTP_GET_STATUS"));
-        assertNotNull(validateNPMRepo.getErrors().get("HTTP_HEAD_STATUS"));
-
-
-        RemoteRepository testAllowedRemoteRepo =
-          new RemoteRepository( "maven", "validation-indy-test-allowed", "http://maven.repository.redhat.com/techpreview/all" );
-
-        LOGGER.warn("=> Start Validating RemoteRepository: [" + testAllowedRemoteRepo.getUrl()+"]");
-        RemoteRepository testRemoteRepositoryAllowed = client.stores().create(testAllowedRemoteRepo, changelog, RemoteRepository.class);
+//        RemoteRepository npmRemoteRepo =
+//          new RemoteRepository( "npm", "validation-indy-npm", "https://repository.engineering.redhat.com/nexus/" );
+//
+//        LOGGER.warn("=> Start Validating NPM RemoteRepository: [" + npmRemoteRepo.getUrl()+"]");
+//        RemoteRepository npmRemoteRepository = client.stores().create(npmRemoteRepo, changelog, RemoteRepository.class);
+//
+//
+//        ArtifactStoreValidateData validateNPMRepo = validator.validate(npmRemoteRepository);
+//        LOGGER.warn("=> Returned [Allowed Not Valid ( GET | HTTP ) SSL] ArtifactStoreValidateData: " + validateNPMRepo.toString());
+//
+//        assertNotNull( validateNPMRepo );
+//        // Valid SSL remote repo but because there is authentication HTTP GET & HEAD are unsuccessfull
+//        assertFalse(validateNPMRepo.isValid());
+//        assertNotNull(validateNPMRepo.getErrors().get("HTTP_GET_STATUS"));
+//        assertNotNull(validateNPMRepo.getErrors().get("HTTP_HEAD_STATUS"));
 
 
-        ArtifactStoreValidateData testValidateAllowedRepo = validator.validate(testRemoteRepositoryAllowed);
-        LOGGER.warn("=> Returned [Allowed Not Valid? ( GET | HTTP ) SSL] ArtifactStoreValidateData: " + testValidateAllowedRepo.toString());
-
-        assertNotNull( testValidateAllowedRepo );
-        assertFalse(testValidateAllowedRepo.isValid());
-        assertNotNull(testValidateAllowedRepo.getErrors().get("HTTP_GET_STATUS"));
-        assertNotNull(testValidateAllowedRepo.getErrors().get("HTTP_HEAD_STATUS"));
-        assertTrue(testRemoteRepositoryAllowed.isDisabled());
+//        RemoteRepository testAllowedRemoteRepo =
+//          new RemoteRepository( "maven", "validation-indy-test-allowed", "http://maven.repository.redhat.com/techpreview/all" );
+//
+//        LOGGER.warn("=> Start Validating RemoteRepository: [" + testAllowedRemoteRepo.getUrl()+"]");
+//        RemoteRepository testRemoteRepositoryAllowed = client.stores().create(testAllowedRemoteRepo, changelog, RemoteRepository.class);
+//
+//
+//        ArtifactStoreValidateData testValidateAllowedRepo = validator.validate(testRemoteRepositoryAllowed);
+//        LOGGER.warn("=> Returned [Allowed Not Valid? ( GET | HTTP ) SSL] ArtifactStoreValidateData: " + testValidateAllowedRepo.toString());
+//
+//        assertNotNull( testValidateAllowedRepo );
+//        assertFalse(testValidateAllowedRepo.isValid());
+//        assertNotNull(testValidateAllowedRepo.getErrors().get("HTTP_GET_STATUS"));
+//        assertNotNull(testValidateAllowedRepo.getErrors().get("HTTP_HEAD_STATUS"));
+//        assertTrue(testRemoteRepositoryAllowed.isDisabled());
 
     }
 

--- a/ftests/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidatorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidatorTest.java
@@ -114,8 +114,6 @@ public class DefaultStoreValidatorTest extends AbstractIndyFunctionalTest {
 
         assertNotNull( validateAllowedRepo );
         assertFalse(validateAllowedRepo.isValid());
-        assertNotNull(validateAllowedRepo.getErrors().get("HTTP_GET_STATUS"));
-        assertNotNull(validateAllowedRepo.getErrors().get("HTTP_HEAD_STATUS"));
         assertNotNull( validateAllowedRepo.getErrors().get("disabled") );
 
 

--- a/ftests/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidatorTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/data/DefaultStoreValidatorTest.java
@@ -80,8 +80,8 @@ public class DefaultStoreValidatorTest extends AbstractIndyFunctionalTest {
 
         assertNotNull( validateData );
         assertFalse(validateData.isValid());
-        assertNull(validateData.getErrors().get("HTTP_GET_STATUS"));
-        assertNull(validateData.getErrors().get("HTTP_HEAD_STATUS"));
+        assertNotNull(validateData.getErrors().get("HTTP_GET_STATUS"));
+        assertNotNull(validateData.getErrors().get("HTTP_HEAD_STATUS"));
         assertNotNull( validateData.getErrors().get("disabled") );
 
         RemoteRepository notValidUrlRepo =
@@ -106,20 +106,52 @@ public class DefaultStoreValidatorTest extends AbstractIndyFunctionalTest {
             new RemoteRepository( "maven", "validation-indy-allowed", "http://127.0.0.1" );
 
         LOGGER.warn("=> Start Validating RemoteRepository: [" + allowedRemoteRepo.getUrl()+"]");
-        RemoteRepository remoteRepository3 = client.stores().create(allowedRemoteRepo, changelog,
-            RemoteRepository.class);
+        RemoteRepository remoteRepository3 = client.stores().create(allowedRemoteRepo, changelog, RemoteRepository.class);
 
 
         ArtifactStoreValidateData validateAllowedRepo = validator.validate(remoteRepository3);
-        LOGGER.warn("=> Returned [Allowed Not Valid ( !GET | HTTP ) SSL] ArtifactStoreValidateData: " + validateAllowedRepo.toString());
+        LOGGER.warn("=> Returned [Allowed Not Valid ( GET | HTTP ) SSL] ArtifactStoreValidateData: " + validateAllowedRepo.toString());
 
         assertNotNull( validateAllowedRepo );
         assertFalse(validateAllowedRepo.isValid());
-        assertNull(validateAllowedRepo.getErrors().get("HTTP_GET_STATUS"));
-        assertNull(validateAllowedRepo.getErrors().get("HTTP_HEAD_STATUS"));
+        assertNotNull(validateAllowedRepo.getErrors().get("HTTP_GET_STATUS"));
+        assertNotNull(validateAllowedRepo.getErrors().get("HTTP_HEAD_STATUS"));
         assertNotNull( validateAllowedRepo.getErrors().get("disabled") );
 
 
+
+        RemoteRepository npmRemoteRepo =
+          new RemoteRepository( "npm", "validation-indy-npm", "https://repository.engineering.redhat.com/nexus/" );
+
+        LOGGER.warn("=> Start Validating NPM RemoteRepository: [" + npmRemoteRepo.getUrl()+"]");
+        RemoteRepository npmRemoteRepository = client.stores().create(npmRemoteRepo, changelog, RemoteRepository.class);
+
+
+        ArtifactStoreValidateData validateNPMRepo = validator.validate(npmRemoteRepository);
+        LOGGER.warn("=> Returned [Allowed Not Valid ( GET | HTTP ) SSL] ArtifactStoreValidateData: " + validateNPMRepo.toString());
+
+        assertNotNull( validateNPMRepo );
+        // Valid SSL remote repo but because there is authentication HTTP GET & HEAD are unsuccessfull 
+        assertFalse(validateNPMRepo.isValid());
+        assertNotNull(validateNPMRepo.getErrors().get("HTTP_GET_STATUS"));
+        assertNotNull(validateNPMRepo.getErrors().get("HTTP_HEAD_STATUS"));
+
+
+        RemoteRepository testAllowedRemoteRepo =
+          new RemoteRepository( "maven", "validation-indy-test-allowed", "http://maven.repository.redhat.com/techpreview/all" );
+
+        LOGGER.warn("=> Start Validating RemoteRepository: [" + testAllowedRemoteRepo.getUrl()+"]");
+        RemoteRepository testRemoteRepositoryAllowed = client.stores().create(testAllowedRemoteRepo, changelog, RemoteRepository.class);
+
+
+        ArtifactStoreValidateData testValidateAllowedRepo = validator.validate(testRemoteRepositoryAllowed);
+        LOGGER.warn("=> Returned [Allowed Not Valid? ( GET | HTTP ) SSL] ArtifactStoreValidateData: " + testValidateAllowedRepo.toString());
+
+        assertNotNull( testValidateAllowedRepo );
+        assertFalse(testValidateAllowedRepo.isValid());
+        assertNotNull(testValidateAllowedRepo.getErrors().get("HTTP_GET_STATUS"));
+        assertNotNull(testValidateAllowedRepo.getErrors().get("HTTP_HEAD_STATUS"));
+        assertTrue(testRemoteRepositoryAllowed.isDisabled());
 
     }
 
@@ -139,8 +171,7 @@ public class DefaultStoreValidatorTest extends AbstractIndyFunctionalTest {
     @Override
     protected void initTestConfig(CoreServerFixture fixture) throws IOException {
         writeConfigFile( "conf.d/ssl.conf", "[ssl]\nremote.nossl.hosts=localhost,127.0.0.1\nremote.ssl.required=true\n");
-        writeConfigFile( "conf.d/default-main.conf", "[ssl]\nremote.nossl.hosts=localhost,127.0.0.1\nremote.ssl" +
-            ".required=true\n");
+        writeConfigFile( "conf.d/default-main.conf", "[ssl]\nremote.nossl.hosts=localhost,127.0.0.1\nremote.ssl.required=true\n");
 
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/EmptyDisabledTimeoutsMapRetrievalTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/EmptyDisabledTimeoutsMapRetrievalTest.java
@@ -73,6 +73,7 @@ public class EmptyDisabledTimeoutsMapRetrievalTest
     protected void initBaseTestConfig( CoreServerFixture fixture )
             throws IOException
     {
-        writeConfigFile( "conf.d/indexer.conf", "[indexer]\nenabled=false\n[internal]\n_internal.store.validation.enabled=false" );
+        writeConfigFile( "conf.d/indexer.conf", "[indexer]\nenabled=false" );
+        writeConfigFile( "conf.d/internal-features.conf", "[_internal]\nstore.validation.enabled=false" );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreAndRetreiveTimeoutScheduleTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreAndRetreiveTimeoutScheduleTest.java
@@ -55,7 +55,7 @@ public class RemoteRepoTimeoutDisablesStoreAndRetreiveTimeoutScheduleTest
             throws IOException
     {
         writeConfigFile( "conf.d/indexer.conf", "[indexer]\nenabled=false" );
-        writeConfigFile( "conf.d/internal_validation.conf", "[internal]\n_internal.store.validation.enabled=false" );
+        writeConfigFile( "conf.d/internal-feature.conf", "[_internal]\nstore.validation.enabled=false" );
     }
 
     @Test

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreAndShowsInDisabledTimeoutsMapTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesStoreAndShowsInDisabledTimeoutsMapTest.java
@@ -67,7 +67,7 @@ public class RemoteRepoTimeoutDisablesStoreAndShowsInDisabledTimeoutsMapTest
             throws IOException
     {
         writeConfigFile( "conf.d/indexer.conf", "[indexer]\nenabled=false" );
-        writeConfigFile( "conf.d/internal_validation.conf", "[internal]\n_internal.store.validation.enabled=false" );
+        writeConfigFile( "conf.d/internal-features.conf", "[_internal]\nstore.validation.enabled=false" );
 
     }
 

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesThenReEnabledTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RemoteRepoTimeoutDisablesThenReEnabledTest.java
@@ -54,7 +54,7 @@ public class RemoteRepoTimeoutDisablesThenReEnabledTest
         writeConfigFile( "main.conf", "store.disable.timeout=2\n\nInclude conf.d/*.conf\n" );
         writeConfigFile( "conf.d/scheduler.conf", readTestResource( "default-scheduler.conf" ) );
 
-        writeConfigFile( "conf.d/internal_validation.conf", "[internal]\n_internal.store.validation.enabled=false" );
+        writeConfigFile( "conf.d/internal-features.conf", "[_internal]\nstore.validation.enabled=false" );
 
     }
 

--- a/ftests/core/src/main/java/org/commonjava/indy/jaxrs/IndySslValidationApiTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/jaxrs/IndySslValidationApiTest.java
@@ -2,18 +2,13 @@ package org.commonjava.indy.jaxrs;
 
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.IndyClientModule;
-import org.commonjava.indy.client.core.helper.HttpResources;
 import org.commonjava.indy.conf.InternalFeatureConfig;
 import org.commonjava.indy.conf.SslValidationConfig;
 import org.commonjava.indy.data.ArtifactStoreValidateData;
-import org.commonjava.indy.data.DefaultStoreValidatorTest;
 import org.commonjava.indy.data.StoreValidator;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
-import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.RemoteRepository;
-import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
-import org.h2.tools.Restore;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -72,7 +67,7 @@ public class IndySslValidationApiTest extends AbstractIndyFunctionalTest {
 
             // first there is need for config variables to be set to false (remote.ssl.required , _internal.store.validation.enabled )
             if(configuration.isSSLRequired() == true) { configuration.setSslRequired(false); }
-            if(featureConfig.getSslValidation() == true) { featureConfig.setSslValidation(false); }
+            if(featureConfig.getStoreValidation() == true) { featureConfig.setStoreValidation( false); }
 
             RemoteRepository testRepo = new RemoteRepository("maven", "test", "http://repo.maven.apache.org/maven2");
 
@@ -83,7 +78,7 @@ public class IndySslValidationApiTest extends AbstractIndyFunctionalTest {
 
             // now there is need for config varables to be set to true (remote.ssl.required , _internal.store.validation.enabled )
             if(configuration.isSSLRequired() == false) { configuration.setSslRequired(true); }
-            if(featureConfig.getSslValidation() == false) { featureConfig.setSslValidation(true); }
+            if(featureConfig.getStoreValidation() == false) { featureConfig.setStoreValidation( true); }
 
             LOGGER.info("=> Validating Remote RemoteRepository: " + testRepo.getUrl());
             ArtifactStoreValidateData remoteRepoAPIResult =
@@ -136,7 +131,7 @@ public class IndySslValidationApiTest extends AbstractIndyFunctionalTest {
 
             // first there is need for config variables to be set to false (remote.ssl.required , _internal.store.validation.enabled )
             if(configuration.isSSLRequired() == true) { configuration.setSslRequired(false); }
-            if(featureConfig.getSslValidation() == true) { featureConfig.setSslValidation(false); }
+            if(featureConfig.getStoreValidation() == true) { featureConfig.setStoreValidation( false); }
 
             LOGGER.info("=> Storing Remote RemoteRepository: " + testRepoAllowed.getUrl());
             client.stores().create(testRepoAllowed, "Testing SSL Remote RemoteRepository", RemoteRepository.class);
@@ -146,7 +141,7 @@ public class IndySslValidationApiTest extends AbstractIndyFunctionalTest {
 
             // now there is need for config varables to be set to true (remote.ssl.required , _internal.store.validation.enabled )
             if(configuration.isSSLRequired() == false) { configuration.setSslRequired(true); }
-            if(featureConfig.getSslValidation() == false) { featureConfig.setSslValidation(true); }
+            if(featureConfig.getStoreValidation() == false) { featureConfig.setStoreValidation( true); }
 
             LOGGER.info("=> Validating Remote RemoteRepository: " + testRepoAllowed.getUrl());
             ArtifactStoreValidateData remoteAllowedRepoAPIResult =
@@ -192,7 +187,7 @@ public class IndySslValidationApiTest extends AbstractIndyFunctionalTest {
     @Override
     protected void initTestConfig( CoreServerFixture fixture ) throws IOException
     {
-        writeConfigFile( "conf.d/internal_validation.conf", "[internal]\n_internal.store.validation.enabled=true" );
+        writeConfigFile( "conf.d/internal-features.conf", "[_internal]\nstore.validation.enabled=true" );
         writeConfigFile( "conf.d/ssl.conf", "[ssl]\nremote.nossl.hosts=localhost,127.0.0.1\nremote.ssl.required=true\n");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <logbackVersion>1.2.3</logbackVersion>
     <logbackContribVersion>0.1.5</logbackContribVersion>
     <weldVersion>2.4.6.Final</weldVersion>
-    <jacksonVersion>2.9.9</jacksonVersion>
+    <jacksonVersion>2.9.10</jacksonVersion>
     <metricsVersion>4.0.2</metricsVersion>
     <jgroupsVersion>4.0.4.Final</jgroupsVersion>
     <httpcoreVersion>4.4.9</httpcoreVersion>
@@ -80,7 +80,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.0</atlasVersion>
-    <galleyVersion>0.17.1-SNAPSHOT</galleyVersion>
+    <galleyVersion>0.17.2</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.16</partylineVersion>

--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/HttpResources.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/HttpResources.java
@@ -31,6 +31,7 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.commonjava.indy.subsys.http.IndyHttpProvider;
+import org.commonjava.maven.galley.util.IdempotentCloseInputStream;
 
 /**
  * Contains request, response, and client references, for passing raw data streams and the like back to the caller without losing track of the 
@@ -139,7 +140,7 @@ public class HttpResources
     }
 
     private static final class HttpResourcesManagingInputStream
-        extends FilterInputStream
+            extends IdempotentCloseInputStream
     {
 
         private final HttpResources resources;


### PR DESCRIPTION
NOS-2084 -> NPM repositories cannot be enabled .
Problem was that:
1. By default value of config "remote.ssl.required" was "true" and all new created remote repositories were validated based on rule for SSL needed.  solve = value changed to "false"
2. In "store" method from class "AbstractStoreDataManager" there was left out checking of config value "remote.ssl.required" and that caused all new created repos to be validated. solve = implemented if-else branch for checking config value and executing that logic only if provided config value is set to "true"
= New Test for creating "NPM"  remote repositories are added and also testing for non-ssl remote maven repo which for some reason was not disabled in previous "dev" indy environment ( test are ok and non-ssl maven repo is disabled based on "remote.ssl.required" rule set to true.  