### PR TITLE
Fix the path mapped migrator checksum issue

### DIFF
--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateCmd.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateCmd.java
@@ -111,7 +111,10 @@ public class MigrateCmd
             }
         }
 
+        stop( options );
     }
+
+    private Timer progressTimer = new Timer();
 
     private void init( MigrateOptions options )
     {
@@ -142,7 +145,13 @@ public class MigrateCmd
 
         final long period = 15000L;
         // Trigger progress update task.
-        new Timer().schedule( new UpdateProgressTask( options ), period, period );
+        progressTimer.schedule( new UpdateProgressTask( options ), period, period );
+    }
+
+    private void stop( MigrateOptions options )
+    {
+        new UpdateProgressTask( options ).run(); // last run
+        progressTimer.cancel();
     }
 
     private void storeFailedPaths( MigrateOptions options, List<String> failedPaths )

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateOptions.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateOptions.java
@@ -411,12 +411,11 @@ public class MigrateOptions
                 cassandraProps.put( PROP_CASSANDRA_PASS, getCassandraPass() );
             }
             
-            ChecksumCalculator calculator = null;
             if ( isDedupe() )
             {
                 try
                 {
-                    calculator = new ChecksumCalculator( getDedupeAlgorithm() );
+                    new ChecksumCalculator( getDedupeAlgorithm() ); // verify algo
                 }
                 catch ( NoSuchAlgorithmException e )
                 {
@@ -424,7 +423,7 @@ public class MigrateOptions
                             String.format( "Error: checksum algorithm not supported: %s", getDedupeAlgorithm() ), e );
                 }
             }
-            migrator = CassandraMigrator.getMigrator( cassandraProps, getBaseDir(), calculator );
+            migrator = CassandraMigrator.getMigrator( cassandraProps, getBaseDir(), isDedupe(), getDedupeAlgorithm() );
         }
     }
 

--- a/deployments/pathmap-migrator/src/test/java/org/commonjava/indy/pathmap/migrate/ChecksumCalculatorTest.java
+++ b/deployments/pathmap-migrator/src/test/java/org/commonjava/indy/pathmap/migrate/ChecksumCalculatorTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmap.migrate;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.storage.pathmapped.util.ChecksumCalculator;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class ChecksumCalculatorTest
+{
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private String dupContent = "abc";
+
+    private String otherContent = "def";
+
+    private File f1, f2, f3;
+
+    @Before
+    public void prepare() throws Exception
+    {
+        f1 = temporaryFolder.newFile( "f1" );
+        try (FileOutputStream out = new FileOutputStream( f1 ))
+        {
+            IOUtils.write( dupContent, out );
+        }
+        f2 = temporaryFolder.newFile( "f2" );
+        try (FileOutputStream out = new FileOutputStream( f2 ))
+        {
+            IOUtils.write( dupContent, out );
+        }
+        f3 = temporaryFolder.newFile( "f3" );
+        try (FileOutputStream out = new FileOutputStream( f3 ))
+        {
+            IOUtils.write( otherContent, out );
+        }
+    }
+
+    @Ignore
+    @Test
+    public void run() throws Exception
+    {
+        String s1 = calculateChecksum( f1 );
+        System.out.println( ">>> s1=" + s1 );
+
+        String s2 = calculateChecksum( f2 );
+        System.out.println( ">>> s2=" + s2 );
+
+        String s3 = calculateChecksum( f3 );
+        System.out.println( ">>> s3=" + s3 );
+
+        assertEquals( s1, s2 );
+        assertNotEquals( s1, s3 );
+    }
+
+    private String calculateChecksum( File file ) throws Exception
+    {
+        ChecksumCalculator checksumCalculator = new ChecksumCalculator( "MD5" );
+
+        if ( !file.exists() || !file.isFile() )
+        {
+            throw new IOException(
+                            String.format( "Digest error: file not exists or not a regular file for file %s", file ) );
+        }
+        try (FileInputStream is = new FileInputStream( file ))
+        {
+            checksumCalculator.update( IOUtils.toByteArray( is ) );
+        }
+        return checksumCalculator.getDigestHex();
+    }
+}


### PR DESCRIPTION
I tested the new migrator. It has two problems. 1. The checksum is always the same so all the records are thrown to reclaim table. 2. It does not stop after done. 
This pr fix the #1 issue. 
I try to fix #2 by stop a timer. But not tested. I will test it soon. 