### PR TITLE
Apply cassandra-maven-plugin for ftests

### DIFF
--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataFileDeletionTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataFileDeletionTest.java
@@ -19,6 +19,7 @@ import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.util.LocationUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -55,7 +56,7 @@ import static org.jgroups.util.Util.assertTrue;
 public class GroupMetadataFileDeletionTest
                 extends AbstractContentManagementTest
 {
-    private static final String METADATA_PATH = "/org/foo/bar/maven-metadata.xml";
+    private static final String METADATA_PATH = "org/foo/bar/maven-metadata.xml";
 
     /* @formatter:off */
     private static final String METADATA_CONTENT = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -96,8 +97,8 @@ public class GroupMetadataFileDeletionTest
     @Test
     public void run() throws Exception
     {
-        File f1 = new File( storageDir, "maven/group-" + g1.getName() + METADATA_PATH );
-        File f2 = new File( storageDir, "maven/group-" + g2.getName() + METADATA_PATH );
+        File f1 = getPhysicalStorageFile( LocationUtils.toLocation( g1 ), METADATA_PATH );
+        File f2 = getPhysicalStorageFile( LocationUtils.toLocation( g2 ), METADATA_PATH );
 
         // Files exist
         assertTrue( f1.exists() );
@@ -105,6 +106,8 @@ public class GroupMetadataFileDeletionTest
 
         // Delete cache file from G1, which will delete parent G2's cache too
         client.content().deleteCache( g1.getKey(), METADATA_PATH );
+
+        sleepAndRunFileGC( 1000 );
 
         // Verify files were deleted
         assertFalse( f1.exists() );

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -1193,7 +1193,7 @@ public class DefaultDownloadManager
         final List<Transfer> result = new ArrayList<>();
         final Transfer transfer = getStorageReference( src, startPath );
         recurseListing( transfer, result );
-
+        logger.debug( "listRecursively result: {}", result );
         return result;
     }
 

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -404,6 +404,25 @@
             </execution>
           </executions>
         </plugin>
+
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>cassandra-maven-plugin</artifactId>
+          <version>3.6</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>start</goal>
+                <goal>stop</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <startNativeTransport>true</startNativeTransport>
+            <cqlVersion>3.4.4</cqlVersion>
+            <maxMemory>1024</maxMemory>
+          </configuration>
+        </plugin>
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
           <configuration>
@@ -457,6 +476,10 @@
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cassandra-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/embedder/src/cassandra/cql/load.cql
+++ b/embedder/src/cassandra/cql/load.cql
@@ -1,0 +1,5 @@
+// This empty file is necessary for cassandra-maven-plugin. If missing, the plugin start-up will fail.
+CREATE  KEYSPACE IF NOT EXISTS test WITH REPLICATION = {
+    'class' : 'SimpleStrategy',
+    'replication_factor' : 1
+};

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -161,20 +161,6 @@ public class AbstractContentManagementTest
         return ret;
     }
 
-    protected void sleepAndRunFileGC( long milliseconds )
-    {
-        try
-        {
-            Thread.sleep( milliseconds );
-        }
-        catch ( InterruptedException e )
-        {
-            e.printStackTrace();
-        }
-        CacheProvider cacheProvider = CDI.current().select( CacheProvider.class).get();
-        cacheProvider.asAdminView().gc();
-    }
-
     protected void assertExistence( ArtifactStore store, String path, boolean expected )
             throws IndyClientException
     {

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -203,6 +203,20 @@ public abstract class AbstractIndyFunctionalTest
         }
     }
 
+    protected void sleepAndRunFileGC( long milliseconds )
+    {
+        try
+        {
+            Thread.sleep( milliseconds );
+        }
+        catch ( InterruptedException e )
+        {
+            e.printStackTrace();
+        }
+        CacheProvider cacheProvider = CDI.current().select( CacheProvider.class).get();
+        cacheProvider.asAdminView().gc();
+    }
+
     protected final CoreServerFixture newServerFixture()
             throws BootException, IOException
     {

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -18,8 +18,8 @@ package org.commonjava.indy.ftest.core;
 import com.fasterxml.jackson.databind.Module;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.commonjava.indy.action.IndyLifecycleException;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.propulsor.boot.BootStatus;
 import org.commonjava.propulsor.boot.BootException;
 import org.commonjava.indy.client.core.Indy;
@@ -42,7 +42,6 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.inject.spi.CDI;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -54,7 +53,6 @@ import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
-import static org.cassandraunit.utils.EmbeddedCassandraServerHelper.CASSANDRA_RNDPORT_YML_FILE;
 import static org.junit.Assert.fail;
 
 public abstract class AbstractIndyFunctionalTest
@@ -88,8 +86,6 @@ public abstract class AbstractIndyFunctionalTest
 
     protected File storageDir;
 
-    private int cassandraPort;
-
     @SuppressWarnings( "resource" )
     @Before
     public void start()
@@ -113,15 +109,6 @@ public abstract class AbstractIndyFunctionalTest
             new Timer().scheduleAtFixedRate( task, 0, 5000 );
 
             Thread.currentThread().setName( getClass().getSimpleName() + "." + name.getMethodName() );
-
-            if ( isPathMappedStorageEnabled() )
-            {
-                String tempDir = "target/embeddedCassandra_" + getClass().getSimpleName();
-                EmbeddedCassandraServerHelper.startEmbeddedCassandra( CASSANDRA_RNDPORT_YML_FILE, tempDir );
-                //EmbeddedCassandraServerHelper.startEmbeddedCassandra();
-                cassandraPort = EmbeddedCassandraServerHelper.getNativeTransportPort();
-                logger.debug( "Embedded Cassandra server started, port: {}", cassandraPort );
-            }
 
             fixture = newServerFixture();
             fixture.start();
@@ -201,8 +188,19 @@ public abstract class AbstractIndyFunctionalTest
     public void stop()
             throws IndyLifecycleException
     {
+        closeCacheProvider();
         closeQuietly( fixture );
         closeQuietly( client );
+    }
+
+    // TODO: this is a hack due to the "shutdown action not executed" issue. Once propulsor lifecycle shutdown is applied, this can be replaced.
+    private void closeCacheProvider()
+    {
+        CacheProvider cacheProvider = CDI.current().select( CacheProvider.class ).get();
+        if ( cacheProvider != null )
+        {
+            cacheProvider.asAdminView().close();
+        }
     }
 
     protected final CoreServerFixture newServerFixture()
@@ -249,7 +247,7 @@ public abstract class AbstractIndyFunctionalTest
         writeConfigFile( "conf.d/storage.conf", "[storage-default]\n"
                         + "storage.dir=" + fixture.getBootOptions().getHomeDir() + "/var/lib/indy/storage\n"
                         + "storage.gc.graceperiodinhours=0\n"
-                        + "storage.cassandra.port=" + cassandraPort + "\n"
+                        + "storage.cassandra.port=9042\n"
                         + "storage.cassandra.keyspace=" + keyspace );
         if ( isSchedulerEnabled() )
         {

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentDeletionMayDisruptGroupMetadataTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/ContentDeletionMayDisruptGroupMetadataTest.java
@@ -100,6 +100,8 @@ public class ContentDeletionMayDisruptGroupMetadataTest
         String retCode = user2.get();
         assertThat( retCode, equalTo( "OK" ) );
 
+        sleepAndRunFileGC( 1000 );
+
         String metadata = user1.get();
         assertThat( metadata, equalTo( null ) );
 

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoWhenNotInPathMaskTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupHttpHeadersFromSameRepoWhenNotInPathMaskTest.java
@@ -27,6 +27,7 @@ import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.util.LocationUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -127,8 +128,7 @@ public class GroupHttpHeadersFromSameRepoWhenNotInPathMaskTest
 //        repoX.setDisabled( true );
 //        client.stores().update( repoX, "disabling" );
 
-        File remoteYFile = Paths.get( fixture.getBootOptions().getHomeDir(), "var/lib/indy/storage", MAVEN_PKG_KEY,
-                                      remote.singularEndpointName() + "-Y", PATH ).toFile();
+        File remoteYFile = getPhysicalStorageFile( LocationUtils.toLocation( repoY ), PATH );
 
         waitForEventPropagation();
 

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeInfoGenTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/GroupMetadataMergeInfoGenTest.java
@@ -24,6 +24,7 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.util.LocationUtils;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -195,12 +196,7 @@ public class GroupMetadataMergeInfoGenTest
     private void assertInfoContent( final ArtifactStore store, final String path, final String expectedContent )
             throws Exception
     {
-
-//        final String infoFilePath =
-//                String.format( "%s/var/lib/indy/storage/%s-%s/%s", fixture.getBootOptions().getIndyHome(), group.name(),
-//                               store.getName(), path + GroupMergeHelper.MERGEINFO_SUFFIX );
-        final File infoFile = Paths.get( fixture.getBootOptions().getHomeDir(), "var/lib/indy/storage", store.getPackageType(),
-                                         group.singularEndpointName() + "-" + store.getName(), path + GroupMergeHelper.MERGEINFO_SUFFIX ).toFile();
+        final File infoFile = getPhysicalStorageFile( LocationUtils.toLocation( store ), path + GroupMergeHelper.MERGEINFO_SUFFIX );
         assertThat( "info file doesn't exist", infoFile.exists(), equalTo( true ) );
 
         try (final InputStream stream = new FileInputStream( infoFile ))


### PR DESCRIPTION
This pr abandon the embedded Cassandra server because those servers conflict with each other on file system. I move to cassandra-maven-plugin that is started up before ftests. All ftests use different keyspace to separate from others.