### PR TITLE
Cassandra NFC to use executeAsync when do clearing

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/inject/CassandraNotFoundCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CassandraNotFoundCache.java
@@ -168,7 +168,7 @@ public class CassandraNotFoundCache
 
         BoundStatement bound = preparedInsert.bind( key.toString(), resource.getPath(), curDate, timeoutDate,
                                                     timeoutInSeconds );
-        session.execute( bound );
+        session.executeAsync( bound );
         inMemoryCache.put( resource, DUMB_CACHE_VALUE, timeoutInSeconds, TimeUnit.SECONDS );
     }
 
@@ -208,7 +208,7 @@ public class CassandraNotFoundCache
     {
         StoreKey key = ( (KeyedLocation) location ).getKey();
         BoundStatement bound = preparedDeleteByStore.bind( key.toString() );
-        session.execute( bound );
+        session.executeAsync( bound );
         clearInMemoryCache( location );
     }
 
@@ -237,7 +237,7 @@ public class CassandraNotFoundCache
     {
         StoreKey key = getResourceKey( resource );
         BoundStatement bound = preparedDelete.bind( key.toString(), resource.getPath() );
-        session.execute( bound );
+        session.executeAsync( bound );
         inMemoryCache.remove( resource );
     }
 


### PR DESCRIPTION
For cleaning, we don't need result and it is proper to use executeAsync to improve performance.