### PR TITLE
don't build cache migrator or record extractor in main build.

### DIFF
--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -31,8 +31,8 @@
   
   <modules>
     <module>launcher</module>
-    <module>cache-migrator</module>
-    <module>record-extractor</module>
+<!--     <module>cache-migrator</module>
+    <module>record-extractor</module> -->
   </modules>
 
   <profiles>


### PR DESCRIPTION
These don't need to be on the main release cycle, and it seems there's some recursion
problem in the maven-assembly-plugin with one of them that's screwing up Indy builds.