### PR TITLE
Add subsys/cassandra for general connection settings

### DIFF
--- a/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataFileDeletionTest.java
+++ b/addons/pkg-maven/ftests/src/main/java/org/commonjava/indy/pkg/maven/content/GroupMetadataFileDeletionTest.java
@@ -20,6 +20,7 @@ import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.maven.galley.model.ConcreteResource;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -110,8 +111,10 @@ public class GroupMetadataFileDeletionTest
         sleepAndRunFileGC( 1000 );
 
         // Verify files were deleted
-        assertFalse( f1.exists() );
-        assertFalse( f2.exists() );
+        ConcreteResource r1 = new ConcreteResource( LocationUtils.toLocation( g1 ), METADATA_PATH );
+        ConcreteResource r2 = new ConcreteResource( LocationUtils.toLocation( g2 ), METADATA_PATH );
+        assertFalse( cacheProvider.exists( r1 ) );
+        assertFalse( cacheProvider.exists( r2 ) );
 
         // Re-generate
         assertContent( g1, METADATA_PATH, METADATA_CONTENT );

--- a/filers/default/pom.xml
+++ b/filers/default/pom.xml
@@ -50,6 +50,10 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-cassandra</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-metrics-core</artifactId>
     </dependency>
   </dependencies>

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractContentManagementTest.java
@@ -43,6 +43,8 @@ import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.galley.KeyedLocation;
+import org.commonjava.maven.galley.cache.pathmapped.PathMappedCacheProvider;
+import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.test.http.expect.ExpectationServer;
@@ -137,25 +139,7 @@ public class AbstractContentManagementTest
         }
         else
         {
-            // For something like repo-1:/foo/bar.jar, the physical file should be always in same folder (via getStorageDir),
-            // and the latest file under this folder should be (not theoretically but practically) what we want.
-            String fileSystem = location.getName();
-            String d = getStorageDir( fileSystem, path );
-            File dir = Paths.get( homeDir, storageDir, d ).toFile();
-            File[] files = dir.listFiles();
-            File target = null;
-            for ( File file : files )
-            {
-                if ( target == null )
-                {
-                    target = file;
-                }
-                else if ( target.lastModified() < file.lastModified() )
-                {
-                    target = file;
-                }
-            }
-            ret = target.getAbsoluteFile();
+            ret = ( (PathMappedCacheProvider) cacheProvider ).getDetachedFile( new ConcreteResource( location, path ) );
         }
         logger.debug( "Get physical storage file: {}", ret );
         return ret;

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -201,10 +201,15 @@ public abstract class AbstractIndyFunctionalTest
     // TODO: this is a hack due to the "shutdown action not executed" issue. Once propulsor lifecycle shutdown is applied, this can be replaced.
     private void closeCacheProvider()
     {
+        dropKeyspace();
         if ( cacheProvider != null )
         {
             cacheProvider.asAdminView().close();
         }
+    }
+
+    private void dropKeyspace()
+    {
         String keyspace = getKeyspace();
         logger.debug( "Drop cassandra keyspace: {}", keyspace );
         CassandraClient cassandraClient = CDI.current().select( CassandraClient.class ).get();
@@ -219,7 +224,6 @@ public abstract class AbstractIndyFunctionalTest
             {
                 logger.warn( "Failed to drop keyspace: {}, reason: {}", keyspace, ex );
             }
-            session.close();
         }
     }
 

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -263,8 +263,11 @@ public abstract class AbstractIndyFunctionalTest
         writeConfigFile( "conf.d/storage.conf", "[storage-default]\n"
                         + "storage.dir=" + fixture.getBootOptions().getHomeDir() + "/var/lib/indy/storage\n"
                         + "storage.gc.graceperiodinhours=0\n"
-                        + "storage.cassandra.port=9042\n"
+                        + "storage.gc.batchsize=0\n"
                         + "storage.cassandra.keyspace=" + keyspace );
+
+        writeConfigFile( "conf.d/cassandra.conf", "[cassandra]\nenabled=true" );
+
         if ( isSchedulerEnabled() )
         {
             writeConfigFile( "conf.d/scheduler.conf", readTestResource( "default-test-scheduler.conf" ) );

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -211,7 +211,14 @@ public abstract class AbstractIndyFunctionalTest
         Session session = cassandraClient.getSession();
         if ( session != null )
         {
-            session.execute( "DROP KEYSPACE IF EXISTS " + keyspace );
+            try
+            {
+                session.execute( "DROP KEYSPACE IF EXISTS " + keyspace );
+            }
+            catch ( Exception ex )
+            {
+                logger.warn( "Failed to drop keyspace: {}, reason: {}", keyspace, ex );
+            }
             session.close();
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <httpcoreVersion>4.4.9</httpcoreVersion>
     <httpclientVersion>4.5.9</httpclientVersion>
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
+    <datastaxVersion>3.7.2</datastaxVersion>
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.0</atlasVersion>
@@ -381,6 +382,11 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-flatfile</artifactId>
+        <version>1.9.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-subsys-cassandra</artifactId>
         <version>1.9.6-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -1542,6 +1548,18 @@
         <groupId>org.commonjava.propulsor.content-audit</groupId>
         <artifactId>propulsor-content-audit-api</artifactId>
         <version>${propulsorVersion}</version>
+      </dependency>
+
+      <!--Datastax Java Driver-->
+      <dependency>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-core</artifactId>
+        <version>${datastaxVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.datastax.cassandra</groupId>
+        <artifactId>cassandra-driver-mapping</artifactId>
+        <version>${datastaxVersion}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/subsys/cassandra/pom.xml
+++ b/subsys/cassandra/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-subsystems</artifactId>
+        <version>1.9.6-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>indy-subsys-cassandra</artifactId>
+
+    <name>Indy :: Subsystems :: Cassandra</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.commonjava.indy</groupId>
+            <artifactId>indy-api</artifactId>
+        </dependency>
+        <!--Datastax Java Driver-->
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-mapping</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/subsys/cassandra/src/main/conf/conf.d/cassandra.conf
+++ b/subsys/cassandra/src/main/conf/conf.d/cassandra.conf
@@ -1,0 +1,10 @@
+[cassandra]
+
+# By default, the cassandra is disabled.
+#
+# enabled=true
+
+#cassandra.host=localhost
+#cassandra.port=9042
+#cassandra.user=cassandra
+#cassandra.pass=cassandra

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.cassandra;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Session;
+import org.commonjava.indy.subsys.cassandra.config.CassandraConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
+
+@ApplicationScoped
+public class CassandraClient
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private CassandraConfig config;
+
+    private Session session;
+
+    public CassandraClient()
+    {
+    }
+
+    public CassandraClient( CassandraConfig config )
+    {
+        this.config = config;
+        init();
+    }
+
+    @PostConstruct
+    private void init()
+    {
+        if ( !config.isEnabled() )
+        {
+            logger.debug( "Cassandra client not enabled" );
+            return;
+        }
+
+        String host = config.getCassandraHost();
+        int port = config.getCassandraPort();
+        Cluster.Builder builder = Cluster.builder().withoutJMXReporting().addContactPoint( host ).withPort( port );
+        String username = config.getCassandraUser();
+        String password = config.getCassandraPass();
+        if ( isNotBlank( username ) && isNotBlank( password ) )
+        {
+            logger.debug( "Build with credentials, user: {}, pass: ****", username );
+            builder.withCredentials( username, password );
+        }
+        Cluster cluster = builder.build();
+
+        logger.debug( "Connecting to Cassandra, host:{}, port:{}", host, port );
+        session = cluster.connect();
+    }
+
+    public Session getSession()
+    {
+        return session;
+    }
+}

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
@@ -55,21 +55,27 @@ public class CassandraClient
             logger.debug( "Cassandra client not enabled" );
             return;
         }
-
-        String host = config.getCassandraHost();
-        int port = config.getCassandraPort();
-        Cluster.Builder builder = Cluster.builder().withoutJMXReporting().addContactPoint( host ).withPort( port );
-        String username = config.getCassandraUser();
-        String password = config.getCassandraPass();
-        if ( isNotBlank( username ) && isNotBlank( password ) )
+        try
         {
-            logger.debug( "Build with credentials, user: {}, pass: ****", username );
-            builder.withCredentials( username, password );
-        }
-        Cluster cluster = builder.build();
+            String host = config.getCassandraHost();
+            int port = config.getCassandraPort();
+            Cluster.Builder builder = Cluster.builder().withoutJMXReporting().addContactPoint( host ).withPort( port );
+            String username = config.getCassandraUser();
+            String password = config.getCassandraPass();
+            if ( isNotBlank( username ) && isNotBlank( password ) )
+            {
+                logger.debug( "Build with credentials, user: {}, pass: ****", username );
+                builder.withCredentials( username, password );
+            }
+            Cluster cluster = builder.build();
 
-        logger.debug( "Connecting to Cassandra, host:{}, port:{}", host, port );
-        session = cluster.connect();
+            logger.debug( "Connecting to Cassandra, host:{}, port:{}", host, port );
+            session = cluster.connect();
+        }
+        catch ( Exception e )
+        {
+            logger.warn( "Connecting to Cassandra failed, reason: {}", e.toString() );
+        }
     }
 
     public Session getSession()

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/config/CassandraConfig.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/config/CassandraConfig.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.cassandra.config;
+
+import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.propulsor.config.annotation.ConfigName;
+import org.commonjava.propulsor.config.annotation.SectionName;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.InputStream;
+
+@SectionName( "cassandra" )
+@ApplicationScoped
+public class CassandraConfig
+                implements IndyConfigInfo
+{
+    private String cassandraHost;
+
+    private Integer cassandraPort;
+
+    private String cassandraUser;
+
+    private String cassandraPass;
+
+    public CassandraConfig()
+    {
+    }
+
+    private static final String DEFAULT_CASSANDRA_HOST = "localhost";
+
+    private static final int DEFAULT_CASSANDRA_PORT = 9042;
+
+    @ConfigName( "cassandra.host" )
+    public void setCassandraHost( String host )
+    {
+        cassandraHost = host;
+    }
+
+    @ConfigName( "cassandra.port" )
+    public void setCassandraPort( Integer port )
+    {
+        cassandraPort = port;
+    }
+
+    @ConfigName( "cassandra.user" )
+    public void setCassandraUser( String cassandraUser )
+    {
+        this.cassandraUser = cassandraUser;
+    }
+
+    @ConfigName( "cassandra.pass" )
+    public void setCassandraPass( String cassandraPass )
+    {
+        this.cassandraPass = cassandraPass;
+    }
+
+    public String getCassandraHost()
+    {
+        return cassandraHost == null ? DEFAULT_CASSANDRA_HOST : cassandraHost;
+    }
+
+    public Integer getCassandraPort()
+    {
+        return cassandraPort == null ? DEFAULT_CASSANDRA_PORT : cassandraPort;
+    }
+
+    public String getCassandraUser()
+    {
+        return cassandraUser;
+    }
+
+    public String getCassandraPass()
+    {
+        return cassandraPass;
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return "default-cassandra.conf";
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream( "default-cassandra.conf" );
+    }
+
+}

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/config/CassandraConfig.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/config/CassandraConfig.java
@@ -27,6 +27,8 @@ import java.io.InputStream;
 public class CassandraConfig
                 implements IndyConfigInfo
 {
+    private Boolean enabled = Boolean.FALSE;
+
     private String cassandraHost;
 
     private Integer cassandraPort;
@@ -37,6 +39,17 @@ public class CassandraConfig
 
     public CassandraConfig()
     {
+    }
+
+    public Boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @ConfigName( "enabled" )
+    public void setEnabled( Boolean enabled )
+    {
+        this.enabled = enabled;
     }
 
     private static final String DEFAULT_CASSANDRA_HOST = "localhost";

--- a/subsys/cassandra/src/main/resources/META-INF/beans.xml
+++ b/subsys/cassandra/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_2.xsd"
+       version="1.2" bean-discovery-mode="all">
+</beans>

--- a/subsys/cassandra/src/main/resources/default-cassandra.conf
+++ b/subsys/cassandra/src/main/resources/default-cassandra.conf
@@ -1,0 +1,10 @@
+[cassandra]
+
+# By default, the cassandra is disabled.
+#
+# enabled=true
+
+#cassandra.host=localhost
+#cassandra.port=9042
+#cassandra.user=cassandra
+#cassandra.pass=cassandra

--- a/subsys/pom.xml
+++ b/subsys/pom.xml
@@ -41,6 +41,7 @@
     <module>prefetch</module>
     <module>kafka</module>
     <module>cpool</module>
+    <module>cassandra</module>
   </modules>
   
 </project>


### PR DESCRIPTION
This pr adds a subsystem/cassandra and separates the connection config from the storage section. So far it only contains a config object. But we might use cassandra for other purposes in the future.