### PR TITLE
Add an in memory facade before ispn store manager

### DIFF
--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -54,6 +54,7 @@ public class InfinispanStoreDataManager
     @StoreDataCache
     private CacheHandle<StoreKey, String> stores;
 
+    //TODO: Warning: this in mem facade store cache may bring mem issue if the repo grows to very big number in future!
     private final Map<StoreKey, ArtifactStore> inMemoryStores = new ConcurrentHashMap<>();
 
     @Inject
@@ -214,14 +215,14 @@ public class InfinispanStoreDataManager
         synchronized ( inMemoryStores )
         {
             String org = stores.put( storeKey, json );
-            putInMemoryStores( readValueByJson( org, storeKey ) );
+            putInMemoryStores( readValueByJson( json, storeKey ) );
         }
         return inMemoryStores.get( storeKey );
     }
 
     private void putInMemoryStores( final ArtifactStore store )
     {
-        // ConcurrentHashMap does not null key and null value
+        // ConcurrentHashMap does not allow null key and null value
         if ( store != null )
         {
             inMemoryStores.put( store.getKey(), store );


### PR DESCRIPTION
Now in ISPNDataStoreMgr, we are storing the store data as json
string, and when querying we need to deser the json to object each time.
As the query for store is a high frequent ops, this may cause some time
wasting, so we need to think about to use the store object directly in.
   To avoid object externalizing incompatibility problem, I think we
should not change the way of ispn marshalling/unmarshalling from
persistence. So I added a in memory facade map between caller and
underlying ispn cache. As this store data cache is not a big one, so I
think it will not bring memory problem here.