### PR TITLE
[DRAFT] Add reverse map for afffected by relationship of stores

### DIFF
--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -17,11 +17,13 @@ package org.commonjava.indy.data;
 
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.maven.galley.event.EventMetadata;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -134,4 +136,7 @@ public interface StoreDataManager
      * Stream of StoreKey instances present in the system.
      */
     Stream<StoreKey> streamArtifactStoreKeys();
+
+    Set<Group> affectedBy( Collection<StoreKey> keys )
+            throws IndyDataException;
 }

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -151,6 +151,11 @@ public abstract class AbstractStoreDataManager
                 }
             }
         }
+        // Hosted or Remote update does not change affectedBy relationships
+        if ( store instanceof Group )
+        {
+            refreshAffectedBy( store, original );
+        }
     }
 
     protected void preDelete( final ArtifactStore store, final ChangeSummary summary, final boolean fireEvents,
@@ -174,6 +179,14 @@ public abstract class AbstractStoreDataManager
         {
             dispatcher.deleted( eventMetadata, store );
         }
+
+        refreshAffectedBy( store, null );
+    }
+
+    protected void refreshAffectedBy( final ArtifactStore store, final ArtifactStore original )
+            throws IndyDataException
+    {
+        //do nothing by default
     }
 
     protected abstract ArtifactStore removeArtifactStoreInternal( StoreKey key );

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -20,9 +20,15 @@ import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
 import org.commonjava.indy.conf.InternalFeatureConfig;
 import org.commonjava.indy.conf.SslValidationConfig;
-import org.commonjava.indy.data.*;
+import org.commonjava.indy.data.ArtifactStoreQuery;
+import org.commonjava.indy.data.ArtifactStoreValidateData;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.data.StoreEventDispatcher;
+import org.commonjava.indy.data.StoreValidator;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
@@ -32,14 +38,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
@@ -402,6 +412,76 @@ public abstract class AbstractStoreDataManager
 //            logger.warn("=> Disabling this store has thrown IndyDataException: " + e.getMessage());
 //            throw new IndyDataException("=> Disabling store is not applicable!", null);
 //        }
+    }
+
+    @Override
+    public Set<Group> affectedBy( final Collection<StoreKey> keys )
+            throws IndyDataException
+    {
+        return affectedByFromStores( keys );
+    }
+
+    protected Set<Group> affectedByFromStores( final Collection<StoreKey> keys )
+            throws IndyDataException
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.debug( "Getting groups affected by: {}", keys );
+
+        List<StoreKey> toProcess = new ArrayList<>( new HashSet<>( keys ) );
+
+        Set<Group> groups = new HashSet<>();
+        if ( toProcess.isEmpty() )
+        {
+            return groups;
+        }
+
+        Set<StoreKey> processed = new HashSet<>();
+        final String packageType = toProcess.get( 0 ).getPackageType();
+
+        Set<ArtifactStore> all = this.getAllArtifactStores().stream().filter( st -> {
+            if ( packageType != null && !st.getPackageType().equals( packageType ) )
+            {
+                return false;
+            }
+
+            if ( st.getType() != StoreType.group )
+            {
+                return false;
+            }
+
+            return true;
+        } ).collect( Collectors.toSet() );
+
+        while ( !toProcess.isEmpty() )
+        {
+            // as long as we have another key to process, pop it off the list (remove it) and process it.
+            StoreKey next = toProcess.remove( 0 );
+            if ( processed.contains( next ) )
+            {
+                // if we've already handled this group (via another branch in the group membership tree, etc. then don't bother.
+                continue;
+            }
+
+            // use this to avoid reprocessing groups we've already encountered.
+            processed.add( next );
+
+            for ( ArtifactStore store : all )
+            {
+                if ( ( store instanceof Group ) && !processed.contains( store.getKey() )  )
+                {
+                    Group g = (Group) store;
+                    if ( g.getConstituents() != null && g.getConstituents().contains( next ) )
+                    {
+                        groups.add( g );
+
+                        // add this group as another one to process for groups that contain it...and recurse upwards
+                        toProcess.add( g.getKey() );
+                    }
+                }
+            }
+        }
+
+        return groups;
     }
 
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/AffectedByStoreCache.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/AffectedByStoreCache.java
@@ -1,0 +1,16 @@
+package org.commonjava.indy.infinispan.data;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface AffectedByStoreCache
+{
+}

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -16,11 +16,13 @@
 package org.commonjava.indy.infinispan.data;
 
 import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
 import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.db.common.AbstractStoreDataManager;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.infinispan.Cache;
@@ -31,13 +33,18 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.AFFECTED_BY_STORE_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_DATA_CACHE;
+import static org.commonjava.indy.model.core.StoreType.group;
 
 @ApplicationScoped
 @Alternative
@@ -49,6 +56,10 @@ public class InfinispanStoreDataManager
     @Inject
     @StoreDataCache
     private CacheHandle<StoreKey, ArtifactStore> stores;
+
+    @Inject
+    @AffectedByStoreCache
+    private CacheHandle<StoreKey, Set<StoreKey>> affectedByStores;
 
     @Inject
     private StoreEventDispatcher dispatcher;
@@ -69,10 +80,12 @@ public class InfinispanStoreDataManager
     {
     }
 
-    public InfinispanStoreDataManager( final Cache<StoreKey, ArtifactStore> cache )
+    public InfinispanStoreDataManager( final Cache<StoreKey, ArtifactStore> cache,
+                                       final Cache<StoreKey, Set<StoreKey>> affectedByStoresCache )
     {
         this.dispatcher = new NoOpStoreEventDispatcher();
         this.stores = new CacheHandle( STORE_DATA_CACHE, cache );
+        this.affectedByStores = new CacheHandle( AFFECTED_BY_STORE_CACHE, affectedByStoresCache );
     }
 
     @Override
@@ -91,7 +104,9 @@ public class InfinispanStoreDataManager
     @Override
     public void clear( final ChangeSummary summary )
     {
+        //TODO: I'm really concern if we need this implementation as we don't know if ISPN will clean all persistent entries!!!
         stores.clear();
+        affectedByStores.clear();
     }
 
     @Override
@@ -144,4 +159,78 @@ public class InfinispanStoreDataManager
         return stores.put( storeKey, store );
     }
 
+    @Override
+    public Set<Group> affectedBy( final Collection<StoreKey> keys )
+    {
+        final Set<Group> groups = new HashSet<>();
+        for ( StoreKey key : keys )
+        {
+            Set<StoreKey> affected = affectedByStores.get( key );
+            if ( affected != null )
+            {
+                affected = affected.stream().filter( k -> k.getType() == group ).collect( Collectors.toSet() );
+                for ( StoreKey gKey : affected )
+                {
+                    ArtifactStore store = getArtifactStoreInternal( gKey );
+                    groups.add( (Group) store );
+                }
+            }
+        }
+        return groups;
+    }
+
+    @Override
+    protected void refreshAffectedBy( final ArtifactStore store, final ArtifactStore original )
+            throws IndyDataException
+    {
+        if ( store == null )
+        {
+            return;
+        }
+        if ( store instanceof Group )
+        {
+            final Set<StoreKey> updatedConstituents = new HashSet<>( ((Group)store).getConstituents() );
+            final Set<StoreKey> originalConstituents;
+            if ( original != null )
+            {
+                originalConstituents = new HashSet<>( ((Group)original).getConstituents() );
+            }
+            else
+            {
+                originalConstituents = new HashSet<>();
+            }
+
+            final Set<StoreKey> added = new HashSet<>();
+            final Set<StoreKey> removed = new HashSet<>();
+            for ( StoreKey updKey : updatedConstituents )
+            {
+                if ( !originalConstituents.contains( updKey ) )
+                {
+                    added.add( updKey );
+                }
+            }
+
+            for ( StoreKey oriKey : originalConstituents )
+            {
+                if ( !updatedConstituents.contains( oriKey ) )
+                {
+                    removed.add( oriKey );
+                }
+            }
+
+            final Set<StoreKey> allChangedSubs = new HashSet<>( added );
+            allChangedSubs.addAll( removed );
+
+            for ( StoreKey key : allChangedSubs )
+            {
+                final ArtifactStore sub = getArtifactStoreInternal( key );
+                refreshAffectedBy( sub, null );
+            }
+        }
+
+        final Set<Group> affectedBy = affectedByFromStores( Collections.singleton( store.getKey() ) );
+        affectedByStores.put( store.getKey(),
+                              affectedBy.stream().map( ArtifactStore::getKey ).collect( Collectors.toSet() ) );
+
+    }
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
@@ -23,10 +23,13 @@ import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+import java.util.Set;
 
 public class StoreDataCacheProducer
 {
     public static final String STORE_DATA_CACHE = "store-data-v2";
+
+    public static final String AFFECTED_BY_STORE_CACHE = "affected-by-stores";
 
     @Inject
     private CacheProducer cacheProducer;
@@ -39,13 +42,12 @@ public class StoreDataCacheProducer
         return cacheProducer.getCache( STORE_DATA_CACHE );
     }
 
-//    @StoreDataCache
-//    @Produces
-//    @ApplicationScoped
-//    public CacheHandle<StoreKey, String> getStoreDataCache()
-//    {
-//        return cacheProducer.getCache( STORE_DATA_CACHE );
-//    }
-
+    @AffectedByStoreCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<StoreKey, Set<StoreKey>> getAffectedByStores()
+    {
+        return cacheProducer.getCache( AFFECTED_BY_STORE_CACHE );
+    }
 
 }

--- a/db/infinispan/src/test/src/org/commonjava/indy/infinispan/data/InfinispanTCKFixtureProvider.java
+++ b/db/infinispan/src/test/src/org/commonjava/indy/infinispan/data/InfinispanTCKFixtureProvider.java
@@ -23,6 +23,9 @@ import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 
+import java.util.Set;
+
+import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.AFFECTED_BY_STORE_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_DATA_CACHE;
 
 public class InfinispanTCKFixtureProvider
@@ -35,7 +38,8 @@ public class InfinispanTCKFixtureProvider
         DefaultCacheManager cacheManager =
                 new DefaultCacheManager( new ConfigurationBuilder().simpleCache( true ).build() );
         Cache<StoreKey, ArtifactStore> storeCache = cacheManager.getCache( STORE_DATA_CACHE, true );
-        dataManager = new InfinispanStoreDataManager( storeCache );
+        Cache<StoreKey, Set<StoreKey>> affected = cacheManager.getCache( AFFECTED_BY_STORE_CACHE, true );
+        dataManager = new InfinispanStoreDataManager( storeCache, affected );
     }
 
     @Override

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/BasicCacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/BasicCacheHandle.java
@@ -153,6 +153,10 @@ public class BasicCacheHandle<K,V>
         return doExecute( "get", cache -> cache.get( key ) );
     }
 
+    /**
+     * WARNING: Be careful to use this clear operation, because we don't know if it will swept out all persistent data
+     * of this cache if the persistence has been enabled for it!!!
+     */
     public void clear()
     {
         doExecute( "clear", cache -> {

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -124,6 +124,12 @@
       </persistence>
     </local-cache>
 
+    <local-cache name="affected-by-stores" configuration="local-template">
+      <persistence passivation="true">
+        <file-store shared="false" preload="true" fetch-state="false" path="${indy.data}/affected-by-stores"/>
+      </persistence>
+    </local-cache>
+
     <!--
     A clustered lock is a lock which is distributed and shared among all nodes in the Infinispan cluster and
     provides a way to execute code that will be synchronized between the nodes. Since 9.x.


### PR DESCRIPTION
This reverse map will store all affected by relation ship for the constituents of groups. Beaware that I don't find a good solution now to calculate the relationship change simply based on the store changes, because we can not know the full stores tree diagram from one single store changes. So the way I used here is calculate it by full scan after the store changes, and replace the result in the map. So this will bring performance problem during the store change process. We must be aware of this.