### PR TITLE
Remove affectedByAsyncRunner from AbstractStoreDataManager constructor

### DIFF
--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -89,21 +89,15 @@ public abstract class AbstractStoreDataManager
     @Inject
     InternalFeatureConfig internalFeatureConfig;
 
-    private static final String AFFECTED_BY_ASYNC_RUNNER_NAME = "store-affected-by-async-runner";
+    protected static final String AFFECTED_BY_ASYNC_RUNNER_NAME = "store-affected-by-async-runner";
 
     @Inject
     @WeftManaged
     @ExecutorConfig( named = AFFECTED_BY_ASYNC_RUNNER_NAME, priority = 4, threads = 32 )
-    private ExecutorService affectedByAsyncRunner;
+    protected ExecutorService affectedByAsyncRunner;
 
     protected AbstractStoreDataManager()
     {
-        if ( affectedByAsyncRunner == null )
-        {
-            //for testing
-            affectedByAsyncRunner = Executors.newFixedThreadPool( 32, new NamedThreadFactory(
-                    AFFECTED_BY_ASYNC_RUNNER_NAME, new ThreadGroup( AFFECTED_BY_ASYNC_RUNNER_NAME ), true, 4 ) );
-        }
     }
 
     @Override

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.mem.data;
 
+import org.commonjava.cdi.util.weft.NamedThreadFactory;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
@@ -33,6 +34,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 
 @ApplicationScoped
@@ -54,6 +56,12 @@ public class MemoryStoreDataManager
     public MemoryStoreDataManager( final boolean unitTestUsage )
     {
         this.dispatcher = new NoOpStoreEventDispatcher();
+        if ( unitTestUsage )
+        {
+            super.affectedByAsyncRunner = Executors.newFixedThreadPool( 4, new NamedThreadFactory(
+                            AFFECTED_BY_ASYNC_RUNNER_NAME, new ThreadGroup( AFFECTED_BY_ASYNC_RUNNER_NAME ), true,
+                            4 ) );
+        }
     }
 
     public MemoryStoreDataManager( final StoreEventDispatcher dispatcher )


### PR DESCRIPTION
The affectedByAsyncRunner in constructor is only for testing. It will always be overriden by field injection in real case. GC will reclaim this abandoned thread pool but this waste time.