### PR TITLE
Add creation time for all repos

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
@@ -32,6 +32,7 @@ public abstract class AbstractRepository
 
     AbstractRepository()
     {
+        super();
     }
 
     protected AbstractRepository( final String packageType, final StoreType type, final String name )

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -15,12 +15,6 @@
  */
 package org.commonjava.indy.model.core;
 
-import java.io.Serializable;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -28,6 +22,14 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+
+import java.io.Serializable;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TimeZone;
 
 import static org.commonjava.indy.model.core.PathStyle.plain;
 
@@ -80,7 +82,7 @@ public abstract class ArtifactStore
     private Boolean authoritativeIndex;
 
     @JsonProperty("create_time")
-    private Date createTime;
+    private String createTime;
 
     @JsonIgnore
     private Boolean rescanInProgress = false;
@@ -314,12 +316,15 @@ public abstract class ArtifactStore
         this.rescanInProgress = rescanInProgress;
     }
 
-    public Date getCreateTime()
+    public String getCreateTime()
     {
         return createTime;
     }
 
-    private void initRepoTime(){
-        this.createTime = new Date( System.currentTimeMillis() );
+    private void initRepoTime()
+    {
+        final SimpleDateFormat format = new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss ZZZ" );
+        format.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
+        this.createTime = format.format( new Date( System.currentTimeMillis() ) );
     }
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.model.core;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -78,16 +79,21 @@ public abstract class ArtifactStore
     @JsonProperty("authoritative_index")
     private Boolean authoritativeIndex;
 
+    @JsonProperty("create_time")
+    private Date createTime;
+
     @JsonIgnore
     private Boolean rescanInProgress = false;
 
     protected ArtifactStore()
     {
+        initRepoTime();
     }
 
     protected ArtifactStore( final String packageType, final StoreType type, final String name )
     {
         this.key = StoreKey.dedupe( new StoreKey( packageType, type, name ) );
+        initRepoTime();
     }
 
     public String getName()
@@ -306,5 +312,14 @@ public abstract class ArtifactStore
     public void setRescanInProgress( Boolean rescanInProgress )
     {
         this.rescanInProgress = rescanInProgress;
+    }
+
+    public Date getCreateTime()
+    {
+        return createTime;
+    }
+
+    private void initRepoTime(){
+        this.createTime = new Date( System.currentTimeMillis() );
     }
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
@@ -38,6 +38,7 @@ public class Group
 
     Group()
     {
+        super();
         this.constituents = new ArrayList<>();
     }
 

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -118,6 +118,7 @@ public class RemoteRepository
 
     RemoteRepository()
     {
+        super();
     }
 
     @Deprecated


### PR DESCRIPTION
Seems there is no creation time for all of our current repos. I think
it is useful for tracking, especially for the auto-created repos like
koji-proxy and implied repos.
  BTW, I'm also thinking if we also need to add the "last_update_time"
for all repos.