### PR TITLE
Consolidate all async getGroupAffectedBy ops in StoreDataManager

### DIFF
--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -143,4 +143,37 @@ public interface StoreDataManager
 
     Set<Group> affectedBy( Collection<StoreKey> keys )
             throws IndyDataException;
+
+    /**
+     * This api is used for some time-sensitive tasks which should use getGroupsAffectedBy service, as
+     * this service is a little time-consuming now.
+     *
+     * @param task
+     * @param <R>
+     */
+    void asyncGroupAffectedBy( ContextualTask contextualTask );
+
+    class ContextualTask
+    {
+        private String taskContext;
+
+        private Runnable task;
+
+        public ContextualTask( String taskContext, Runnable task )
+        {
+            this.taskContext = taskContext;
+            this.task = task;
+        }
+
+        public String getTaskContext()
+        {
+            return taskContext;
+        }
+
+        public Runnable getTask()
+        {
+            return task;
+        }
+
+    }
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -16,7 +16,6 @@
 package org.commonjava.indy.infinispan.data;
 
 import org.commonjava.indy.audit.ChangeSummary;
-import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
 import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.db.common.AbstractStoreDataManager;
@@ -31,7 +30,6 @@ import org.infinispan.Cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
 import javax.inject.Inject;


### PR DESCRIPTION
We've used multiple threads to async the ops which are referring getGroupsAffectedBy. It's not easy to manage and refactor in the future, so this pr consolidate all these ops into single thread which is managed in StoreDataManager itself.