### PR TITLE
Deprecated listContents in client module as it is not working now

### DIFF
--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyContentClientModule.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/module/IndyContentClientModule.java
@@ -65,6 +65,12 @@ public class IndyContentClientModule
         return buildUrl( null, aggregatePathParts( key, path ) );
     }
 
+    /**
+     * Please do not use this method to get list content, because new content browse is not using html but using json now,
+     * so this method will return wrong result now. Please use {@link org.commonjava.indy.content.browse.client.IndyContentBrowseClientModule} instead.
+     * This method will be removed in recent release.
+     */
+    @Deprecated
     public DirectoryListingDTO listContents( final StoreKey key, final String path )
             throws IndyClientException
     {
@@ -77,6 +83,11 @@ public class IndyContentClientModule
         return http.get( contentPath( key, p ), DirectoryListingDTO.class );
     }
 
+    /**
+     * Please do not use this method to get list content, because new content browse is not using html but using json now,
+     * so this method will return wrong result now. Please use {@link org.commonjava.indy.content.browse.client.IndyContentBrowseClientModule} instead.
+     * This method will be removed in recent release.
+     */
     @Deprecated
     public DirectoryListingDTO listContents( final StoreType type, final String name, final String path )
             throws IndyClientException

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/DirectoryListingDTO.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/dto/DirectoryListingDTO.java
@@ -17,6 +17,10 @@ package org.commonjava.indy.model.core.dto;
 
 import java.util.List;
 
+/**
+ * @deprecated New content browse service is json based now, so this DTO is not used anymore. Will be removed in recent release
+ */
+@Deprecated
 public class DirectoryListingDTO
 {
 


### PR DESCRIPTION
These methods & classes are totally not working now. If we will not switch back to the old way of content-listing again, I suggest to remove them in next release.