### PR TITLE
Calculate promotion batch size by the pool size

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/change/MetadataMergePomChangeListener.java
@@ -40,6 +40,7 @@ import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Set;
 
+import static org.commonjava.indy.data.StoreDataManager.AFFECTED_GROUPS;
 import static org.commonjava.indy.data.StoreDataManager.TARGET_STORE;
 import static org.commonjava.indy.model.core.StoreType.hosted;
 import static org.commonjava.indy.pkg.maven.content.MetadataUtil.getMetadataPath;
@@ -96,12 +97,13 @@ public class MetadataMergePomChangeListener
 
         final StoreKey key = getKey( event );
         final String clearPath = getMetadataPath( path );
-        logger.info( "Pom file {} {}, will clean its matched metadata file {}, eventMetadata: {}", path, eventOps,
-                     clearPath, eventMetadata );
+        logger.info( "Pom file {} {}, will clean matched metadata file {}, store: {}", path, eventOps, clearPath, key );
+
         try
         {
             if ( hosted == key.getType() )
             {
+                logger.debug( "Get eventMetadata: {}", eventMetadata );
                 ArtifactStore hosted = null;
                 if ( eventMetadata != null )
                 {

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/conf/PromoteConfig.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/conf/PromoteConfig.java
@@ -39,8 +39,6 @@ public class PromoteConfig
 
     private static final String AUTOLOCK_HOSTED_REPOS = "autolock.hosted.repos";
 
-    public static final int DEFAULT_PARALLELED_BATCH_SIZE = 100;
-
     public static final long DEFAULT_LOCK_TIMEOUT_SECONDS = 30;
 
     public static final boolean DEFAULT_AUTOLOCK = true;
@@ -54,8 +52,6 @@ public class PromoteConfig
     private Boolean autoLockHostedRepos;
 
     private Long lockTimeoutSeconds;
-
-    private Integer paralleledBatchSize;
 
     public PromoteConfig()
     {
@@ -135,19 +131,4 @@ public class PromoteConfig
                      .getResourceAsStream( "default-promote.conf" );
     }
 
-    @ConfigName( "paralleled.batch.size" )
-    public void setParalleledBatchSize( Integer paralleledBatchSize )
-    {
-        this.paralleledBatchSize = paralleledBatchSize;
-    }
-
-    public int getParalleledBatchSize()
-    {
-        int ret = paralleledBatchSize == null ? DEFAULT_PARALLELED_BATCH_SIZE : paralleledBatchSize;
-        if ( ret <= 0 )
-        {
-            ret = DEFAULT_PARALLELED_BATCH_SIZE;
-        }
-        return ret;
-    }
 }

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -88,6 +88,7 @@ import static org.commonjava.indy.promote.data.PromotionHelper.throwProperExcept
 import static org.commonjava.indy.promote.data.PromotionHelper.timeInMillSeconds;
 import static org.commonjava.indy.promote.data.PromotionHelper.timeInSeconds;
 import static org.commonjava.indy.promote.util.Batcher.batch;
+import static org.commonjava.indy.promote.util.Batcher.getParalleledBatchSize;
 import static org.commonjava.maven.galley.model.TransferOperation.UPLOAD;
 
 /**
@@ -777,8 +778,10 @@ public class PromotionManager
         DrainingExecutorCompletionService<Set<PathTransferResult>> svc =
                         new DrainingExecutorCompletionService<>( transferService );
 
-        int batchSize = config.getParalleledBatchSize();
-        logger.trace( "Exe parallel on collection {} in batch {}", contents, batchSize );
+        int corePoolSize = transferService.getCorePoolSize();
+        int size = contents.size();
+        int batchSize = getParalleledBatchSize( size, corePoolSize );
+        logger.info( "Execute parallel on collection, size: {}, batch: {}", size, batchSize );
         Collection<Collection<Transfer>> batches = batch( contents, batchSize );
 
         final List<String> errors = new ArrayList<>();
@@ -859,8 +862,6 @@ public class PromotionManager
                      timeInSeconds( begin ) );
         return result;
     }
-
-
 
     private Callable<Set<PathTransferResult>> newPathPromotionsJob( final Collection<Transfer> transfers,
                                                                     final ArtifactStore tgt,

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/util/Batcher.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/util/Batcher.java
@@ -43,4 +43,18 @@ public class Batcher
         }
         return batches;
     }
+
+    /**
+     * Calculate the batch size. If transfers size is less than pool size, return 1 (no batch). Or return size/core. e.g.
+     * if core is 40, size is 100, return 2; if size is 1000, return 1000/40 = 25.
+     */
+    public static int getParalleledBatchSize( int size, int corePoolSize )
+    {
+        if ( size < corePoolSize )
+        {
+            return 1;
+        }
+        return size / corePoolSize;
+    }
+
 }

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/util/Batcher.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/util/Batcher.java
@@ -50,7 +50,7 @@ public class Batcher
      */
     public static int getParalleledBatchSize( int size, int corePoolSize )
     {
-        if ( size < corePoolSize )
+        if ( size < corePoolSize || corePoolSize <= 0)
         {
             return 1;
         }

--- a/addons/promote/common/src/test/java/org/commonjava/indy/promote/validate/PromotionValidationToolsTest.java
+++ b/addons/promote/common/src/test/java/org/commonjava/indy/promote/validate/PromotionValidationToolsTest.java
@@ -22,8 +22,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -37,7 +37,7 @@ public class PromotionValidationToolsTest
     public void testParalleledInBatch()
     {
         PromoteConfig config = new PromoteConfig();
-        Executor executor = Executors.newCachedThreadPool();
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
         PromotionValidationTools tools =
                         new PromotionValidationTools( null, null, null, null, null, null, null, null, executor,
                                                       config );
@@ -64,9 +64,8 @@ public class PromotionValidationToolsTest
     public void testParalleledInBatch_smallSize()
     {
         PromoteConfig config = new PromoteConfig();
-        config.setParalleledBatchSize( 2 );
 
-        Executor executor = Executors.newCachedThreadPool();
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newFixedThreadPool( 2 );
         PromotionValidationTools tools =
                         new PromotionValidationTools( null, null, null, null, null, null, null, null, executor,
                                                       config );


### PR DESCRIPTION
We have a problem using batch to promote files. 
I noticed that there is only one thread doing promotion for a small build. It promotes less than 10 files but takes 15+ minutes.
I see the promotion thread pool size is 200 which is pretty large. If the files are less, e.g., 10 files, it will ends up with one thread doing the promotion. Current batch size only works for large build with thousands of files.
This pr calculate the batch size according to thread pool size. It will work for both small and large builds. It will boost the performance of smaller builds significantly. 