### PR TITLE
Save and reuse affectedBy groups during promotion

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/IndexingContentManagerDecorator.java
@@ -45,6 +45,7 @@ import javax.enterprise.inject.Any;
 import javax.inject.Inject;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -725,7 +726,8 @@ public abstract class IndexingContentManagerDecorator
                 storeDataManager.asyncGroupAffectedBy( new StoreDataManager.ContextualTask(name, context, () -> {
                     try
                     {
-                        Set<Group> groups = storeDataManager.query().getGroupsAffectedBy( store.getKey() );
+                        Set<Group> groups =
+                                        storeDataManager.affectedBy( Arrays.asList( store.getKey() ), eventMetadata );
                         if ( groups != null && !groups.isEmpty() && indexCfg.isEnabled() )
                         {
                             groups.forEach( g -> indexManager.deIndexStorePath( g.getKey(), path ) );
@@ -740,17 +742,8 @@ public abstract class IndexingContentManagerDecorator
                 } ) );
             }
         }
-//        nfcClearByContaining( store, path );
-
         return transfer;
     }
-
-    //    @Override
-    //    public Transfer store( final List<? extends ArtifactStore> stores, final String path, final InputStream stream, final TransferOperation op )
-    //            throws IndyWorkflowException
-    //    {
-    //        return store( stores, path, stream, op, new EventMetadata() );
-    //    }
 
     @Override
     public Transfer store( final List<? extends ArtifactStore> stores, final StoreKey topKey, final String path,

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
@@ -92,6 +92,10 @@ class NFCContentListener
     //
     //    }
 
+/*
+ * Not need to aggressively add missing. In case of path P promoted to pnc-builds, it triggers removal of P in
+ * affected groups, e.g, DA. This does not mean the DA/P is missing. We just let it rebuild next time when retrieved.
+ *
     @CacheEntryRemoved
     public void removeIndex( final CacheEntryRemovedEvent<IndexedStorePath, IndexedStorePath> e )
     {
@@ -110,6 +114,7 @@ class NFCContentListener
             }
         }
     }
+*/
 
     private void nfcClearByContaining( final ArtifactStore store, final String path )
     {

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -39,6 +39,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Set;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
@@ -115,10 +116,12 @@ public class MetadataMergePomChangeListener
                                            clearPath, hosted, e.getMessage() ), e );
                 }
 
-                final Set<Group> groups = dataManager.query().getGroupsAffectedBy( key );
+                final Set<Group> groups = dataManager.affectedBy( Arrays.asList( key ), event.getEventMetadata() );
+
                 if ( groups != null )
                 {
-                    logger.info( "Clearing metadata file {} for groups affected by {}: {}", clearPath, key, groups );
+                    logger.info( "Clearing metadata file {} for {} groups affected by {}", clearPath, groups.size(), key );
+                    logger.trace( "Groups affected by {}: {}", key, groups );
                     for ( final Group group : groups )
                     {
                         try

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionHelper.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionHelper.java
@@ -86,7 +86,7 @@ public class PromotionHelper
      * @param sourcePaths The set of paths that need to be cleared from the NFC.
      * @param store The store whose affected groups should have their NFC entries cleared
      */
-    public void clearStoreNFC( final Set<String> sourcePaths, ArtifactStore store )
+    public void clearStoreNFC( final Set<String> sourcePaths, final ArtifactStore store, final Set<Group> affectedGroups )
     {
         Set<String> paths = sourcePaths.stream()
                                .map( sp -> sp.startsWith( "/" ) && sp.length() > 1 ? sp.substring( 1 ) : sp )
@@ -99,16 +99,23 @@ public class PromotionHelper
         } );
 
         Set<Group> groups;
-        try
-        {
-            groups = storeManager.query().getGroupsAffectedBy( store.getKey() );
-        }
-        catch ( IndyDataException e )
-        {
-            logger.warn( "Failed to clear NFC for groups affected by " + store.getKey(), e );
-            return;
-        }
 
+        if ( affectedGroups != null )
+        {
+            groups = affectedGroups;
+        }
+        else
+        {
+            try
+            {
+                groups = storeManager.query().getGroupsAffectedBy( store.getKey() );
+            }
+            catch ( IndyDataException e )
+            {
+                logger.warn( "Failed to clear NFC for groups affected by " + store.getKey(), e );
+                return;
+            }
+        }
         if ( groups != null )
         {
             groups.forEach( group -> {

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -45,6 +45,11 @@ public interface StoreDataManager
     String IGNORE_READONLY = "ignore-readonly";
 
     /**
+     * We calculate and pass the affected groups through different modules, e.g, in case of promotion.
+     */
+    String AFFECTED_GROUPS = "affected_groups";
+
+    /**
      * Need to store change summary for repository change processing
      */
     String CHANGE_SUMMARY = "change-summary";
@@ -143,6 +148,13 @@ public interface StoreDataManager
 
     Set<Group> affectedBy( Collection<StoreKey> keys )
             throws IndyDataException;
+
+    /**
+     * Get affected-by groups from event metadata if provided.
+     * @param keys
+     * @param eventMetadata
+     */
+    Set<Group> affectedBy( Collection<StoreKey> keys, EventMetadata eventMetadata ) throws IndyDataException;
 
     /**
      * This api is used for some time-sensitive tasks which should use getGroupsAffectedBy service, as

--- a/api/src/main/java/org/commonjava/indy/util/ValuePipe.java
+++ b/api/src/main/java/org/commonjava/indy/util/ValuePipe.java
@@ -15,10 +15,24 @@
  */
 package org.commonjava.indy.util;
 
+/**
+ * ValuePipe can hold a single value object. We can use it to wrap a collection object to avoid unintentional
+ * toString that may produce huge strings.
+ * @param <T>
+ */
 public class ValuePipe<T>
 {
 
     private T value;
+
+    public ValuePipe()
+    {
+    }
+
+    public ValuePipe( T value )
+    {
+        this.value = value;
+    }
 
     public boolean isFilled()
     {
@@ -38,7 +52,6 @@ public class ValuePipe<T>
     public synchronized void set( final T value )
     {
         this.value = value;
-        this.notifyAll();
     }
 
 }

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -37,6 +37,7 @@ import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.util.ApplicationStatus;
+import org.commonjava.indy.util.ValuePipe;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -474,6 +475,22 @@ public abstract class AbstractStoreDataManager
     {
         return streamArtifactStoreKeys().filter( key -> key.getPackageType().equals( pkg ) && key.getType() == type )
                                         .collect( Collectors.toSet() );
+    }
+
+    @Override
+    public Set<Group> affectedBy( Collection<StoreKey> keys, EventMetadata eventMetadata ) throws IndyDataException
+    {
+        Set<Group> groups = null;
+        if ( eventMetadata != null )
+        {
+            ValuePipe<Set<Group>> valuePipe = (ValuePipe) eventMetadata.get( AFFECTED_GROUPS );
+            groups = valuePipe != null ? valuePipe.get() : null;
+        }
+        if ( groups == null )
+        {
+            groups = affectedBy( keys );
+        }
+        return groups;
     }
 
     public Set<Group> affectedBy( final Collection<StoreKey> keys )


### PR DESCRIPTION
This pr get affectedBy groups at the beginning of promotion and pass it to clearStoreNFC() and contentIndex via eventMetadata. Some big builds promote throusands of paths. The fix should reduce quite some promotion time for them. 