### PR TITLE
[migration-tool] shutdown pathDB after done

### DIFF
--- a/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateCmd.java
+++ b/deployments/pathmap-migrator/src/main/java/org/commonjava/indy/pathmap/migrate/MigrateCmd.java
@@ -152,6 +152,7 @@ public class MigrateCmd
     {
         new UpdateProgressTask( options ).run(); // last run
         progressTimer.cancel();
+        migrator.shutdown();
     }
 
     private void storeFailedPaths( MigrateOptions options, List<String> failedPaths )


### PR DESCRIPTION
This should be able to fix the migrator not exit issue.