### PR TITLE
Start path map storage migrator

### DIFF
--- a/deployments/pathmap-migrator/README.md
+++ b/deployments/pathmap-migrator/README.md
@@ -1,0 +1,31 @@
+Indy path mapped storage migrator
+---
+
+This command line tools is used to do one-off migration task from legacy file based storage to new path mapped storage
+
+
+### How to use
+There are two commands here: scan and migrate
+
+#### scan: generate files to store all paths
+Usage: java -jar ${package}.jar scan [options]
+
+Options:  
+-B (--batch) N      : Batch of paths to process each time  
+-b (--base) VAL     : Base dir of storage for all indy artifacts  
+-w (--workdir) VAL  : Work dir to store all generated working files  
+
+#### migrate: read all files for paths and migrate them to cassandra db
+##### Note: Before this command, please use "scan" to generate all paths files first
+Usage: java -jar ${package}.jar migrate [options]
+
+Options:  
+-w (--workdir) VAL  : Work dir to store all generated working files  
+-H (--host) VAL     : Cassandra server hostname  
+-P (--port) VAL     : Cassandra server port  
+-k (--keyspace) VAL : Cassandra server keyspace  
+-p (--password) VAL : Cassandra server password  
+-u (--user) VAL     : Cassandra server username  
+-d (--dedupe)       : If to use checksum to dedupe all files in file storage  
+
+For migrate command, when it start, there will be a "status" file generated in ${workDir} to record current processing status, and will be updated every 30 seconds.

--- a/deployments/pathmap-migrator/pom.xml
+++ b/deployments/pathmap-migrator/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>indy-deployments</artifactId>
+    <groupId>org.commonjava.indy</groupId>
+    <version>1.9.6-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>indy-pathmap-migrator</artifactId>
+
+
+  <dependencies>
+    <dependency>
+      <groupId>args4j</groupId>
+      <artifactId>args4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>path-mapped-storage</artifactId>
+      <version>0.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>executable-jar</id>
+              <goals>
+                <goal>single</goal>
+              </goals>
+              <phase>package</phase>
+              <configuration>
+                <descriptorRefs>
+                  <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+                <appendAssemblyId>false</appendAssemblyId>
+                <archive>
+                  <manifest>
+                    <mainClass>org.commonjava.indy.pathmap.migrate.Main</mainClass>
+                  </manifest>
+                </archive>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/deployments/pathmap-migrator/pom.xml
+++ b/deployments/pathmap-migrator/pom.xml
@@ -11,6 +11,9 @@
 
   <artifactId>indy-pathmap-migrator</artifactId>
 
+  <properties>
+    <pathmap.version>0.1-SNAPSHOT</pathmap.version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -27,8 +30,18 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
+      <artifactId>path-mapped-common</artifactId>
+      <version>${pathmap.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
       <artifactId>path-mapped-storage</artifactId>
-      <version>0.1-SNAPSHOT</version>
+      <version>${pathmap.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>path-mapped-pathdb-datastax</artifactId>
+      <version>${pathmap.version}</version>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/CassandraMigrator.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/CassandraMigrator.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.storage.pathmapped.config.DefaultPathMappedStorageConfig;
+import org.commonjava.storage.pathmapped.config.PathMappedStorageConfig;
+import org.commonjava.storage.pathmapped.core.FileBasedPhysicalStore;
+import org.commonjava.storage.pathmapped.core.FileInfo;
+import org.commonjava.storage.pathmapped.datastax.CassandraPathDB;
+import org.commonjava.storage.pathmapped.spi.PhysicalStore;
+import org.commonjava.storage.pathmapped.util.ChecksumCalculator;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Date;
+import java.util.Map;
+
+public class CassandraMigrator
+{
+    private static CassandraMigrator migrator;
+
+    private final CassandraPathDB pathDB;
+
+    private final PhysicalStore physicalStore;
+
+    private final IndyStoreBasedPathGenerator storePathGen;
+
+    private final ChecksumCalculator checksumCalculator;
+
+    private final String baseDir;
+
+    private CassandraMigrator( final PathMappedStorageConfig config, final String baseDir,
+                               final ChecksumCalculator checksumCalculator )
+    {
+        this.pathDB = new CassandraPathDB( config );
+        this.storePathGen = new IndyStoreBasedPathGenerator( baseDir );
+        this.physicalStore = new FileBasedPhysicalStore( new File( baseDir ) );
+        this.checksumCalculator = checksumCalculator;
+        this.baseDir = baseDir;
+    }
+
+    public static CassandraMigrator getMigrator( final Map<String, Object> cassandraConfig, final String baseDir,
+                                          final ChecksumCalculator checksumCalculator )
+    {
+        synchronized ( CassandraMigrator.class )
+        {
+            if ( migrator == null )
+            {
+                final PathMappedStorageConfig config = new DefaultPathMappedStorageConfig( cassandraConfig );
+                migrator = new CassandraMigrator( config, baseDir, checksumCalculator );
+            }
+        }
+        return migrator;
+
+    }
+
+    public void startUp()
+    {
+
+    }
+
+    public void migrate( final String physicalFilePath )
+            throws MigrateException
+    {
+
+        File file = Paths.get( physicalFilePath ).normalize().toFile();
+        if ( !file.exists() || !file.isFile() )
+        {
+            throw new MigrateException( "Error: the physical path {} does not exists or is not a real file.",
+                                        physicalFilePath );
+        }
+
+        final String checksum;
+        try
+        {
+            checksum = calculateChecksum( file );
+        }
+        catch ( IOException e )
+        {
+            throw new MigrateException(
+                    String.format( "Error: Can not get file checksum for file of %s", physicalFilePath ), e );
+        }
+
+        final String fileSystem = storePathGen.generateFileSystem( physicalFilePath );
+        final String path = storePathGen.generatePath( physicalFilePath );
+        final String storePath = storePathGen.generateStorePath( physicalFilePath );
+        FileInfo fileInfo = physicalStore.getFileInfo( fileSystem, path );
+
+        try
+        {
+            pathDB.insert( fileSystem, path, new Date(), fileInfo.getFileId(), file.length(), storePath, checksum );
+        }
+        catch ( Exception e )
+        {
+            throw new MigrateException( "Error: something wrong happened during update path db.", e );
+        }
+    }
+
+    private String calculateChecksum( File file )
+            throws IOException
+    {
+        if ( checksumCalculator == null )
+        {
+            return null;
+        }
+
+        if ( !file.exists() || !file.isFile() )
+        {
+            throw new IOException(
+                    String.format( "Digest error: file not exists or not a regular file for file %s", file ) );
+        }
+        try (FileInputStream is = new FileInputStream( file ))
+        {
+            checksumCalculator.update( IOUtils.toByteArray( is ) );
+        }
+        return checksumCalculator.getDigestHex();
+    }
+
+    public void shutdown()
+    {
+        migrator = null;
+        pathDB.close();
+    }
+}

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/CassandraMigrator.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/CassandraMigrator.java
@@ -19,8 +19,8 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.storage.pathmapped.config.DefaultPathMappedStorageConfig;
 import org.commonjava.storage.pathmapped.config.PathMappedStorageConfig;
 import org.commonjava.storage.pathmapped.core.FileBasedPhysicalStore;
-import org.commonjava.storage.pathmapped.core.FileInfo;
-import org.commonjava.storage.pathmapped.datastax.CassandraPathDB;
+import org.commonjava.storage.pathmapped.pathdb.datastax.CassandraPathDB;
+import org.commonjava.storage.pathmapped.spi.FileInfo;
 import org.commonjava.storage.pathmapped.spi.PhysicalStore;
 import org.commonjava.storage.pathmapped.util.ChecksumCalculator;
 

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/Command.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/Command.java
@@ -1,0 +1,6 @@
+package org.commonjava.indy.pathmap.migrate;
+
+public interface Command
+{
+    void run(MigrateOptions options) throws MigrateException;
+}

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/IndyStoreBasedPathGenerator.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/IndyStoreBasedPathGenerator.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.storage.pathmapped.util.PathMapUtils;
+
+public class IndyStoreBasedPathGenerator
+{
+    private final String baseDir;
+
+    IndyStoreBasedPathGenerator( final String baseDir )
+    {
+        this.baseDir = baseDir;
+    }
+
+    public String generatePath( String physicalPath )
+    {
+        final String storePath = generateStorePath( physicalPath );
+        final String[] parts = storePath.split( "/" );
+        String path = "";
+        for ( int i = 3; i < parts.length; i++ )
+        {
+            path = PathMapUtils.normalize( path, parts[i] );
+        }
+        return path.startsWith( "/" ) ? path : "/" + path;
+    }
+
+    public String generateFileSystem( String physicalPath )
+    {
+        final String storePath = generateStorePath( physicalPath );
+        final String[] parts = storePath.split( "/" );
+        final String pkg = parts[1];
+        final String repo = parts[2];
+        final String[] keyAName = repo.split( "-" );
+        final String type = keyAName[0];
+        StringBuilder name = new StringBuilder();
+        if ( keyAName.length > 2 )
+        {
+            for ( int i = 1; i < keyAName.length; i++ )
+            {
+                if ( name.length() != 0 )
+                {
+                    name.append( "-" );
+                }
+                name.append( keyAName[i] );
+            }
+
+        }
+        else
+        {
+            name.append( keyAName[1] );
+        }
+        return pkg + ":" + type + ":" + name.toString();
+    }
+
+    public String generateStorePath( String physicalPath )
+    {
+        if ( StringUtils.isBlank( baseDir ) || !physicalPath.contains( baseDir ) )
+        {
+            return physicalPath;
+        }
+
+        final int storePathStart = physicalPath.indexOf( baseDir ) + baseDir.length();
+        final String storePath = physicalPath.substring( storePathStart );
+        return storePath.startsWith( "/" ) ? storePath : "/" + storePath;
+    }
+}

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/IndyStoreBasedPathGenerator.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/IndyStoreBasedPathGenerator.java
@@ -32,7 +32,7 @@ public class IndyStoreBasedPathGenerator
         final String storePath = generateStorePath( physicalPath );
         final String[] parts = storePath.split( "/" );
         String path = "";
-        for ( int i = 3; i < parts.length; i++ )
+        for ( int i = 2; i < parts.length; i++ )
         {
             path = PathMapUtils.normalize( path, parts[i] );
         }
@@ -43,8 +43,8 @@ public class IndyStoreBasedPathGenerator
     {
         final String storePath = generateStorePath( physicalPath );
         final String[] parts = storePath.split( "/" );
-        final String pkg = parts[1];
-        final String repo = parts[2];
+        final String pkg = parts[0];
+        final String repo = parts[1];
         final String[] keyAName = repo.split( "-" );
         final String type = keyAName[0];
         StringBuilder name = new StringBuilder();
@@ -76,6 +76,6 @@ public class IndyStoreBasedPathGenerator
 
         final int storePathStart = physicalPath.indexOf( baseDir ) + baseDir.length();
         final String storePath = physicalPath.substring( storePathStart );
-        return storePath.startsWith( "/" ) ? storePath : "/" + storePath;
+        return storePath.startsWith( "/" ) ? storePath.substring( 1 ) : storePath;
     }
 }

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/Main.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/Main.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+import static org.commonjava.indy.pathmap.migrate.Util.CMD_MIGRATE;
+import static org.commonjava.indy.pathmap.migrate.Util.CMD_SCAN;
+import static org.commonjava.indy.pathmap.migrate.Util.prepareWorkingDir;
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        Thread.currentThread().setUncaughtExceptionHandler( ( thread, error ) -> {
+            if ( error instanceof InvocationTargetException )
+            {
+                final InvocationTargetException ite = (InvocationTargetException) error;
+                System.err.println(
+                        "In: " + thread.getName() + "(" + thread.getId() + "), caught InvocationTargetException:" );
+                ite.getTargetException().printStackTrace();
+
+                System.err.println( "...via:" );
+                error.printStackTrace();
+            }
+            else
+            {
+                System.err.println( "In: " + thread.getName() + "(" + thread.getId() + ") Uncaught error:" );
+                error.printStackTrace();
+            }
+        } );
+
+        final MigrateOptions options = new MigrateOptions();
+        try
+        {
+            if ( options.parseArgs( args ) )
+            {
+                prepareWorkingDir( options.getWorkDir() );
+                Command cmd = decideCommand( options );
+                if ( cmd != null )
+                {
+                    cmd.run( options );
+                }
+            }
+        }
+        catch ( final IllegalArgumentException | IOException | MigrateException e )
+        {
+            System.err.printf( "ERROR: %s", e.getMessage() );
+            System.exit( 1 );
+        }
+    }
+
+    private static Command decideCommand( MigrateOptions options )
+    {
+        switch ( options.getCommand().toLowerCase().trim() )
+        {
+            case CMD_SCAN:
+                return new ScanCmd();
+            case CMD_MIGRATE:
+                return new MigrateCmd();
+        }
+        return null;
+    }
+}

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateCmd.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateCmd.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import static org.commonjava.indy.pathmap.migrate.Util.FAILED_PATHS_FILE;
+import static org.commonjava.indy.pathmap.migrate.Util.TODO_FILES_DIR;
+
+public class MigrateCmd
+        implements Command
+{
+    private CassandraMigrator migrator;
+
+    private AtomicInteger processedCount = new AtomicInteger( 0 );
+
+    static final Predicate<Path> WORKING_FILES_FILTER =
+            p -> Files.isRegularFile( p ) && p.getFileName().toString().startsWith( TODO_FILES_DIR );
+
+    @Override
+    public void run( final MigrateOptions options )
+            throws MigrateException
+    {
+        init( options );
+        migrator = options.getMigrator();
+
+        final List<String> failedPaths = new ArrayList<>( options.getBatchSize() );
+
+        try
+        {
+            Files.walk( Paths.get( options.getToDoDir() ), 1 ).filter( WORKING_FILES_FILTER ).forEach( p -> {
+                List<String> paths = null;
+                try (InputStream is = new FileInputStream( p.toFile() ))
+                {
+                    paths = IOUtils.readLines( is );
+                    Files.delete( p );
+                }
+                catch ( IOException e )
+                {
+                    //FIXME: how to handle this exception?
+                    e.printStackTrace();
+                }
+                if ( paths != null && !paths.isEmpty() )
+                {
+                    paths.forEach( path -> {
+                        try
+                        {
+                            migrator.migrate( path );
+                            processedCount.getAndIncrement();
+                        }
+                        catch ( MigrateException e )
+                        {
+                            e.printStackTrace();
+                            failedPaths.add( path );
+                            if ( failedPaths.size() > Util.DEFAULT_BATCH_SIZE )
+                            {
+                                storeFailedPaths( options, failedPaths );
+                                failedPaths.clear();
+                            }
+                        }
+                    } );
+                }
+            } );
+        }
+        catch ( Throwable e )
+        {
+            throw new MigrateException( "Error: Some error happened!", e );
+        }
+        finally
+        {
+            if ( !failedPaths.isEmpty() )
+            {
+                storeFailedPaths( options, failedPaths );
+                failedPaths.clear();
+            }
+        }
+
+    }
+
+    private void init( MigrateOptions options )
+    {
+        new Timer().schedule( new UpdateProgressTask( options ), 30000L, 30000L );
+    }
+
+    private void storeFailedPaths( MigrateOptions options, List<String> failedPaths )
+    {
+        File failedFile = Paths.get( options.getWorkDir(), FAILED_PATHS_FILE ).toFile();
+        try
+        {
+            if ( !failedFile.exists() )
+            {
+                failedFile.createNewFile();
+            }
+            try (OutputStream os = new FileOutputStream( failedFile ))
+            {
+                IOUtils.writeLines( failedPaths, null, os );
+            }
+        }
+        catch ( IOException e )
+        {
+            //FIXME: how to handle this?
+            e.printStackTrace();
+        }
+    }
+
+    private class UpdateProgressTask
+            extends TimerTask
+    {
+        private final MigrateOptions options;
+
+        UpdateProgressTask( final MigrateOptions options )
+        {
+            this.options = options;
+        }
+
+        @Override
+        public void run()
+        {
+            int currentProcessedCnt = MigrateCmd.this.processedCount.get();
+            Path statusFilePath = Paths.get( options.getWorkDir(), Util.STATUS_FILE );
+            File statusFile = statusFilePath.toFile();
+            int totalCnt = 0;
+            if ( statusFile.exists() )
+            {
+                try (BufferedReader reader = new BufferedReader( new FileReader( statusFile ) ))
+                {
+                    String line = reader.readLine();
+                    while ( line != null )
+                    {
+                        if ( line.trim().startsWith( "Total" ) )
+                        {
+                            totalCnt = Integer.parseInt( line.split( ":" )[1] );
+                        }
+                    }
+                    Files.delete( statusFilePath );
+                }
+                catch ( IOException e )
+                {
+                    e.printStackTrace();
+                }
+            }
+
+            double progress = currentProcessedCnt / totalCnt;
+            String progressString = new DecimalFormat( "##.##" ).format( progress );
+
+            try
+            {
+                boolean created = statusFile.createNewFile();
+                if ( created )
+                {
+                    try (BufferedWriter writer = new BufferedWriter( new FileWriter( statusFile ) ))
+                    {
+                        writer.write( String.format( "Total:%s", totalCnt ) );
+                        writer.newLine();
+                        writer.write( String.format( "Processed:%s", currentProcessedCnt ) );
+                        writer.newLine();
+                        writer.write( String.format( "Progress:%s", progressString ) + "%" );
+                    }
+                }
+            }
+            catch ( IOException e )
+            {
+                e.printStackTrace();
+            }
+
+        }
+    }
+}

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateException.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateException.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import java.text.MessageFormat;
+import java.util.IllegalFormatException;
+
+public class MigrateException
+        extends Exception
+{
+
+    private static final long serialVersionUID = 1L;
+
+    private Object[] params;
+
+    private transient String formatted;
+
+    public MigrateException( final String format, final Object... params )
+    {
+        super( format );
+        this.params = params;
+    }
+
+    public MigrateException( final String format, final Throwable error, final Object... params )
+    {
+        super( format, error );
+        this.params = params;
+    }
+
+    @Override
+    public String getMessage()
+    {
+        if ( formatted == null )
+        {
+            formatted = super.getMessage();
+
+            if ( params != null )
+            {
+                try
+                {
+                    formatted = String.format( formatted.replaceAll( "\\{\\}", "%s" ), params );
+                }
+                catch ( final IllegalFormatException ife )
+                {
+                    try
+                    {
+                        formatted = MessageFormat.format( formatted, params );
+                    }
+                    catch ( final IllegalArgumentException ignored )
+                    {
+                    }
+                }
+            }
+        }
+
+        return formatted;
+    }
+
+}

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateOptions.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateOptions.java
@@ -41,11 +41,11 @@ import static org.commonjava.indy.pathmap.migrate.Util.DEFAULT_WORK_DIR;
 import static org.commonjava.indy.pathmap.migrate.Util.PROCESSED_FILES_DIR;
 import static org.commonjava.indy.pathmap.migrate.Util.STATUS_FILE;
 import static org.commonjava.indy.pathmap.migrate.Util.TODO_FILES_DIR;
-import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_HOST;
-import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_KEYSPACE;
-import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_PASS;
-import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_PORT;
-import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_USER;
+import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_HOST;
+import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_KEYSPACE;
+import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_PASS;
+import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_PORT;
+import static org.commonjava.storage.pathmapped.pathdb.datastax.util.CassandraPathDBUtils.PROP_CASSANDRA_USER;
 
 public class MigrateOptions
 {

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateOptions.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateOptions.java
@@ -1,0 +1,441 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import org.apache.commons.lang3.StringUtils;
+import org.kohsuke.args4j.Argument;
+import org.kohsuke.args4j.CmdLineException;
+import org.kohsuke.args4j.CmdLineParser;
+import org.kohsuke.args4j.Option;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.commonjava.indy.pathmap.migrate.Util.CMD_MIGRATE;
+import static org.commonjava.indy.pathmap.migrate.Util.CMD_SCAN;
+import static org.commonjava.indy.pathmap.migrate.Util.DEFAULT_BASE_DIR;
+import static org.commonjava.indy.pathmap.migrate.Util.DEFAULT_BATCH_SIZE;
+import static org.commonjava.indy.pathmap.migrate.Util.DEFAULT_WORK_DIR;
+import static org.commonjava.indy.pathmap.migrate.Util.PROCESSED_FILES_DIR;
+import static org.commonjava.indy.pathmap.migrate.Util.STATUS_FILE;
+import static org.commonjava.indy.pathmap.migrate.Util.TODO_FILES_DIR;
+import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_HOST;
+import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_KEYSPACE;
+import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_PASS;
+import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_PORT;
+import static org.commonjava.storage.pathmapped.util.CassandraPathDBUtils.PROP_CASSANDRA_USER;
+
+public class MigrateOptions
+{
+    @Option( name = "-h", aliases = "--help", usage = "Print this and exit" )
+    private boolean help;
+
+    @Option( name = "-b", aliases = "--base", usage = "Base dir of storage for all indy artifacts" )
+    private String baseDir;
+
+    @Option( name = "-w", aliases = "--workdir", usage = "Work dir to store all generated working files" )
+    private String workDir;
+
+    //    @Option( name = "-t", aliases = "--threads", usage = "Number of threads to execute the migrating process" )
+    //    private int threads;
+
+    @Option( name = "-B", aliases = "--batch", usage = "Batch of paths to process each time" )
+    private int batchSize;
+
+    @Option( name = "-d", aliases = "--dedupe", usage = "If to use checksum to dedupe all files in file storage" )
+    private boolean dedupe;
+
+    @Option( name = "-H", aliases = "--host", usage = "Cassandra server hostname" )
+    private String cassandraHost;
+
+    @Option( name = "-P", aliases = "--port", usage = "Cassandra server port" )
+    private String cassandraPort;
+
+    @Option( name = "-u", aliases = "--user", usage = "Cassandra server username" )
+    private String cassandraUser;
+
+    @Option( name = "-p", aliases = "--password", usage = "Cassandra server password" )
+    private String cassandraPass;
+
+    @Option( name = "-k", aliases = "--keyspace", usage = "Cassandra server keyspace" )
+    private String cassandraKeyspace;
+
+    @Argument( index = 0, metaVar = "command", required = false,
+               usage = "Name of command to run, use scan | migrate | resume" )
+    private String command;
+
+    public boolean isHelp()
+    {
+        return help;
+    }
+
+    public void setHelp( boolean help )
+    {
+        this.help = help;
+    }
+
+    public String getBaseDir()
+    {
+        return isBlank( baseDir ) ? DEFAULT_BASE_DIR : baseDir;
+    }
+
+    public void setBaseDir( String baseDir )
+    {
+        this.baseDir = baseDir;
+    }
+
+    public String getWorkDir()
+    {
+        return isBlank( workDir ) ? DEFAULT_WORK_DIR : workDir;
+    }
+
+    public void setWorkDir( String workDir )
+    {
+        this.workDir = workDir;
+    }
+
+    //    public int getThreads()
+    //    {
+    //        return threads <= 0 ? DEFAULT_THREADS_NUM : threads;
+    //    }
+    //
+    //    public void setThreads( int threads )
+    //    {
+    //        this.threads = threads;
+    //    }
+
+    public int getBatchSize()
+    {
+        return batchSize <= 0 ? DEFAULT_BATCH_SIZE : batchSize;
+    }
+
+    public void setBatchSize( int batchSize )
+    {
+        this.batchSize = batchSize;
+    }
+
+    public boolean isDedupe()
+    {
+        return dedupe;
+    }
+
+    public void setDedupe( boolean dedupe )
+    {
+        this.dedupe = dedupe;
+    }
+
+    public String getCommand()
+    {
+        return command == null ? "" : command.toLowerCase().trim();
+    }
+
+    public void setCommand( String command )
+    {
+        this.command = command;
+    }
+
+    public String getCassandraHost()
+    {
+        return StringUtils.isBlank( cassandraHost ) ? "localhost" : cassandraHost;
+    }
+
+    public void setCassandraHost( String cassandraHost )
+    {
+        this.cassandraHost = cassandraHost;
+    }
+
+    public String getCassandraPort()
+    {
+        return StringUtils.isBlank( cassandraPort ) ? "9142" : cassandraPort;
+    }
+
+    public void setCassandraPort( String cassandraPort )
+    {
+        this.cassandraPort = cassandraPort;
+    }
+
+    public String getCassandraUser()
+    {
+        return cassandraUser;
+    }
+
+    public void setCassandraUser( String cassandraUser )
+    {
+        this.cassandraUser = cassandraUser;
+    }
+
+    public String getCassandraPass()
+    {
+        return cassandraPass;
+    }
+
+    public void setCassandraPass( String cassandraPass )
+    {
+        this.cassandraPass = cassandraPass;
+    }
+
+    public String getCassandraKeyspace()
+    {
+        return cassandraKeyspace;
+    }
+
+    public void setCassandraKeyspace( String cassandraKeyspace )
+    {
+        this.cassandraKeyspace = cassandraKeyspace;
+    }
+
+    public boolean parseArgs( final String[] args )
+    {
+        final CmdLineParser parser = new CmdLineParser( this );
+        try
+        {
+            parser.parseArgument( args );
+        }
+        catch ( final CmdLineException e )
+        {
+            e.printStackTrace();
+            throw new IllegalArgumentException(
+                    String.format( "Failed to parse command-line args: %s", Arrays.toString( args ) ), e );
+
+        }
+
+        if ( isHelp() )
+        {
+            printUsage( parser, null );
+        }
+
+        if ( StringUtils.isBlank( getCommand() ) )
+        {
+            System.out.println( "Command can not be null" );
+            return false;
+        }
+        final String cmd = getCommand().toLowerCase().trim();
+        if ( !cmd.equals( Util.CMD_SCAN ) && !cmd.equals( Util.CMD_MIGRATE ) )
+        {
+            System.out.println( String.format( "Invalid command %s, use scan | migrate | resume", cmd ) );
+            return false;
+        }
+
+        return validateOptions();
+
+    }
+
+    private boolean validateOptions()
+    {
+        System.out.println( String.format( "Working dir for whole migration process: %s", getAbsoluteWorkDir() ) );
+        if ( getCommand().equals( CMD_SCAN ) )
+        {
+            System.out.println( String.format( "Base storage dir for artifacts: %s", getBaseDir() ) );
+            System.out.println( String.format( "Batch of paths to process each time: %s", getBatchSize() ) );
+        }
+
+        if ( getCommand().equals( CMD_MIGRATE ) )
+        {
+            System.out.println( String.format( "Cassandra server host: %s", getCassandraHost() ) );
+            System.out.println( String.format( "Cassandra server port: %s", getCassandraPort() ) );
+            System.out.println( String.format( "Cassandra server username: %s", getCassandraUser() ) );
+            System.out.println( String.format( "Cassandra server keyspace: %s", getCassandraKeyspace() ) );
+            System.out.println( String.format( "Will use checksum to dedupe files? %s", isDedupe() ) );
+        }
+
+        System.out.println();
+        //        System.out.println( String.format( "Threads number to run the whole process? %s", getThreads() ) );
+        if ( getCommand().equals( CMD_SCAN ) && !validateBaseDir() )
+        {
+            return false;
+        }
+
+        if ( getCommand().equals( CMD_MIGRATE ) )
+        {
+            return validateTodoDir() && validateCassandra();
+        }
+
+        return true;
+    }
+
+    private boolean validateBaseDir()
+    {
+        Path basePath = Paths.get( getBaseDir() );
+        if ( !Files.isDirectory( basePath ) )
+        {
+            System.out.println( String.format( "Error: base dir %s is not a directory", getBaseDir() ) );
+            return false;
+        }
+        List<String> childs = new ArrayList<>( 3 );
+        try
+        {
+            Files.walk( basePath, 1 ).map( Path::toString ).forEach( childs::add );
+        }
+        catch ( IOException e )
+        {
+            System.out.println(
+                    String.format( "Error: io error happened during listing sub dirs: %s", e.getMessage() ) );
+            return false;
+        }
+        boolean containsMaven = false;
+        for ( String child : childs )
+        {
+            if ( child.contains( "maven" ) )
+            {
+                containsMaven = true;
+                break;
+            }
+        }
+
+        if ( !containsMaven )
+        {
+            System.out.println( String.format( "Error: the base dir %s is not a valid volume to store indy artifacts.",
+                                               getBaseDir() ) );
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean validateTodoDir()
+    {
+        Path todoPath = Paths.get( getToDoDir() );
+        if ( !Files.isDirectory( todoPath ) )
+        {
+            System.out.println( String.format(
+                    "Validation failed: todo folder %s in workdir %s does not exist or is not a directory. Make sure you have used 'scan' command to generate the path files in this folder.",
+                    getToDoDir(), getWorkDir() ) );
+            return false;
+        }
+
+        final AtomicInteger todoFilesCount = new AtomicInteger( 0 );
+        try
+        {
+            Files.walk( Paths.get( getToDoDir() ), 1 )
+                 .filter( MigrateCmd.WORKING_FILES_FILTER )
+                 .forEach( p -> todoFilesCount.getAndIncrement() );
+        }
+        catch ( IOException e )
+        {
+            System.out.println( String.format( "Error: Can not list dir %s", getToDoDir() ) );
+            return false;
+        }
+
+        if ( todoFilesCount.get() <= 0 )
+        {
+            System.out.println(
+                    "Error: There are no path entries generated for migrating, please use 'scan' command first to generate them." );
+            return false;
+        }
+
+        return true;
+    }
+
+    private CassandraMigrator migrator;
+
+    public boolean validateCassandra()
+    {
+        try
+        {
+            initMigrator();
+        }
+        catch ( Throwable t )
+        {
+            System.out.println( String.format( "Error: cassandra validation failed: %s", t.getMessage() ) );
+            return false;
+        }
+        return true;
+    }
+
+    public CassandraMigrator getMigrator()
+    {
+        if ( migrator == null )
+        {
+            initMigrator();
+        }
+        return migrator;
+    }
+
+    private void initMigrator()
+    {
+        if ( migrator == null )
+        {
+            HashMap<String, Object> cassandraProps = new HashMap<>();
+            cassandraProps.put( PROP_CASSANDRA_HOST, getCassandraHost() );
+            cassandraProps.put( PROP_CASSANDRA_PORT, Integer.parseInt( getCassandraPort() ) );
+            cassandraProps.put( PROP_CASSANDRA_KEYSPACE, getCassandraKeyspace() );
+            if ( StringUtils.isNotBlank( getCassandraUser() ) )
+            {
+                cassandraProps.put( PROP_CASSANDRA_USER, getCassandraUser() );
+            }
+            if ( StringUtils.isNotBlank( getCassandraPass() ) )
+            {
+                cassandraProps.put( PROP_CASSANDRA_PASS, getCassandraPass() );
+            }
+            //TODO set checksum calculator based on dedupe option
+            migrator = CassandraMigrator.getMigrator( cassandraProps, getBaseDir(), null );
+        }
+    }
+
+    public static void printUsage( final CmdLineParser parser, final CmdLineException error )
+    {
+        if ( error != null )
+        {
+            System.out.println( "Invalid option(s): " + error.getMessage() );
+            System.out.println();
+        }
+
+        System.out.println( "Usage: $0 $command [OPTIONS]" );
+        System.out.println();
+        System.out.println();
+        // If we are running under a Linux shell COLUMNS might be available for the width
+        // of the terminal.
+        parser.setUsageWidth(
+                ( System.getenv( "COLUMNS" ) == null ? 100 : Integer.parseInt( System.getenv( "COLUMNS" ) ) ) );
+        parser.printUsage( System.out );
+        System.out.println();
+    }
+
+    public String getAbsoluteWorkDir()
+    {
+        return Paths.get( getWorkDir() ).toAbsolutePath().toString();
+    }
+
+    public String getToDoDir()
+    {
+        return Paths.get( getWorkDir(), TODO_FILES_DIR ).toAbsolutePath().toString();
+    }
+
+    public String getProcessedDir()
+    {
+        return Paths.get( getWorkDir(), PROCESSED_FILES_DIR ).toAbsolutePath().toString();
+    }
+
+    public File getStatusFile()
+            throws IOException
+    {
+        File statusFile = Paths.get( getWorkDir(), STATUS_FILE ).toFile();
+        if ( !statusFile.exists() )
+        {
+            statusFile.createNewFile();
+        }
+        return statusFile;
+    }
+}

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/ScanCmd.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/ScanCmd.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.pkg.PackageTypeConstants;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import static org.commonjava.indy.pathmap.migrate.Util.TODO_FILES_DIR;
+
+public class ScanCmd
+        implements Command
+{
+
+    public void run( MigrateOptions options )
+            throws MigrateException
+    {
+        final long start = System.currentTimeMillis();
+        final List<String> pkgFolderPaths;
+        try
+        {
+            pkgFolderPaths = listValidPkgFolders( options.getBaseDir() );
+        }
+        catch ( IOException e )
+        {
+            throw new MigrateException( "Something run when doing scan.", e );
+        }
+
+        //        final List<String> allReposPath = new ArrayList<>( 20000 );
+        //        pkgFolderPaths.forEach( p -> {
+        //            try
+        //            {
+        //                allReposPath.addAll( this.listReposPath( p ) );
+        //            }
+        //            catch ( IOException e )
+        //            {
+        //                e.printStackTrace();
+        //            }
+        //        } );
+        final AtomicInteger total = new AtomicInteger( 0 );
+        pkgFolderPaths.forEach( p -> {
+            try
+            {
+                total.addAndGet( listFiles( p, options ) );
+            }
+            catch ( IOException e )
+            {
+                e.printStackTrace();
+            }
+        } );
+        final long end = System.currentTimeMillis();
+        System.out.println( "\n\n" );
+        System.out.println( String.format( "File Scan completed, there are %s files need to migrate.", total.get() ) );
+        System.out.println( String.format( "Time consumed: %s milliseconds", end - start ) );
+
+        try
+        {
+            storeTotal( total.get(), options );
+        }
+        catch ( IOException e )
+        {
+            e.printStackTrace();
+        }
+    }
+
+    private List<String> listValidPkgFolders( final String baseDir )
+            throws IOException
+    {
+        final Predicate<Path> validPkgFolderPredicate =
+                p -> Files.isDirectory( p ) && PackageTypeConstants.isValidPackageType(
+                        p.getName( p.getNameCount() - 1 ).toString() );
+        return listPaths( baseDir, 1, 3, validPkgFolderPredicate );
+    }
+
+    //    private List<String> listReposPath( final String pkgDir )
+    //            throws IOException
+    //    {
+    //        final List<String> allReposPath =
+    //                listPaths( pkgDir, 1, 2000, p -> Files.isDirectory( p ) && !p.equals( Paths.get( pkgDir ) ) );
+    //        System.out.println(
+    //                String.format( "There are %s repos in the pkg folder %s to migrate", allReposPath.size(), pkgDir ) );
+    //        return allReposPath;
+    //    }
+
+    private int listFiles( final String pkgDir, final MigrateOptions options )
+            throws IOException
+    {
+        final Path repoPath = Paths.get( pkgDir );
+        final String pkgName = repoPath.getName( repoPath.getNameCount() - 1 ).toString();
+        //        final String repoName = repoPath.getName( repoPath.getNameCount() - 1 ).toString();
+        final String todoPrefix = TODO_FILES_DIR + "-" + pkgName;
+        System.out.println( String.format( "Start to scan package %s for files", pkgDir ) );
+        final List<String> filePaths = new ArrayList<>( options.getBatchSize() );
+        final AtomicInteger batchNum = new AtomicInteger( 0 );
+        final AtomicInteger totalFileNum = new AtomicInteger( 0 );
+        //        final List<String> generatedToDoFiles = Collections.synchronizedList( new ArrayList<>( 200 ) );
+        Files.walk( repoPath, Integer.MAX_VALUE ).filter( Files::isRegularFile ).forEach( p -> {
+            filePaths.add( p.toString() );
+            if ( filePaths.size() >= options.getBatchSize() )
+            {
+                //                final ArrayList<String> filePathsToStore = new ArrayList<>( filePaths );
+                storeBatchToFile( filePaths, options.getToDoDir(), todoPrefix, batchNum.get() );
+                totalFileNum.addAndGet( filePaths.size() );
+                filePaths.clear();
+                batchNum.getAndIncrement();
+            }
+        } );
+
+        if ( !filePaths.isEmpty() )
+        {
+            storeBatchToFile( filePaths, options.getToDoDir(), todoPrefix, batchNum.get() );
+            totalFileNum.addAndGet( filePaths.size() );
+            filePaths.clear();
+        }
+        System.out.println(
+                String.format( "There are %s files in package path %s to migrate", totalFileNum.get(), pkgDir ) );
+        //        System.out.println( String.format( "There are %s files for paths in package dir %s generated to migrate",
+        //                                           generatedToDoFiles.size(), pkgDir ) );
+        return totalFileNum.get();
+    }
+
+    private List<String> listPaths( final String rootPath, final int maxDepth, final int initFactor,
+                                    final Predicate<Path> filter )
+            throws IOException
+    {
+        final List<String> allReposPath = new ArrayList<>( 2000 );
+        final Path base = Paths.get( rootPath );
+        Files.walk( base, maxDepth ).filter( filter ).forEach( p -> allReposPath.add( p.toString() ) );
+        return allReposPath;
+    }
+
+    private void storeBatchToFile( final List<String> filePaths, final String todoDir, final String prefix,
+                                   final int batch )
+    {
+        final String batchFileName = prefix + "-" + "batch-" + batch + ".txt";
+        final Path batchFilePath = Paths.get( todoDir, batchFileName );
+        System.out.println(
+                String.format( "Start to store paths for batch %s to file %s for %s", batch, batchFileName, todoDir ) );
+        try (OutputStream os = new FileOutputStream( batchFilePath.toFile() ))
+        {
+            IOUtils.writeLines( filePaths, null, os );
+        }
+        catch ( IOException e )
+        {
+            System.out.println( String.format( "Error: Cannot write paths to files for batch %s", batchFileName ) );
+        }
+        System.out.println( String.format( "Batch %s to file %s for %s finished", batch, batchFileName, todoDir ) );
+        //        generatedFilePaths.add( batchFileName );
+    }
+
+    private void storeTotal( final int totalNum, final MigrateOptions options )
+            throws IOException
+    {
+        final File f = options.getStatusFile();
+        try (FileOutputStream os = new FileOutputStream( f ))
+        {
+            IOUtils.write( String.format( "Total:%s", totalNum ), os );
+        }
+    }
+
+}

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/Util.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/Util.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class Util
+{
+    static final String DEFAULT_BASE_DIR = "/opt/indy/var/lib/indy/storage";
+
+    static final String DEFAULT_WORK_DIR = "./";
+
+    static final int DEFAULT_THREADS_NUM = 1;
+
+    static final int DEFAULT_BATCH_SIZE = 100000;
+
+    static final String TODO_FILES_DIR = "todo";
+
+    static final String PROCESSED_FILES_DIR = "processed";
+
+    static final String FAILED_PATHS_FILE = "faile_paths";
+
+    static final String STATUS_FILE = "status";
+
+    static final String CMD_SCAN = "scan";
+
+    static final String CMD_MIGRATE = "migrate";
+
+    static void prepareWorkingDir( final String workDir )
+            throws IOException
+    {
+        Path todoDir = Paths.get( workDir, TODO_FILES_DIR );
+        if ( !todoDir.toFile().exists() || !Files.isDirectory( todoDir ) )
+        {
+            Files.createDirectories( todoDir );
+        }
+        Path processedDir = Paths.get( workDir, PROCESSED_FILES_DIR );
+        if ( !processedDir.toFile().exists() || !Files.isDirectory( processedDir ) )
+        {
+            Files.createDirectories( processedDir );
+        }
+    }
+
+    static File getStatusFile( final String workDir )
+            throws IOException
+    {
+        File statusFile = Paths.get( workDir, STATUS_FILE ).toFile();
+        if ( statusFile.exists() )
+        {
+            statusFile.createNewFile();
+        }
+        return statusFile;
+    }
+
+}

--- a/deployments/pathmap-migrator/src/test/java/org/commonjava/indy/pathmap/migrate/IndyStoreBasedPhysicalPathGeneratorTest.java
+++ b/deployments/pathmap-migrator/src/test/java/org/commonjava/indy/pathmap/migrate/IndyStoreBasedPhysicalPathGeneratorTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class IndyStoreBasedPhysicalPathGeneratorTest
+{
+    private final String PHYSICAL_PATH1 = "/opt/indy/var/lib/indy/storage/maven/hosted-public/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom";
+
+    private final String PHYSICAL_PATH2 = "/opt/indy/var/lib/indy/storage/maven/hosted-shared-imports-redhat/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom";
+
+    private final String PHYSICAL_PATH3 = "/opt/indy/var/lib/indy/storage/maven/remote-koji-org.jboss.classfilewriter-jboss-classfilewriter-1.2.3.Final_redhat_00001-1/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom";
+
+
+    IndyStoreBasedPathGenerator generator =
+            new IndyStoreBasedPathGenerator( "/opt/indy/var/lib/indy/storage/" );
+
+    @Test
+    public void getPath()
+    {
+        assertThat( generator.generatePath( PHYSICAL_PATH1 ), equalTo( "/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+        assertThat( generator.generatePath( PHYSICAL_PATH2 ), equalTo( "/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+        assertThat( generator.generatePath( PHYSICAL_PATH3 ), equalTo( "/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+    }
+
+    @Test
+    public void getFileSystem()
+    {
+        assertThat( generator.generateFileSystem( PHYSICAL_PATH1 ), equalTo( "maven:hosted:public" ) );
+        assertThat( generator.generateFileSystem( PHYSICAL_PATH2 ), equalTo( "maven:hosted:shared-imports-redhat" ) );
+        assertThat( generator.generateFileSystem( PHYSICAL_PATH3 ), equalTo( "maven:remote:koji-org.jboss.classfilewriter-jboss-classfilewriter-1.2.3.Final_redhat_00001-1" ) );
+    }
+
+    @Test
+    public void getStorePath()
+    {
+        assertThat( generator.generateStorePath( PHYSICAL_PATH1 ), equalTo( "/maven/hosted-public/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+        assertThat( generator.generateStorePath( PHYSICAL_PATH2 ), equalTo( "/maven/hosted-shared-imports-redhat/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+        assertThat( generator.generateStorePath( PHYSICAL_PATH3 ), equalTo( "/maven/remote-koji-org.jboss.classfilewriter-jboss-classfilewriter-1.2.3.Final_redhat_00001-1/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+    }
+}

--- a/deployments/pathmap-migrator/src/test/java/org/commonjava/indy/pathmap/migrate/IndyStoreBasedPhysicalPathGeneratorTest.java
+++ b/deployments/pathmap-migrator/src/test/java/org/commonjava/indy/pathmap/migrate/IndyStoreBasedPhysicalPathGeneratorTest.java
@@ -51,8 +51,8 @@ public class IndyStoreBasedPhysicalPathGeneratorTest
     @Test
     public void getStorePath()
     {
-        assertThat( generator.generateStorePath( PHYSICAL_PATH1 ), equalTo( "/maven/hosted-public/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
-        assertThat( generator.generateStorePath( PHYSICAL_PATH2 ), equalTo( "/maven/hosted-shared-imports-redhat/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
-        assertThat( generator.generateStorePath( PHYSICAL_PATH3 ), equalTo( "/maven/remote-koji-org.jboss.classfilewriter-jboss-classfilewriter-1.2.3.Final_redhat_00001-1/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+        assertThat( generator.generateStorePath( PHYSICAL_PATH1 ), equalTo( "maven/hosted-public/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+        assertThat( generator.generateStorePath( PHYSICAL_PATH2 ), equalTo( "maven/hosted-shared-imports-redhat/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+        assertThat( generator.generateStorePath( PHYSICAL_PATH3 ), equalTo( "maven/remote-koji-org.jboss.classfilewriter-jboss-classfilewriter-1.2.3.Final_redhat_00001-1/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
     }
 }

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -33,6 +33,7 @@
     <module>launcher</module>
     <module>cache-migrator</module>
     <module>record-extractor</module>
+    <module>pathmap-migrator</module>
   </modules>
 
   <profiles>


### PR DESCRIPTION
This is a draft pr for the path mapped migrator. This migrator has two commands:
   * scan: will scan the storage folder for all file paths, and records them to files by batch to a work dir
   * migrate: will read all paths from files in work dir, and generate path mapped records into db storage
   
   I've only tested "scan" command on a test storage with 10+ million paths with batch 50000 for a file, and it
will take about 30 mins to finish. I did not test the "migrate" command because I did not setup a local cassandra 
instance successfully yet. I'll try to do that later.
   
   Now all commands are working in single thread mode, maybe we can try to multi-thread them later if performance is unacceptable.