### PR TITLE
Lower the log level from info to debug in Honeycomb interceptor

### DIFF
--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
@@ -55,7 +55,7 @@ public class CassandraClient
     {
         if ( !config.isEnabled() )
         {
-            logger.debug( "Cassandra client not enabled" );
+            logger.info( "Cassandra client not enabled" );
             return;
         }
         try
@@ -74,13 +74,13 @@ public class CassandraClient
             String password = config.getCassandraPass();
             if ( isNotBlank( username ) && isNotBlank( password ) )
             {
-                logger.debug( "Build with credentials, user: {}, pass: ****", username );
+                logger.info( "Build with credentials, user: {}, pass: ****", username );
                 builder.withCredentials( username, password );
             }
 
             cluster = builder.build();
 
-            logger.debug( "Connecting to Cassandra, host:{}, port:{}, user:{}", host, port, username );
+            logger.info( "Connecting to Cassandra, host:{}, port:{}, user:{}", host, port, username );
             session = cluster.connect();
         }
         catch ( Exception e )
@@ -100,7 +100,7 @@ public class CassandraClient
     {
         if ( !closed && cluster != null && session != null )
         {
-            logger.debug( "Close cassandra client" );
+            logger.info( "Close cassandra client" );
             session.close();
             cluster.close();
             session = null;

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/HoneycombFilter.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/HoneycombFilter.java
@@ -58,7 +58,7 @@ public class HoneycombFilter
         logger.trace( "START: {}", getClass().getSimpleName() );
 
         HttpServletRequest hsr = (HttpServletRequest) request;
-        logger.info( "START: {}", hsr.getPathInfo() );
+        logger.debug( "START: {}", hsr.getPathInfo() );
 
         Span rootSpan = null;
         try
@@ -73,7 +73,7 @@ public class HoneycombFilter
         }
         finally
         {
-            logger.info( "END: {}", hsr.getPathInfo() );
+            logger.debug( "END: {}", hsr.getPathInfo() );
             if ( rootSpan != null )
             {
                 honeycombManager.addFields( rootSpan );

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/HoneycombManager.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/HoneycombManager.java
@@ -117,7 +117,7 @@ public class HoneycombManager
                         new PropagationContext( parentContext.getTraceId(), parentContext.getParentSpanId(), null,
                                                 null );
 
-                logger.info( "Starting root span: {} based on parent context: {}, thread: {}", spanName, propContext, Thread.currentThread().getId() );
+                logger.debug( "Starting root span: {} based on parent context: {}, thread: {}", spanName, propContext, Thread.currentThread().getId() );
                 span = beeline.getSpanBuilderFactory()
                               .createBuilder()
                               .setParentContext( propContext )
@@ -130,10 +130,6 @@ public class HoneycombManager
             {
                 String traceId = RequestContextHelper.getContext( TRACE_ID );
                 String parentId = RequestContextHelper.getContext( REQUEST_PARENT_SPAN );
-                //
-                //
-                //            PropagationContext parentContext = new PropagationContext( traceId, parentId, null, null );
-                //            logger.info( "Starting span: {} based on parent context: {}", spanName, parentContext );
 
                 span = beeline.getSpanBuilderFactory().createBuilder()
                               //                                   .setParentContext( parentContext )
@@ -214,7 +210,7 @@ public class HoneycombManager
     {
         if ( beeline != null )
         {
-            logger.info( "Ending trace: {}", Thread.currentThread().getId() );
+            logger.debug( "Ending trace: {}", Thread.currentThread().getId() );
             getBeeline().getTracer().endTrace();
         }
     }

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyTraceSampler.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyTraceSampler.java
@@ -37,13 +37,13 @@ public class IndyTraceSampler
         ThreadContext ctx = ThreadContext.getContext( false );
         if ( ctx == null )
         {
-            logger.info( "No ThreadContext for functional diagnosis; skipping span: {}", input );
+            logger.debug( "No ThreadContext for functional diagnosis; skipping span: {}", input );
             return 0;
         }
 
         if ( ctx.get( SAMPLE_OVERRIDE ) != null )
         {
-            logger.info( "Including span via override (span: {})", input );
+            logger.debug( "Including span via override (span: {})", input );
             return 1;
         }
 

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyTracingContext.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyTracingContext.java
@@ -26,7 +26,7 @@ public class IndyTracingContext
     {
         if ( config.isEnabled() )
         {
-            logger.info( "Clearing spans in current thread: {}", Thread.currentThread().getId() );
+            logger.debug( "Clearing spans in current thread: {}", Thread.currentThread().getId() );
             SPANS.set( new ArrayDeque<>() );
         }
     }
@@ -35,7 +35,7 @@ public class IndyTracingContext
     {
         if ( config.isEnabled() )
         {
-            logger.info( "Clearing context...SPANs in current thread: {} (thread: {})", SPANS.get().size(),
+            logger.debug( "Clearing context...SPANs in current thread: {} (thread: {})", SPANS.get().size(),
                          Thread.currentThread().getId() );
             TracerSpan tracerSpan = SPANS.get().peekLast();
             if ( tracerSpan != null )
@@ -43,7 +43,7 @@ public class IndyTracingContext
                 tracerSpan.close();
             }
 
-            logger.info( "Clearing spans deque in: {}", Thread.currentThread().getId() );
+            logger.debug( "Clearing spans deque in: {}", Thread.currentThread().getId() );
             SPANS.remove();
         }
     }
@@ -57,21 +57,21 @@ public class IndyTracingContext
     @Override
     public int size()
     {
-        logger.info( "SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId() );
+        logger.debug( "SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId() );
         return SPANS.get().size();
     }
 
     @Override
     public TracerSpan peekLast()
     {
-        logger.info( "SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId()  );
+        logger.debug( "SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId()  );
         return SPANS.get().peekLast();
     }
 
     @Override
     public TracerSpan peekFirst()
     {
-        logger.info( "SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId() );
+        logger.debug( "SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId() );
         return SPANS.get().peekFirst();
     }
 
@@ -79,28 +79,28 @@ public class IndyTracingContext
     public boolean isEmpty()
     {
         Deque<TracerSpan> spans = SPANS.get();
-        logger.info( "SPANs in current thread: {} (thread: {})", spans.size(), Thread.currentThread().getId() );
+        logger.debug( "SPANs in current thread: {} (thread: {})", spans.size(), Thread.currentThread().getId() );
         boolean empty = spans.isEmpty();
 
-        logger.info( "SPANs.isEmpty() ? {}", empty );
+        logger.debug( "SPANs.isEmpty() ? {}", empty );
         return empty;
     }
 
     @Override
     public void push( final TracerSpan span )
     {
-        logger.info( "SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId()  );
+        logger.debug( "SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId()  );
         SPANS.get().push( span );
     }
 
     @Override
     public TracerSpan pop()
     {
-        logger.info( "Pre-POP SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId()  );
+        logger.debug( "Pre-POP SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId()  );
 
         TracerSpan span = SPANS.get().pop();
 
-        logger.info( "Post-POP SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId()  );
+        logger.debug( "Post-POP SPANs in current thread: {} (thread: {})", SPANS.get().size(), Thread.currentThread().getId()  );
         return span;
     }
 }

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombWrapperInterceptor.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/interceptor/HoneycombWrapperInterceptor.java
@@ -49,16 +49,16 @@ public class HoneycombWrapperInterceptor
     public Object operation( InvocationContext context ) throws Exception
     {
         String name = HoneycombInterceptorUtils.getMetricNameFromParam( context );
-        logger.info( "START: Honeycomb lambda wrapper: {}", name );
+        logger.debug( "START: Honeycomb lambda wrapper: {}", name );
         if ( !config.isEnabled() )
         {
-            logger.info( "SKIP Honeycomb lambda wrapper: {}", name );
+            logger.debug( "SKIP Honeycomb lambda wrapper: {}", name );
             return context.proceed();
         }
 
         if ( name == null || SKIP_METRIC.equals( name ) || config.getSampleRate( name ) < 1 )
         {
-            logger.info( "SKIP Honeycomb lambda wrapper (no span name or span not configured: {})", name );
+            logger.debug( "SKIP Honeycomb lambda wrapper (no span name or span not configured: {})", name );
             return context.proceed();
         }
 
@@ -79,7 +79,7 @@ public class HoneycombWrapperInterceptor
                 span.close();
             }
 
-            logger.info( "END: Honeycomb lambda wrapper: {}", name );
+            logger.debug( "END: Honeycomb lambda wrapper: {}", name );
         }
     }
 


### PR DESCRIPTION
I find tons of Honeycomb info level messages in indy.log. Might be better to lower it to debug.