### PR TITLE
Fix TrackedContentEntryTest

### DIFF
--- a/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/model/TrackedContentEntryTest.java
+++ b/addons/folo/model-java/src/test/java/org/commonjava/indy/folo/model/TrackedContentEntryTest.java
@@ -157,6 +157,8 @@ public class TrackedContentEntryTest
                                          entry.getOriginUrl(), entry.getPath(), entry.getEffect(), entry.getSize(),
                                          entry.getMd5(), entry.getSha1(), entry.getSha256() );
 
+        test.setTimestamps( entry.getTimestamps() );
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream( baos );
         oos.writeObject( entry );


### PR DESCRIPTION
Sometimes this test failed and the timestamp of entry and test is different (e.g., a millisecond difference). This is due to the way the timestamp was set (currentTimeMillis) and there is a gap between those two objects' creation. 