### PR TITLE
Add filter to filter out the files not need to migrate

### DIFF
--- a/deployments/pathmap-migrator/README.md
+++ b/deployments/pathmap-migrator/README.md
@@ -13,7 +13,8 @@ Usage: java -jar ${package}.jar scan [options]
 Options:  
 -B (--batch) N      : Batch of paths to process each time  
 -b (--base) VAL     : Base dir of storage for all indy artifacts  
--w (--workdir) VAL  : Work dir to store all generated working files  
+-w (--workdir) VAL  : Work dir to store all generated working files
+-f (--filter) VAL   : Regex style filter string to filter some files which are unwanted
 
 #### migrate: read all files for paths and migrate them to cassandra db
 ##### Note: Before this command, please use "scan" to generate all paths files first

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateOptions.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateOptions.java
@@ -60,6 +60,10 @@ public class MigrateOptions
     @Option( name = "-w", aliases = "--workdir", usage = "Work dir to store all generated working files" )
     private String workDir;
 
+    @Option( name = "-f", aliases = "--filter",
+             usage = "Regex style filter string to filter some files which are unwanted" )
+    private String filterPattern;
+
     //    @Option( name = "-t", aliases = "--threads", usage = "Number of threads to execute the migrating process" )
     //    private int threads;
 
@@ -118,6 +122,16 @@ public class MigrateOptions
     public void setWorkDir( String workDir )
     {
         this.workDir = workDir;
+    }
+
+    public String getFilterPattern()
+    {
+        return filterPattern;
+    }
+
+    public void setFilterPattern( String filterPattern )
+    {
+        this.filterPattern = filterPattern;
     }
 
     //    public int getThreads()
@@ -268,6 +282,7 @@ public class MigrateOptions
         {
             System.out.println( String.format( "Base storage dir for artifacts: %s", getBaseDir() ) );
             System.out.println( String.format( "Batch of paths to process each time: %s", getBatchSize() ) );
+            System.out.println( String.format( "Filter pattern for unwanted files: %s", getFilterPattern() ) );
         }
 
         if ( getCommand().equals( CMD_MIGRATE ) )
@@ -410,7 +425,7 @@ public class MigrateOptions
             {
                 cassandraProps.put( PROP_CASSANDRA_PASS, getCassandraPass() );
             }
-            
+
             if ( isDedupe() )
             {
                 try

--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/Util.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/Util.java
@@ -38,7 +38,7 @@ public class Util
 
     static final String FAILED_PATHS_FILE = "failed_paths";
 
-    static final String STATUS_FILE = "status";
+    static final String STATUS_FILE = "scan_status";
 
     static final String CMD_SCAN = "scan";
 


### PR DESCRIPTION
To use, add "-f" during scan mode. One example to filter http-metadata.json is:
  -f .*http-metadata.json