### PR TITLE
Integrate with pathmapped storage

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -509,7 +509,7 @@ public class MavenMetadataGenerator
                       path, metaMergeInfo );
         helper.writeMergeInfo( metaMergeInfo, group, path );
         logger.trace( ".info file regenerated for group {} of members {} in path. Full path: {}", group.getKey(), contributingMembers,
-                      path, mergeInfoTarget.getDetachedFile() );
+                      path, mergeInfoTarget.getFullPath() );
 
         return metaMergeInfo;
     }

--- a/bin/test-setup.sh
+++ b/bin/test-setup.sh
@@ -82,7 +82,6 @@ else
   <logger name="org.jboss.resteasy" level="DEBUG" />
   <logger name="org.jboss" level="ERROR"/>
   <logger name="org.commonjava" level="DEBUG" />
-  <logger name="org.apache.http.wire" level="DEBUG" />
   <root level="INFO">
     <appender-ref ref="STDOUT" />
     <appender-ref ref="FILE" />

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -328,6 +328,13 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-ftests-changelog</artifactId>
     </dependency>
+
+<!--
+    <dependency>
+      <groupId>org.cassandraunit</groupId>
+      <artifactId>cassandra-unit</artifactId>
+    </dependency>
+-->
   </dependencies>
   
   <build>

--- a/filers/default/pom.xml
+++ b/filers/default/pom.xml
@@ -41,6 +41,10 @@
       <artifactId>galley-cache-partyline</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.maven.galley</groupId>
+      <artifactId>galley-cache-path-mapped</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-infinispan</artifactId>
     </dependency>

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -26,7 +26,7 @@ import org.commonjava.indy.filer.def.conf.DefaultStorageProviderConfiguration;
 import org.commonjava.indy.metrics.IndyMetricsManager;
 import org.commonjava.maven.galley.GalleyInitException;
 import org.commonjava.maven.galley.cache.CacheProviderFactory;
-import org.commonjava.maven.galley.cache.partyline.PartyLineCacheProviderFactory;
+import org.commonjava.maven.galley.cache.pathmapped.PathMappedCacheProviderFactory;
 import org.commonjava.maven.galley.config.TransportManagerConfig;
 import org.commonjava.maven.galley.io.ChecksummingTransferDecorator;
 import org.commonjava.maven.galley.io.NoCacheTransferDecorator;
@@ -148,9 +148,7 @@ public class DefaultGalleyStorageProvider
         setupTransferDecoratorPipeline();
 
         final File storeRoot = config.getStorageRootDirectory();
-
-        // Apply partyline gloable lock manager if in cluster Env
-        cacheProviderFactory = new PartyLineCacheProviderFactory( storeRoot, deleteExecutor );
+        cacheProviderFactory = new PathMappedCacheProviderFactory( storeRoot, deleteExecutor, config );
 
         // TODO: Tie this into a config file!
         transportManagerConfig = new TransportManagerConfig();

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
@@ -69,14 +69,15 @@ public class DefaultStorageProviderConfiguration
         this.setUpPathMappedStorage();
     }
 
+    private final Map<String, Object> cassandraProps = new HashMap<>();
+
     @PostConstruct
     public void setUpPathMappedStorage()
     {
-        Map<String, Object> props = new HashMap<>();
-        props.put( PROP_CASSANDRA_HOST, cassandraHost );
-        props.put( PROP_CASSANDRA_PORT, cassandraPort );
-        props.put( PROP_CASSANDRA_KEYSPACE, cassandraKeyspace );
-        this.pathMappedStorageConfig = new DefaultPathMappedStorageConfig( props );
+        cassandraProps.put( PROP_CASSANDRA_HOST, cassandraHost );
+        cassandraProps.put( PROP_CASSANDRA_PORT, cassandraPort );
+        cassandraProps.put( PROP_CASSANDRA_KEYSPACE, cassandraKeyspace );
+        this.pathMappedStorageConfig = new DefaultPathMappedStorageConfig( cassandraProps );
     }
 
     public File getStorageRootDirectory()
@@ -133,6 +134,7 @@ public class DefaultStorageProviderConfiguration
     public void setCassandraHost( String host )
     {
         cassandraHost = host;
+        cassandraProps.put( PROP_CASSANDRA_HOST, cassandraHost );
     }
 
     private int cassandraPort = 9042;
@@ -141,6 +143,7 @@ public class DefaultStorageProviderConfiguration
     public void setCassandraPort( int port )
     {
         cassandraPort = port;
+        cassandraProps.put( PROP_CASSANDRA_PORT, cassandraPort );
     }
 
     private String cassandraKeyspace = "indy";
@@ -149,6 +152,7 @@ public class DefaultStorageProviderConfiguration
     public void setCassandraKeyspace( String keyspace )
     {
         cassandraKeyspace = keyspace;
+        cassandraProps.put( PROP_CASSANDRA_KEYSPACE, cassandraKeyspace );
     }
 
     private PathMappedStorageConfig pathMappedStorageConfig;

--- a/ftests/common/pom.xml
+++ b/ftests/common/pom.xml
@@ -65,5 +65,9 @@
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.cassandraunit</groupId>
+      <artifactId>cassandra-unit</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.ftest.core;
 import com.fasterxml.jackson.databind.Module;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+//import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.propulsor.boot.BootStatus;
 import org.commonjava.propulsor.boot.BootException;
@@ -118,6 +119,10 @@ public abstract class AbstractIndyFunctionalTest
                 final BootStatus status = fixture.getBootStatus();
                 throw new IllegalStateException( "server fixture failed to boot.", status.getError() );
             }
+/*
+            EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+            logger.debug( "Embedded Cassandra server started" );
+*/
 
             client = createIndyClient();
         }
@@ -222,7 +227,7 @@ public abstract class AbstractIndyFunctionalTest
     protected void initBaseTestConfig( CoreServerFixture fixture )
             throws IOException
     {
-        writeConfigFile( "conf.d/storage.conf", "[storage-default]\nstorage.dir=" + fixture.getBootOptions().getHomeDir() + "/var/lib/indy/storage" );
+        writeConfigFile( "conf.d/storage.conf", "[storage-default]\nstorage.dir=" + fixture.getBootOptions().getHomeDir() + "/var/lib/indy/storage\nstorage.cassandra.port=9142" );
         if ( isSchedulerEnabled() )
         {
             writeConfigFile( "conf.d/scheduler.conf", readTestResource( "default-test-scheduler.conf" ) );

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -18,7 +18,7 @@ package org.commonjava.indy.ftest.core;
 import com.fasterxml.jackson.databind.Module;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-//import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.commonjava.propulsor.boot.BootStatus;
 import org.commonjava.propulsor.boot.BootException;
@@ -119,10 +119,9 @@ public abstract class AbstractIndyFunctionalTest
                 final BootStatus status = fixture.getBootStatus();
                 throw new IllegalStateException( "server fixture failed to boot.", status.getError() );
             }
-/*
+
             EmbeddedCassandraServerHelper.startEmbeddedCassandra();
             logger.debug( "Embedded Cassandra server started" );
-*/
 
             client = createIndyClient();
         }
@@ -227,7 +226,10 @@ public abstract class AbstractIndyFunctionalTest
     protected void initBaseTestConfig( CoreServerFixture fixture )
             throws IOException
     {
-        writeConfigFile( "conf.d/storage.conf", "[storage-default]\nstorage.dir=" + fixture.getBootOptions().getHomeDir() + "/var/lib/indy/storage\nstorage.cassandra.port=9142" );
+        writeConfigFile( "conf.d/storage.conf", "[storage-default]\n"
+                        + "storage.dir=" + fixture.getBootOptions().getHomeDir() + "/var/lib/indy/storage\n"
+                        + "storage.cassandra.port=9142\n"
+                        + "storage.cassandra.keyspace=" + getClass().getSimpleName() );
         if ( isSchedulerEnabled() )
         {
             writeConfigFile( "conf.d/scheduler.conf", readTestResource( "default-test-scheduler.conf" ) );

--- a/pom.xml
+++ b/pom.xml
@@ -77,10 +77,11 @@
     <jgroupsVersion>4.0.4.Final</jgroupsVersion>
     <httpcoreVersion>4.4.9</httpcoreVersion>
     <httpclientVersion>4.5.9</httpclientVersion>
+    <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.0</atlasVersion>
-    <galleyVersion>0.17.2</galleyVersion>
+    <galleyVersion>0.17.3-SNAPSHOT</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.16</partylineVersion>
@@ -1118,6 +1119,16 @@
         <groupId>org.commonjava.maven.galley</groupId>
         <artifactId>galley-cache-partyline</artifactId>
         <version>${galleyVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.maven.galley</groupId>
+        <artifactId>galley-cache-path-mapped</artifactId>
+        <version>${galleyVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.cassandraunit</groupId>
+        <artifactId>cassandra-unit</artifactId>
+        <version>${cassandraUnitVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.maven.galley</groupId>


### PR DESCRIPTION
I created a branch "master-integration-pathmap" for the integration. 
This is the first PR. With this one, you can build Indy and run bin/test-setup.sh with a local Cassandra (yum install cassandra cassandra-server; systemctl start cassandra). 
I am struggling with the ftests. It seems the cassandra unit bring some conflicts to io.netty dependency. But if you don't care about ftests, this works well. I was able to build some small projects (like partyline, weft) against this integrated Indy instance. 
Have fun playing with it!