### PR TITLE
Avoid affectedBy building long log messages

### DIFF
--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -265,9 +265,11 @@ public class InfinispanStoreDataManager
             }
         }
 
-        logger.trace( "Groups affected by {} are: {}", keys,
-                     result.stream().map( ArtifactStore::getKey ).collect( Collectors.toSet() ) );
-
+        if ( logger.isTraceEnabled() )
+        {
+            logger.trace( "Groups affected by {} are: {}", keys,
+                          result.stream().map( ArtifactStore::getKey ).collect( Collectors.toSet() ) );
+        }
         return result;
     }
 


### PR DESCRIPTION
The affectedBy result could be very huge in some cases. This pr avoid useless string objects being built.