### PR TITLE
Async the group de-index during upload in content-index service

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/ContentIndexCacheProducer.java
@@ -15,8 +15,10 @@
  */
 package org.commonjava.indy.content.index;
 
-import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.content.index.deindex.DeIndexHandlingCache;
+import org.commonjava.indy.content.index.deindex.DeIndexInfo;
 import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -80,5 +82,13 @@ public class ContentIndexCacheProducer
     public BasicCacheHandle<IndexedStorePath, IndexedStorePath> contentIndexCacheCfg()
     {
         return cacheProducer.getBasicCache( "content-index" );
+    }
+
+    @DeIndexHandlingCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<Long, DeIndexInfo> produceDeIndexHandlingCache()
+    {
+        return cacheProducer.getCache( "content-de-index" );
     }
 }

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/deindex/DeIndexHandlingCache.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/deindex/DeIndexHandlingCache.java
@@ -1,0 +1,19 @@
+package org.commonjava.indy.content.index.deindex;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This DeIndexHandlingCache is used as a async event queue to
+ */
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface DeIndexHandlingCache
+{
+}

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/deindex/DeIndexHandlingCacheListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/deindex/DeIndexHandlingCacheListener.java
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.content.index.deindex;
+
+import org.commonjava.indy.content.index.ContentIndexManager;
+import org.commonjava.indy.content.index.conf.ContentIndexConfig;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryCreated;
+import org.infinispan.notifications.cachelistener.event.CacheEntryCreatedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Set;
+
+import static org.commonjava.indy.content.index.deindex.DeIndexInfo.TYPE_MULTI;
+import static org.commonjava.indy.content.index.deindex.DeIndexInfo.TYPE_SINGLE;
+
+@Listener( sync = false )
+@ApplicationScoped
+public class DeIndexHandlingCacheListener
+{
+    private static final Logger logger = LoggerFactory.getLogger( DeIndexHandlingCacheListener.class );
+
+    @Inject
+    private StoreDataManager storeDataManager;
+
+    @Inject
+    private ContentIndexManager indexManager;
+
+    @Inject
+    private ContentIndexConfig indexCfg;
+
+    @Inject
+    private NotFoundCache nfc;
+
+    @Inject
+    @DeIndexHandlingCache
+    private CacheHandle<Long, DeIndexInfo> deIndexQueue;
+
+    @CacheEntryCreated
+    public void handleDeIndex( CacheEntryCreatedEvent<Long, DeIndexInfo> e )
+    {
+        if ( !e.isPre() )
+        {
+            final DeIndexInfo info = e.getValue();
+            final String deIndexType = info.deIndexType;
+            switch ( deIndexType )
+            {
+                case TYPE_SINGLE:
+                    processSingle( info );
+                    break;
+                case TYPE_MULTI:
+                    processMultiple( info );
+                    break;
+                default:
+                    break;
+            }
+        }
+        deIndexQueue.remove( e.getKey() );
+    }
+
+    private void processSingle( final DeIndexInfo info )
+    {
+        final Transfer transfer = info.transfer;
+        final ArtifactStore store = info.store;
+        final String path = transfer.getPath();
+
+        logger.trace( "Do de-index in storing process of content-index for transfer {} and store {}", transfer, store.getKey() );
+
+        indexTransfer( transfer, store.getKey() );
+
+        if ( store instanceof Group )
+        {
+            nfc.clearMissing( new ConcreteResource( LocationUtils.toLocation( store ), path ) );
+        }
+        // We should deIndex the path for all parent groups because the new content of the path
+        // may change the content index sequence based on the constituents sequence in parent groups
+        if ( store.getType() == StoreType.hosted )
+        {
+            try
+            {
+                Set<Group> groups = storeDataManager.query().getGroupsAffectedBy( store.getKey() );
+                if ( groups != null && !groups.isEmpty() && indexCfg.isEnabled() )
+                {
+                    groups.forEach( g -> indexManager.deIndexStorePath( g.getKey(), path ) );
+                }
+            }
+            catch ( IndyDataException e )
+            {
+                logger.error( String.format( "Failed to get groups which contains: %s for NFC handling. Reason: %s",
+                                             store.getKey(), e.getMessage() ), e );
+            }
+        }
+    }
+
+    private void processMultiple( final DeIndexInfo info )
+    {
+        final Transfer transfer = info.transfer;
+        final StoreKey topKey = info.topKey;
+        final String path = transfer.getPath();
+
+        logger.trace( "Do multiple de-index in storing process of content-index for transfer {} and top store {}", transfer, topKey );
+
+        indexTransfer( transfer, topKey );
+
+        try
+        {
+            ArtifactStore topStore = storeDataManager.getArtifactStore( topKey );
+            nfc.clearMissing( new ConcreteResource( LocationUtils.toLocation( topStore ), path ) );
+
+            if ( indexCfg.isEnabled() )
+            {
+                // We should deIndex the path for all parent groups because the new content of the path
+                // may change the content index sequence based on the constituents sequence in parent groups
+                indexManager.deIndexStorePath( topKey, path );
+            }
+        }
+        catch ( IndyDataException e )
+        {
+            Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.error( String.format( "Failed to retrieve top store: %s for NFC management. Reason: %s", topKey,
+                                         e.getMessage() ), e );
+        }
+    }
+
+    private void indexTransfer( final Transfer transfer, final StoreKey key )
+    {
+        if ( indexCfg.isEnabled() )
+        {
+            logger.trace( "Indexing: {} in: {}", transfer, key );
+            indexManager.indexTransferIn( transfer, key );
+        }
+    }
+}

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/deindex/DeIndexInfo.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/deindex/DeIndexInfo.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2013~2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.content.index.deindex;
+
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.maven.galley.model.Transfer;
+
+public class DeIndexInfo
+{
+    public static final String TYPE_SINGLE = "SINGLE";
+
+    public static final String TYPE_MULTI = "MULTIPLE";
+
+    final Transfer transfer;
+
+    final ArtifactStore store;
+
+    final String deIndexType;
+
+    final StoreKey topKey;
+
+    public DeIndexInfo( final Transfer transfer, final ArtifactStore store, final String deIndexType )
+    {
+        this( transfer, store, null, deIndexType );
+    }
+
+    public DeIndexInfo( final Transfer transfer, final ArtifactStore store, final StoreKey topKey,
+                        final String deIndexType )
+    {
+        this.transfer = transfer;
+        this.store = store;
+        this.deIndexType = deIndexType;
+        this.topKey = topKey;
+    }
+}

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -124,6 +124,17 @@
       </persistence>
     </local-cache>
 
+    <local-cache name="content-de-index" configuration="local-template">
+      <memory>
+        <object size="100000" strategy="REMOVE" />
+      </memory>
+
+      <indexing index="LOCAL">
+        <property name="default.indexmanager">near-real-time</property>
+        <property name="default.directory_provider">local-heap</property>
+      </indexing>
+    </local-cache>
+
     <!--
     A clustered lock is a lock which is distributed and shared among all nodes in the Infinispan cluster and
     provides a way to execute code that will be synchronized between the nodes. Since 9.x.


### PR DESCRIPTION
Recent performance problem we met for uploading & promotion is all caused by the getAffectedBy operation, which is a time-consumed one for a full scan on store data. After checking, I found that it is mainly used for de-index or re-index content-index entries for the uploading repo. I think this de-index will not be a block factor during the upload or promotion process, which means we could make it async. This pr is doing this fix.
In this pr, I created a ISPN cache and used it like a queue, which decouple the de-index opeartion from storing process in content-index to an aync listener of ISPN listener.
Why not use a weft executor? Because the storing operation is high frequent, which means it could be blocked again if the de-index effeciency is much slower than the real physical storing operation. Use this queue-liked way we can delegate all these to underlying ISPN and we have a position to set the queue size from ISPN config.