### PR TITLE
Implement affected-by reverse cache

### DIFF
--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -82,6 +82,9 @@ public class NPMContentAccessHandler
     @Inject
     private ResponseHelper responseHelper;
 
+    @Inject
+    private PackageMetadataMerger packageMetadataMerger;
+
     @Override
     public Response doCreate( String packageType, String type, String name, String path, HttpServletRequest request,
                               EventMetadata eventMetadata, Supplier<URI> uriBuilder )
@@ -127,7 +130,7 @@ public class NPMContentAccessHandler
             // then store the transfer, delete unuseful temp and meta transfers.
             if ( temp != null && temp.exists() )
             {
-                stream = new PackageMetadataMerger().merge( temp, tomerge );
+                stream = packageMetadataMerger.merge( temp, tomerge );
                 Transfer merged = contentController.store( sk, path, stream, eventMetadata );
 
                 // for npm group, will not replace with the new http meta when re-upload,

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -143,8 +143,4 @@ public interface StoreDataManager
 
     Set<Group> affectedBy( Collection<StoreKey> keys )
             throws IndyDataException;
-
-    Set<StoreKey> getStoreKeysByPkg( String pkg );
-
-    Set<StoreKey> getStoreKeysByPkgAndType( final String pkg, final StoreType type );
 }

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -17,11 +17,13 @@ package org.commonjava.indy.data;
 
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.maven.galley.event.EventMetadata;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -138,4 +140,7 @@ public interface StoreDataManager
     Set<StoreKey> getStoreKeysByPkg( String pkg );
 
     Set<StoreKey> getStoreKeysByPkgAndType( final String pkg, final StoreType type );
+
+    Set<Group> affectedBy( Collection<StoreKey> keys )
+            throws IndyDataException;
 }

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -143,4 +143,8 @@ public interface StoreDataManager
 
     Set<Group> affectedBy( Collection<StoreKey> keys )
             throws IndyDataException;
+
+    Set<StoreKey> getStoreKeysByPkg( String pkg );
+
+    Set<StoreKey> getStoreKeysByPkgAndType( final String pkg, final StoreType type );
 }

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -511,17 +511,4 @@ public abstract class AbstractStoreDataManager
 
         return groups;
     }
-
-    public Set<StoreKey> getStoreKeysByPkg( String pkg )
-    {
-        return streamArtifactStoreKeys().filter( key -> key.getPackageType().equals( pkg ) )
-                                        .collect( Collectors.toSet() );
-    }
-
-    @Override
-    public Set<StoreKey> getStoreKeysByPkgAndType( final String pkg, final StoreType type )
-    {
-        return streamArtifactStoreKeys().filter( key -> key.getPackageType().equals( pkg ) && key.getType() == type )
-                                        .collect( Collectors.toSet() );
-    }
 }

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -151,6 +151,11 @@ public abstract class AbstractStoreDataManager
                 }
             }
         }
+        // Hosted or Remote update does not change affectedBy relationships
+        if ( store instanceof Group )
+        {
+            refreshAffectedBy( store, original );
+        }
     }
 
     protected void preDelete( final ArtifactStore store, final ChangeSummary summary, final boolean fireEvents,
@@ -174,6 +179,14 @@ public abstract class AbstractStoreDataManager
         {
             dispatcher.deleted( eventMetadata, store );
         }
+
+        refreshAffectedBy( store, null );
+    }
+
+    protected void refreshAffectedBy( final ArtifactStore store, final ArtifactStore original )
+            throws IndyDataException
+    {
+        //do nothing by default
     }
 
     protected abstract ArtifactStore removeArtifactStoreInternal( StoreKey key );

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -510,4 +510,16 @@ public abstract class AbstractStoreDataManager
         return groups;
     }
 
+    public Set<StoreKey> getStoreKeysByPkg( String pkg )
+    {
+        return streamArtifactStoreKeys().filter( key -> key.getPackageType().equals( pkg ) )
+                                        .collect( Collectors.toSet() );
+    }
+
+    @Override
+    public Set<StoreKey> getStoreKeysByPkgAndType( final String pkg, final StoreType type )
+    {
+        return streamArtifactStoreKeys().filter( key -> key.getPackageType().equals( pkg ) && key.getType() == type )
+                                        .collect( Collectors.toSet() );
+    }
 }

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -28,6 +28,7 @@ import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.data.StoreValidator;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
@@ -37,7 +38,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -422,4 +427,74 @@ public abstract class AbstractStoreDataManager
         return streamArtifactStoreKeys().filter( key -> key.getPackageType().equals( pkg ) && key.getType() == type )
                                         .collect( Collectors.toSet() );
     }
+
+    public Set<Group> affectedBy( final Collection<StoreKey> keys )
+            throws IndyDataException
+    {
+        return affectedByFromStores( keys );
+    }
+
+    protected Set<Group> affectedByFromStores( final Collection<StoreKey> keys )
+            throws IndyDataException
+    {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.debug( "Getting groups affected by: {}", keys );
+
+        List<StoreKey> toProcess = new ArrayList<>( new HashSet<>( keys ) );
+
+        Set<Group> groups = new HashSet<>();
+        if ( toProcess.isEmpty() )
+        {
+            return groups;
+        }
+
+        Set<StoreKey> processed = new HashSet<>();
+        final String packageType = toProcess.get( 0 ).getPackageType();
+
+        Set<ArtifactStore> all = this.getAllArtifactStores().stream().filter( st -> {
+            if ( packageType != null && !st.getPackageType().equals( packageType ) )
+            {
+                return false;
+            }
+
+            if ( st.getType() != StoreType.group )
+            {
+                return false;
+            }
+
+            return true;
+        } ).collect( Collectors.toSet() );
+
+        while ( !toProcess.isEmpty() )
+        {
+            // as long as we have another key to process, pop it off the list (remove it) and process it.
+            StoreKey next = toProcess.remove( 0 );
+            if ( processed.contains( next ) )
+            {
+                // if we've already handled this group (via another branch in the group membership tree, etc. then don't bother.
+                continue;
+            }
+
+            // use this to avoid reprocessing groups we've already encountered.
+            processed.add( next );
+
+            for ( ArtifactStore store : all )
+            {
+                if ( ( store instanceof Group ) && !processed.contains( store.getKey() )  )
+                {
+                    Group g = (Group) store;
+                    if ( g.getConstituents() != null && g.getConstituents().contains( next ) )
+                    {
+                        groups.add( g );
+
+                        // add this group as another one to process for groups that contain it...and recurse upwards
+                        toProcess.add( g.getKey() );
+                    }
+                }
+            }
+        }
+
+        return groups;
+    }
+
 }

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -52,6 +52,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.commonjava.indy.db.common.StoreUpdateAction.DELETE;
+import static org.commonjava.indy.db.common.StoreUpdateAction.STORE;
 import static org.commonjava.indy.model.core.StoreType.hosted;
 
 public abstract class AbstractStoreDataManager
@@ -154,7 +156,7 @@ public abstract class AbstractStoreDataManager
         // Hosted or Remote update does not change affectedBy relationships
         if ( store instanceof Group )
         {
-            refreshAffectedBy( store, original );
+            refreshAffectedBy( store, original, STORE );
         }
     }
 
@@ -180,10 +182,10 @@ public abstract class AbstractStoreDataManager
             dispatcher.deleted( eventMetadata, store );
         }
 
-        refreshAffectedBy( store, null );
+        refreshAffectedBy( store, null, DELETE );
     }
 
-    protected void refreshAffectedBy( final ArtifactStore store, final ArtifactStore original )
+    protected void refreshAffectedBy( final ArtifactStore store, final ArtifactStore original, StoreUpdateAction action )
             throws IndyDataException
     {
         //do nothing by default

--- a/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
@@ -527,18 +527,10 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
         }
 
         final List<ArtifactStore> result = new ArrayList<>();
-        recurseGroup( master, result, new HashSet<>(), includeGroups, recurseGroups );
 
-        return result;
-    }
-
-    private void recurseGroup( final Group master,
-                               final List<ArtifactStore> result, final Set<StoreKey> seen, final boolean includeGroups,
-                               final boolean recurseGroups )
-            throws IndyDataException
-    {
         AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
         LinkedList<Group> toCheck = new LinkedList<>();
+        Set<StoreKey> seen = new HashSet<>();
         toCheck.add( master );
 
         while ( !toCheck.isEmpty() )
@@ -547,7 +539,7 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
 
             if ( next == null || next.isDisabled() && Boolean.TRUE.equals( enabled ) )
             {
-                return;
+                continue;
             }
 
             List<StoreKey> members = new ArrayList<>( next.getConstituents() );
@@ -556,7 +548,6 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
                 result.add( next );
             }
 
-            // TODO: Need to refactor away from actual recursion.
             members.forEach( ( key ) ->
                              {
                                  if ( !seen.contains( key ) )
@@ -593,6 +584,8 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
                 throw error;
             }
         }
+
+        return result;
     }
 
 }

--- a/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
@@ -404,65 +404,7 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
     public Set<Group> getGroupsAffectedBy( Collection<StoreKey> keys )
             throws IndyDataException
     {
-        Logger logger = LoggerFactory.getLogger( getClass() );
-        logger.debug( "Getting groups affected by: {}", keys );
-
-        List<StoreKey> toProcess = new ArrayList<>( new HashSet<>( keys ) );
-
-        Set<Group> groups = new HashSet<>();
-        if ( toProcess.isEmpty() )
-        {
-            return groups;
-        }
-
-        Set<StoreKey> processed = new HashSet<>();
-
-        Set<StoreKey> all = dataManager.getStoreKeysByPkgAndType( toProcess.get( 0 ).getPackageType(), group );
-
-        logger.debug( "There are {} groups need to loop checking for affected by", all.size() );
-
-        Set<ArtifactStore> allStores = all.stream().map( k-> {
-            try
-            {
-                return dataManager.getArtifactStore( k );
-            }
-            catch ( IndyDataException e )
-            {
-                logger.error( "Error to get store {}", k );
-                return null;
-            }
-        } ).filter( Objects::nonNull ).collect( Collectors.toSet());
-
-        while ( !toProcess.isEmpty() )
-        {
-            // as long as we have another key to process, pop it off the list (remove it) and process it.
-            StoreKey next = toProcess.remove( 0 );
-            if ( processed.contains( next ) )
-            {
-                // if we've already handled this group (via another branch in the group membership tree, etc. then don't bother.
-                continue;
-            }
-
-            // use this to avoid reprocessing groups we've already encountered.
-            processed.add( next );
-
-            for (  ArtifactStore store : allStores )
-            {
-                if ( ( store instanceof Group ) && !processed.contains( store.getKey() ) )
-                {
-                    Group g = (Group) store;
-                    if ( g.getConstituents() != null && g.getConstituents().contains( next ) )
-                    {
-                        groups.add( g );
-
-                        // add this group as another one to process for groups that contain it...and recurse upwards
-                        toProcess.add( g.getKey() );
-                    }
-                }
-            }
-        }
-
-        return groups;
+        return dataManager.affectedBy( keys );
     }
 
     public Stream<StoreKey> keyStream()

--- a/db/common/src/main/java/org/commonjava/indy/db/common/StoreUpdateAction.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/StoreUpdateAction.java
@@ -1,0 +1,6 @@
+package org.commonjava.indy.db.common;
+
+public enum StoreUpdateAction
+{
+    STORE, DELETE;
+}

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/AffectedByStoreCache.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/AffectedByStoreCache.java
@@ -1,0 +1,16 @@
+package org.commonjava.indy.infinispan.data;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface AffectedByStoreCache
+{
+}

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -16,11 +16,13 @@
 package org.commonjava.indy.infinispan.data;
 
 import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
 import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.db.common.AbstractStoreDataManager;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
@@ -32,15 +34,19 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_BY_PKG_CACHE;
+import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.AFFECTED_BY_STORE_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_DATA_CACHE;
+import static org.commonjava.indy.model.core.StoreType.group;
 
 @ApplicationScoped
 @Alternative
@@ -56,6 +62,10 @@ public class InfinispanStoreDataManager
     @Inject
     @StoreByPkgCache
     private CacheHandle<String, Map<StoreType, Set<StoreKey>>> storesByPkg;
+
+    @Inject
+    @AffectedByStoreCache
+    private CacheHandle<StoreKey, Set<StoreKey>> affectedByStores;
 
     @Inject
     private StoreEventDispatcher dispatcher;
@@ -92,11 +102,13 @@ public class InfinispanStoreDataManager
     }
 
     public InfinispanStoreDataManager( final Cache<StoreKey, ArtifactStore> cache,
-                                       final Cache<String, Map<StoreType, Set<StoreKey>>> storesByPkg )
+                                       final Cache<String, Map<StoreType, Set<StoreKey>>> storesByPkg,
+                                       final Cache<StoreKey, Set<StoreKey>> affectedByStoresCache )
     {
         this.dispatcher = new NoOpStoreEventDispatcher();
         this.stores = new CacheHandle( STORE_DATA_CACHE, cache );
         this.storesByPkg = new CacheHandle( STORE_BY_PKG_CACHE, storesByPkg );
+        this.affectedByStores = new CacheHandle( AFFECTED_BY_STORE_CACHE, affectedByStoresCache );
     }
 
     @Override
@@ -124,8 +136,10 @@ public class InfinispanStoreDataManager
     @Override
     public void clear( final ChangeSummary summary )
     {
+        //TODO: I'm really concern if we need this implementation as we don't know if ISPN will clean all persistent entries!!!
         stores.clear();
         storesByPkg.clear();
+        affectedByStores.clear();
     }
 
     @Override
@@ -218,4 +232,78 @@ public class InfinispanStoreDataManager
         return Collections.emptySet();
     }
 
+    @Override
+    public Set<Group> affectedBy( final Collection<StoreKey> keys )
+    {
+        final Set<Group> groups = new HashSet<>();
+        for ( StoreKey key : keys )
+        {
+            Set<StoreKey> affected = affectedByStores.get( key );
+            if ( affected != null )
+            {
+                affected = affected.stream().filter( k -> k.getType() == group ).collect( Collectors.toSet() );
+                for ( StoreKey gKey : affected )
+                {
+                    ArtifactStore store = getArtifactStoreInternal( gKey );
+                    groups.add( (Group) store );
+                }
+            }
+        }
+        return groups;
+    }
+
+    @Override
+    protected void refreshAffectedBy( final ArtifactStore store, final ArtifactStore original )
+            throws IndyDataException
+    {
+        if ( store == null )
+        {
+            return;
+        }
+        if ( store instanceof Group )
+        {
+            final Set<StoreKey> updatedConstituents = new HashSet<>( ((Group)store).getConstituents() );
+            final Set<StoreKey> originalConstituents;
+            if ( original != null )
+            {
+                originalConstituents = new HashSet<>( ((Group)original).getConstituents() );
+            }
+            else
+            {
+                originalConstituents = new HashSet<>();
+            }
+
+            final Set<StoreKey> added = new HashSet<>();
+            final Set<StoreKey> removed = new HashSet<>();
+            for ( StoreKey updKey : updatedConstituents )
+            {
+                if ( !originalConstituents.contains( updKey ) )
+                {
+                    added.add( updKey );
+                }
+            }
+
+            for ( StoreKey oriKey : originalConstituents )
+            {
+                if ( !updatedConstituents.contains( oriKey ) )
+                {
+                    removed.add( oriKey );
+                }
+            }
+
+            final Set<StoreKey> allChangedSubs = new HashSet<>( added );
+            allChangedSubs.addAll( removed );
+
+            for ( StoreKey key : allChangedSubs )
+            {
+                final ArtifactStore sub = getArtifactStoreInternal( key );
+                refreshAffectedBy( sub, null );
+            }
+        }
+
+        final Set<Group> affectedBy = affectedByFromStores( Collections.singleton( store.getKey() ) );
+        affectedByStores.put( store.getKey(),
+                              affectedBy.stream().map( ArtifactStore::getKey ).collect( Collectors.toSet() ) );
+
+    }
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -45,6 +45,7 @@ import java.util.stream.Stream;
 
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_BY_PKG_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.AFFECTED_BY_STORE_CACHE;
+import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_BY_PKG_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_DATA_CACHE;
 import static org.commonjava.indy.model.core.StoreType.group;
 
@@ -66,6 +67,10 @@ public class InfinispanStoreDataManager
     @Inject
     @AffectedByStoreCache
     private CacheHandle<StoreKey, Set<StoreKey>> affectedByStores;
+
+    @Inject
+    @StoreByPkgCache
+    private CacheHandle<String, Map<StoreType, Set<StoreKey>>> storesByPkg;
 
     @Inject
     private StoreEventDispatcher dispatcher;
@@ -140,6 +145,7 @@ public class InfinispanStoreDataManager
         stores.clear();
         storesByPkg.clear();
         affectedByStores.clear();
+        storesByPkg.clear();
     }
 
     @Override
@@ -232,6 +238,7 @@ public class InfinispanStoreDataManager
         return Collections.emptySet();
     }
 
+    // FIXME: We need simple affected-by caching, not fully denormalized caching
     @Override
     public Set<Group> affectedBy( final Collection<StoreKey> keys )
     {
@@ -252,6 +259,7 @@ public class InfinispanStoreDataManager
         return groups;
     }
 
+    // FIXME: We need simple affected-by caching, not fully denormalized caching
     @Override
     protected void refreshAffectedBy( final ArtifactStore store, final ArtifactStore original )
             throws IndyDataException

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
@@ -35,6 +35,8 @@ public class StoreDataCacheProducer
 
     public static final String AFFECTED_BY_STORE_CACHE = "affected-by-stores";
 
+    public static final String STORE_BY_PKG_CACHE = "store-by-package";
+
     @Inject
     private CacheProducer cacheProducer;
 
@@ -68,6 +70,14 @@ public class StoreDataCacheProducer
     public CacheHandle<StoreKey, Set<StoreKey>> getAffectedByStores()
     {
         return cacheProducer.getCache( AFFECTED_BY_STORE_CACHE );
+    }
+
+    @StoreByPkgCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<String, Map<StoreType, Set<StoreKey>>> getStoreByPkgCache()
+    {
+        return cacheProducer.getCache( STORE_BY_PKG_CACHE );
     }
 
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
@@ -35,8 +35,6 @@ public class StoreDataCacheProducer
 
     public static final String AFFECTED_BY_STORE_CACHE = "affected-by-stores";
 
-    public static final String STORE_BY_PKG_CACHE = "store-by-package";
-
     @Inject
     private CacheProducer cacheProducer;
 
@@ -70,14 +68,6 @@ public class StoreDataCacheProducer
     public CacheHandle<StoreKey, Set<StoreKey>> getAffectedByStores()
     {
         return cacheProducer.getCache( AFFECTED_BY_STORE_CACHE );
-    }
-
-    @StoreByPkgCache
-    @Produces
-    @ApplicationScoped
-    public CacheHandle<String, Map<StoreType, Set<StoreKey>>> getStoreByPkgCache()
-    {
-        return cacheProducer.getCache( STORE_BY_PKG_CACHE );
     }
 
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/StoreDataCacheProducer.java
@@ -33,6 +33,8 @@ public class StoreDataCacheProducer
 
     public static final String STORE_BY_PKG_CACHE = "store-by-package";
 
+    public static final String AFFECTED_BY_STORE_CACHE = "affected-by-stores";
+
     @Inject
     private CacheProducer cacheProducer;
 
@@ -58,6 +60,14 @@ public class StoreDataCacheProducer
     public CacheHandle<String, Map<StoreType, Set<StoreKey>>> getStoreByPkgCache()
     {
         return cacheProducer.getCache( STORE_BY_PKG_CACHE );
+    }
+
+    @AffectedByStoreCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<StoreKey, Set<StoreKey>> getAffectedByStores()
+    {
+        return cacheProducer.getCache( AFFECTED_BY_STORE_CACHE );
     }
 
 }

--- a/db/infinispan/src/test/src/org/commonjava/indy/infinispan/data/InfinispanTCKFixtureProvider.java
+++ b/db/infinispan/src/test/src/org/commonjava/indy/infinispan/data/InfinispanTCKFixtureProvider.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_BY_PKG_CACHE;
+import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.AFFECTED_BY_STORE_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_DATA_CACHE;
 
 public class InfinispanTCKFixtureProvider
@@ -41,7 +42,8 @@ public class InfinispanTCKFixtureProvider
                 new DefaultCacheManager( new ConfigurationBuilder().simpleCache( true ).build() );
         Cache<StoreKey, ArtifactStore> storeCache = cacheManager.getCache( STORE_DATA_CACHE, true );
         Cache<String, Map<StoreType, Set<StoreKey>>> storesByPkgCache = cacheManager.getCache( STORE_BY_PKG_CACHE, true );
-        dataManager = new InfinispanStoreDataManager( storeCache, storesByPkgCache );
+        Cache<StoreKey, Set<StoreKey>> affected = cacheManager.getCache( AFFECTED_BY_STORE_CACHE, true );
+        dataManager = new InfinispanStoreDataManager( storeCache, storesByPkgCache, affected );
         dataManager.init();
     }
 

--- a/db/infinispan/src/test/src/org/commonjava/indy/infinispan/data/InfinispanTCKFixtureProvider.java
+++ b/db/infinispan/src/test/src/org/commonjava/indy/infinispan/data/InfinispanTCKFixtureProvider.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_BY_PKG_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.AFFECTED_BY_STORE_CACHE;
+import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_BY_PKG_CACHE;
 import static org.commonjava.indy.infinispan.data.StoreDataCacheProducer.STORE_DATA_CACHE;
 
 public class InfinispanTCKFixtureProvider

--- a/ftests/core/src/main/java/org/commonjava/indy/jaxrs/IndySslValidationApiTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/jaxrs/IndySslValidationApiTest.java
@@ -135,7 +135,7 @@ public class IndySslValidationApiTest extends AbstractIndyFunctionalTest {
 
 
         } catch (IndyClientException ice) {
-            LOGGER.warn("=> Exception in revalidating store " + storedTestSslRepo.getUrl() +" API call");
+            LOGGER.warn("=> Exception in revalidating store " + storedTestSslRepo +" API call");
         }
 
 

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/BasicCacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/BasicCacheHandle.java
@@ -153,6 +153,10 @@ public class BasicCacheHandle<K,V>
         return doExecute( "get", cache -> cache.get( key ) );
     }
 
+    /**
+     * WARNING: Be careful to use this clear operation, because we don't know if it will swept out all persistent data
+     * of this cache if the persistence has been enabled for it!!!
+     */
     public void clear()
     {
         doExecute( "clear", cache -> {

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -134,6 +134,9 @@
       </indexing>
     </local-cache>
 
+    <local-cache name="affected-by-stores" configuration="local-template">
+    </local-cache>
+
     <!--
     A clustered lock is a lock which is distributed and shared among all nodes in the Infinispan cluster and
     provides a way to execute code that will be synchronized between the nodes. Since 9.x.


### PR DESCRIPTION
This supercedes #1470 by extending the work there and simplifying the mapping represented in the affected-by cache to be a simple reverse-map of the group-to-constituent map contained in the Group definition. This will simplify updates to the cache and should make it perform a bit better, while also avoiding potential unforseen bugs when using multiple levels of group constituent nesting (groups within groups while also containing repos). If something in the middle of such a chain gets updated, recalculating a fully flattened affected-by mapping could become error prone and would definitely be expensive.

The new code simply stores a reverse map of the constituent mapping, aggregated for all groups. When the affectedBy() method is called, this reverse map is iterated using processed / toProcess sets to avoid recursion. This should be relatively light-weight because we don't need to iterate the cache itself; we're still loading entries by their keys. Memory usage could be a bit higher I suppose, since we might end up storing reverse-mappings for more intermediary groups...but that's not clear, since a fully flattened structure would still contain nearly all of the same references.

**Additionally,** I added logic to the InfinispanStoreDataManager.init() method that will check whether the affected-by cache is empty. If it is, and while iterating all store definitions for purposes of booting up the by-package-type cache, this method will also create the affected-by reverse mapping for all groups that it knows about. After that point, the refreshAffectedBy method should enable us to maintain the data. Of course, leaving the affected-by cache as an in-memory cache will also work well, and similarly to the by-pacakge-type cache.

Longer term, we need a proper data-driven (not cache-based) store data manager, where we can handle these reverse-mapping optimizations. Until then, I think this will help improve performance a bit. 