### PR TITLE
Directly use store object in data-store cache instead of a json string

### DIFF
--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.indy.infinispan.data;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
@@ -35,7 +34,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -51,7 +50,7 @@ public class InfinispanStoreDataManager
 
     @Inject
     @StoreDataCache
-    private CacheHandle<StoreKey, String> stores;
+    private CacheHandle<StoreKey, ArtifactStore> stores;
 
     @Inject
     private CacheProducer cacheProducer;
@@ -88,8 +87,7 @@ public class InfinispanStoreDataManager
     @Override
     protected ArtifactStore getArtifactStoreInternal( StoreKey key )
     {
-        String json = stores.get( key );
-        return readValueByJson( json, key );
+        return stores.get( key );
     }
 
     private ArtifactStore readValueByJson( String json, StoreKey key )
@@ -112,8 +110,7 @@ public class InfinispanStoreDataManager
     @Override
     protected ArtifactStore removeArtifactStoreInternal( StoreKey key )
     {
-        String json = stores.executeCache( ( c ) -> c.remove( key ) );
-        return readValueByJson( json, key );
+        return stores.executeCache( ( c ) -> c.remove( key ) );
     }
 
     @Override
@@ -129,15 +126,17 @@ public class InfinispanStoreDataManager
     public Set<ArtifactStore> getAllArtifactStores() throws IndyDataException
     {
         return stores.executeCache( c -> {
-            Set<ArtifactStore> ret = new HashSet<>();
-            c.forEach( ( k, v ) -> {
-                ArtifactStore store = readValueByJson( v, k );
-                if ( store != null )
-                {
-                    ret.add( store );
-                }
-            } );
-            return ret;
+            return Collections.unmodifiableSet( new HashSet<>( c.values() ) );
+
+//            c.forEach( ( k, v ) -> {
+//                ArtifactStore store = readValueByJson( v, k );
+//                if ( store != null )
+//                {
+//                    ret.add( store );
+//                }
+//                ret.add( v );
+//            } );
+//            return ret;
         } );
     }
 
@@ -145,15 +144,16 @@ public class InfinispanStoreDataManager
     public Map<StoreKey, ArtifactStore> getArtifactStoresByKey()
     {
         return stores.executeCache( c -> {
-            Map<StoreKey, ArtifactStore> ret = new HashMap<>();
-            c.forEach( ( k, v ) -> {
-                ArtifactStore store = readValueByJson( v, k );
-                if ( store != null )
-                {
-                    ret.put( store.getKey(), store );
-                }
-            } );
-            return ret;
+            return Collections.unmodifiableMap( c );
+//            Map<StoreKey, ArtifactStore> ret = new HashMap<>();
+//            c.forEach( ( k, v ) -> {
+//                ArtifactStore store = readValueByJson( v, k );
+//                if ( store != null )
+//                {
+//                    ret.put( store.getKey(), store );
+//                }
+//            } );
+//            return ret;
         } );
     }
 
@@ -178,19 +178,18 @@ public class InfinispanStoreDataManager
     @Override
     protected ArtifactStore putArtifactStoreInternal( StoreKey storeKey, ArtifactStore store )
     {
-        final String json;
-        try
-        {
-            json = serializer.writeValueAsString( store );
-        }
-        catch ( JsonProcessingException e )
-        {
-            logger.error( "Failed to put", e );
-            return null;
-        }
+//        final String json;
+//        try
+//        {
+//            json = serializer.writeValueAsString( store );
+//        }
+//        catch ( JsonProcessingException e )
+//        {
+//            logger.error( "Failed to put", e );
+//            return null;
+//        }
 
-        String org = stores.put( storeKey, json );
-        return readValueByJson( org, storeKey );
+        return stores.put( storeKey, store );
     }
 
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.infinispan.data;
 
+import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
@@ -33,7 +34,7 @@ public class StoreDataCacheProducer
     @StoreDataCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<StoreKey, String> getStoreDataCache()
+    public CacheHandle<StoreKey, ArtifactStore> getStoreDataCache()
     {
         return cacheProducer.getCache( STORE_DATA_CACHE );
     }

--- a/models/core-java/pom.xml
+++ b/models/core-java/pom.xml
@@ -73,6 +73,10 @@
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-commons</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
@@ -17,7 +17,9 @@ package org.commonjava.indy.model.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
+import org.commonjava.indy.model.core.externalize.GroupExternalizer;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.infinispan.commons.marshall.SerializeWith;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -25,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 
 @ApiModel( description = "Grouping of other artifact stores, with a defined order to the membership that determines content preference", parent = ArtifactStore.class )
+@SerializeWith( GroupExternalizer.class )
 public class Group
     extends ArtifactStore
 {

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
@@ -17,11 +17,14 @@ package org.commonjava.indy.model.core;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.commonjava.indy.model.core.externalize.HostedRepositoryExternalizer;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.infinispan.commons.marshall.SerializeWith;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
 
 @ApiModel( description = "Hosts artifact content on the local system", parent = ArtifactStore.class )
+@SerializeWith( HostedRepositoryExternalizer.class )
 public class HostedRepository
     extends AbstractRepository
 {

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -21,7 +21,9 @@ import java.net.URL;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.commonjava.indy.model.core.externalize.RemoteRepositoryExternalizer;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.infinispan.commons.marshall.SerializeWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +33,7 @@ import static org.commonjava.indy.model.core.StoreType.remote;
 
 @ApiModel( description = "Proxy to a remote server's artifact content, with local cache storage.",
            parent = ArtifactStore.class )
+@SerializeWith( RemoteRepositoryExternalizer.class )
 public class RemoteRepository
         extends AbstractRepository
 {

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/externalize/GroupExternalizer.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/externalize/GroupExternalizer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.model.core.externalize;
+
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.infinispan.commons.marshall.Externalizer;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class GroupExternalizer
+        implements Externalizer<Group>
+{
+    private IndyObjectMapper objectMapper = new IndyObjectMapper( true );
+
+    @Override
+    public void writeObject( ObjectOutput output, Group object )
+            throws IOException
+    {
+        objectMapper.writeValue( output, object );
+    }
+
+    @Override
+    public Group readObject( ObjectInput input )
+            throws IOException, ClassNotFoundException
+    {
+        return objectMapper.readValue( input, Group.class );
+    }
+}

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/externalize/HostedRepositoryExternalizer.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/externalize/HostedRepositoryExternalizer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.model.core.externalize;
+
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.infinispan.commons.marshall.Externalizer;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class HostedRepositoryExternalizer
+        implements Externalizer<HostedRepository>
+{
+    private IndyObjectMapper objectMapper = new IndyObjectMapper( true );
+
+    @Override
+    public void writeObject( ObjectOutput output, HostedRepository object )
+            throws IOException
+    {
+        objectMapper.writeValue( output, object );
+    }
+
+    @Override
+    public HostedRepository readObject( ObjectInput input )
+            throws IOException, ClassNotFoundException
+    {
+        return objectMapper.readValue( input, HostedRepository.class );
+    }
+}

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/externalize/RemoteRepositoryExternalizer.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/externalize/RemoteRepositoryExternalizer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.model.core.externalize;
+
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.infinispan.commons.marshall.Externalizer;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class RemoteRepositoryExternalizer
+        implements Externalizer<RemoteRepository>
+{
+    private IndyObjectMapper objectMapper = new IndyObjectMapper( true );
+
+    @Override
+    public void writeObject( ObjectOutput output, RemoteRepository object )
+            throws IOException
+    {
+        objectMapper.writeValue( output, object );
+    }
+
+    @Override
+    public RemoteRepository readObject( ObjectInput input )
+            throws IOException, ClassNotFoundException
+    {
+        return objectMapper.readValue( input, RemoteRepository.class );
+    }
+}


### PR DESCRIPTION
Now in our ISPNDataStoreMgr, we are storing the store data as json
string, and when querying we need to deser the json to object each time.
As the query for store is a high frequent ops, this may cause some time
wasting, so we need to think about to use the store object directly in
cache.