### PR TITLE
Add some trace log for metadata clearing of pom update

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -70,7 +70,7 @@ public class MetadataMergePomChangeListener
      */
     public void onPomStorageEvent( @Observes final FileStorageEvent event )
     {
-        metaClear( event );
+        metaClear( event, "updated" );
     }
 
     /**
@@ -80,10 +80,10 @@ public class MetadataMergePomChangeListener
      */
     public void onPomDeletionEvent( @Observes final FileDeletionEvent event )
     {
-        metaClear( event );
+        metaClear( event, "deleted" );
     }
 
-    private void metaClear( final FileEvent event )
+    private void metaClear( final FileEvent event, final String eventOps )
     {
         final String path = event.getTransfer().getPath();
 
@@ -94,6 +94,7 @@ public class MetadataMergePomChangeListener
 
         final StoreKey key = getKey( event );
         final String clearPath = getMetadataPath( path );
+        logger.info( "Pom file {} {}, will clean its matched metadata file {}", path, eventOps, clearPath );
         try
         {
             if ( hosted == key.getType() )
@@ -104,6 +105,7 @@ public class MetadataMergePomChangeListener
                     if ( doClear( hosted, clearPath ) )
                     {
                         cacheManager.remove( hosted.getKey(), clearPath );
+                        logger.info( "Metadata file {} in store {} cleared.", path, key );
                     }
                 }
                 catch ( final IOException e )
@@ -116,6 +118,8 @@ public class MetadataMergePomChangeListener
                 final Set<Group> groups = dataManager.query().getGroupsAffectedBy( key );
                 if ( groups != null )
                 {
+                    logger.info( "Clearing metadata file {} for following groups which are affected by {}: {}", path,
+                                 key, groups );
                     for ( final Group group : groups )
                     {
                         try


### PR DESCRIPTION
I think these logs can help us check which pom file updating triggered the metadata file clearing, which should happen in promotion process for refreshing the metadata.