### PR TITLE
FIX: NPE happened during getAffectedBy

### DIFF
--- a/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
@@ -433,7 +433,7 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
             {
                 ArtifactStore store = dataManager.getArtifactStore( key );
 
-                if ( !processed.contains( store.getKey() ) && ( store instanceof Group ) )
+                if ( ( store instanceof Group ) && !processed.contains( store.getKey() ) )
                 {
                     Group g = (Group) store;
                     if ( g.getConstituents() != null && g.getConstituents().contains( next ) )


### PR DESCRIPTION
Seems the new refactored code brings some new way to get affected
    groups, but it missed some NPE check which caused 500 error.