### PR TITLE
Add maint endpoint to expose ispn cache/entry and affectedby result

### DIFF
--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
@@ -199,7 +199,18 @@ public class MaintenanceHandler
     public Response cleanInfinispanCache(
                     @ApiParam( "The name of cache to clean" ) @PathParam( "name" ) final String name )
     {
-        return Response.status( FORBIDDEN ).build();
+        Response response;
+        try
+        {
+            ispnCacheController.clean( name );
+            response = Response.ok().build();
+        }
+        catch ( IndyWorkflowException e )
+        {
+            logger.error( String.format( "Failed to clean: %s. Reason: %s", name, e.getMessage() ), e );
+            response = responseHelper.formatResponse( e );
+        }
+        return response;
     }
 
     @ApiOperation( "Export the specified Infinispan cache." )

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.core.bind.jaxrs.admin;
 
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
 
 import javax.inject.Inject;
@@ -22,6 +23,7 @@ import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import io.swagger.annotations.Api;
@@ -34,12 +36,17 @@ import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.core.ctl.IspnCacheController;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Set;
 
 @Api( value="Maintenance", description = "Basic repository maintenance functions" )
 @Path( "/api/admin/maint" )
@@ -52,6 +59,12 @@ public class MaintenanceHandler
 
     @Inject
     private ContentController contentController;
+
+    @Inject
+    private StoreDataManager storeDataManager;
+
+    @Inject
+    private IndyObjectMapper mapper;
 
     @Inject
     private ResponseHelper responseHelper;
@@ -184,17 +197,53 @@ public class MaintenanceHandler
     @Path( "/infinispan/cache/{name}" )
     @DELETE
     public Response cleanInfinispanCache(
-                    @ApiParam( "The name of cache to clean, 'all' for all caches" ) @PathParam( "name" ) final String name )
+                    @ApiParam( "The name of cache to clean" ) @PathParam( "name" ) final String name )
+    {
+        return Response.status( FORBIDDEN ).build();
+    }
+
+    @ApiOperation( "Export the specified Infinispan cache." )
+    @ApiResponse( code = 200, message = "Export complete." )
+    @Produces( "application/json" )
+    @Path( "/infinispan/cache/{name}{key: (/.+)?}" )
+    @GET
+    public Response exportInfinispanCache(
+                    @ApiParam( "The name of cache to export" ) @PathParam( "name" ) final String name,
+                    @ApiParam( "The cache key" ) @PathParam( "key" ) final String key
+    )
     {
         Response response;
         try
         {
-            ispnCacheController.clean( name );
-            response = Response.ok().build();
+            String json = ispnCacheController.export( name, key );
+            response = Response.ok( json ).build();
         }
-        catch ( final IndyWorkflowException e )
+        catch ( final Exception e )
         {
-            logger.error( String.format( "Failed to clean: %s. Reason: %s", name, e.getMessage() ), e );
+            logger.error( String.format( "Failed to export: %s. Reason: %s", name, e.getMessage() ), e );
+            response = responseHelper.formatResponse( e );
+        }
+        return response;
+    }
+
+    @ApiOperation( "Get groups affected by specified repo." )
+    @ApiResponse( code = 200, message = "Complete." )
+    @Produces( "application/json" )
+    @Path( "/store/affected/{key}" )
+    @GET
+    public Response affectedBy( @ApiParam( "The store key" ) @PathParam( "key" ) final String key )
+    {
+        Response response;
+        try
+        {
+            Set<StoreKey> storeKeys = new HashSet<>();
+            storeKeys.add( StoreKey.fromString( key ) );
+            Set<Group> groups = storeDataManager.affectedBy( storeKeys );
+            response = Response.ok( mapper.writeValueAsString( groups ) ).build();
+        }
+        catch ( final Exception e )
+        {
+            logger.error( String.format( "Failed to export: %s. Reason: %s", key, e.getMessage() ), e );
             response = responseHelper.formatResponse( e );
         }
         return response;

--- a/core/src/main/java/org/commonjava/indy/core/ctl/IspnCacheController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/IspnCacheController.java
@@ -59,6 +59,21 @@ public class IspnCacheController
         string2keyMapper.put( "default", "org.commonjava.indy.pkg.maven.content.StoreKey2StringMapper" );
     }
 
+    public void clean( String name ) throws IndyWorkflowException
+    {
+        if ( name.startsWith( "folo" ) || name.startsWith( "store" ) || name.startsWith( "schedule" ) )
+        {
+            throw new IndyWorkflowException( "Can not clean cache, name: " + name );
+        }
+
+        Cache<Object, Object> cache = cacheManager.getCache( name );
+        if ( cache == null )
+        {
+            throw new IndyWorkflowException( "Cache not found, name: " + name );
+        }
+        cache.clear();
+    }
+
     // only work for some caches for debugging
     public String export( String cacheName, String key ) throws Exception
     {

--- a/core/src/main/java/org/commonjava/indy/core/ctl/IspnCacheController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/IspnCacheController.java
@@ -16,16 +16,22 @@
 package org.commonjava.indy.core.ctl;
 
 import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import org.infinispan.Cache;
 import org.infinispan.manager.EmbeddedCacheManager;
+import org.infinispan.persistence.keymappers.TwoWayKey2StringMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.Set;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 @ApplicationScoped
 public class IspnCacheController
@@ -37,44 +43,49 @@ public class IspnCacheController
     @Inject
     private CacheProducer cacheProducer;
 
+    @Inject
+    private IndyObjectMapper mapper;
+
     private EmbeddedCacheManager cacheManager;
+
+    private Map<String, String> string2keyMapper;
 
     @PostConstruct
     private void setUp()
     {
         cacheManager = cacheProducer.getCacheManager();
+        string2keyMapper = new HashMap<>();
+        string2keyMapper.put( "content-index", "org.commonjava.indy.content.index.ISPFieldStringKey2StringMapper" );
+        string2keyMapper.put( "default", "org.commonjava.indy.pkg.maven.content.StoreKey2StringMapper" );
     }
 
-    public void clean( String name ) throws IndyWorkflowException
+    // only work for some caches for debugging
+    public String export( String cacheName, String key ) throws Exception
     {
-        if ( ALL_CACHES.equals( name ) ) // clean all caches
-        {
-            Set<String> names = cacheManager.getCacheNames();
-            names.forEach( ( n ) -> {
-                if ( !isFoloCache( n ) ) // Prohibit clear of folo caches
-                {
-                   cacheManager.getCache( n ).clear();
-                }
-            } );
-            return;
-        }
-
-        if ( isFoloCache( name ) )
-        {
-            throw new IndyWorkflowException( "Can not clean folo caches, name: " + name );
-        }
-
-        // clean named cache
-        Cache<Object, Object> cache = cacheManager.getCache( name );
+        Cache<Object, Object> cache = cacheManager.getCache( cacheName );
         if ( cache == null )
         {
-            throw new IndyWorkflowException( "Cache not found, name: " + name );
+            throw new IndyWorkflowException( "Cache not found, name: " + cacheName );
         }
-        cache.clear();
+        if ( isNotBlank( key ) )
+        {
+            if ( key.startsWith( "/" ) )
+            {
+                key = key.substring( 1 );
+            }
+            String stringMapperClass = string2keyMapper.get( cacheName );
+            if ( stringMapperClass == null )
+            {
+                stringMapperClass = string2keyMapper.get( "default" );
+            }
+            TwoWayKey2StringMapper stringMapper =
+                            (TwoWayKey2StringMapper) Class.forName( stringMapperClass ).newInstance();
+            return mapper.writeValueAsString( cache.get( stringMapper.getKeyMapping( key ) ) );
+        }
+        else
+        {
+            return mapper.writeValueAsString( cache.entrySet() );
+        }
     }
 
-    private boolean isFoloCache( String name )
-    {
-        return name != null && name.startsWith( "folo" );
-    }
 }


### PR DESCRIPTION
This PR add a few endpoints for debugging store related issues. It does:
1. Get the affected-by for a repo, e.g., /api/admin/maint/store/affected/maven:remote:central
2. Expose ISPN cache content ( or entry given the key ). e.g.,
/api/admin/maint/infinispan/cache/affected-by-stores
/api/admin/maint/infinispan/cache/store-data/maven:group:public
3. Forbid a dangerous clean cache endpoint ( that was added when most caches were disposable but now it is really a risk ) 
