### PR TITLE
Re-name threads in store-affected-by-async-runner pool

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -718,10 +718,11 @@ public abstract class IndexingContentManagerDecorator
                 //FIXME: One potential problem here: The fixed thread pool is using a blocking queue to
                 // cache runnables, which could cause OOM if there are bunch of uploading happened in
                 // a short time period. We need to monitor if this could happen.
+                final String name = String.format( "ContentIndexStoreDeIndex-store(%s)-path(%s)", store.getKey(), path );
                 final String context =
                         String.format( "Class: %s, method: %s, store: %s, path: %s", this.getClass().getName(), "store",
                                        store.getKey(), path );
-                storeDataManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask( context, () -> {
+                storeDataManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask(name, context, () -> {
                     try
                     {
                         Set<Group> groups = storeDataManager.query().getGroupsAffectedBy( store.getKey() );

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
@@ -117,10 +117,11 @@ class NFCContentListener
         {
             return;
         }
+        final String name = String.format("ContentIndexNFCClean-store(%s)-path(%s)", store.getKey(), path  );
         final String context =
                 String.format( "Class: %s, method: %s, store: %s, path: %s", this.getClass().getName(), "nfcClearByContaining",
                                store.getKey(), path );
-        storeDataManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask( context, () -> {
+        storeDataManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask(name, context, () -> {
             logger.debug( "Start to clear nfc for groups affected by {} of path {}", store, path );
             try
             {

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -270,11 +270,14 @@ public class PromotionManager
 
                             storeManager.storeArtifactStore( target, changeSummary, false, true, new EventMetadata() );
                             final Group targetForNfcCleaning = target;
+                            final String name = String.format( "PromoteNFCClean-method(%s)-source(%s)-target(%s)",
+                                                               "doValidationAndPromote", validationRequest.getSource(),
+                                                               targetForNfcCleaning.getKey() );
                             final String context = String.format( "Class: %s, method: %s, source: %s, target: %s",
                                                                   this.getClass().getName(), "doValidationAndPromote",
                                                                   validationRequest.getSource(),
                                                                   targetForNfcCleaning.getKey() );
-                            storeManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask( context, () -> {
+                            storeManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask( name, context, () -> {
                                 try
                                 {
                                     promotionHelper.clearStoreNFC( validationRequest.getSourcePaths(),
@@ -818,10 +821,12 @@ public class PromotionManager
         else
         {
             result = new PathsPromoteResult( request, emptySet(), completed, skipped, null, validation );
+            final String name = String.format( "PromoteNFCClean-method(%s)-source(%s)-target(%s)", "runPathPromotions",
+                                               request.getSource(), targetStore.getKey() );
             final String context =
                     String.format( "Class: %s, method: %s, source: %s, target: %s", this.getClass().getName(),
                                    "runPathPromotions", request.getSource(), targetStore.getKey() );
-            storeManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask( context,
+            storeManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask( name, context,
                                                                                     () -> promotionHelper.clearStoreNFC(
                                                                                             completed,
                                                                                             targetStore ) ) );

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -148,26 +148,32 @@ public interface StoreDataManager
      * This api is used for some time-sensitive tasks which should use getGroupsAffectedBy service, as
      * this service is a little time-consuming now.
      *
-     * @param task
-     * @param <R>
+     * @param contextualTask
      */
     void asyncGroupAffectedBy( ContextualTask contextualTask );
 
     class ContextualTask
     {
+        private String threadName;
+
         private String taskContext;
 
         private Runnable task;
 
-        public ContextualTask( String taskContext, Runnable task )
+        public ContextualTask( String threadName, String taskContext, Runnable task )
         {
+            this.threadName = threadName;
             this.taskContext = taskContext;
             this.task = task;
         }
 
         public String getTaskContext()
         {
-            return taskContext;
+            return this.taskContext;
+        }
+
+        public String getThreadName(){
+            return this.threadName;
         }
 
         public Runnable getTask()

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -26,7 +26,6 @@ import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.measure.annotation.Measure;
-import org.commonjava.indy.measure.annotation.MetricNamed;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
@@ -374,11 +373,12 @@ public class DefaultContentManager
 
             contentGeneratorManager.handleContentStorage( transferStore, path, txfr, eventMetadata );
 
+            final String name = String.format("ContentNFCClean-StoreSingle-store(%s)-path(%s)", store.getKey(), path  );
             final String context =
                     String.format( "Class: %s, method: %s, store: %s, path: %s", this.getClass().getName(), "store",
                                    store.getKey(), path );
             storeManager.asyncGroupAffectedBy(
-                    new StoreDataManager.ContextualTask( context, () -> clearNFCEntries( kl, path ) ) );
+                    new StoreDataManager.ContextualTask( name, context, () -> clearNFCEntries( kl, path ) ) );
         }
 
         return txfr;
@@ -428,11 +428,12 @@ public class DefaultContentManager
 
             contentGeneratorManager.handleContentStorage( transferStore, path, txfr, eventMetadata );
 
+            final String name = String.format("ContentNFCClean-StoreList-location(%s)-path(%s)", kl, path  );
             final String context =
                     String.format( "Class: %s, method: %s, location: %s, path: %s", this.getClass().getName(), "store-stores",
                                    kl, path );
             storeManager.asyncGroupAffectedBy(
-                    new StoreDataManager.ContextualTask( context, () -> clearNFCEntries( kl, path ) ) );
+                    new StoreDataManager.ContextualTask(name, context, () -> clearNFCEntries( kl, path ) ) );
         }
 
         return txfr;


### PR DESCRIPTION
Currently we consolidated all "store affected by" async tasks to run
  in one single entry point in AbstractStoreDataManager for easy
  management, but it brings a problem for debugging: for thread dump, we
  don't know the thread context for which task. So in this pr, we use
  thread name that contains some context info for the task for easy
  tracing.