### PR TITLE
Using store-data-v1 for new object-based store-data cache

### DIFF
--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataMigrationAction.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataMigrationAction.java
@@ -46,7 +46,7 @@ public class InfinispanStoreDataMigrationAction
                 implements MigrationAction
 {
 
-    private static final String STORE_DATA_V1_CACHE = "store-data-v1";
+    private static final String STORE_DATA_V1_CACHE = "store-data";
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
@@ -26,7 +26,7 @@ import javax.inject.Inject;
 
 public class StoreDataCacheProducer
 {
-    public static final String STORE_DATA_CACHE = "store-data";
+    public static final String STORE_DATA_CACHE = "store-data-v1";
 
     @Inject
     private CacheProducer cacheProducer;


### PR DESCRIPTION
I found a problem for migration process. When we use db-based
persistence for store cache, we can not control the table name for which
store use by applying a simple "table-name" like attr in ispn xml
because it does not support this. The table name is applied by its cache
name directly. So we need to use a new cache name for the new obj-based
store, ane use the legacy "store-data" cache for migration purpose.