### PR TITLE
Cumulative call count in logging MDC and metering ratio

### DIFF
--- a/api/src/main/java/org/commonjava/indy/metrics/RequestContextHelper.java
+++ b/api/src/main/java/org/commonjava/indy/metrics/RequestContextHelper.java
@@ -163,7 +163,15 @@ public class RequestContextHelper
     public static final String PREFERRED_ID = "preferred-id";
 
     @Thread
+    public static final String IS_METERED = "is-metered";
+
+    @Thread
+    @MDC
     public static final String CUMULATIVE_TIMINGS = "cumulative-timings";
+
+    @Thread
+    @MDC
+    public static final String CUMULATIVE_COUNTS = "cumulative-counts";
 
 
     // these are well-known values we'll be using in our log aggregation filters

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/ArtifactStore.java
@@ -337,7 +337,6 @@ public abstract class ArtifactStore
     {
         out.writeInt( ARTIFACT_STORE_VERSION );
         out.writeObject( key );
-//        key.writeExternal( out );
 
         out.writeObject( description );
         out.writeObject( metadata );
@@ -370,8 +369,6 @@ public abstract class ArtifactStore
                                            + " but this class can only deserialize up to version: " + ARTIFACT_STORE_VERSION );
         }
 
-//        this.key = new StoreKey();
-//        key.readExternal( in );
         this.key = (StoreKey) in.readObject();
 
         this.description = (String) in.readObject();

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/Group.java
@@ -181,26 +181,6 @@ public class Group
 
         out.writeObject( constituents );
 
-//        if ( constituents == null )
-//        {
-//            out.writeObject( null );
-//        }
-//        else
-//        {
-//            int count = (int) constituents.stream().filter( c -> c != null ).count();
-//            out.writeObject( count );
-//        }
-//
-//        for ( StoreKey key : constituents )
-//        {
-//            if ( key == null )
-//            {
-//                continue;
-//            }
-//
-//            key.writeExternal( out );
-//        }
-
         out.writeBoolean( prependConstituent );
     }
 
@@ -218,21 +198,6 @@ public class Group
         }
 
         this.constituents = (List<StoreKey>) in.readObject();
-//        Object constituentCountRaw = in.readObject();
-//        if ( constituentCountRaw == null )
-//        {
-//            this.constituents = null;
-//        }
-//        else
-//        {
-//            this.constituents = new ArrayList<>( (Integer) constituentCountRaw );
-//            for(int i=0; i<((Integer) constituentCountRaw); i++)
-//            {
-//                StoreKey key = new StoreKey();
-//                key.readExternal( in );
-//                this.constituents.add( key );
-//            }
-//        }
 
         this.prependConstituent = in.readBoolean();
     }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/GroupSerializationTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/GroupSerializationTest.java
@@ -62,19 +62,6 @@ public class GroupSerializationTest
 
     private void compareRepos( final Group in, final Group out )
     {
-//        long inCount = in.getConstituents().stream().filter( Objects::nonNull ).count();
-//        List<StoreKey> inNonNull =
-//                in.getConstituents().stream().filter( Objects::nonNull ).collect( Collectors.toList() );
-//
-//        long outCount = out.getConstituents().stream().filter( Objects::nonNull ).count();
-//        assertThat( "Groups do not contain the same number of non-null constituent references", outCount, equalTo( inCount ) );
-//
-//        for(int i=0; i<inCount; i++)
-//        {
-//            assertThat( "Group constituents at index: " + i + " do not match.", out.getConstituents().get( i ),
-//                        equalTo( inNonNull.get( i ) ) );
-//        }
-
         assertThat( out.getConstituents(), equalTo( in.getConstituents() ) );
         assertThat( out.isPrependConstituent(), equalTo( in.isPrependConstituent() ) );
 

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
@@ -43,9 +43,11 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import static org.commonjava.indy.metrics.RequestContextHelper.CLIENT_ADDR;
+import static org.commonjava.indy.metrics.RequestContextHelper.CUMULATIVE_COUNTS;
 import static org.commonjava.indy.metrics.RequestContextHelper.CUMULATIVE_TIMINGS;
 import static org.commonjava.indy.metrics.RequestContextHelper.EXTERNAL_ID;
 import static org.commonjava.indy.metrics.RequestContextHelper.INTERNAL_ID;
+import static org.commonjava.indy.metrics.RequestContextHelper.IS_METERED;
 import static org.commonjava.indy.metrics.RequestContextHelper.PREFERRED_ID;
 import static org.commonjava.indy.metrics.RequestContextHelper.REQUEST_PHASE;
 import static org.commonjava.indy.metrics.RequestContextHelper.REQUEST_PHASE_START;
@@ -71,6 +73,8 @@ public class ResourceManagementFilter
     private static final String METADATA_CONTENT_METRIC = BASE_CONTENT_METRIC + "metadata";
 
     private static final String SPECIAL_CONTENT_METRIC = BASE_CONTENT_METRIC + "special";
+
+    private static final String FORCE_METERED = "force-metered";
 
     @Inject
     private CacheProvider cacheProvider;
@@ -120,6 +124,13 @@ public class ResourceManagementFilter
         {
             ThreadContext.clearContext();
             ThreadContext threadContext = ThreadContext.getContext( true );
+
+            boolean isMetered = metricsManager.isMetered( ()->{
+                String header = hsr.getHeader( FORCE_METERED );
+                return ( header == null || Boolean.parseBoolean( header ) );
+            } );
+
+            threadContext.put( IS_METERED, isMetered );
 
             threadContext.put( ORIGINAL_THREAD_NAME, name );
 
@@ -192,6 +203,13 @@ public class ResourceManagementFilter
                 {
                     cumulativeTimings.forEach(
                             ( k, v ) -> MDC.put( CUMULATIVE_TIMINGS + "." + k, String.format( "%.3f", v ) ) );
+                }
+
+                Map<String, Integer> cumulativeCounts = (Map<String, Integer>) ctx.get( CUMULATIVE_COUNTS );
+                if ( cumulativeCounts != null )
+                {
+                    cumulativeCounts.forEach(
+                            ( k, v ) -> MDC.put( CUMULATIVE_COUNTS + "." + k, String.format( "%d", v ) ) );
                 }
             }
 

--- a/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/conf/IndyMetricsConfig.java
+++ b/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/conf/IndyMetricsConfig.java
@@ -55,6 +55,8 @@ public class IndyMetricsConfig
 
     private final static String INDY_METRICS_ISENABLED = "enabled";
 
+    private static final String INDY_METRICS_METER_RATIO = "meter.ratio";
+
     private final static String INDY_METRICS_ISPN_ENABLED = "ispn.enabled";
 
     private final static String INDY_METRICS_ISPN_GAUGES = "ispn.gauges";
@@ -99,6 +101,8 @@ public class IndyMetricsConfig
     private static final String INDY_METRICS_MEASURE_TRANSPORT_REPOS = "measure.transport.repos";
 
     private final static String INDY_METRICS_KOJI_ENABLED = "koji.enabled";
+
+    private static final int DEFAULT_METER_RATIO = 1;
 
     private boolean ispnMetricsEnabled;
 
@@ -163,6 +167,8 @@ public class IndyMetricsConfig
     private boolean kojiMetricEnabled;
 
     private String nodePrefix;
+
+    private Integer meterRatio;
 
     public boolean isMeasureTransport()
     {
@@ -403,6 +409,17 @@ public class IndyMetricsConfig
     public void setMetricsEnabled( boolean metricsEnabled )
     {
         this.metricsEnabled = metricsEnabled;
+    }
+
+    @ConfigName( INDY_METRICS_METER_RATIO )
+    public void setMeterRatio( int meterRatio )
+    {
+        this.meterRatio = meterRatio;
+    }
+
+    public int getMeterRatio()
+    {
+        return meterRatio == null ? DEFAULT_METER_RATIO : meterRatio;
     }
 
     public String getReporter()

--- a/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
+++ b/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
@@ -59,7 +59,7 @@ public class MetricsInterceptor
     @AroundInvoke
     public Object operation( InvocationContext context ) throws Exception
     {
-        if ( !config.isMetricsEnabled() )
+        if ( !config.isMetricsEnabled() || !metricsManager.checkMetered() )
         {
             return context.proceed();
         }


### PR DESCRIPTION
Adding cumulative call counts alongside cumulative timings, in the logging MDC. These will be logged at the end of each REST call, via the ResourceManagementFilter. We may need to do something similar for generic proxy requests, but it's not done yet.

Also, because metering latency is starting to become a bit of a concern with all the low-level metrics around file I/O, I've added configuration to allow us to specify a metering ratio, which by default will be 1:1. We can set this higher to sample 1/1, 1/10, 1/100, 1/1000 requests. This will modulo a random integer by the ratio to see if the result is zero, which should give us a sampling pattern that matches the desired ratio. This will apply the ratio to ALL requests evenly, regardless of the destination function being called.