### PR TITLE
Addon path-mapped to provide direct listing/get/delete operations

### DIFF
--- a/addons/path-mapped/common/pom.xml
+++ b/addons/path-mapped/common/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-path-mapped</artifactId>
+    <version>1.9.6-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>indy-path-mapped-common</artifactId>
+  <name>Indy :: Add-Ons :: Path Mapped :: Common</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-path-mapped-model-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-cassandra</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-filer-default</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-db-memory</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-test-fixtures-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/common/PathMappedController.java
+++ b/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/common/PathMappedController.java
@@ -1,0 +1,85 @@
+package org.commonjava.indy.pathmapped.common;
+
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pathmapped.model.PathMappedDeleteResult;
+import org.commonjava.indy.pathmapped.model.PathMappedListResult;
+import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.maven.galley.cache.pathmapped.PathMappedCacheProvider;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.commonjava.storage.pathmapped.core.PathMappedFileManager;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.InputStream;
+
+@ApplicationScoped
+public class PathMappedController
+{
+    @Inject
+    private CacheProvider cacheProvider;
+
+    @Inject
+    private StoreDataManager storeDataManager;
+
+    private PathMappedCacheProvider pathMappedCacheProvider;
+
+    private PathMappedFileManager fileManager;
+
+    private static final int DEFAULT_RECURSIVE_LIST_LIMIT = 5000;
+
+    public PathMappedController()
+    {
+    }
+
+    @PostConstruct
+    private void init()
+    {
+        if ( cacheProvider instanceof PathMappedCacheProvider )
+        {
+            pathMappedCacheProvider = (PathMappedCacheProvider) cacheProvider;
+            fileManager = pathMappedCacheProvider.getPathMappedFileManager();
+        }
+    }
+
+    public PathMappedDeleteResult delete( String packageType, String type, String name, String path ) throws Exception
+    {
+        ConcreteResource resource = getConcreteResource( packageType, type, name, path );
+        boolean result = pathMappedCacheProvider.delete( resource );
+        return new PathMappedDeleteResult( packageType, type, name, path, result );
+    }
+
+    public PathMappedListResult list( String packageType, String type, String name, String path, boolean recursive )
+    {
+        String[] list;
+        StoreKey storeKey = new StoreKey( packageType, StoreType.get( type ), name );
+        if ( recursive )
+        {
+            list = fileManager.list( storeKey.toString(), path, true, DEFAULT_RECURSIVE_LIST_LIMIT );
+        }
+        else
+        {
+            list = fileManager.list( storeKey.toString(), path );
+        }
+        return new PathMappedListResult( packageType, type, name, path, list );
+    }
+
+    public InputStream get( String packageType, String type, String name, String path ) throws Exception
+    {
+        ConcreteResource resource = getConcreteResource( packageType, type, name, path );
+        return pathMappedCacheProvider.openInputStream( resource );
+    }
+
+    private ConcreteResource getConcreteResource( String packageType, String type, String name, String path )
+                    throws Exception
+    {
+        StoreKey storeKey = new StoreKey( packageType, StoreType.get( type ), name );
+        ArtifactStore store = storeDataManager.getArtifactStore( storeKey );
+        return new ConcreteResource( LocationUtils.toLocation( store ), path );
+    }
+
+}

--- a/addons/path-mapped/common/src/main/resources/META-INF/beans.xml
+++ b/addons/path-mapped/common/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2014 Red Hat, Inc..
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the GNU Public License v3.0
+  which accompanies this distribution, and is available at
+  http://www.gnu.org/licenses/gpl.html
+  
+  Contributors:
+      Red Hat, Inc. - initial API and implementation
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>

--- a/addons/path-mapped/jaxrs/pom.xml
+++ b/addons/path-mapped/jaxrs/pom.xml
@@ -1,0 +1,67 @@
+<!--
+
+    Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-path-mapped</artifactId>
+    <version>1.9.6-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>indy-path-mapped-jaxrs</artifactId>
+
+  <name>Indy :: Add-Ons :: Path Mapped :: JAX-RS Bindings</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-path-mapped-common</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-bindings-jaxrs</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>javax.enterprise</groupId>
+      <artifactId>cdi-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+  </dependencies>
+  
+</project>

--- a/addons/path-mapped/jaxrs/src/main/java/org/commonjava/indy/pathmapped/jaxrs/PathMappedResource.java
+++ b/addons/path-mapped/jaxrs/src/main/java/org/commonjava/indy/pathmapped/jaxrs/PathMappedResource.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pathmapped.jaxrs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.SecurityManager;
+import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
+import org.commonjava.indy.pathmapped.common.PathMappedController;
+import org.commonjava.indy.pathmapped.model.PathMappedDeleteResult;
+import org.commonjava.indy.pathmapped.model.PathMappedListResult;
+import org.commonjava.indy.util.ApplicationHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+
+import java.io.InputStream;
+
+import static org.commonjava.indy.util.ApplicationContent.application_json;
+import static org.commonjava.storage.pathmapped.util.PathMapUtils.ROOT_DIR;
+
+@Api( value = "Path-mapped storage maintenance operation", description = "Repair path-mapped storage problems." )
+@Path( "/api/admin/pathmapped" )
+@REST
+public class PathMappedResource
+                implements IndyResources
+{
+    private static final String BROWSE_BASE = "/browse/{packageType}/{type: (hosted|group|remote)}/{name}";
+
+    private static final String CONCRETE_CONTENT_PATH = "/content/{packageType}/{type: (hosted|group|remote)}/{name}/{path: (.*)}";
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private ObjectMapper mapper;
+
+    @Inject
+    private SecurityManager securityManager;
+
+    @Inject
+    private PathMappedController controller;
+
+    @Inject
+    private ResponseHelper responseHelper;
+
+    @ApiOperation( "List root." )
+    @ApiResponse( code = 200, message = "Operation finished.", response = PathMappedListResult.class )
+    @GET
+    @Path( BROWSE_BASE )
+    @Produces( { application_json } )
+    public PathMappedListResult listRoot( final @ApiParam( required = true ) @PathParam( "packageType" ) String packageType,
+                                      final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" ) String type,
+                                      final @ApiParam( required = true ) @PathParam( "name" ) String name,
+                                      final @QueryParam( "recursive" ) boolean recursive,
+                                      final @Context HttpServletRequest request,
+                                      final @Context SecurityContext securityContext )
+    {
+        logger.debug( "List, packageType:{}, type:{}, name:{}, recursive:{}", packageType, type, name, recursive );
+        return controller.list( packageType, type, name, ROOT_DIR, recursive );
+    }
+
+    @ApiOperation( "List specified path." )
+    @ApiResponse( code = 200, message = "Operation finished.", response = PathMappedListResult.class )
+    @GET
+    @Path( BROWSE_BASE + "/{path: (.*)}" )
+    @Produces( { application_json } )
+    public PathMappedListResult list( final @ApiParam( required = true ) @PathParam( "packageType" ) String packageType,
+                                      final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" ) String type,
+                                      final @ApiParam( required = true ) @PathParam( "name" ) String name,
+                                      final @PathParam( "path" ) String path,
+                                      final @QueryParam( "recursive" ) boolean recursive,
+                                      final @Context HttpServletRequest request,
+                                      final @Context SecurityContext securityContext )
+    {
+        logger.debug( "List, packageType:{}, type:{}, name:{}, path:{}, recursive:{}", packageType, type, name, path,
+                      recursive );
+        return controller.list( packageType, type, name, path, recursive );
+    }
+
+    @ApiOperation( "Get specified path." )
+    @ApiResponse( code = 200, message = "Operation finished." )
+    @GET
+    @Path( CONCRETE_CONTENT_PATH )
+    public Response get( final @PathParam( "packageType" ) String packageType,
+                            final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" ) String type,
+                            final @ApiParam( required = true ) @PathParam( "name" ) String name,
+                            final @PathParam( "path" ) String path,
+                            final @Context HttpServletRequest request,
+                            final @Context SecurityContext securityContext )
+    {
+        try
+        {
+            logger.debug( "Get, packageType:{}, type:{}, name:{}, path:{}", packageType, type, name, path );
+            InputStream inputStream = controller.get( packageType, type, name, path );
+            return Response.ok( inputStream )
+                           .header( ApplicationHeader.content_disposition.key(),
+                                    "attachment" )
+                           .build();
+        }
+        catch ( Exception e )
+        {
+            logger.error( e.getMessage(), e );
+            responseHelper.throwError( e );
+        }
+        return null;
+    }
+
+    @ApiOperation( "Delete specified path." )
+    @ApiResponse( code = 200, message = "Operation finished.", response = PathMappedDeleteResult.class )
+    @DELETE
+    @Path( CONCRETE_CONTENT_PATH )
+    @Produces( { application_json } )
+    public PathMappedDeleteResult delete( final @PathParam( "packageType" ) String packageType,
+                                          final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" ) String type,
+                                          final @ApiParam( required = true ) @PathParam( "name" ) String name,
+                                          final @PathParam( "path" ) String path,
+                                          final @Context HttpServletRequest request,
+                                          final @Context SecurityContext securityContext )
+    {
+        try
+        {
+            logger.debug( "Delete, packageType:{}, type:{}, name:{}, path:{}", packageType, type, name, path );
+            return controller.delete( packageType, type, name, path );
+        }
+        catch ( Exception e )
+        {
+            logger.error( e.getMessage(), e );
+            responseHelper.throwError( e );
+        }
+        return null;
+    }
+}

--- a/addons/path-mapped/jaxrs/src/main/resources/META-INF/beans.xml
+++ b/addons/path-mapped/jaxrs/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2014 Red Hat, Inc..
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the GNU Public License v3.0
+  which accompanies this distribution, and is available at
+  http://www.gnu.org/licenses/gpl.html
+  
+  Contributors:
+      Red Hat, Inc. - initial API and implementation
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+</beans>

--- a/addons/path-mapped/model-java/pom.xml
+++ b/addons/path-mapped/model-java/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 
     Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
@@ -18,36 +18,33 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.commonjava.indy</groupId>
-    <artifactId>indy-parent</artifactId>
+    <artifactId>indy-path-mapped</artifactId>
     <version>1.9.6-SNAPSHOT</version>
   </parent>
-  
-  <artifactId>indy-addons</artifactId>
-  <packaging>pom</packaging>
 
-  <name>Indy :: Add-Ons :: Parent</name>
-  
-  <modules>
-    <module>content-index</module>
-    <module>dot-maven</module>
-    <module>folo</module>
-    <module>httprox</module>
-    <module>implied-repos</module>
-    <module>koji</module>
-    <module>promote</module>
-    <module>revisions</module>
-    <module>pkg-maven</module>
-    <module>diagnostics</module>
-    <module>pkg-npm</module>
-    <module>hosted-by-archive</module>
-    <module>content-browse</module>
-    <module>changelog</module>
-    <module>event-audit</module>
-    <module>sli</module>
-    <module>path-mapped</module>
-    <!-- DO NOT REMOVE: append::addon -->
-  </modules>
+  <artifactId>indy-path-mapped-model-java</artifactId>
+  <name>Indy :: Add-Ons :: Path Mapped :: Java Domain Model</name>
+
+  <dependencies>
+    <dependency>
+    	<groupId>org.commonjava.indy</groupId>
+    	<artifactId>indy-model-core-java</artifactId>
+    </dependency>
+    <dependency>
+    	<groupId>junit</groupId>
+    	<artifactId>junit</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/addons/path-mapped/model-java/src/main/java/org/commonjava/indy/pathmapped/model/PathMappedDeleteResult.java
+++ b/addons/path-mapped/model-java/src/main/java/org/commonjava/indy/pathmapped/model/PathMappedDeleteResult.java
@@ -1,0 +1,77 @@
+package org.commonjava.indy.pathmapped.model;
+
+public class PathMappedDeleteResult
+{
+    private String packageType;
+
+    private String type;
+
+    private String name;
+
+    private String path;
+
+    boolean result;
+
+    public PathMappedDeleteResult()
+    {
+    }
+
+    public PathMappedDeleteResult( String packageType, String type, String name, String path, boolean result )
+    {
+        this.packageType = packageType;
+        this.type = type;
+        this.name = name;
+        this.path = path;
+        this.result = result;
+    }
+
+    public String getPackageType()
+    {
+        return packageType;
+    }
+
+    public void setPackageType( String packageType )
+    {
+        this.packageType = packageType;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType( String type )
+    {
+        this.type = type;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName( String name )
+    {
+        this.name = name;
+    }
+
+    public String getPath()
+    {
+        return path;
+    }
+
+    public void setPath( String path )
+    {
+        this.path = path;
+    }
+
+    public boolean isResult()
+    {
+        return result;
+    }
+
+    public void setResult( boolean result )
+    {
+        this.result = result;
+    }
+}

--- a/addons/path-mapped/model-java/src/main/java/org/commonjava/indy/pathmapped/model/PathMappedListResult.java
+++ b/addons/path-mapped/model-java/src/main/java/org/commonjava/indy/pathmapped/model/PathMappedListResult.java
@@ -1,0 +1,73 @@
+package org.commonjava.indy.pathmapped.model;
+
+public class PathMappedListResult
+{
+    private String packageType;
+
+    private String type;
+
+    private String name;
+
+    private String path;
+
+    private String[] list;
+
+    public PathMappedListResult( String packageType, String type, String name, String path, String[] list )
+    {
+        this.packageType = packageType;
+        this.type = type;
+        this.name = name;
+        this.path = path;
+        this.list = list;
+    }
+
+    public String getPackageType()
+    {
+        return packageType;
+    }
+
+    public void setPackageType( String packageType )
+    {
+        this.packageType = packageType;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType( String type )
+    {
+        this.type = type;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName( String name )
+    {
+        this.name = name;
+    }
+
+    public String getPath()
+    {
+        return path;
+    }
+
+    public void setPath( String path )
+    {
+        this.path = path;
+    }
+
+    public String[] getList()
+    {
+        return list;
+    }
+
+    public void setList( String[] list )
+    {
+        this.list = list;
+    }
+}

--- a/addons/path-mapped/pom.xml
+++ b/addons/path-mapped/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 
     Copyright (C) 2011-2019 Red Hat, Inc. (https://github.com/Commonjava/indy)
@@ -18,36 +18,19 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.commonjava.indy</groupId>
-    <artifactId>indy-parent</artifactId>
+    <artifactId>indy-addons</artifactId>
     <version>1.9.6-SNAPSHOT</version>
   </parent>
-  
-  <artifactId>indy-addons</artifactId>
+  <artifactId>indy-path-mapped</artifactId>
+  <name>Indy :: Add-Ons :: Path Mapped :: Parent</name>
   <packaging>pom</packaging>
 
-  <name>Indy :: Add-Ons :: Parent</name>
-  
   <modules>
-    <module>content-index</module>
-    <module>dot-maven</module>
-    <module>folo</module>
-    <module>httprox</module>
-    <module>implied-repos</module>
-    <module>koji</module>
-    <module>promote</module>
-    <module>revisions</module>
-    <module>pkg-maven</module>
-    <module>diagnostics</module>
-    <module>pkg-npm</module>
-    <module>hosted-by-archive</module>
-    <module>content-browse</module>
-    <module>changelog</module>
-    <module>event-audit</module>
-    <module>sli</module>
-    <module>path-mapped</module>
-    <!-- DO NOT REMOVE: append::addon -->
+    <module>common</module>
+    <module>jaxrs</module>
+    <module>model-java</module>
   </modules>
+
 </project>

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -196,6 +196,14 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-path-mapped-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-path-mapped-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-changelog-common</artifactId>
     </dependency>
     <dependency>

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
@@ -23,12 +23,7 @@ import org.commonjava.propulsor.config.annotation.SectionName;
 import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
-
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @SectionName( "storage-default" )
 @ApplicationScoped
@@ -113,7 +108,7 @@ public class DefaultStorageProviderConfiguration
 
     // Path mapped storage config
 
-    private static final String DEFAULT_STORAGE_KEYSPACE = "indy";
+    private static final String DEFAULT_STORAGE_KEYSPACE = "indystorage";
 
     private String cassandraKeyspace = DEFAULT_STORAGE_KEYSPACE;
 
@@ -180,20 +175,4 @@ public class DefaultStorageProviderConfiguration
         return fileChecksumAlgorithm;
     }
 
-    private List<String> subsystemEnabledFileSystems = new ArrayList<>();
-
-    // comma separated file system names
-    @ConfigName( "storage.subsystem.enabled.filesystems" )
-    public void setSubsystemEnabledFileSystems( String fileSystems )
-    {
-        if ( fileSystems != null && isNotBlank( fileSystems.trim() ) )
-        {
-            this.subsystemEnabledFileSystems = Arrays.asList( fileSystems.split( "," ) );
-        }
-    }
-
-    public List<String> getSubsystemEnabledFileSystems()
-    {
-        return subsystemEnabledFileSystems;
-    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -399,6 +399,11 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-subsys-pathmapped</artifactId>
+        <version>1.9.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-infinispan</artifactId>
         <version>1.9.6-SNAPSHOT</version>
       </dependency>
@@ -628,6 +633,22 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-jaxrs</artifactId>
+        <version>1.9.6-SNAPSHOT</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-path-mapped-common</artifactId>
+        <version>1.9.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-path-mapped-model-java</artifactId>
+        <version>1.9.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-path-mapped-jaxrs</artifactId>
         <version>1.9.6-SNAPSHOT</version>
       </dependency>
 

--- a/subsys/cassandra/src/main/conf/conf.d/cassandra.conf
+++ b/subsys/cassandra/src/main/conf/conf.d/cassandra.conf
@@ -2,7 +2,7 @@
 
 # By default, the cassandra is disabled.
 #
-# enabled=true
+enabled=true
 
 #cassandra.host=localhost
 #cassandra.port=9042

--- a/subsys/cassandra/src/main/resources/default-cassandra.conf
+++ b/subsys/cassandra/src/main/resources/default-cassandra.conf
@@ -2,7 +2,7 @@
 
 # By default, the cassandra is disabled.
 #
-# enabled=true
+enabled=true
 
 #cassandra.host=localhost
 #cassandra.port=9042


### PR DESCRIPTION
Add-on for the direct list, get and delete path-mapped files. It mainly for the maintenance, e.g, remove a stale metadata.xml, etc. 
This add-on provides below REST endpoints under "/api/admin/pathmapped".
1. list, "browse/{packageType}/{type: (hosted|group|remote)}/{name}/{path: (.*)}?recursive=true/false". If recursive is true, it lists all paths recursively. Default is false (meaning to list the direct children).
2. get/delete, "content/{packageType}/{type: (hosted|group|remote)}/{name}".
