### PR TITLE
rollback Infinispan version to 9.4.15.Final (still a net upgrade from Indy 1.9.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <javaVersion>1.8</javaVersion>
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
-    <infinispanVersion>9.4.16.Final</infinispanVersion>
+    <infinispanVersion>9.4.15.Final</infinispanVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <hibernateVersion>5.8.1.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>


### PR DESCRIPTION
This needs to be tested in an environment to make sure it's safe.