### PR TITLE
Allow disable of content index, and add prometheus metrics adapter

### DIFF
--- a/addons/content-index/src/main/conf/conf.d/content-index.conf
+++ b/addons/content-index/src/main/conf/conf.d/content-index.conf
@@ -1,4 +1,6 @@
 [content-index]
+#enabled=false
+
 # This property is used to control if authoritative index is enabled. the authoritative index means:
 # in terms of performance consideration, we will use content-index as the one-time check for the content
 # access, and if not found in content indexing, will treat it as "no content" and bypass the following access to the storage.
@@ -6,4 +8,4 @@
 
 # This property is used to enable content index warmer, which will scan all repos and load all artifacts
 # into content index when startup.
-# index.warmer.enable=true
+# index.warmer.enabled=true

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.content.index;
 
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.indy.action.ShutdownAction;
+import org.commonjava.indy.content.index.conf.ContentIndexConfig;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
@@ -77,6 +78,9 @@ public class DefaultContentIndexManager
     @Inject
     private Instance<PackageIndexingStrategy> indexingStrategyComponents;
 
+    @Inject
+    private ContentIndexConfig config;
+
     private Map<String, PackageIndexingStrategy> indexingStrategies;
 
     private QueryFactory queryFactory;
@@ -98,6 +102,12 @@ public class DefaultContentIndexManager
     @PostConstruct
     public void constructed()
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         if ( indexingStrategyComponents != null )
         {
             Map<String, PackageIndexingStrategy> strats = new HashMap<>();
@@ -126,6 +136,12 @@ public class DefaultContentIndexManager
     public void stop()
             throws IndyLifecycleException
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         logger.debug( "Shutdown index cache" );
         contentIndex.stop();
     }
@@ -140,6 +156,12 @@ public class DefaultContentIndexManager
     @Measure
     public boolean removeIndexedStorePath( String rawPath, StoreKey key, Consumer<IndexedStorePath> pathConsumer )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return false;
+        }
+
         String path = getStrategyPath( key, rawPath );
         IndexedStorePath topPath = new IndexedStorePath( key, path );
         logger.trace( "Attempting to remove indexed path: {}", topPath );
@@ -158,6 +180,12 @@ public class DefaultContentIndexManager
 
     public String getStrategyPath( final StoreKey key, final String rawPath )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return rawPath;
+        }
+
         PackageIndexingStrategy strategy = indexingStrategies.get( key.getPackageType() );
         if ( strategy == null )
         {
@@ -174,6 +202,12 @@ public class DefaultContentIndexManager
     @Measure
     public void deIndexStorePath( final StoreKey key, final String rawPath )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         String path = getStrategyPath( key, rawPath );
         IndexedStorePath toRemove = new IndexedStorePath( key, path );
         IndexedStorePath val = contentIndex.remove( toRemove );
@@ -184,6 +218,12 @@ public class DefaultContentIndexManager
     @Measure
     public StoreKey getIndexedStoreKey( final StoreKey key, final String rawPath )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return null;
+        }
+
         String path = getStrategyPath( key, rawPath );
         IndexedStorePath ispKey = new IndexedStorePath( key, path );
         IndexedStorePath val = contentIndex.get( ispKey );
@@ -204,6 +244,12 @@ public class DefaultContentIndexManager
     @Measure
     public void indexTransferIn( Transfer transfer, StoreKey...topKeys )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         if ( transfer != null && transfer.exists() )
         {
             StoreKey key = LocationUtils.getKey( transfer );
@@ -219,6 +265,12 @@ public class DefaultContentIndexManager
     @Measure
     public void indexPathInStores( String rawPath, StoreKey originKey, StoreKey... topKeys )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         String path = getStrategyPath( originKey, rawPath );
 
         IndexedStorePath origin = new IndexedStorePath( originKey, path );
@@ -237,6 +289,12 @@ public class DefaultContentIndexManager
     @Measure
     public void clearAllIndexedPathInStore( ArtifactStore store )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         StoreKey sk = store.getKey();
 
         long total = iterateRemove( () -> queryFactory.from( IndexedStorePath.class )
@@ -259,6 +317,12 @@ public class DefaultContentIndexManager
     @Measure
     public void clearAllIndexedPathWithOriginalStore( ArtifactStore originalStore )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         StoreKey osk = originalStore.getKey();
 
         long total = iterateRemove( () -> queryFactory.from( IndexedStorePath.class )
@@ -303,6 +367,12 @@ public class DefaultContentIndexManager
     @Measure
     public void clearAllIndexedPathInStoreWithOriginal( ArtifactStore store, ArtifactStore originalStore )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         StoreKey sk = store.getKey();
         StoreKey osk = originalStore.getKey();
 
@@ -337,6 +407,12 @@ public class DefaultContentIndexManager
     @Measure
     public void clearIndexedPathFrom( String rawPath, Set<Group> groups, Consumer<IndexedStorePath> pathConsumer )
     {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Content indexing is disabled." );
+            return;
+        }
+
         if ( groups == null || groups.isEmpty() )
         {
             return;

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -66,7 +66,7 @@ import static org.commonjava.indy.measure.annotation.MetricNamed.DEFAULT;
 public abstract class IndexingContentManagerDecorator
         implements ContentManager
 {
-    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+    private final Logger logger = LoggerFactory.getLogger( IndexingContentManagerDecorator.class.getName() );
 
     @Inject
     private StoreDataManager storeDataManager;
@@ -296,6 +296,7 @@ public abstract class IndexingContentManagerDecorator
             }
         }
 
+        logger.trace( "Delegating retrieve call for concrete repository: {}/{}", store, path );
         transfer = delegate.retrieve( store, path, eventMetadata );
 
         if ( exists( transfer ) && indexCfg.isEnabled() )
@@ -370,7 +371,7 @@ public abstract class IndexingContentManagerDecorator
     {
         if ( !indexCfg.isEnabled() )
         {
-            logger.debug( "Content indexing is disabled." );
+            logger.debug( "Content indexing is disabled. Returning null for indexedTransfer of: {}/{}", storeKey, path );
             return null;
         }
 

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/ContentIndexConfig.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/ContentIndexConfig.java
@@ -18,6 +18,8 @@ package org.commonjava.indy.content.index.conf;
 import org.commonjava.indy.conf.IndyConfigInfo;
 import org.commonjava.propulsor.config.annotation.ConfigName;
 import org.commonjava.propulsor.config.annotation.SectionName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.io.InputStream;
@@ -92,7 +94,12 @@ public class ContentIndexConfig
 
     public boolean isEnabled()
     {
-        return enabled == null ? DEFAULT_ENABLED : enabled;
+        Boolean result = enabled == null ? DEFAULT_ENABLED : enabled;
+
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.debug( "Is content indexer enabled? {}", result );
+
+        return result;
     }
 
     @ConfigName( ContentIndexConfig.ENABLE )

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/ContentIndexConfig.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/ContentIndexConfig.java
@@ -31,15 +31,21 @@ public class ContentIndexConfig
 
     public static final String AUTH_INDEX_PARAM = "support.authoritative.indexes";
 
-    public static final String ENABLE_INDEX_WARMER = "index.warmer.enable";
+    public static final String ENABLE_INDEX_WARMER = "index.warmer.enabled";
+
+    private static final String ENABLE = "enabled";
 
     private static final Boolean DEFAULT_AUTHORITATIVE_INDEXES = Boolean.FALSE;
 
     private static final Boolean DEFAULT_WARMER_ENABLED = Boolean.FALSE;
 
+    private static final Boolean DEFAULT_ENABLED = Boolean.FALSE;
+
     private Boolean authoritativeIndex;
 
     private Boolean warmerEnabled;
+
+    private Boolean enabled;
 
     public ContentIndexConfig()
     {
@@ -82,5 +88,16 @@ public class ContentIndexConfig
     public InputStream getDefaultConfig()
     {
         return Thread.currentThread().getContextClassLoader().getResourceAsStream( "default-content-index.conf" );
+    }
+
+    public boolean isEnabled()
+    {
+        return enabled == null ? DEFAULT_ENABLED : enabled;
+    }
+
+    @ConfigName( ContentIndexConfig.ENABLE )
+    public void setEnabled( Boolean enabled )
+    {
+        this.enabled = enabled;
     }
 }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/HostedContentIndexRescanManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/conf/HostedContentIndexRescanManager.java
@@ -59,6 +59,9 @@ public class HostedContentIndexRescanManager implements ContentIndexRescanManage
     private ContentIndexManager contentIndexManager;
 
     @Inject
+    private ContentIndexConfig indexConfig;
+
+    @Inject
     private DownloadManager downloadManager;
 
     protected HostedContentIndexRescanManager()
@@ -68,6 +71,12 @@ public class HostedContentIndexRescanManager implements ContentIndexRescanManage
     public void indexPreRescan( @Observes final ArtifactStorePreRescanEvent e )
             throws IndyWorkflowException
     {
+        if ( !indexConfig.isEnabled() )
+        {
+            LOGGER.debug( "Content index is disabled." );
+            return;
+        }
+
         Collection<ArtifactStore> affectedRepos = e.getStores();
         for ( ArtifactStore repo : affectedRepos )
         {
@@ -89,6 +98,12 @@ public class HostedContentIndexRescanManager implements ContentIndexRescanManage
     public void indexPostRescan( @Observes final ArtifactStorePostRescanEvent e )
             throws IndyWorkflowException
     {
+        if ( !indexConfig.isEnabled() )
+        {
+            LOGGER.debug( "Content index is disabled." );
+            return;
+        }
+
         Collection<ArtifactStore> hostedStores = e.getStores();
         for ( ArtifactStore repo : hostedStores )
         {

--- a/addons/content-index/src/main/resources/default-content-index.conf
+++ b/addons/content-index/src/main/resources/default-content-index.conf
@@ -1,9 +1,11 @@
 [content-index]
+#enabled = false
+
 # This property is used to control if authoritative index is enabled. the authoritative index means:
 # in terms of performance consideration, we will use content-index as the one-time check for the content
 # access, and if not found in content indexing, will treat it as "no content" and bypass the following access to the storage.
-support.authoritative.indexes=false
+#support.authoritative.indexes=false
 
 # This property is used to enable content index warmer, which will scan all repos and load all artifacts
 # into content index when startup.
-index.warmer.enable=false
+#index.warmer.enabled=false

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiContentManagerDecorator.java
@@ -97,7 +97,7 @@ import static org.commonjava.maven.galley.maven.util.ArtifactPathUtils.formatMet
 public abstract class KojiContentManagerDecorator
         implements ContentManager
 {
-    private Logger logger = LoggerFactory.getLogger( getClass() );
+    private Logger logger = LoggerFactory.getLogger( KojiContentManagerDecorator.class.getName() );
 
     public static final String CREATION_TRIGGER_GAV = "creation-trigger-GAV";
 

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -64,7 +64,7 @@ public class DefaultContentManager
         implements ContentManager
 {
 
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    private final Logger logger = LoggerFactory.getLogger( DefaultContentManager.class.getName() );
 
     @Inject
     private ContentGeneratorManager contentGeneratorManager;

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -69,6 +69,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-metrics-prometheus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-cpool</artifactId>
     </dependency>
     <dependency>

--- a/embedder/src/test/resources/logback-test.xml
+++ b/embedder/src/test/resources/logback-test.xml
@@ -48,7 +48,7 @@
   <logger name="org.commonjava.indy.pkg.npm.content.NPMStoragePathCalculator" level="INFO" />
   <logger name="org.commonjava.indy.metrics" level="INFO" />
 
-  <root level="INFO">
+  <root level="DEBUG">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />
   </root>

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedContentIndexRescanTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/HostedContentIndexRescanTest.java
@@ -80,6 +80,6 @@ public class HostedContentIndexRescanTest
             throws IOException
     {
         super.initTestConfig( fixture );
-        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nsupport.authoritative.indexes=true" );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true\nsupport.authoritative.indexes=true" );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/RepositoryPathMaskMetadataTest.java
@@ -103,7 +103,7 @@ public class RepositoryPathMaskMetadataTest
 
         HostedRepository hostedRepo1 = new HostedRepository( hosted1 );
         pathMaskPatterns = new HashSet<>();
-        pathMaskPatterns.add("org/bar.*");
+        pathMaskPatterns.add("r|org/bar.*|");
         hostedRepo1.setPathMaskPatterns(pathMaskPatterns);
         hostedRepo1 = client.stores().create( hostedRepo1, "adding hosted 1", HostedRepository.class );
         client.content().store( hosted, hosted1, path_metadata, new ByteArrayInputStream( meta2.getBytes() ) );

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/AuthoritativeIndexedContentInHostedTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/AuthoritativeIndexedContentInHostedTest.java
@@ -154,6 +154,6 @@ public class AuthoritativeIndexedContentInHostedTest
             throws IOException
     {
         super.initTestConfig( fixture );
-        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nsupport.authoritative.indexes=true" );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true\nsupport.authoritative.indexes=true" );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/AuthoritativeIndexedContentInRemoteTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/AuthoritativeIndexedContentInRemoteTest.java
@@ -137,6 +137,6 @@ public class AuthoritativeIndexedContentInRemoteTest
             throws IOException
     {
         super.initTestConfig( fixture );
-        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nsupport.authoritative.indexes=true" );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true\nsupport.authoritative.indexes=true" );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithArtifactsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithArtifactsTest.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.infinispan.AdvancedCache;
 import org.junit.Before;
@@ -29,6 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import javax.enterprise.inject.spi.CDI;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
@@ -168,4 +170,11 @@ public class ContentIndexDirLvWithArtifactsTest
 
     }
 
+    @Override
+    protected void initTestConfig( final CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true" );
+    }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexDirLvWithMetadataTest.java
@@ -24,6 +24,7 @@ import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.infinispan.AdvancedCache;
 import org.junit.Before;
@@ -31,6 +32,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import javax.enterprise.inject.spi.CDI;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
@@ -133,4 +135,11 @@ public class ContentIndexDirLvWithMetadataTest
 
     }
 
+    @Override
+    protected void initTestConfig( final CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true" );
+    }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexGroupUsageTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexGroupUsageTest.java
@@ -22,12 +22,14 @@ import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import javax.enterprise.inject.spi.CDI;
+import java.io.IOException;
 import java.io.InputStream;
 
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
@@ -76,6 +78,14 @@ public class ContentIndexGroupUsageTest
     public void getIndexManager()
     {
         indexManager = CDI.current().select( ContentIndexManager.class ).get();
+    }
+
+    @Override
+    protected void initTestConfig( final CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true" );
     }
 
     @Test

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexNestedGroupAndStoreDeletionTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexNestedGroupAndStoreDeletionTest.java
@@ -23,12 +23,14 @@ import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import javax.enterprise.inject.spi.CDI;
+import java.io.IOException;
 import java.io.InputStream;
 
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
@@ -147,5 +149,13 @@ public class ContentIndexNestedGroupAndStoreDeletionTest
             logger.debug( "\n\n\nGot indexedStoreKey: " + indexedStoreKey + "\n\n\n" );
             assertThat( "Indexed StoreKey not found for " + store.getKey(), indexedStoreKey, notNullValue() );
         }
+    }
+
+    @Override
+    protected void initTestConfig( final CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true" );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexRemoteRepoUsageTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/contentindex/ContentIndexRemoteRepoUsageTest.java
@@ -23,12 +23,14 @@ import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 import javax.enterprise.inject.spi.CDI;
+import java.io.IOException;
 import java.io.InputStream;
 
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
@@ -123,5 +125,13 @@ public class ContentIndexRemoteRepoUsageTest
 
         // object equality should work since we haven't persisted this anywhere yet.
         assertThat( indexedStoreKey == indexedStoreKey2, equalTo( true ) );
+    }
+
+    @Override
+    protected void initTestConfig( final CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true" );
     }
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/HostedAuthIndexWithReadonly.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/store/HostedAuthIndexWithReadonly.java
@@ -96,6 +96,6 @@ public class HostedAuthIndexWithReadonly
             throws IOException
     {
         super.initTestConfig( fixture );
-        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nsupport.authoritative.indexes=true"  );
+        writeConfigFile( "conf.d/content-index.conf", "[content-index]\nenabled=true\nsupport.authoritative.indexes=true"  );
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1024,6 +1024,17 @@
       </dependency>
 
       <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_servlet</artifactId>
+        <version>0.7.0</version>
+      </dependency>
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_dropwizard</artifactId>
+        <version>0.7.0</version>
+      </dependency>
+
+      <dependency>
         <groupId>io.github.hengyunabc</groupId>
         <artifactId>zabbix-api</artifactId>
         <version>0.0.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -724,6 +724,11 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-subsys-metrics-prometheus</artifactId>
+        <version>1.9.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-reporter</artifactId>
         <version>1.9.6-SNAPSHOT</version>
         <classifier>confset</classifier>

--- a/subsys/metrics/pom.xml
+++ b/subsys/metrics/pom.xml
@@ -32,6 +32,7 @@
   <modules>
     <module>core</module>
     <module>reporter</module>
+    <module>prometheus</module>
   </modules>
 
 </project>

--- a/subsys/metrics/prometheus/pom.xml
+++ b/subsys/metrics/prometheus/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>indy-subsys-metrics</artifactId>
+    <groupId>org.commonjava.indy</groupId>
+    <version>1.9.6-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>indy-subsys-metrics-prometheus</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_dropwizard</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-metrics-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-flatfile</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>http-testserver</artifactId>
+    </dependency>
+  </dependencies>
+
+<!--   <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>confset</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>confset</descriptorRef>
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+ -->
+</project>

--- a/subsys/metrics/prometheus/src/main/java/org/commonjava/indy/metrics/prometheus/PrometheusDeployment.java
+++ b/subsys/metrics/prometheus/src/main/java/org/commonjava/indy/metrics/prometheus/PrometheusDeployment.java
@@ -1,0 +1,57 @@
+package org.commonjava.indy.metrics.prometheus;
+
+import com.codahale.metrics.MetricRegistry;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.dropwizard.DropwizardExports;
+import io.prometheus.client.exporter.MetricsServlet;
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.ServletInfo;
+import org.commonjava.indy.bind.jaxrs.IndyDeploymentProvider;
+import org.commonjava.indy.bind.jaxrs.metrics.IndyHealthCheckServletContextListener;
+import org.commonjava.indy.metrics.conf.IndyMetricsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.Application;
+
+@ApplicationScoped
+public class PrometheusDeployment
+        extends IndyDeploymentProvider
+{
+    private static final String PROMETHEUS_REPORTER = "prometheus";
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private IndyMetricsConfig config;
+
+    @Inject
+    private MetricRegistry metricRegistry;
+
+    @Override
+    public DeploymentInfo getDeploymentInfo( String contextRoot, Application application )
+    {
+        if ( !config.isMetricsEnabled() || !config.getReporter().contains( PROMETHEUS_REPORTER ) )
+        {
+            return null;
+        }
+
+        CollectorRegistry.defaultRegistry.register( new DropwizardExports( metricRegistry ) );
+
+        final ServletInfo servlet =
+                Servlets.servlet( "prometheus-metrics", MetricsServlet.class ).addMapping( "/metrics" );
+
+        final DeploymentInfo di = new DeploymentInfo().addListener(
+                Servlets.listener( IndyHealthCheckServletContextListener.class ) )
+                                                      .setContextPath( contextRoot )
+                                                      .addServlet( servlet )
+                                                      .setDeploymentName( "Prometheus Metrics Deployment" )
+                                                      .setClassLoader( ClassLoader.getSystemClassLoader() );
+
+        logger.info( "Returning deployment info for Prometheus metrics servlet" );
+        return di;
+    }
+}


### PR DESCRIPTION
Adding Dropwizard Metrics adapter to publish metrics to Prometheus via servlet, since our perf-test instance can't deploy GraphiteDB to a pod. This gets us ready for Prometheus anyway.

We may not need content indexing anymore in our particular deployment environment, and it might actually be hurting performance for our use case. Adding an option to disable it via config.