### PR TITLE
Switch to using Externalizable/ArtifactStore for InfinispanStoreDataManager

### DIFF
--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.indy.infinispan.data;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
@@ -23,9 +22,7 @@ import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.db.common.AbstractStoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
-import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import org.infinispan.Cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,11 +31,10 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
-import java.io.IOException;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_DATA_CACHE;
 
@@ -51,16 +47,16 @@ public class InfinispanStoreDataManager
 
     @Inject
     @StoreDataCache
-    private CacheHandle<StoreKey, String> stores;
+    private CacheHandle<StoreKey, ArtifactStore> stores;
 
-    @Inject
-    private CacheProducer cacheProducer;
+//    @Inject
+//    private CacheProducer cacheProducer;
 
     @Inject
     private StoreEventDispatcher dispatcher;
 
-    @Inject
-    private IndyObjectMapper serializer;
+//    @Inject
+//    private IndyObjectMapper serializer;
 
     @Override
     protected StoreEventDispatcher getStoreEventDispatcher()
@@ -77,43 +73,42 @@ public class InfinispanStoreDataManager
     {
     }
 
-    public InfinispanStoreDataManager( final Cache<String, String> jsonStoreDataCache,
-                                       final IndyObjectMapper serializer )
+    public InfinispanStoreDataManager( final Cache<String, ArtifactStore> cache )
     {
         this.dispatcher = new NoOpStoreEventDispatcher();
-        this.stores = new CacheHandle( STORE_DATA_CACHE, jsonStoreDataCache );
-        this.serializer = serializer;
+        this.stores = new CacheHandle( STORE_DATA_CACHE, cache );
+//        this.serializer = serializer;
     }
 
     @Override
     protected ArtifactStore getArtifactStoreInternal( StoreKey key )
     {
-        String json = stores.get( key );
-        return readValueByJson( json, key );
+        return stores.get( key );
+//        return readValueByJson( json, key );
     }
 
-    private ArtifactStore readValueByJson( String json, StoreKey key )
-    {
-        if ( json == null )
-        {
-            return null;
-        }
-        try
-        {
-            return serializer.readValue( json, key.getType().getStoreClass() );
-        }
-        catch ( IOException e )
-        {
-            logger.error( "Failed to read value", e );
-        }
-        return null;
-    }
+//    private ArtifactStore readValueByJson( String json, StoreKey key )
+//    {
+//        if ( json == null )
+//        {
+//            return null;
+//        }
+//        try
+//        {
+//            return serializer.readValue( json, key.getType().getStoreClass() );
+//        }
+//        catch ( IOException e )
+//        {
+//            logger.error( "Failed to read value", e );
+//        }
+//        return null;
+//    }
 
     @Override
     protected ArtifactStore removeArtifactStoreInternal( StoreKey key )
     {
-        String json = stores.executeCache( ( c ) -> c.remove( key ) );
-        return readValueByJson( json, key );
+        return stores.executeCache( ( c ) -> c.remove( key ) );
+//        return readValueByJson( json, key );
     }
 
     @Override
@@ -129,15 +124,16 @@ public class InfinispanStoreDataManager
     public Set<ArtifactStore> getAllArtifactStores() throws IndyDataException
     {
         return stores.executeCache( c -> {
-            Set<ArtifactStore> ret = new HashSet<>();
-            c.forEach( ( k, v ) -> {
-                ArtifactStore store = readValueByJson( v, k );
-                if ( store != null )
-                {
-                    ret.add( store );
-                }
-            } );
-            return ret;
+//            Set<ArtifactStore> ret = new HashSet<>();
+//            c.forEach( ( k, v ) -> {
+//                ArtifactStore store = readValueByJson( v, k );
+//                if ( store != null )
+//                {
+//                    ret.add( store );
+//                }
+//            } );
+//            return ret;
+            return c.values().stream().collect( Collectors.toSet() );
         } );
     }
 
@@ -146,14 +142,17 @@ public class InfinispanStoreDataManager
     {
         return stores.executeCache( c -> {
             Map<StoreKey, ArtifactStore> ret = new HashMap<>();
-            c.forEach( ( k, v ) -> {
-                ArtifactStore store = readValueByJson( v, k );
-                if ( store != null )
-                {
-                    ret.put( store.getKey(), store );
-                }
-            } );
+//            c.forEach( ( k, v ) -> {
+//                ArtifactStore store = readValueByJson( v, k );
+//                if ( store != null )
+//                {
+//                    ret.put( store.getKey(), store );
+//                }
+//            } );
+
+            c.values().stream().forEach( v -> ret.put( v.getKey(), v ) );
             return ret;
+
         } );
     }
 
@@ -178,19 +177,19 @@ public class InfinispanStoreDataManager
     @Override
     protected ArtifactStore putArtifactStoreInternal( StoreKey storeKey, ArtifactStore store )
     {
-        final String json;
-        try
-        {
-            json = serializer.writeValueAsString( store );
-        }
-        catch ( JsonProcessingException e )
-        {
-            logger.error( "Failed to put", e );
-            return null;
-        }
+//        final String json;
+//        try
+//        {
+//            json = serializer.writeValueAsString( store );
+//        }
+//        catch ( JsonProcessingException e )
+//        {
+//            logger.error( "Failed to put", e );
+//            return null;
+//        }
 
-        String org = stores.put( storeKey, json );
-        return readValueByJson( org, storeKey );
+        return stores.put( storeKey, store );
+//        return readValueByJson( org, storeKey );
     }
 
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.infinispan.data;
 
+import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
@@ -33,9 +34,18 @@ public class StoreDataCacheProducer
     @StoreDataCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<StoreKey, String> getStoreDataCache()
+    public CacheHandle<StoreKey, ArtifactStore> getStoreDataCache()
     {
         return cacheProducer.getCache( STORE_DATA_CACHE );
     }
+
+//    @StoreDataCache
+//    @Produces
+//    @ApplicationScoped
+//    public CacheHandle<StoreKey, String> getStoreDataCache()
+//    {
+//        return cacheProducer.getCache( STORE_DATA_CACHE );
+//    }
+
 
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
@@ -37,7 +37,7 @@ public abstract class AbstractRepository
     private boolean allowReleases = true;
 
 
-    AbstractRepository()
+    public AbstractRepository()
     {
         super();
     }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/AbstractRepository.java
@@ -17,11 +17,18 @@ package org.commonjava.indy.model.core;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Map;
+import java.util.Set;
+
 public abstract class AbstractRepository
     extends ArtifactStore
+        implements Externalizable
 {
-
-    private static final long serialVersionUID = 1L;
+    private static final int ABSTRACT_REPOSITORY_VERSION = 1;
 
     @JsonProperty( "allow_snapshots" )
     private boolean allowSnapshots = false;
@@ -64,6 +71,34 @@ public abstract class AbstractRepository
     {
         repo.setAllowReleases( isAllowReleases() );
         repo.setAllowSnapshots( isAllowSnapshots() );
+    }
+
+    @Override
+    public void writeExternal( final ObjectOutput out )
+            throws IOException
+    {
+        super.writeExternal( out );
+
+        out.writeInt( ABSTRACT_REPOSITORY_VERSION );
+        out.writeBoolean( allowReleases );
+        out.writeBoolean( allowSnapshots );
+    }
+
+    @Override
+    public void readExternal( final ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        super.readExternal( in );
+
+        int abstractRepositoryVersion = in.readInt();
+        if ( abstractRepositoryVersion > ABSTRACT_REPOSITORY_VERSION )
+        {
+            throw new IOException( "Cannot deserialize. AbstractRepository version in data stream is: " + abstractRepositoryVersion
+                                           + " but this class can only deserialize up to version: " + ABSTRACT_REPOSITORY_VERSION );
+        }
+
+        this.allowReleases = in.readBoolean();
+        this.allowSnapshots = in.readBoolean();
     }
 
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -90,7 +90,7 @@ public abstract class ArtifactStore
     @JsonIgnore
     private Boolean rescanInProgress = false;
 
-    protected ArtifactStore()
+    public ArtifactStore()
     {
         initRepoTime();
     }
@@ -336,7 +336,8 @@ public abstract class ArtifactStore
             throws IOException
     {
         out.writeInt( ARTIFACT_STORE_VERSION );
-        key.writeExternal( out );
+        out.writeObject( key );
+//        key.writeExternal( out );
 
         out.writeObject( description );
         out.writeObject( metadata );
@@ -369,8 +370,9 @@ public abstract class ArtifactStore
                                            + " but this class can only deserialize up to version: " + ARTIFACT_STORE_VERSION );
         }
 
-        this.key = new StoreKey();
-        key.readExternal( in );
+//        this.key = new StoreKey();
+//        key.readExternal( in );
+        this.key = (StoreKey) in.readObject();
 
         this.description = (String) in.readObject();
         this.metadata = (Map<String, String>) in.readObject();

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -23,7 +23,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 
-import java.io.Serializable;
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
@@ -39,8 +42,10 @@ import static org.commonjava.indy.model.core.PathStyle.plain;
 @ApiModel( description = "Definition of a content store on Indy, whether it proxies content from a remote server, hosts artifacts on this system, or groups other content stores.", discriminator = "type", subTypes = {
     HostedRepository.class, Group.class, RemoteRepository.class } )
 public abstract class ArtifactStore
-    implements Serializable
+        implements Externalizable
 {
+
+    private static final int ARTIFACT_STORE_VERSION = 1;
 
     public static final String PKG_TYPE_ATTR = "packageType";
 
@@ -53,8 +58,6 @@ public abstract class ArtifactStore
     public static final String METADATA_ORIGIN = "origin";
 
     public static final String TRACKING_ID = "trackingId";
-
-    private static final long serialVersionUID = 1L;
 
     @ApiModelProperty( required = true, dataType = "string", value = "Serialized store key, of the form: '[hosted|group|remote]:name'" )
     private StoreKey key;
@@ -326,5 +329,67 @@ public abstract class ArtifactStore
         final SimpleDateFormat format = new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss ZZZ" );
         format.setTimeZone( TimeZone.getTimeZone( "UTC" ) );
         this.createTime = format.format( new Date( System.currentTimeMillis() ) );
+    }
+
+    @Override
+    public void writeExternal( final ObjectOutput out )
+            throws IOException
+    {
+        out.writeInt( ARTIFACT_STORE_VERSION );
+        key.writeExternal( out );
+
+        out.writeObject( description );
+        out.writeObject( metadata );
+        out.writeBoolean( disabled );
+        out.writeInt( disableTimeout );
+
+        if ( pathStyle == null )
+        {
+            out.writeObject( null );
+        }
+        else
+        {
+            out.writeObject( pathStyle.name() );
+        }
+
+        out.writeObject( pathMaskPatterns );
+        out.writeObject( authoritativeIndex );
+        out.writeObject( createTime );
+        out.writeObject( rescanInProgress );
+    }
+
+    @Override
+    public void readExternal( final ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        int artifactStoreVersion = in.readInt();
+        if ( artifactStoreVersion > ARTIFACT_STORE_VERSION )
+        {
+            throw new IOException( "Cannot deserialize. ArtifactStore version in data stream is: " + artifactStoreVersion
+                                           + " but this class can only deserialize up to version: " + ARTIFACT_STORE_VERSION );
+        }
+
+        this.key = new StoreKey();
+        key.readExternal( in );
+
+        this.description = (String) in.readObject();
+        this.metadata = (Map<String, String>) in.readObject();
+        this.disabled = in.readBoolean();
+        this.disableTimeout = in.readInt();
+
+        Object rawPathStyle = in.readObject();
+        if ( rawPathStyle == null )
+        {
+            this.pathStyle = null;
+        }
+        else
+        {
+            this.pathStyle = PathStyle.valueOf( (String) rawPathStyle );
+        }
+
+        this.pathMaskPatterns = (Set<String>) in.readObject();
+        this.authoritativeIndex = (Boolean) in.readObject();
+        this.createTime = (String) in.readObject();
+        this.rescanInProgress = (Boolean) in.readObject();
     }
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
@@ -41,7 +41,7 @@ public class Group
     @JsonProperty( "prepend_constituent" )
     private boolean prependConstituent = false;
 
-    Group()
+    public Group()
     {
         super();
         this.constituents = new ArrayList<>();
@@ -179,25 +179,27 @@ public class Group
 
         out.writeInt( STORE_VERSION );
 
-        if ( constituents == null )
-        {
-            out.writeObject( null );
-        }
-        else
-        {
-            int count = (int) constituents.stream().filter( c -> c != null ).count();
-            out.writeObject( count );
-        }
+        out.writeObject( constituents );
 
-        for ( StoreKey key : constituents )
-        {
-            if ( key == null )
-            {
-                continue;
-            }
-
-            key.writeExternal( out );
-        }
+//        if ( constituents == null )
+//        {
+//            out.writeObject( null );
+//        }
+//        else
+//        {
+//            int count = (int) constituents.stream().filter( c -> c != null ).count();
+//            out.writeObject( count );
+//        }
+//
+//        for ( StoreKey key : constituents )
+//        {
+//            if ( key == null )
+//            {
+//                continue;
+//            }
+//
+//            key.writeExternal( out );
+//        }
 
         out.writeBoolean( prependConstituent );
     }
@@ -215,21 +217,22 @@ public class Group
                                            + " but this class can only deserialize up to version: " + STORE_VERSION );
         }
 
-        Object constituentCountRaw = in.readObject();
-        if ( constituentCountRaw == null )
-        {
-            this.constituents = null;
-        }
-        else
-        {
-            this.constituents = new ArrayList<>( (Integer) constituentCountRaw );
-            for(int i=0; i<((Integer) constituentCountRaw); i++)
-            {
-                StoreKey key = new StoreKey();
-                key.readExternal( in );
-                this.constituents.add( key );
-            }
-        }
+        this.constituents = (List<StoreKey>) in.readObject();
+//        Object constituentCountRaw = in.readObject();
+//        if ( constituentCountRaw == null )
+//        {
+//            this.constituents = null;
+//        }
+//        else
+//        {
+//            this.constituents = new ArrayList<>( (Integer) constituentCountRaw );
+//            for(int i=0; i<((Integer) constituentCountRaw); i++)
+//            {
+//                StoreKey key = new StoreKey();
+//                key.readExternal( in );
+//                this.constituents.add( key );
+//            }
+//        }
 
         this.prependConstituent = in.readBoolean();
     }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
@@ -19,14 +19,20 @@ import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
 import static org.commonjava.indy.model.core.StoreType.hosted;
 
 @ApiModel( description = "Hosts artifact content on the local system", parent = ArtifactStore.class )
 public class HostedRepository
     extends AbstractRepository
+        implements Externalizable
 {
 
-    private static final long serialVersionUID = 1L;
+    private static final int STORE_VERSION = 1;
 
     private String storage;
 
@@ -118,4 +124,36 @@ public class HostedRepository
 
         return repo;
     }
+
+    @Override
+    public void writeExternal( final ObjectOutput out )
+            throws IOException
+    {
+        super.writeExternal( out );
+
+        out.writeInt( STORE_VERSION );
+
+        out.writeObject( storage );
+        out.writeInt( snapshotTimeoutSeconds );
+        out.writeBoolean( readonly );
+    }
+
+    @Override
+    public void readExternal( final ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        super.readExternal( in );
+
+        int storeVersion = in.readInt();
+        if ( storeVersion > STORE_VERSION )
+        {
+            throw new IOException( "Cannot deserialize. HostedRepository version in data stream is: " + storeVersion
+                                           + " but this class can only deserialize up to version: " + STORE_VERSION );
+        }
+
+        this.storage = (String) in.readObject();
+        this.snapshotTimeoutSeconds = in.readInt();
+        this.readonly = in.readBoolean();
+    }
+
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/HostedRepository.java
@@ -42,7 +42,7 @@ public class HostedRepository
     @ApiModelProperty( required = false, dataType = "boolean", value = "identify if the hoste repo is readonly" )
     private boolean readonly = false;
 
-    HostedRepository()
+    public HostedRepository()
     {
         super();
     }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -121,7 +121,7 @@ public class RemoteRepository
     @JsonProperty( "prefetch_rescan_time" )
     private String prefetchRescanTimestamp;
 
-    RemoteRepository()
+    public RemoteRepository()
     {
         super();
     }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -15,6 +15,10 @@
  */
 package org.commonjava.indy.model.core;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -33,8 +37,9 @@ import static org.commonjava.indy.model.core.StoreType.remote;
            parent = ArtifactStore.class )
 public class RemoteRepository
         extends AbstractRepository
+        implements Externalizable
 {
-    private static final long serialVersionUID = 1L;
+    private static final int STORE_VERSION = 1;
 
     private static final Logger LOGGER = LoggerFactory.getLogger( RemoteRepository.class );
 
@@ -492,4 +497,78 @@ public class RemoteRepository
         copyBase( repo );
         return repo;
     }
+
+    @Override
+    public void writeExternal( final ObjectOutput out )
+            throws IOException
+    {
+        super.writeExternal( out );
+
+        out.writeInt( STORE_VERSION );
+
+        out.writeObject( url );
+        out.writeInt( timeoutSeconds );
+        out.writeInt( maxConnections );
+        out.writeBoolean( ignoreHostnameVerification );
+        out.writeInt( nfcTimeoutSeconds );
+        out.writeObject( host );
+        out.writeInt( port );
+        out.writeObject( user );
+        out.writeObject( password );
+        out.writeBoolean( passthrough );
+        out.writeInt( cacheTimeoutSeconds );
+        out.writeInt( metadataTimeoutSeconds );
+        out.writeObject( keyPassword );
+        out.writeObject( keyCertificatePem );
+        out.writeObject( serverCertificatePem );
+        out.writeObject( proxyHost );
+        out.writeInt( proxyPort );
+        out.writeObject( proxyUser );
+        out.writeObject( proxyPassword );
+        out.writeObject( serverTrustPolicy );
+        out.writeObject( prefetchPriority );
+        out.writeBoolean( prefetchRescan );
+        out.writeObject( prefetchListingType );
+        out.writeObject( prefetchRescanTimestamp );
+    }
+
+    @Override
+    public void readExternal( final ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        super.readExternal( in );
+
+        int storeVersion = in.readInt();
+        if ( storeVersion > STORE_VERSION )
+        {
+            throw new IOException( "Cannot deserialize. RemoteRepository version in data stream is: " + storeVersion
+                                           + " but this class can only deserialize up to version: " + STORE_VERSION );
+        }
+
+        this.url = (String) in.readObject();
+        this.timeoutSeconds = in.readInt();
+        this.maxConnections = in.readInt();
+        this.ignoreHostnameVerification = in.readBoolean();
+        this.nfcTimeoutSeconds = in.readInt();
+        this.host = (String) in.readObject();
+        this.port = in.readInt();
+        this.user = (String) in.readObject();
+        this.password = (String) in.readObject();
+        this.passthrough = in.readBoolean();
+        this.cacheTimeoutSeconds = in.readInt();
+        this.metadataTimeoutSeconds = in.readInt();
+        this.keyPassword = (String) in.readObject();
+        this.keyCertificatePem = (String) in.readObject();
+        this.serverCertificatePem = (String) in.readObject();
+        this.proxyHost = (String) in.readObject();
+        this.proxyPort = in.readInt();
+        this.proxyUser = (String) in.readObject();
+        this.proxyPassword = (String) in.readObject();
+        this.serverTrustPolicy = (String) in.readObject();
+        this.prefetchPriority = (Integer) in.readObject();
+        this.prefetchRescan = in.readBoolean();
+        this.prefetchListingType = (String) in.readObject();
+        this.prefetchRescanTimestamp = (String) in.readObject();
+    }
+
 }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
@@ -40,7 +40,7 @@ public final class StoreKey
 
     private String name;
 
-    StoreKey(){}
+    public StoreKey(){}
 
     public StoreKey( final String packageType, final StoreType type, final String name )
     {

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
@@ -18,6 +18,10 @@ package org.commonjava.indy.model.core;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,15 +30,17 @@ import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
 
 public final class StoreKey
-    implements Serializable, Comparable<StoreKey>
+    implements Comparable<StoreKey>, Externalizable
 {
-    private static final long serialVersionUID = 1L;
+    private static final int VERSION = 1;
 
     private String packageType;
 
-    private final StoreType type;
+    private StoreType type;
 
-    private final String name;
+    private String name;
+
+    StoreKey(){}
 
     public StoreKey( final String packageType, final StoreType type, final String name )
     {
@@ -204,4 +210,44 @@ public final class StoreKey
         return result;
     }
 
+    @Override
+    public void writeExternal( final ObjectOutput out )
+            throws IOException
+    {
+        out.writeInt( VERSION );
+
+        out.writeObject( packageType );
+
+        if ( type == null )
+        {
+            out.writeObject( null );
+        }
+        else
+        {
+            out.writeObject( type.name() );
+        }
+
+        out.writeObject( name );
+    }
+
+    @Override
+    public void readExternal( final ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        int keyVersion = in.readInt();
+
+        this.packageType = (String) in.readObject();
+
+        Object rawType = in.readObject();
+        if ( rawType == null )
+        {
+            this.type = null;
+        }
+        else
+        {
+            this.type = StoreType.valueOf( (String) rawType );
+        }
+
+        this.name = (String) in.readObject();
+    }
 }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/GroupSerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/GroupSerializationTest.java
@@ -101,15 +101,12 @@ public class GroupSerializationTest
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream( baos );
         oos.writeObject( in );
-//        in.writeExternal( oos );
 
         oos.flush();
         ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
 
-//        Group out = new Group();
-//        out.readExternal( ois );
-//        return out;
+        ArtifactStore store = (ArtifactStore) ois.readObject();
 
-        return (Group) ois.readObject();
+        return (Group) store;
     }
 }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/GroupSerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/GroupSerializationTest.java
@@ -62,19 +62,20 @@ public class GroupSerializationTest
 
     private void compareRepos( final Group in, final Group out )
     {
-        long inCount = in.getConstituents().stream().filter( Objects::nonNull ).count();
-        List<StoreKey> inNonNull =
-                in.getConstituents().stream().filter( Objects::nonNull ).collect( Collectors.toList() );
+//        long inCount = in.getConstituents().stream().filter( Objects::nonNull ).count();
+//        List<StoreKey> inNonNull =
+//                in.getConstituents().stream().filter( Objects::nonNull ).collect( Collectors.toList() );
+//
+//        long outCount = out.getConstituents().stream().filter( Objects::nonNull ).count();
+//        assertThat( "Groups do not contain the same number of non-null constituent references", outCount, equalTo( inCount ) );
+//
+//        for(int i=0; i<inCount; i++)
+//        {
+//            assertThat( "Group constituents at index: " + i + " do not match.", out.getConstituents().get( i ),
+//                        equalTo( inNonNull.get( i ) ) );
+//        }
 
-        long outCount = out.getConstituents().stream().filter( Objects::nonNull ).count();
-        assertThat( "Groups do not contain the same number of non-null constituent references", outCount, equalTo( inCount ) );
-
-        for(int i=0; i<inCount; i++)
-        {
-            assertThat( "Group constituents at index: " + i + " do not match.", out.getConstituents().get( i ),
-                        equalTo( inNonNull.get( i ) ) );
-        }
-
+        assertThat( out.getConstituents(), equalTo( in.getConstituents() ) );
         assertThat( out.isPrependConstituent(), equalTo( in.isPrependConstituent() ) );
 
         assertThat( out.getKey(), equalTo( in.getKey() ) );
@@ -99,13 +100,16 @@ public class GroupSerializationTest
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream( baos );
-        in.writeExternal( oos );
+        oos.writeObject( in );
+//        in.writeExternal( oos );
 
         oos.flush();
         ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
 
-        Group out = new Group();
-        out.readExternal( ois );
-        return out;
+//        Group out = new Group();
+//        out.readExternal( ois );
+//        return out;
+
+        return (Group) ois.readObject();
     }
 }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/GroupSerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/GroupSerializationTest.java
@@ -1,0 +1,111 @@
+package org.commonjava.indy.model.core;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.commonjava.indy.model.core.StoreType.group;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class GroupSerializationTest
+{
+    @Test
+    public void simpleRoundTrip()
+            throws IOException, ClassNotFoundException
+    {
+        Group in = new Group( PKG_TYPE_MAVEN, "test", Arrays.asList( new StoreKey( PKG_TYPE_MAVEN, remote, "test1" ),
+                                                                     new StoreKey( PKG_TYPE_MAVEN, remote,
+                                                                                   "test2" ) ) );
+        Group out = doRoundTrip( in );
+
+        compareRepos( in, out );
+    }
+
+    @Test
+    public void fullRoundTrip()
+            throws IOException, ClassNotFoundException
+    {
+        Group in = new Group( PKG_TYPE_MAVEN, "test", Arrays.asList( new StoreKey( PKG_TYPE_MAVEN, remote, "test1" ),
+                                                                     null,
+                                                                     new StoreKey( PKG_TYPE_MAVEN, hosted, "test2" ),
+                                                                     new StoreKey( PKG_TYPE_MAVEN, group, "test3" ) ) );
+
+        in.setDescription( "Test description" );
+        in.setPrependConstituent( true );
+        in.setMetadata( "Test key 1", "foo" );
+        in.setDisabled( true );
+        in.setRescanInProgress( true );
+        in.setPathMaskPatterns( Collections.singleton( "foo" ) );
+        in.setPathStyle( PathStyle.hashed );
+        in.setAuthoritativeIndex( true );
+        in.setDisableTimeout( -1 );
+        in.setTransientMetadata( "transient key", "value" );
+
+        Group out = doRoundTrip( in );
+
+        compareRepos( in, out );
+    }
+
+    private void compareRepos( final Group in, final Group out )
+    {
+        long inCount = in.getConstituents().stream().filter( Objects::nonNull ).count();
+        List<StoreKey> inNonNull =
+                in.getConstituents().stream().filter( Objects::nonNull ).collect( Collectors.toList() );
+
+        long outCount = out.getConstituents().stream().filter( Objects::nonNull ).count();
+        assertThat( "Groups do not contain the same number of non-null constituent references", outCount, equalTo( inCount ) );
+
+        for(int i=0; i<inCount; i++)
+        {
+            assertThat( "Group constituents at index: " + i + " do not match.", out.getConstituents().get( i ),
+                        equalTo( inNonNull.get( i ) ) );
+        }
+
+        assertThat( out.isPrependConstituent(), equalTo( in.isPrependConstituent() ) );
+
+        assertThat( out.getKey(), equalTo( in.getKey() ) );
+        assertThat( out.getDescription(), equalTo( in.getDescription() ) );
+        assertThat( out.getMetadata(), equalTo( in.getMetadata() ) );
+        assertThat( out.isDisabled(), equalTo( in.isDisabled() ) );
+        assertThat( out.getDisableTimeout(), equalTo( in.getDisableTimeout() ) );
+        assertThat( out.getPathStyle(), equalTo( in.getPathStyle() ) );
+        assertThat( out.getPathMaskPatterns(), equalTo( in.getPathMaskPatterns() ) );
+        assertThat( out.isAuthoritativeIndex(), equalTo( in.isAuthoritativeIndex() ) );
+        assertThat( out.getCreateTime(), equalTo( in.getCreateTime() ) );
+        assertThat( out.isRescanInProgress(), equalTo( in.isRescanInProgress() ) );
+
+        if ( out.getTransientMetadata() != null && !out.getTransientMetadata().isEmpty())
+        {
+            fail( "Transient metadata should be empty from deserialized object. Was: " + out.getTransientMetadata() );
+        }
+    }
+
+    private Group doRoundTrip( final Group in )
+            throws IOException, ClassNotFoundException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream( baos );
+        in.writeExternal( oos );
+
+        oos.flush();
+        ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
+
+        Group out = new Group();
+        out.readExternal( ois );
+        return out;
+    }
+}

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/HostedRepositorySerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/HostedRepositorySerializationTest.java
@@ -84,14 +84,11 @@ public class HostedRepositorySerializationTest
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream( baos );
         oos.writeObject( in );
-//        in.writeExternal( oos );
 
         oos.flush();
         ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
 
-//        HostedRepository out = new HostedRepository();
-//        out.readExternal( ois );
-//        return out;
-        return (HostedRepository) ois.readObject();
+        ArtifactStore store = (ArtifactStore) ois.readObject();
+        return (HostedRepository) store;
     }
 }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/HostedRepositorySerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/HostedRepositorySerializationTest.java
@@ -83,13 +83,15 @@ public class HostedRepositorySerializationTest
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream( baos );
-        in.writeExternal( oos );
+        oos.writeObject( in );
+//        in.writeExternal( oos );
 
         oos.flush();
         ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
 
-        HostedRepository out = new HostedRepository();
-        out.readExternal( ois );
-        return out;
+//        HostedRepository out = new HostedRepository();
+//        out.readExternal( ois );
+//        return out;
+        return (HostedRepository) ois.readObject();
     }
 }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/HostedRepositorySerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/HostedRepositorySerializationTest.java
@@ -1,0 +1,95 @@
+package org.commonjava.indy.model.core;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collections;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class HostedRepositorySerializationTest
+{
+    @Test
+    public void simpleRoundTrip()
+            throws IOException, ClassNotFoundException
+    {
+        HostedRepository in = new HostedRepository( PKG_TYPE_MAVEN, "test" );
+        HostedRepository out = doRoundTrip( in );
+
+        compareRepos( in, out );
+    }
+
+    @Test
+    public void fullRoundTrip()
+            throws IOException, ClassNotFoundException
+    {
+        HostedRepository in = new HostedRepository( PKG_TYPE_MAVEN, "test" );
+
+        in.setReadonly( true );
+        in.setAuthoritativeIndex( true );
+        in.setSnapshotTimeoutSeconds( 100 );
+        in.setStorage( "/path/to/alt/storage" );
+        in.setMetadata( "foo", "bar" );
+        in.setDisabled( true );
+        in.setRescanInProgress( true );
+        in.setDescription( "This is a description" );
+        in.setPathMaskPatterns( Collections.singleton( "somepath" ) );
+        in.setPathStyle( PathStyle.hashed );
+        in.setAllowReleases( false );
+        in.setAllowSnapshots( true );
+        in.setDisableTimeout( -1 );
+        in.setTransientMetadata( "transient", "value" );
+
+        HostedRepository out = doRoundTrip( in );
+
+        compareRepos( in, out );
+    }
+
+    private void compareRepos( final HostedRepository in, final HostedRepository out )
+    {
+        assertThat( out.getStorage(), equalTo( in.getStorage() ) );
+        assertThat( out.getSnapshotTimeoutSeconds(), equalTo( in.getSnapshotTimeoutSeconds() ) );
+        assertThat( out.isReadonly(), equalTo( in.isReadonly() ) );
+
+        assertThat( out.isAllowReleases(), equalTo( in.isAllowReleases() ) );
+        assertThat( out.isAllowSnapshots(), equalTo( in.isAllowSnapshots() ) );
+
+        assertThat( out.getKey(), equalTo( in.getKey() ) );
+        assertThat( out.getDescription(), equalTo( in.getDescription() ) );
+        assertThat( out.getMetadata(), equalTo( in.getMetadata() ) );
+        assertThat( out.isDisabled(), equalTo( in.isDisabled() ) );
+        assertThat( out.getDisableTimeout(), equalTo( in.getDisableTimeout() ) );
+        assertThat( out.getPathStyle(), equalTo( in.getPathStyle() ) );
+        assertThat( out.getPathMaskPatterns(), equalTo( in.getPathMaskPatterns() ) );
+        assertThat( out.isAuthoritativeIndex(), equalTo( in.isAuthoritativeIndex() ) );
+        assertThat( out.getCreateTime(), equalTo( in.getCreateTime() ) );
+        assertThat( out.isRescanInProgress(), equalTo( in.isRescanInProgress() ) );
+
+        if ( out.getTransientMetadata() != null && !out.getTransientMetadata().isEmpty())
+        {
+            fail( "Transient metadata should be empty from deserialized object. Was: " + out.getTransientMetadata() );
+        }
+    }
+
+    private HostedRepository doRoundTrip( final HostedRepository in )
+            throws IOException, ClassNotFoundException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream( baos );
+        in.writeExternal( oos );
+
+        oos.flush();
+        ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
+
+        HostedRepository out = new HostedRepository();
+        out.readExternal( ois );
+        return out;
+    }
+}

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/MixedStoreSerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/MixedStoreSerializationTest.java
@@ -1,0 +1,50 @@
+package org.commonjava.indy.model.core;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class MixedStoreSerializationTest
+{
+    @Test
+    public void simpleRoundTrip()
+            throws IOException, ClassNotFoundException
+    {
+        List<ArtifactStore> in = new ArrayList<>();
+        in.add( new HostedRepository( PKG_TYPE_MAVEN, "test-hosted" ) );
+        in.add( new RemoteRepository( PKG_TYPE_MAVEN, "test-remote", "http://nowhere.com" ) );
+        in.add( new Group( PKG_TYPE_MAVEN, "test-group",
+                                      new StoreKey( PKG_TYPE_MAVEN, hosted, "test-hosted" ),
+                                      new StoreKey( PKG_TYPE_MAVEN, remote, "test-remote" ) ) );
+
+        List<ArtifactStore> out = doRoundTrip( in );
+        System.out.println( out );
+    }
+
+    private List<ArtifactStore> doRoundTrip( final List<ArtifactStore> in )
+            throws IOException, ClassNotFoundException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream( baos );
+        oos.writeObject( in );
+
+        oos.flush();
+        ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
+
+        return (List<ArtifactStore>) ois.readObject();
+    }
+}

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/RemoteRepositorySerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/RemoteRepositorySerializationTest.java
@@ -1,0 +1,141 @@
+package org.commonjava.indy.model.core;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class RemoteRepositorySerializationTest
+{
+    @Test
+    public void simpleRoundTrip()
+            throws IOException, ClassNotFoundException
+    {
+        RemoteRepository in = new RemoteRepository( PKG_TYPE_MAVEN, "test", "http://nowhere.com/test/repo" );
+        RemoteRepository out = doRoundTrip( in );
+
+        compareRepos( in, out );
+    }
+
+    @Test
+    public void fullRoundTrip()
+            throws IOException, ClassNotFoundException
+    {
+        RemoteRepository in = new RemoteRepository( PKG_TYPE_MAVEN, "test", "http://nowhere.com/test/repo" );
+        in.setTimeoutSeconds( -1 );
+        in.setPrefetchPriority( 1 );
+        in.setMetadataTimeoutSeconds( -1 );
+        in.setMetadata( "metadata", "value" );
+        in.setPrefetchRescanTimestamp( "2019-08-12T00:00:11.000" );
+        in.setCacheTimeoutSeconds( 1000 );
+        in.setPassthrough( true );
+        in.setPrefetchListingType( "html" );
+        in.setServerCertPem( "asdf;alksdjfa;sdlgjgds;lkjs;gkajgd;akjdga;" );
+        in.setServerTrustPolicy( "TRUST NO ONE" );
+        in.setKeyCertPem( ";lakjdsf;alfdkja;glkjqroipgnevfowenvrwpoerihe" );
+        in.setKeyPassword( "key-password" );
+        in.setNfcTimeoutSeconds( 10000 );
+        in.setPassword( "regular-password" );
+        in.setProxyHost( "proxy.host.com" );
+        in.setProxyPassword( "proxy-password" );
+        in.setProxyPort( 8090 );
+        in.setProxyUser( "proxy-user" );
+        in.setUser( "regular-user" );
+        in.setIgnoreHostnameVerification( true );
+        in.setHost( "nowheres.com" );
+        in.setMaxConnections( 2000 );
+        in.setPort( 1010 );
+        in.setDisabled( true );
+        in.setRescanInProgress( true );
+        in.setDescription( "This is a description" );
+        in.setPathMaskPatterns( new HashSet<>( Arrays.asList( "some-path/mask/pattern", null, "another/path" ) ) );
+        in.setPathStyle( PathStyle.hashed );
+        in.setAllowReleases( false );
+        in.setAllowSnapshots( true );
+        in.setDisableTimeout( 10 );
+        in.setTransientMetadata( "transient", "metadata" );
+
+        RemoteRepository out = doRoundTrip( in );
+
+        compareRepos( in, out );
+    }
+
+    private void compareRepos( final RemoteRepository in, final RemoteRepository out )
+    {
+        assertThat( out.getUrl(), equalTo( in.getUrl() ) );
+        assertThat( out.getTimeoutSeconds(), equalTo( in.getTimeoutSeconds() ) );
+        assertThat( out.getMaxConnections(), equalTo( in.getMaxConnections() ) );
+        assertThat( out.isIgnoreHostnameVerification(), equalTo( in.isIgnoreHostnameVerification() ) );
+        assertThat( out.getNfcTimeoutSeconds(), equalTo( in.getNfcTimeoutSeconds() ) );
+        assertThat( out.getHost(), equalTo( in.getHost() ) );
+        assertThat( out.getPort(), equalTo( in.getPort() ) );
+        assertThat( out.getUser(), equalTo( in.getUser() ) );
+        assertThat( out.getPassword(), equalTo( in.getPassword() ) );
+        assertThat( out.isPassthrough(), equalTo( in.isPassthrough() ) );
+        assertThat( out.getCacheTimeoutSeconds(), equalTo( in.getCacheTimeoutSeconds() ) );
+        assertThat( out.getMetadataTimeoutSeconds(), equalTo( in.getMetadataTimeoutSeconds() ) );
+        assertThat( out.getKeyPassword(), equalTo( in.getKeyPassword() ) );
+        assertThat( out.getKeyCertPem(), equalTo( in.getKeyCertPem() ) );
+        assertThat( out.getServerCertPem(), equalTo( in.getServerCertPem() ) );
+        assertThat( out.getProxyHost(), equalTo( in.getProxyHost() ) );
+        assertThat( out.getProxyPort(), equalTo( in.getProxyPort() ) );
+        assertThat( out.getProxyUser(), equalTo( in.getProxyUser() ) );
+        assertThat( out.getProxyPassword(), equalTo( in.getProxyPassword() ) );
+        assertThat( out.getServerTrustPolicy(), equalTo( in.getServerTrustPolicy() ) );
+        assertThat( out.getPrefetchPriority(), equalTo( in.getPrefetchPriority() ) );
+        assertThat( out.isPrefetchRescan(), equalTo( in.isPrefetchRescan() ) );
+        assertThat( out.getPrefetchListingType(), equalTo( in.getPrefetchListingType() ) );
+        assertThat( out.getPrefetchRescanTimestamp(), equalTo( in.getPrefetchRescanTimestamp() ) );
+
+        assertThat( out.isAllowReleases(), equalTo( in.isAllowReleases() ) );
+        assertThat( out.isAllowSnapshots(), equalTo( in.isAllowSnapshots() ) );
+
+        assertThat( out.getKey(), equalTo( in.getKey() ) );
+        assertThat( out.getDescription(), equalTo( in.getDescription() ) );
+        assertThat( out.getMetadata(), equalTo( in.getMetadata() ) );
+        assertThat( out.isDisabled(), equalTo( in.isDisabled() ) );
+        assertThat( out.getDisableTimeout(), equalTo( in.getDisableTimeout() ) );
+        assertThat( out.getPathStyle(), equalTo( in.getPathStyle() ) );
+        assertThat( out.getPathMaskPatterns(), equalTo( in.getPathMaskPatterns() ) );
+        assertThat( out.isAuthoritativeIndex(), equalTo( in.isAuthoritativeIndex() ) );
+        assertThat( out.getCreateTime(), equalTo( in.getCreateTime() ) );
+        assertThat( out.isRescanInProgress(), equalTo( in.isRescanInProgress() ) );
+
+        if ( out.getTransientMetadata() != null && !out.getTransientMetadata().isEmpty())
+        {
+            fail( "Transient metadata should be empty from deserialized object. Was: " + out.getTransientMetadata() );
+        }
+    }
+
+    private RemoteRepository doRoundTrip( final RemoteRepository in )
+            throws IOException, ClassNotFoundException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream( baos );
+        in.writeExternal( oos );
+
+        oos.flush();
+        ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
+
+        RemoteRepository out = new RemoteRepository();
+        out.readExternal( ois );
+        return out;
+    }
+}

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/RemoteRepositorySerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/RemoteRepositorySerializationTest.java
@@ -131,14 +131,11 @@ public class RemoteRepositorySerializationTest
         ObjectOutputStream oos = new ObjectOutputStream( baos );
 
         oos.writeObject( in );
-//        in.writeExternal( oos );
 
         oos.flush();
         ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
 
-//        RemoteRepository out = new RemoteRepository();
-        RemoteRepository out = (RemoteRepository) ois.readObject();
-//        out.readExternal( ois );
-        return out;
+        ArtifactStore store = (ArtifactStore) ois.readObject();
+        return (RemoteRepository) store;
     }
 }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/RemoteRepositorySerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/RemoteRepositorySerializationTest.java
@@ -129,13 +129,16 @@ public class RemoteRepositorySerializationTest
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream( baos );
-        in.writeExternal( oos );
+
+        oos.writeObject( in );
+//        in.writeExternal( oos );
 
         oos.flush();
         ObjectInputStream ois = new ObjectInputStream( new ByteArrayInputStream( baos.toByteArray() ) );
 
-        RemoteRepository out = new RemoteRepository();
-        out.readExternal( ois );
+//        RemoteRepository out = new RemoteRepository();
+        RemoteRepository out = (RemoteRepository) ois.readObject();
+//        out.readExternal( ois );
         return out;
     }
 }

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -112,9 +112,15 @@
     </local-cache>
 
     <!-- TODO: these should be a distributed persist cache when enable cluster -->
-    <local-cache name="store-data" configuration="local-template">
+    <local-cache name="store-data-v1" configuration="local-template">
       <persistence passivation="true">
         <file-store shared="false" preload="true" fetch-state="false" path="${indy.data}/store"/>
+      </persistence>
+    </local-cache>
+
+    <local-cache name="store-data" configuration="local-template">
+      <persistence passivation="true">
+        <file-store shared="false" preload="true" fetch-state="false" path="${indy.data}/store-v2"/>
       </persistence>
     </local-cache>
 


### PR DESCRIPTION
Counter-proposal to #1454 .

Previously, storing `ArtifactStore` definitions as JSON requires us to serialize/deserialize (render and parse) constantly, every time we access a repository definition. We can access dozens or even thousands of these in a request, especially in an upload request or a promotion request.

Looking at our current production deployment, we see that upload latency is up around 7 seconds at times, with about 6.98 seconds of that being consumed in the process of working with the store-definition cache.

This change implements Externalizable for all `ArtifactStore` derivatives, `StoreKey`, and related classes in the core model of Indy. It adds some testing to ensure these can be read / written appropriately using readExternal / writeExternal methods, and verifies that round-trip data is preserved.

Then, it switches the cache used by InfinispanStoreDataManager to use `Cache<StoreKey, ArtifactStore>` instead of `Cache<StoreKey, String>`, and relies on Infinispan itself to use the Externalizable implementations to serialize data when it is persisted to the backing database.

Along with this comes a need to migrate existing JSON data to the new binary format. To handle
this, I've modified the `InfinispanStoreDataMigrationAction` class to look for a cache named 'store-data-v1' and if it finds it, to migrate the old-style store definitions from JSON to the new cache, managed by `InfinispanStoreDataManager`. It will **NOT** use the really old filesystem storage location if it finds this legacy cache.