### PR TITLE
Limit "affected-by" with full scan opeartion in package type based set

### DIFF
--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -134,4 +134,8 @@ public interface StoreDataManager
      * Stream of StoreKey instances present in the system.
      */
     Stream<StoreKey> streamArtifactStoreKeys();
+
+    Set<StoreKey> getStoreKeysByPkg( String pkg );
+
+    Set<StoreKey> getStoreKeysByPkgAndType( final String pkg, final StoreType type );
 }

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -20,7 +20,12 @@ import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
 import org.commonjava.indy.conf.InternalFeatureConfig;
 import org.commonjava.indy.conf.SslValidationConfig;
-import org.commonjava.indy.data.*;
+import org.commonjava.indy.data.ArtifactStoreQuery;
+import org.commonjava.indy.data.ArtifactStoreValidateData;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.data.StoreEventDispatcher;
+import org.commonjava.indy.data.StoreValidator;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -32,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
-import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +44,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
@@ -404,4 +409,17 @@ public abstract class AbstractStoreDataManager
 //        }
     }
 
+    @Override
+    public Set<StoreKey> getStoreKeysByPkg( String pkg )
+    {
+        return streamArtifactStoreKeys().filter( key -> key.getPackageType().equals( pkg ) )
+                                        .collect( Collectors.toSet() );
+    }
+
+    @Override
+    public Set<StoreKey> getStoreKeysByPkgAndType( final String pkg, final StoreType type )
+    {
+        return streamArtifactStoreKeys().filter( key -> key.getPackageType().equals( pkg ) && key.getType() == type )
+                                        .collect( Collectors.toSet() );
+    }
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreByPkgCache.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreByPkgCache.java
@@ -1,0 +1,16 @@
+package org.commonjava.indy.infinispan.data;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface StoreByPkgCache
+{
+}

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
@@ -17,16 +17,21 @@ package org.commonjava.indy.infinispan.data;
 
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+import java.util.Map;
+import java.util.Set;
 
 public class StoreDataCacheProducer
 {
     public static final String STORE_DATA_CACHE = "store-data-v2";
+
+    public static final String STORE_BY_PKG_CACHE = "store-by-package";
 
     @Inject
     private CacheProducer cacheProducer;
@@ -47,5 +52,12 @@ public class StoreDataCacheProducer
 //        return cacheProducer.getCache( STORE_DATA_CACHE );
 //    }
 
+    @StoreByPkgCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<String, Map<StoreType, Set<StoreKey>>> getStoreByPkgCache()
+    {
+        return cacheProducer.getCache( STORE_BY_PKG_CACHE );
+    }
 
 }

--- a/db/infinispan/src/test/src/org/commonjava/indy/infinispan/data/InfinispanTCKFixtureProvider.java
+++ b/db/infinispan/src/test/src/org/commonjava/indy/infinispan/data/InfinispanTCKFixtureProvider.java
@@ -19,10 +19,15 @@ import org.commonjava.indy.core.data.TCKFixtureProvider;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.DefaultCacheManager;
 
+import java.util.Map;
+import java.util.Set;
+
+import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_BY_PKG_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_DATA_CACHE;
 
 public class InfinispanTCKFixtureProvider
@@ -35,7 +40,9 @@ public class InfinispanTCKFixtureProvider
         DefaultCacheManager cacheManager =
                 new DefaultCacheManager( new ConfigurationBuilder().simpleCache( true ).build() );
         Cache<StoreKey, ArtifactStore> storeCache = cacheManager.getCache( STORE_DATA_CACHE, true );
-        dataManager = new InfinispanStoreDataManager( storeCache );
+        Cache<String, Map<StoreType, Set<StoreKey>>> storesByPkgCache = cacheManager.getCache( STORE_BY_PKG_CACHE, true );
+        dataManager = new InfinispanStoreDataManager( storeCache, storesByPkgCache );
+        dataManager.init();
     }
 
     @Override

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -118,10 +118,20 @@
       </persistence>
     </local-cache>
 
-    <local-cache name="store-data" configuration="local-template">
+    <local-cache name="store-data-v2" configuration="local-template">
       <persistence passivation="true">
         <file-store shared="false" preload="true" fetch-state="false" path="${indy.data}/store-v2"/>
       </persistence>
+    </local-cache>
+
+    <local-cache name="store-by-package" configuration="local-template">
+      <memory>
+        <object size="100" />
+      </memory>
+      <indexing index="LOCAL">
+        <property name="default.indexmanager">near-real-time</property>
+        <property name="default.directory_provider">local-heap</property>
+      </indexing>
     </local-cache>
 
     <!--


### PR DESCRIPTION
Add a new Cache which is <package, Map<type, Set<StoreKey>> to storeall Store keys based on package and type, so for affected group get method, we can avoid the full scan on all repos to get groups, but just simplified to two map get ops.