### PR TITLE
Add creation time for all repos

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
@@ -32,6 +32,7 @@ public abstract class AbstractRepository
 
     AbstractRepository()
     {
+        super();
     }
 
     protected AbstractRepository( final String packageType, final StoreType type, final String name )

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.model.core;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -78,16 +79,21 @@ public abstract class ArtifactStore
     @JsonProperty("authoritative_index")
     private Boolean authoritativeIndex;
 
+    @JsonProperty("create_time")
+    private Date createTime;
+
     @JsonIgnore
     private Boolean rescanInProgress = false;
 
     protected ArtifactStore()
     {
+        initRepoTime();
     }
 
     protected ArtifactStore( final String packageType, final StoreType type, final String name )
     {
         this.key = StoreKey.dedupe( new StoreKey( packageType, type, name ) );
+        initRepoTime();
     }
 
     public String getName()
@@ -306,5 +312,14 @@ public abstract class ArtifactStore
     public void setRescanInProgress( Boolean rescanInProgress )
     {
         this.rescanInProgress = rescanInProgress;
+    }
+
+    public Date getCreateTime()
+    {
+        return createTime;
+    }
+
+    private void initRepoTime(){
+        this.createTime = new Date( System.currentTimeMillis() );
     }
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
@@ -38,6 +38,7 @@ public class Group
 
     Group()
     {
+        super();
         this.constituents = new ArrayList<>();
     }
 

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -118,6 +118,7 @@ public class RemoteRepository
 
     RemoteRepository()
     {
+        super();
     }
 
     @Deprecated


### PR DESCRIPTION
Seems there is no creation time for all of our current repos. I think it is useful for tracking, especially for the auto-created repos like koji-proxy and implied repos.
  BTW, I'm also thinking if we also need to add the "last_update_time" for all repos. But seems we have repo change logs, so I'm not sure if this is a needed option.
@jdcasey @ruhan1 @geored  What's your opinion?