### PR TITLE
Enable collection of more metrics (esp. I/O level) via Honeycomb

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloMavenContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloMavenContentAccessResource.java
@@ -26,11 +26,12 @@ import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.folo.model.TrackingKey;
+import org.commonjava.indy.metrics.RequestContextHelper;
 import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import org.commonjava.indy.metrics.RequestContextHelper;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -124,7 +125,7 @@ public class FoloMavenContentAccessResource
         EventMetadata metadata =
                 new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
-        MDC.put( CONTENT_TRACKING_ID, id );
+        RequestContextHelper.setContext( CONTENT_TRACKING_ID, id );
 
         return handler.doHead( PKG_TYPE_MAVEN, type, name, path, cacheOnly, baseUri, request, metadata );
     }
@@ -147,7 +148,7 @@ public class FoloMavenContentAccessResource
         EventMetadata metadata =
                 new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
-        MDC.put( CONTENT_TRACKING_ID, id );
+        RequestContextHelper.setContext( CONTENT_TRACKING_ID, id );
 
         return handler.doGet( PKG_TYPE_MAVEN, type, name, path, baseUri, request, metadata );
     }

--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
@@ -25,13 +25,14 @@ import org.commonjava.indy.bind.jaxrs.IndyResources;
 import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.core.bind.jaxrs.util.RequestUtils;
 import org.commonjava.indy.folo.model.TrackingKey;
+import org.commonjava.indy.metrics.RequestContextHelper;
 import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.pkg.npm.inject.NPMContentHandler;
 import org.commonjava.indy.pkg.npm.jaxrs.NPMContentAccessHandler;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import org.commonjava.indy.metrics.RequestContextHelper;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -153,7 +154,7 @@ public class FoloNPMContentAccessResource
         EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
                                                     .set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
-        MDC.put( CONTENT_TRACKING_ID, id );
+        RequestContextHelper.setContext( CONTENT_TRACKING_ID, id );
 
         return handler.doHead( NPM_PKG_KEY, type, name, packageName, cacheOnly, baseUri, request, metadata );
     }
@@ -176,7 +177,7 @@ public class FoloNPMContentAccessResource
         EventMetadata metadata =
                 new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
-        MDC.put( CONTENT_TRACKING_ID, id );
+        RequestContextHelper.setContext( CONTENT_TRACKING_ID, id );
 
         final String baseUri =  getBasePath( uriInfo, id );
         final String path = Paths.get( packageName, versionTarball ).toString();
@@ -203,7 +204,7 @@ public class FoloNPMContentAccessResource
         EventMetadata metadata = new EventMetadata().set( TRACKING_KEY, tk )
                                                     .set( ACCESS_CHANNEL, AccessChannel.NATIVE );
 
-        MDC.put( CONTENT_TRACKING_ID, id );
+        RequestContextHelper.setContext( CONTENT_TRACKING_ID, id );
 
         return handler.doGet( NPM_PKG_KEY, type, name, packageName, baseUri, request, metadata );
     }
@@ -225,7 +226,7 @@ public class FoloNPMContentAccessResource
         final TrackingKey tk = new TrackingKey( id );
         EventMetadata metadata =
                 new EventMetadata().set( TRACKING_KEY, tk ).set( ACCESS_CHANNEL, AccessChannel.NATIVE );
-        MDC.put( CONTENT_TRACKING_ID, id );
+        RequestContextHelper.setContext( CONTENT_TRACKING_ID, id );
 
         final String path = Paths.get( packageName, versionTarball ).toString();
         final String baseUri = getBasePath( uriInfo, id );

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyAcceptHandler.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyAcceptHandler.java
@@ -31,7 +31,7 @@ import org.commonjava.indy.subsys.template.ScriptEngine;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import org.commonjava.indy.metrics.RequestContextHelper;
 import org.xnio.ChannelListener;
 import org.xnio.StreamConnection;
 import org.xnio.channels.AcceptingChannel;
@@ -135,7 +135,7 @@ public class ProxyAcceptHandler
     public void handleEvent( AcceptingChannel<StreamConnection> channel )
     {
         long start = System.nanoTime();
-        MDC.put( RequestContextHelper.ACCESS_CHANNEL, AccessChannel.GENERIC_PROXY.toString() );
+        RequestContextHelper.setContext( RequestContextHelper.ACCESS_CHANNEL, AccessChannel.GENERIC_PROXY.toString() );
         setContext( PACKAGE_TYPE, PKG_TYPE_GENERIC_HTTP );
 
         final Logger logger = LoggerFactory.getLogger( getClass() );
@@ -157,10 +157,10 @@ public class ProxyAcceptHandler
             return;
         }
 
-        MDC.put( REQUEST_PHASE, REQUEST_PHASE_START );
+        RequestContextHelper.setContext( REQUEST_PHASE, REQUEST_PHASE_START );
         LoggerFactory.getLogger( PROXY_METRIC_LOGGER )
                      .info( "START HTTProx request (from: {})", accepted.getPeerAddress() );
-        MDC.remove( REQUEST_PHASE );
+        RequestContextHelper.clearContext( REQUEST_PHASE );
 
         logger.debug( "accepted {}", accepted.getPeerAddress() );
 

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -45,7 +45,7 @@ import org.commonjava.indy.util.ApplicationStatus;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import org.commonjava.indy.metrics.RequestContextHelper;
 import org.xnio.ChannelListener;
 import org.xnio.StreamConnection;
 import org.xnio.conduits.ConduitStreamSinkChannel;
@@ -278,7 +278,7 @@ public final class ProxyResponseWriter
                             if ( trackingKey != null )
                             {
                                 trackingId = trackingKey.getId();
-                                MDC.put( RequestContextHelper.CONTENT_TRACKING_ID, trackingId );
+                                RequestContextHelper.setContext( RequestContextHelper.CONTENT_TRACKING_ID, trackingId );
                             }
 
                             String authCacheKey = generateAuthCacheKey( proxyUserPass );

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyMeter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyMeter.java
@@ -17,7 +17,7 @@ package org.commonjava.indy.httprox.util;
 
 import org.commonjava.indy.sli.metrics.GoldenSignalsMetricSet;
 import org.slf4j.Logger;
-import org.slf4j.MDC;
+import org.commonjava.indy.metrics.RequestContextHelper;
 
 import java.net.SocketAddress;
 
@@ -73,7 +73,7 @@ public class ProxyMeter
 
             long latency = System.nanoTime() - startNanos;
 
-            MDC.put( REQUEST_LATENCY_NS, String.valueOf( latency ) );
+            RequestContextHelper.setContext( REQUEST_LATENCY_NS, String.valueOf( latency ) );
             setContext( HTTP_METHOD, method );
 
             // log SLI metrics
@@ -89,9 +89,9 @@ public class ProxyMeter
                 } );
             }
 
-            MDC.put( REQUEST_PHASE, REQUEST_PHASE_END );
+            RequestContextHelper.setContext( REQUEST_PHASE, REQUEST_PHASE_END );
             restLogger.info( "END {} (from: {})", requestLine, peerAddress );
-            MDC.remove( REQUEST_PHASE );
+            RequestContextHelper.clearContext( REQUEST_PHASE );
         }
     }
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenContentsFilteringTransferDecorator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenContentsFilteringTransferDecorator.java
@@ -215,7 +215,7 @@ public class MavenContentsFilteringTransferDecorator
                 return "";
             }
 
-            Timer.Context timer = metricsManager == null ? null : metricsManager.getTimer( TIMER ).time();
+            Timer.Context timer = metricsManager == null ? null : metricsManager.startTimer( TIMER );
             try
             {
                 // filter versions from GA metadata
@@ -321,7 +321,7 @@ public class MavenContentsFilteringTransferDecorator
             {
                 if ( timer != null )
                 {
-                    timer.stop();
+                    metricsManager.stopTimer( TIMER );
                 }
             }
         }

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
@@ -159,7 +159,7 @@ public class NPMPackageMaskingTransferDecorator
 
         private void mask( String contextURL ) throws IOException
         {
-            Timer.Context timer = metricsManager == null ? null : metricsManager.getTimer( TIMER ).time();
+            Timer.Context timer = metricsManager == null ? null : metricsManager.startTimer( TIMER );
             try
             {
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -183,7 +183,7 @@ public class NPMPackageMaskingTransferDecorator
             {
                 if ( timer != null )
                 {
-                    timer.stop();
+                    metricsManager.stopTimer( TIMER );
                 }
             }
         }

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -55,7 +55,7 @@ import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.spi.nfc.NotFoundCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import org.commonjava.indy.metrics.RequestContextHelper;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -203,10 +203,10 @@ public class PromotionManager
     public GroupPromoteResult promoteToGroup( GroupPromoteRequest request, String user, String baseUrl )
             throws PromotionException, IndyWorkflowException
     {
-        MDC.put( PROMOTION_ID, request.getPromotionId() );
-        MDC.put( PROMOTION_TYPE, GROUP_PROMOTION );
-        MDC.put( PROMOTION_SOURCE, request.getSource().toString() );
-        MDC.put( PROMOTION_TARGET, request.getTargetKey().toString() );
+        RequestContextHelper.setContext( PROMOTION_ID, request.getPromotionId() );
+        RequestContextHelper.setContext( PROMOTION_TYPE, GROUP_PROMOTION );
+        RequestContextHelper.setContext( PROMOTION_SOURCE, request.getSource().toString() );
+        RequestContextHelper.setContext( PROMOTION_TARGET, request.getTargetKey().toString() );
 
         if ( !storeManager.hasArtifactStore( request.getSource() ) )
         {
@@ -515,10 +515,10 @@ public class PromotionManager
     public PathsPromoteResult promotePaths( final PathsPromoteRequest request, final String baseUrl )
             throws PromotionException, IndyWorkflowException
     {
-        MDC.put( PROMOTION_ID, request.getPromotionId() );
-        MDC.put( PROMOTION_TYPE, PATH_PROMOTION );
-        MDC.put( PROMOTION_SOURCE, request.getSource().toString() );
-        MDC.put( PROMOTION_TARGET, request.getTargetKey().toString() );
+        RequestContextHelper.setContext( PROMOTION_ID, request.getPromotionId() );
+        RequestContextHelper.setContext( PROMOTION_TYPE, PATH_PROMOTION );
+        RequestContextHelper.setContext( PROMOTION_SOURCE, request.getSource().toString() );
+        RequestContextHelper.setContext( PROMOTION_TARGET, request.getTargetKey().toString() );
 
         Future<PathsPromoteResult> future = submitPathsPromoteRequest( request, baseUrl );
         if ( request.isAsync() )
@@ -858,7 +858,7 @@ public class PromotionManager
                 PathTransferResult ret = doPathTransfer( transfer, tgt, request );
                 results.add( ret );
             }
-            MDC.put( PROMOTION_CONTENT_PATH, pathsForMDC.toString() );
+            RequestContextHelper.setContext( PROMOTION_CONTENT_PATH, pathsForMDC.toString() );
             return results;
         };
     }

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -55,6 +55,7 @@ import org.commonjava.maven.galley.model.TransferOperation;
 import org.commonjava.maven.galley.transport.htcli.model.HttpExchangeMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.commonjava.indy.metrics.RequestContextHelper;
 import org.slf4j.MDC;
 
 import javax.inject.Inject;
@@ -633,8 +634,8 @@ public class PromotionValidationTools
                 logger.trace( "The paralleled exe on batch {}", batch );
                 batch.forEach( e -> {
                     String depthStr = MDC.get( ITERATION_DEPTH );
-                    MDC.put( ITERATION_DEPTH, depthStr == null ? "0" : String.valueOf( Integer.parseInt( depthStr ) + 1 ) );
-                    MDC.put( ITERATION_ITEM, String.valueOf( e ) );
+                    RequestContextHelper.setContext( ITERATION_DEPTH, depthStr == null ? "0" : String.valueOf( Integer.parseInt( depthStr ) + 1 ) );
+                    RequestContextHelper.setContext( ITERATION_ITEM, String.valueOf( e ) );
                     try
                     {
                         closure.call( e );
@@ -661,8 +662,8 @@ public class PromotionValidationTools
         final CountDownLatch latch = new CountDownLatch( todo.size() );
         todo.forEach( e -> ruleParallelExecutor.execute( () -> {
             String depthStr = MDC.get( ITERATION_DEPTH );
-            MDC.put( ITERATION_DEPTH, depthStr == null ? "0" : String.valueOf( Integer.parseInt( depthStr ) + 1 ) );
-            MDC.put( ITERATION_ITEM, String.valueOf( e ) );
+            RequestContextHelper.setContext( ITERATION_DEPTH, depthStr == null ? "0" : String.valueOf( Integer.parseInt( depthStr ) + 1 ) );
+            RequestContextHelper.setContext( ITERATION_ITEM, String.valueOf( e ) );
 
             try
             {

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
@@ -43,6 +43,7 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.model.Transfer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.commonjava.indy.metrics.RequestContextHelper;
 import org.slf4j.MDC;
 
 import javax.inject.Inject;
@@ -145,7 +146,7 @@ public class PromotionValidator
         if ( set != null )
         {
             result.setRuleSet( set.getName() );
-            MDC.put( PROMOTION_VALIDATION_RULE_SET, set.getName() );
+            RequestContextHelper.setContext( PROMOTION_VALIDATION_RULE_SET, set.getName() );
 
             logger.debug( "Running validation rule-set for promotion: {}", set.getName() );
 
@@ -163,7 +164,7 @@ public class PromotionValidator
                         for ( String ruleRef : ruleNames )
                         {
                             svc.submit( () -> {
-                                MDC.put( PROMOTION_VALIDATION_RULE, ruleRef );
+                                RequestContextHelper.setContext( PROMOTION_VALIDATION_RULE, ruleRef );
                                 Exception err = null;
                                 try
                                 {
@@ -175,7 +176,7 @@ public class PromotionValidator
                                 }
                                 finally
                                 {
-                                    MDC.remove( PROMOTION_VALIDATION_RULE );
+                                    RequestContextHelper.clearContext( PROMOTION_VALIDATION_RULE );
                                 }
 
                                 return err;

--- a/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
+++ b/addons/sli/jaxrs/src/main/java/org/commonjava/indy/sli/jaxrs/GoldenSignalsFilter.java
@@ -31,7 +31,7 @@ import org.commonjava.maven.galley.model.SpecialPathInfo;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
+import org.commonjava.indy.metrics.RequestContextHelper;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -53,6 +53,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.StringUtils.join;
+import static org.commonjava.indy.IndyContentConstants.NANOS_PER_MILLISECOND;
+import static org.commonjava.indy.metrics.RequestContextHelper.REQUEST_LATENCY_MILLIS;
 import static org.commonjava.indy.metrics.RequestContextHelper.REQUEST_LATENCY_NS;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
@@ -141,7 +143,8 @@ public class GoldenSignalsFilter
             // latency.
             long end = RequestContextHelper.getRequestEndNanos() - RequestContextHelper.getRawIoWriteNanos();
 
-            MDC.put( REQUEST_LATENCY_NS, String.valueOf( end - start ) );
+            RequestContextHelper.setContext( REQUEST_LATENCY_NS, String.valueOf( end - start ) );
+            RequestContextHelper.setContext( REQUEST_LATENCY_MILLIS, (end-start) / NANOS_PER_MILLISECOND  );
 
             Set<String> functions = new HashSet<>( getFunctions( req.getPathInfo(), req.getMethod() ) );
             boolean error = resp.getStatus() > 499;

--- a/api/src/main/java/org/commonjava/indy/metrics/RequestContextHelper.java
+++ b/api/src/main/java/org/commonjava/indy/metrics/RequestContextHelper.java
@@ -120,6 +120,9 @@ public class RequestContextHelper
     @MDC
     public static final String REQUEST_LATENCY_NS = "request-latency-ns";
 
+    @Thread
+    public static final String REQUEST_LATENCY_MILLIS = "request-latency";
+
     @MDC
     public static final String REQUEST_PHASE = "request-phase";
 

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -31,7 +31,12 @@ import org.commonjava.indy.metrics.conf.IndyMetricsConfig;
 import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
-import org.commonjava.indy.util.*;
+import org.commonjava.indy.util.AcceptInfo;
+import org.commonjava.indy.util.ApplicationContent;
+import org.commonjava.indy.util.ApplicationHeader;
+import org.commonjava.indy.util.ApplicationStatus;
+import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.indy.util.UriFormatter;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.io.checksum.ContentDigest;
 import org.commonjava.maven.galley.model.SpecialPathInfo;
@@ -56,13 +61,13 @@ import java.net.URI;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import static org.commonjava.indy.core.ctl.ContentController.LISTING_HTML_FILE;
 import static org.commonjava.indy.metrics.RequestContextHelper.CONTENT_ENTRY_POINT;
 import static org.commonjava.indy.metrics.RequestContextHelper.HTTP_STATUS;
 import static org.commonjava.indy.metrics.RequestContextHelper.METADATA_CONTENT;
 import static org.commonjava.indy.metrics.RequestContextHelper.PACKAGE_TYPE;
 import static org.commonjava.indy.metrics.RequestContextHelper.PATH;
 import static org.commonjava.indy.metrics.RequestContextHelper.setContext;
-import static org.commonjava.indy.core.ctl.ContentController.LISTING_HTML_FILE;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
 
 @ApplicationScoped

--- a/embedder/src/main/resources/META-INF/beans.xml
+++ b/embedder/src/main/resources/META-INF/beans.xml
@@ -30,7 +30,7 @@
   <interceptors>
     <class>org.commonjava.indy.bind.jaxrs.util.RestInterceptor</class>
     <class>org.commonjava.indy.metrics.jaxrs.interceptor.MetricsInterceptor</class>
-    <class>org.commonjava.indy.subsys.honeycomb.interceptor.HoneycombInterceptor</class>
+    <class>org.commonjava.indy.subsys.honeycomb.interceptor.HoneycombMeasureInterceptor</class>
   </interceptors>
 
   <!-- NOTE: In the decorators below, the FIRST listed will be invoked FIRST (outer-most in the stack) -->

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/IOLatencyDecorator.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/IOLatencyDecorator.java
@@ -23,6 +23,7 @@ import org.commonjava.maven.galley.event.EventMetadata;
 import org.commonjava.maven.galley.io.AbstractTransferDecorator;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.spi.metrics.TimingProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,13 +34,13 @@ import java.util.function.Function;
 public class IOLatencyDecorator
         extends AbstractTransferDecorator
 {
-    private Function<String, Timer.Context> timerProvider;
+    private Function<String, TimingProvider> timerProvider;
 
     private Function<String, Meter> meterProvider;
 
     private BiConsumer<String, Double> cumulativeTimer;
 
-    public IOLatencyDecorator( final Function<String, Timer.Context> timerProvider,
+    public IOLatencyDecorator( final Function<String, TimingProvider> timerProvider,
                                final Function<String, Meter> meterProvider,
                                final BiConsumer<String, Double> cumulativeTimer )
     {

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/IndyTimingProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/IndyTimingProvider.java
@@ -1,0 +1,30 @@
+package org.commonjava.indy.filer.def;
+
+import org.commonjava.indy.metrics.IndyMetricsManager;
+import org.commonjava.maven.galley.spi.metrics.TimingProvider;
+
+public class IndyTimingProvider
+        implements TimingProvider
+{
+    private final String name;
+
+    private final IndyMetricsManager metricsManager;
+
+    public IndyTimingProvider( final String name, final IndyMetricsManager metricsManager )
+    {
+        this.name = name;
+        this.metricsManager = metricsManager;
+    }
+
+    @Override
+    public void start( final String name )
+    {
+        metricsManager.startTimer( name );
+    }
+
+    @Override
+    public long stop()
+    {
+        return metricsManager.stopTimer( name );
+    }
+}

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/TimingInputStream.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/TimingInputStream.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import org.apache.commons.io.input.CountingInputStream;
 import org.commonjava.indy.metrics.RequestContextHelper;
+import org.commonjava.maven.galley.spi.metrics.TimingProvider;
 import org.commonjava.maven.galley.util.IdempotentCloseInputStream;
 
 import java.io.IOException;
@@ -38,17 +39,17 @@ public class TimingInputStream
 
     private Long nanos;
 
-    private Function<String, Timer.Context> timerProvider;
+    private Function<String, TimingProvider> timerProvider;
 
     private final Function<String, Meter> meterProvider;
 
     private BiConsumer<String, Double> cumulativeTimer;
 
-    private Timer.Context timer;
+    private TimingProvider timer;
 
     private Meter meter;
 
-    public TimingInputStream( final CountingInputStream stream, final Function<String, Timer.Context> timerProvider,
+    public TimingInputStream( final CountingInputStream stream, final Function<String, TimingProvider> timerProvider,
                               final Function<String, Meter> meterProvider,
                               final BiConsumer<String, Double> cumulativeTimer )
     {

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/TimingOutputStream.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/TimingOutputStream.java
@@ -19,6 +19,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.commonjava.indy.metrics.RequestContextHelper;
+import org.commonjava.maven.galley.spi.metrics.TimingProvider;
 import org.commonjava.maven.galley.util.IdempotentCloseOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,17 +43,17 @@ public class TimingOutputStream
 
     private Long nanos;
 
-    private Function<String, Timer.Context> timerProvider;
+    private Function<String, TimingProvider> timerProvider;
 
     private Function<String, Meter> meterProvider;
 
-    private Timer.Context timer;
+    private TimingProvider timer;
 
     private Meter meter;
 
     private BiConsumer<String, Double> cumulativeConsumer;
 
-    public TimingOutputStream( final CountingOutputStream stream, Function<String, Timer.Context> timerProvider,
+    public TimingOutputStream( final CountingOutputStream stream, Function<String, TimingProvider> timerProvider,
                                Function<String, Meter> meterProvider, BiConsumer<String, Double> cumulativeConsumer )
     {
         super( stream );

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.0</atlasVersion>
-    <galleyVersion>1.0</galleyVersion>
+    <galleyVersion>1.1-SNAPSHOT</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.16</partylineVersion>

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/HoneycombManager.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/HoneycombManager.java
@@ -61,6 +61,11 @@ public class HoneycombManager
         return client;
     }
 
+    public Beeline getBeeline()
+    {
+        return beeline;
+    }
+
     public Span startRootTracer( String spanName )
     {
         if ( beeline != null )

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/config/HoneycombConfiguration.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/config/HoneycombConfiguration.java
@@ -29,6 +29,8 @@ import static org.commonjava.indy.metrics.RequestContextHelper.HTTP_STATUS;
 import static org.commonjava.indy.metrics.RequestContextHelper.PACKAGE_TYPE;
 import static org.commonjava.indy.metrics.RequestContextHelper.PATH;
 import static org.commonjava.indy.metrics.RequestContextHelper.PREFERRED_ID;
+import static org.commonjava.indy.metrics.RequestContextHelper.REQUEST_LATENCY_MILLIS;
+import static org.commonjava.indy.metrics.RequestContextHelper.REST_ENDPOINT_PATH;
 import static org.commonjava.indy.metrics.RequestContextHelper.REST_METHOD_PATH;
 import static org.commonjava.indy.metrics.RequestContextHelper.X_FORWARDED_FOR;
 
@@ -38,7 +40,7 @@ public class HoneycombConfiguration
                 implements IndyConfigInfo
 {
     private static final String[] FIELDS =
-            { CONTENT_TRACKING_ID, HTTP_METHOD, HTTP_STATUS, PREFERRED_ID, CLIENT_ADDR, PATH, PACKAGE_TYPE, REST_METHOD_PATH };
+            { CONTENT_TRACKING_ID, HTTP_METHOD, HTTP_STATUS, PREFERRED_ID, CLIENT_ADDR, PATH, PACKAGE_TYPE, REST_ENDPOINT_PATH, REQUEST_LATENCY_MILLIS };
 
     private boolean enabled;
 

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombInterceptorUtils.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombInterceptorUtils.java
@@ -1,0 +1,37 @@
+package org.commonjava.indy.subsys.honeycomb.interceptor;
+
+import io.honeycomb.beeline.tracing.Span;
+import org.commonjava.cdi.util.weft.ThreadContext;
+import org.commonjava.indy.measure.annotation.MetricWrapperNamed;
+
+import javax.interceptor.InvocationContext;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.LinkedList;
+
+public class HoneycombInterceptorUtils
+{
+
+    private static final String SPAN_STACK = "honeycomb-span-stack";
+
+    public static String getMetricNameFromParam( InvocationContext context )
+    {
+        String name = null;
+
+        Method method = context.getMethod();
+        Parameter[] parameters = method.getParameters();
+        for ( int i=0; i<parameters.length; i++)
+        {
+            Parameter param = parameters[i];
+            MetricWrapperNamed annotation = param.getAnnotation( MetricWrapperNamed.class );
+            if ( annotation != null )
+            {
+                name = String.valueOf( context.getParameters()[i] );
+                break;
+            }
+        }
+
+        return name;
+    }
+
+}

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombMeasureInterceptor.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombMeasureInterceptor.java
@@ -39,7 +39,7 @@ import static org.commonjava.indy.metrics.RequestContextHelper.getContext;
 
 @Interceptor
 @Measure
-public class HoneycombInterceptor
+public class HoneycombMeasureInterceptor
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombWrapperEndInterceptor.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombWrapperEndInterceptor.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.honeycomb.interceptor;
+
+import io.honeycomb.beeline.tracing.Span;
+import org.commonjava.indy.measure.annotation.MetricWrapper;
+import org.commonjava.indy.measure.annotation.MetricWrapperNamed;
+import org.commonjava.indy.subsys.honeycomb.HoneycombManager;
+import org.commonjava.indy.subsys.honeycomb.config.HoneycombConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.stream.Stream;
+
+import static org.commonjava.indy.metrics.RequestContextHelper.getContext;
+
+@Interceptor
+@MetricWrapper
+public class HoneycombWrapperEndInterceptor
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private HoneycombConfiguration config;
+
+    @Inject
+    private HoneycombManager honeycombManager;
+
+    @AroundInvoke
+    public Object operation( InvocationContext context ) throws Exception
+    {
+        if ( !config.isEnabled() )
+        {
+            return context.proceed();
+        }
+
+        Span span = honeycombManager.getBeeline().getActiveSpan();
+        if ( span != null )
+        {
+            Span theSpan = span;
+            Stream.of( config.getFields()).forEach( field->{
+                Object value = getContext( field );
+                if ( value != null )
+                {
+                    theSpan.addField( field, value );
+                }
+            });
+
+            logger.trace( "closeSpan, {}", span );
+            span.close();
+        }
+
+        return context.proceed();
+    }
+
+}

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombWrapperInterceptor.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombWrapperInterceptor.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.honeycomb.interceptor;
+
+import io.honeycomb.beeline.tracing.Span;
+import org.commonjava.indy.measure.annotation.Measure;
+import org.commonjava.indy.measure.annotation.MetricWrapper;
+import org.commonjava.indy.measure.annotation.MetricWrapperNamed;
+import org.commonjava.indy.subsys.honeycomb.HoneycombManager;
+import org.commonjava.indy.subsys.honeycomb.config.HoneycombConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.stream.Stream;
+
+import static org.commonjava.indy.metrics.IndyMetricsConstants.getDefaultName;
+import static org.commonjava.indy.metrics.RequestContextHelper.getContext;
+
+@Interceptor
+@MetricWrapper
+public class HoneycombWrapperInterceptor
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private HoneycombConfiguration config;
+
+    @Inject
+    private HoneycombManager honeycombManager;
+
+    @AroundInvoke
+    public Object operation( InvocationContext context ) throws Exception
+    {
+        if ( !config.isEnabled() )
+        {
+            return context.proceed();
+        }
+
+        String name = HoneycombInterceptorUtils.getMetricNameFromParam( context );
+        if ( name == null )
+        {
+            context.proceed();
+        }
+
+        Span span = null;
+        try
+        {
+            span = honeycombManager.startChildSpan( name );
+            if ( span != null )
+            {
+                span.markStart();
+            }
+
+            logger.trace( "startChildSpan, span: {}, defaultName: {}", span, name );
+            return context.proceed();
+        }
+        finally
+        {
+            if ( span != null )
+            {
+                Span theSpan = span;
+                Stream.of( config.getFields()).forEach( field->{
+                    Object value = getContext( field );
+                    if ( value != null )
+                    {
+                        theSpan.addField( field, value );
+                    }
+                });
+
+                logger.trace( "closeSpan, {}", span );
+                span.close();
+            }
+        }
+    }
+
+}

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombWrapperStartInterceptor.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombWrapperStartInterceptor.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.subsys.honeycomb.interceptor;
+
+import io.honeycomb.beeline.tracing.Span;
+import org.commonjava.indy.measure.annotation.MetricWrapper;
+import org.commonjava.indy.measure.annotation.MetricWrapperNamed;
+import org.commonjava.indy.measure.annotation.MetricWrapperStart;
+import org.commonjava.indy.subsys.honeycomb.HoneycombManager;
+import org.commonjava.indy.subsys.honeycomb.config.HoneycombConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.stream.Stream;
+
+import static org.commonjava.indy.metrics.RequestContextHelper.getContext;
+
+@Interceptor
+@MetricWrapperStart
+public class HoneycombWrapperStartInterceptor
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private HoneycombConfiguration config;
+
+    @Inject
+    private HoneycombManager honeycombManager;
+
+    @AroundInvoke
+    public Object operation( InvocationContext context ) throws Exception
+    {
+        if ( !config.isEnabled() )
+        {
+            return context.proceed();
+        }
+
+        String name = HoneycombInterceptorUtils.getMetricNameFromParam( context );
+        if ( name == null )
+        {
+            context.proceed();
+        }
+
+        try
+        {
+            Span span = honeycombManager.startChildSpan( name );
+            if ( span != null )
+            {
+                span.markStart();
+            }
+
+            logger.trace( "startChildSpan, span: {}, defaultName: {}", span, name );
+        }
+        catch ( Exception e )
+        {
+            logger.error( "Error in honeycomb subsystem! " + e.getMessage(), e );
+        }
+
+        return context.proceed();
+    }
+
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/MDCManager.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/MDCManager.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.bind.jaxrs;
 import org.apache.http.Header;
 import org.apache.http.HttpRequest;
 import org.commonjava.indy.conf.IndyConfiguration;
+import org.commonjava.indy.metrics.RequestContextHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -26,13 +27,11 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 import static org.apache.commons.lang.StringUtils.isNotBlank;
-
 import static org.commonjava.indy.metrics.RequestContextHelper.CLIENT_ADDR;
 import static org.commonjava.indy.metrics.RequestContextHelper.COMPONENT_ID;
 import static org.commonjava.indy.metrics.RequestContextHelper.EXTERNAL_ID;
@@ -87,26 +86,26 @@ public class MDCManager
 
     public void putRequestIDs( String internalID, String externalID, String preferredID )
     {
-        MDC.put( PREFERRED_ID, preferredID );
-        MDC.put( INTERNAL_ID, internalID );
+        RequestContextHelper.setContext( PREFERRED_ID, preferredID );
+        RequestContextHelper.setContext( INTERNAL_ID, internalID );
 
         if ( externalID != null )
         {
-            MDC.put( EXTERNAL_ID, externalID );
+            RequestContextHelper.setContext( EXTERNAL_ID, externalID );
         }
     }
 
     public void putUserIP( String userIp )
     {
-        MDC.put( CLIENT_ADDR, userIp );
+        RequestContextHelper.setContext( CLIENT_ADDR, userIp );
     }
 
     public void putExtraHeaders( HttpServletRequest request )
     {
         // use setContext here so we get this value in ThreadContext too, for decision-making in the workflow, SLI classification, etc.
         setContext( HTTP_METHOD, request.getMethod() );
-        MDC.put( HTTP_REQUEST_URI, request.getRequestURI() );
-        mdcHeadersList.forEach( ( header ) -> MDC.put( header, request.getHeader( header ) ) );
+        RequestContextHelper.setContext( HTTP_REQUEST_URI, request.getRequestURI() );
+        mdcHeadersList.forEach( ( header ) -> RequestContextHelper.setContext( header, request.getHeader( header ) ) );
     }
 
     public void putExtraHeaders( HttpRequest httpRequest )
@@ -115,7 +114,7 @@ public class MDCManager
             Header h = httpRequest.getFirstHeader( header );
             if ( h != null )
             {
-                MDC.put( header, h.getValue() );
+                RequestContextHelper.setContext( header, h.getValue() );
             }
         } );
     }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ResourceManagementFilter.java
@@ -19,6 +19,7 @@ import org.commonjava.cdi.util.weft.ThreadContext;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.metrics.IndyMetricsConstants;
 import org.commonjava.indy.metrics.IndyMetricsManager;
+import org.commonjava.indy.metrics.RequestContextHelper;
 import org.commonjava.maven.galley.model.SpecialPathInfo;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.maven.galley.spi.io.SpecialPathManager;
@@ -149,7 +150,7 @@ public class ResourceManagementFilter
 
             Thread.currentThread().setName( tn );
 
-            MDC.put( REQUEST_PHASE, REQUEST_PHASE_START );
+            RequestContextHelper.setContext( REQUEST_PHASE, REQUEST_PHASE_START );
             restLogger.info( "START {}{} (from: {})", hsr.getRequestURL(), qs == null ? "" : "?" + qs, clientAddr );
             MDC.remove( REQUEST_PHASE );
 
@@ -201,14 +202,14 @@ public class ResourceManagementFilter
                 if ( cumulativeTimings != null )
                 {
                     cumulativeTimings.forEach(
-                            ( k, v ) -> MDC.put( CUMULATIVE_TIMINGS + "." + k, String.format( "%.3f", v ) ) );
+                            ( k, v ) -> RequestContextHelper.setContext( CUMULATIVE_TIMINGS + "." + k, String.format( "%.3f", v ) ) );
                 }
 
                 Map<String, Integer> cumulativeCounts = (Map<String, Integer>) ctx.get( CUMULATIVE_COUNTS );
                 if ( cumulativeCounts != null )
                 {
                     cumulativeCounts.forEach(
-                            ( k, v ) -> MDC.put( CUMULATIVE_COUNTS + "." + k, String.format( "%d", v ) ) );
+                            ( k, v ) -> RequestContextHelper.setContext( CUMULATIVE_COUNTS + "." + k, String.format( "%d", v ) ) );
                 }
             }
 

--- a/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/MetricWrapper.java
+++ b/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/MetricWrapper.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.measure.annotation;
+
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Target( { METHOD, TYPE } )
+@Retention( RUNTIME )
+public @interface MetricWrapper
+{
+}

--- a/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/MetricWrapperEnd.java
+++ b/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/MetricWrapperEnd.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.measure.annotation;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Target( { METHOD, TYPE } )
+@Retention( RUNTIME )
+public @interface MetricWrapperEnd
+{
+}

--- a/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/MetricWrapperNamed.java
+++ b/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/MetricWrapperNamed.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.measure.annotation;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Target( { PARAMETER } )
+@Retention( RUNTIME )
+public @interface MetricWrapperNamed
+{
+}

--- a/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/MetricWrapperStart.java
+++ b/subsys/metrics/core/src/main/java/org/commonjava/indy/measure/annotation/MetricWrapperStart.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.measure.annotation;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Target( { METHOD, TYPE } )
+@Retention( RUNTIME )
+public @interface MetricWrapperStart
+{
+}

--- a/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
+++ b/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/jaxrs/interceptor/MetricsInterceptor.java
@@ -140,12 +140,12 @@ public class MetricsInterceptor
 
         String name = getName( config.getNodePrefix(), DEFAULT, defaultName, TIMER );
         timers.put(name,
-                metricsManager.getTimer( name ).time() );
+                metricsManager.startTimer( name ) );
 
         MetricNamed[] timerMetrics = measure.timers();
         Stream.of( timerMetrics ).forEach( named -> {
             String timerName = getName( config.getNodePrefix(), named.value(), defaultName, TIMER );
-            Timer.Context tc = metricsManager.getTimer( timerName ).time();
+            Timer.Context tc = metricsManager.startTimer( timerName );
             logger.trace( "START: {} ({})", timerName, tc );
             timers.put( timerName, tc );
         } );


### PR DESCRIPTION
This required refactoring the Galley timing function providers, using a new patch of Galley that
attempts to generalize the metrics interface, at least for I/O operations.

It also involved creating three new interceptors, which would handle methods that are designed to
wrap arbitrary pieces of code in metrics.