### PR TITLE
Not delete read-only legacy files

### DIFF
--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -54,6 +54,7 @@ import org.commonjava.storage.pathmapped.config.PathMappedStorageConfig;
 import org.commonjava.storage.pathmapped.pathdb.datastax.CassandraPathDB;
 import org.commonjava.storage.pathmapped.metrics.MeasuredPathDB;
 import org.commonjava.storage.pathmapped.spi.PathDB;
+import org.commonjava.storage.pathmapped.spi.PhysicalStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +71,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -193,9 +193,11 @@ public class DefaultGalleyStorageProvider
             pathDB = new MeasuredPathDB( pathDB, metricsManager.getMetricRegistry(), getSupername( prefix, "pathDB" ) );
         }
 
+        PhysicalStore physicalStore = new LegacyReadonlyPhysicalStore( storeRoot );
+
         cacheProviderFactory =
                         new PathMappedCacheProviderFactory( storeRoot, deleteExecutor, pathMappedStorageConfig, pathDB,
-                                                            null );
+                                                            physicalStore );
     }
 
     private PathMappedStorageConfig getPathMappedStorageConfig()

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/LegacyReadonlyPhysicalStore.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/LegacyReadonlyPhysicalStore.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.filer.def;
+
+import org.commonjava.storage.pathmapped.core.FileBasedPhysicalStore;
+import org.commonjava.storage.pathmapped.spi.FileInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+public class LegacyReadonlyPhysicalStore
+                extends FileBasedPhysicalStore
+{
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    public LegacyReadonlyPhysicalStore( File baseDir )
+    {
+        super( baseDir );
+    }
+
+    @Override
+    public boolean delete( FileInfo fileInfo )
+    {
+        String fileStorage = fileInfo.getFileStorage();
+        if ( isLegacyFile( fileStorage ) )
+        {
+            logger.debug( "Skip read-only legacy file: {}", fileStorage );
+            return true;
+        }
+        return super.delete( fileInfo );
+    }
+
+    //Legacy folders: generic-http, maven, npm
+    private boolean isLegacyFile( String fileStorage )
+    {
+        return fileStorage != null && ( fileStorage.startsWith( "maven" ) || fileStorage.startsWith( "generic-http" )
+                        || fileStorage.startsWith( "npm" ) );
+    }
+}

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/LegacyReadonlyPhysicalStore.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/LegacyReadonlyPhysicalStore.java
@@ -22,6 +22,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_GENERIC_HTTP;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+
 public class LegacyReadonlyPhysicalStore
                 extends FileBasedPhysicalStore
 {
@@ -47,7 +51,7 @@ public class LegacyReadonlyPhysicalStore
     //Legacy folders: generic-http, maven, npm
     private boolean isLegacyFile( String fileStorage )
     {
-        return fileStorage != null && ( fileStorage.startsWith( "maven" ) || fileStorage.startsWith( "generic-http" )
-                        || fileStorage.startsWith( "npm" ) );
+        return fileStorage != null && ( fileStorage.startsWith( PKG_TYPE_MAVEN ) || fileStorage.startsWith(
+                        PKG_TYPE_GENERIC_HTTP ) || fileStorage.startsWith( PKG_TYPE_NPM ) );
     }
 }


### PR DESCRIPTION
This will prevent legacy files from being deleted. 
Basically we have two ways to handle deletion for legacy files. One is to delay the deletion (turn on GC later, all to-be-deleted files are in db). The other is not to delete them at all ( this PR ). I am not sure which is better and open to suggestion.