### PR TITLE
Nos 2103

### DIFF
--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -233,6 +233,8 @@ public abstract class AbstractIndyFunctionalTest
         else
         {
             writeConfigFile( "conf.d/scheduler.conf", "[scheduler]\nenabled=false" );
+            writeConfigFile( "conf.d/internal-features.conf", "[_internal]\nstore.validation.enabled=false" );
+
         }
     }
 

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/Return404DisableTimeoutForEnabledRepoTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/Return404DisableTimeoutForEnabledRepoTest.java
@@ -74,5 +74,6 @@ public class Return404DisableTimeoutForEnabledRepoTest
             throws IOException
     {
         writeConfigFile( "conf.d/indexer.conf", "[indexer]\nenabled=false" );
+        writeConfigFile( "conf.d/internal-feature.conf", "[_internal]\nstore.validation.enabled=false" );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/jaxrs/IndyRestMapperExceptionHandlerTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/jaxrs/IndyRestMapperExceptionHandlerTest.java
@@ -1,0 +1,118 @@
+package org.commonjava.indy.ftest.core.jaxrs;
+
+import groovy.json.JsonBuilder;
+import io.netty.handler.codec.json.JsonObjectDecoder;
+import io.swagger.util.Json;
+import io.undertow.util.StatusCodes;
+import org.apache.http.HttpStatus;
+import org.commonjava.indy.IndyException;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientHttp;
+import org.commonjava.indy.client.core.module.IndyRawHttpModule;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.rest.IndyRestMapperResponse;
+import org.jboss.resteasy.client.exception.ResteasyHttpException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.internal.Throwables;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+import static org.hamcrest.core.Is.is;
+
+public class IndyRestMapperExceptionHandlerTest extends AbstractIndyFunctionalTest {
+
+
+    @Test
+    public void restTest() {
+
+        try {
+
+            IndyClientHttp indyClient1 = client.module(IndyRawHttpModule.class).getHttp();
+            Response response1 = indyClient1.get("/test/exc1", Response.class);
+            Assert.assertNotNull(response1);
+            Assert.assertThat("Test Exception Message", is(response1.readEntity(IndyRestMapperResponse.class).getMessage()));
+
+            IndyClientHttp indyClient2 = client.module(IndyRawHttpModule.class).getHttp();
+            Response response2 = indyClient2.get("/test/exc2", Response.class);
+            Assert.assertNotNull(response2);
+            Assert.assertNull(response2.readEntity(IndyRestMapperResponse.class).getMessage());
+
+            IndyClientHttp indyClient3 = client.module(IndyRawHttpModule.class).getHttp();
+            Response response3 = indyClient3.get("/test/exc3", Response.class);
+            Assert.assertNotNull(response3);
+            Assert.assertThat("WebApplicationException Message", is(response1.readEntity(IndyRestMapperResponse.class).getMessage()));
+            Assert.assertThat(HttpStatus.SC_OK, is(response3.getStatusInfo().getStatusCode()));
+
+            IndyClientHttp indyClient4 = client.module(IndyRawHttpModule.class).getHttp();
+            Response response4 = indyClient4.get("/test/exc4", Response.class);
+            Assert.assertNotNull(response4);
+            Assert.assertThat("ResteasyHttpException Message", is(response1.readEntity(IndyRestMapperResponse.class).getMessage()));
+            Assert.assertThat(HttpStatus.SC_OK, is(response4.getStatusInfo().getStatusCode()));
+
+            IndyClientHttp indyClient5 = client.module(IndyRawHttpModule.class).getHttp();
+            Response response5 = indyClient5.get("/test/exc5", Response.class);
+            Assert.assertNotNull(response5);
+            Assert.assertThat("Exception Message", is(response1.readEntity(IndyRestMapperResponse.class).getMessage()));
+            Assert.assertThat("Throwable Cause", is(response1.readEntity(IndyRestMapperResponse.class).getCause()));
+            Assert.assertThat(HttpStatus.SC_OK, is(response5.getStatusInfo().getStatusCode()));
+
+            IndyClientHttp indyClient6 = client.module(IndyRawHttpModule.class).getHttp();
+            Response response6 = indyClient6.get("/test/exc6", Response.class);
+            Assert.assertNotNull(response6);
+            Assert.assertThat("Test Throwable", is(response1.readEntity(IndyRestMapperResponse.class).getCause()));
+            Assert.assertThat("Throwable Cause", is(response1.readEntity(IndyRestMapperResponse.class).getCause()));
+            Assert.assertThat(HttpStatus.SC_OK, is(response6.getStatusInfo().getStatusCode()));
+
+
+        } catch (IndyClientException e) {
+            e.printStackTrace();
+        }
+
+
+    }
+
+    @Path("/test")
+    class TestExcpetionResource {
+
+        @GET
+        @Path("/exc1")
+        public Response exc1() {
+            throw new RuntimeException("Test Exception Message");
+        }
+
+        @GET
+        @Path("/exc2")
+        public Response exc2() throws IndyException {
+            throw new IndyException();
+        }
+
+        @GET
+        @Path("/exc3")
+        public Response exc3() {
+            throw new WebApplicationException("WebApplicationException Message", StatusCodes.INTERNAL_SERVER_ERROR);
+        }
+
+        @GET
+        @Path("/exc4")
+        public Response exc4() {
+            throw new ResteasyHttpException("ResteasyHttpException Message");
+        }
+
+        @GET
+        @Path("/exc5")
+        public Response exc5() throws Exception {
+            throw new Exception("Exception Message", new Throwable("Throwable Cause"));
+        }
+
+        @GET
+        @Path("/exc6")
+        public Response exc6() throws Throwable {
+            throw new Throwable("Test Throwable", new Throwable("Throwable Cause"));
+        }
+
+    }
+}

--- a/models/core-java/src/main/java/org/commonjava/indy/IndyException.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/IndyException.java
@@ -31,7 +31,11 @@ public class IndyException
 
     private transient String formattedMessage;
 
-    public IndyException( final String message, final Object... params )
+    public IndyException() {
+        super();
+    }
+
+    public IndyException(final String message, final Object... params )
     {
         super( message );
         this.params = params;

--- a/models/core-java/src/main/java/org/commonjava/indy/model/rest/IndyRestMapperResponse.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/rest/IndyRestMapperResponse.java
@@ -1,0 +1,48 @@
+package org.commonjava.indy.model.rest;
+
+import java.time.LocalDateTime;
+
+public class IndyRestMapperResponse {
+
+    String message;
+    Throwable cause;
+    LocalDateTime timestamp;
+
+    public IndyRestMapperResponse() {
+    }
+
+    public IndyRestMapperResponse(String message, Throwable cause, LocalDateTime timestamp) {
+        this.message = message;
+        this.cause = cause;
+        this.timestamp = timestamp;
+    }
+
+    public IndyRestMapperResponse(String message, LocalDateTime timestamp) {
+        this.message = message;
+        this.timestamp = timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Throwable getCause() {
+        return cause;
+    }
+
+    public void setCause(Throwable cause) {
+        this.cause = cause;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
@@ -206,6 +206,7 @@ public class IndyDeployment
         deploymentProviders.forEach( di -> classes.addAll( di.getAdditionalClasses() ) );
         classes.add( CDIJacksonProvider.class );
         classes.add( UnhandledIOExceptionHandler.class );
+        classes.add(IndyRestMapperExceptionHandler.class);
         return classes;
     }
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
@@ -1,0 +1,33 @@
+package org.commonjava.indy.bind.jaxrs;
+
+
+import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
+import org.commonjava.indy.IndyException;
+import org.commonjava.indy.model.rest.IndyRestMapperResponse;
+import org.jboss.resteasy.client.exception.ResteasyHttpException;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/*
+    Catch all Server Exceptions propagated back to client caller through HTTP REST calls and returning json object
+    representation of exception message.
+ */
+@Provider
+public class IndyRestMapperExceptionHandler implements ExceptionMapper<Exception> {
+
+
+    @Override
+    public Response toResponse(Exception exception) {
+        IndyRestMapperResponse irmpr = new IndyRestMapperResponse(exception.getMessage(), LocalDateTime.now());
+        Optional
+          .ofNullable(exception.getCause())
+          .ifPresent((exc) -> { irmpr.setCause(exc.getCause()); } );
+        return Response.ok(irmpr, MediaType.APPLICATION_JSON).build();
+    }
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
@@ -29,6 +29,6 @@ public class IndyRestMapperExceptionHandler implements ExceptionMapper<Exception
         Optional
           .ofNullable(exception.getCause())
           .ifPresent((exc) -> { irmpr.setCause(exc.getCause()); } );
-        return Response.serverError().entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+        return Response.status(Response.Status.BAD_REQUEST).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
     }
 }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
@@ -39,14 +39,17 @@ public class IndyRestMapperExceptionHandler implements ExceptionMapper<Exception
 
         if(exception instanceof IndyWorkflowException || exception instanceof IOException) {
             return Response.status(Response.Status.BAD_REQUEST).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
-        } else if(exception instanceof ServiceUnavailableException || exception instanceof IOException ) {
+        } else if(exception instanceof ServiceUnavailableException ) {
             return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
         } else if(exception instanceof NotFoundException) {
+//            return null;
             return Response.status(Response.Status.NOT_FOUND).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
-        } else if(exception instanceof RuntimeException) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
-        } else {
-            return Response.status(Response.Status.NOT_FOUND).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+        }
+//        else if(exception instanceof RuntimeException) {
+//            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+//        }
+        else {
+            return Response.status(Response.Status.NOT_FOUND).entity(null).build();
         }
 
     }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
@@ -3,6 +3,7 @@ package org.commonjava.indy.bind.jaxrs;
 
 import com.fasterxml.jackson.databind.jsonFormatVisitors.JsonObjectFormatVisitor;
 import org.commonjava.indy.IndyException;
+import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.model.rest.IndyRestMapperResponse;
 import org.jboss.resteasy.client.exception.ResteasyHttpException;
 
@@ -12,6 +13,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -29,6 +31,15 @@ public class IndyRestMapperExceptionHandler implements ExceptionMapper<Exception
         Optional
           .ofNullable(exception.getCause())
           .ifPresent((exc) -> { irmpr.setCause(exc.getCause()); } );
-        return Response.status(Response.Status.BAD_REQUEST).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+
+        if(exception instanceof RuntimeException) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+        } else if(exception instanceof IndyWorkflowException) {
+            return Response.status(Response.Status.BAD_REQUEST).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+        } else if(exception instanceof IOException) {
+            return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+        } else {
+            return Response.status(Response.Status.NOT_FOUND).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+        }
     }
 }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
@@ -6,6 +6,7 @@ import org.commonjava.indy.IndyException;
 import org.commonjava.indy.model.rest.IndyRestMapperResponse;
 import org.jboss.resteasy.client.exception.ResteasyHttpException;
 
+import javax.print.attribute.standard.Media;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -28,6 +29,6 @@ public class IndyRestMapperExceptionHandler implements ExceptionMapper<Exception
         Optional
           .ofNullable(exception.getCause())
           .ifPresent((exc) -> { irmpr.setCause(exc.getCause()); } );
-        return Response.ok(irmpr, MediaType.APPLICATION_JSON).build();
+        return Response.serverError().entity(irmpr).type(MediaType.APPLICATION_JSON).build();
     }
 }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyRestMapperExceptionHandler.java
@@ -8,6 +8,8 @@ import org.commonjava.indy.model.rest.IndyRestMapperResponse;
 import org.jboss.resteasy.client.exception.ResteasyHttpException;
 
 import javax.print.attribute.standard.Media;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.ServiceUnavailableException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -15,6 +17,9 @@ import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 /*
@@ -32,14 +37,17 @@ public class IndyRestMapperExceptionHandler implements ExceptionMapper<Exception
           .ofNullable(exception.getCause())
           .ifPresent((exc) -> { irmpr.setCause(exc.getCause()); } );
 
-        if(exception instanceof RuntimeException) {
-            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
-        } else if(exception instanceof IndyWorkflowException) {
+        if(exception instanceof IndyWorkflowException || exception instanceof IOException) {
             return Response.status(Response.Status.BAD_REQUEST).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
-        } else if(exception instanceof IOException) {
+        } else if(exception instanceof ServiceUnavailableException || exception instanceof IOException ) {
             return Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+        } else if(exception instanceof NotFoundException) {
+            return Response.status(Response.Status.NOT_FOUND).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
+        } else if(exception instanceof RuntimeException) {
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
         } else {
             return Response.status(Response.Status.NOT_FOUND).entity(irmpr).type(MediaType.APPLICATION_JSON).build();
         }
+
     }
 }


### PR DESCRIPTION
Adding HTTP REST Exception Mapper for catching all server exceptions , errors and not found resources and returning json object with message , throwable cause ( if is it there ) and timestamp when this irregularity happened.
Whit this feature we will return nice representation of parsable json structure object with message what happened in backend environment and not raw exception stack trace message like in previous cases.  