### PR TITLE
Thread-off two nfc cleaning ops which refers getAffectedBy

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -72,6 +72,7 @@ public class DefaultContentIndexManager
     @Inject
     private BasicCacheHandle<IndexedStorePath, IndexedStorePath> contentIndex;
 
+    //FIXME: Seems no cache register this listener?
     @Inject
     private NFCContentListener listener;
 

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -91,7 +91,7 @@ public abstract class IndexingContentManagerDecorator
 
     @Inject
     @WeftManaged
-    @ExecutorConfig( named="content-index-store-deindex", priority = 4, threads = 10)
+    @ExecutorConfig( named = "content-index-store-deindex", priority = 4, threads = 10 )
     private Executor deIndexExecutor;
 
     protected IndexingContentManagerDecorator()

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionHelper.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionHelper.java
@@ -34,7 +34,6 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.model.Transfer;
-import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,8 +89,8 @@ public class PromotionHelper
     public void clearStoreNFC( final Set<String> sourcePaths, ArtifactStore store )
     {
         Set<String> paths = sourcePaths.stream()
-                                       .map( sp -> sp.startsWith( "/" ) && sp.length() > 1 ? sp.substring( 1 ) : sp )
-                                       .collect( Collectors.toSet() );
+                               .map( sp -> sp.startsWith( "/" ) && sp.length() > 1 ? sp.substring( 1 ) : sp )
+                               .collect( Collectors.toSet() );
 
         paths.forEach( path -> {
             ConcreteResource resource = new ConcreteResource( LocationUtils.toLocation( store ), path );
@@ -228,7 +227,7 @@ public class PromotionHelper
     }
 
     // util class to hold repos check results
-    class PromotionRepoRetrievalResult
+    static class PromotionRepoRetrievalResult
     {
         final List<String> errors;
         final ArtifactStore targetStore, sourceStore;

--- a/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/IndyMetricsManager.java
+++ b/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/IndyMetricsManager.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -249,12 +250,12 @@ public class IndyMetricsManager
                 return;
             }
 
-            ctx.putIfAbsent( CUMULATIVE_TIMINGS, new HashMap<String, Double>() );
+            ctx.putIfAbsent( CUMULATIVE_TIMINGS, new ConcurrentHashMap<>() );
             Map<String, Double> timingMap = (Map<String, Double>) ctx.get( CUMULATIVE_TIMINGS );
 
             timingMap.merge( name, elapsed, ( existingVal, newVal ) -> existingVal + newVal );
 
-            ctx.putIfAbsent( CUMULATIVE_COUNTS, new HashMap<String, Integer>() );
+            ctx.putIfAbsent( CUMULATIVE_COUNTS, new ConcurrentHashMap<>() );
             Map<String, Integer> countMap =
                     (Map<String, Integer>) ctx.get( CUMULATIVE_COUNTS );
 


### PR DESCRIPTION
This pr focus on thread-off of two nfc cleaning ops in ContentManager and Promotion validation. These ops are all refering getGroupsAffectedBy, which is a time-consuming calling. As these ops are in the process of file storing, they are affecting the upload performance. And these nfc cleaning ops can be considered as non-real-time, which means thread-off is acceptable. 