### PR TITLE
Cassandra session per keyspace

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/inject/CassandraNotFoundCache.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CassandraNotFoundCache.java
@@ -122,7 +122,7 @@ public class CassandraNotFoundCache
         keyspace = config.getCacheKeyspace();
         maxResultSetSize = config.getNfcMaxResultSetSize();
 
-        session = cassandraClient.getSession();
+        session = cassandraClient.getSession( keyspace );
 
         session.execute( getSchemaCreateKeyspace( keyspace ) );
         session.execute( getSchemaCreateTable( keyspace ) );

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -180,10 +180,12 @@ public class DefaultGalleyStorageProvider
         PathMappedStorageConfig pathMappedStorageConfig = getPathMappedStorageConfig();
         if ( cassandraClient != null )
         {
-            Session session = cassandraClient.getSession();
+            String keyspace = config.getCassandraKeyspace();
+            Session session = cassandraClient.getSession( keyspace );
             if ( session != null )
             {
-                pathDB = new CassandraPathDB( pathMappedStorageConfig, session, config.getCassandraKeyspace() );
+                logger.info( "Create pathDB, keyspace: {}", keyspace );
+                pathDB = new CassandraPathDB( pathMappedStorageConfig, session, keyspace );
             }
         }
 

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -216,7 +216,7 @@ public abstract class AbstractIndyFunctionalTest
         String keyspace = getKeyspace();
         logger.debug( "Drop cassandra keyspace: {}", keyspace );
         CassandraClient cassandraClient = CDI.current().select( CassandraClient.class ).get();
-        Session session = cassandraClient.getSession();
+        Session session = cassandraClient.getSession( keyspace );
         if ( session != null )
         {
             try

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -196,7 +196,8 @@ public abstract class AbstractIndyFunctionalTest
     public void stop()
             throws IndyLifecycleException
     {
-        dropKeyspace();
+        dropKeyspace( "cache_" );
+        dropKeyspace( "storage_" );
         closeCacheProvider();
         closeQuietly( fixture );
         closeQuietly( client );
@@ -211,9 +212,9 @@ public abstract class AbstractIndyFunctionalTest
         }
     }
 
-    private void dropKeyspace()
+    private void dropKeyspace( String prefix )
     {
-        String keyspace = getKeyspace();
+        String keyspace = getKeyspace( prefix );
         logger.debug( "Drop cassandra keyspace: {}", keyspace );
         CassandraClient cassandraClient = CDI.current().select( CassandraClient.class ).get();
         Session session = cassandraClient.getSession( keyspace );
@@ -280,12 +281,12 @@ public abstract class AbstractIndyFunctionalTest
     protected void initBaseTestConfig( CoreServerFixture fixture )
             throws IOException
     {
-        writeConfigFile( "conf.d/cache.conf", "[default]\ncache.keyspace=" + getKeyspace() );
+        writeConfigFile( "conf.d/cache.conf", "[default]\ncache.keyspace=" + getKeyspace( "cache_" ) );
         writeConfigFile( "conf.d/storage.conf", "[storage-default]\n"
                         + "storage.dir=" + fixture.getBootOptions().getHomeDir() + "/var/lib/indy/storage\n"
                         + "storage.gc.graceperiodinhours=0\n"
                         + "storage.gc.batchsize=0\n"
-                        + "storage.cassandra.keyspace=" + getKeyspace() );
+                        + "storage.cassandra.keyspace=" + getKeyspace( "storage_" ) );
 
         writeConfigFile( "conf.d/cassandra.conf", "[cassandra]\nenabled=true" );
 
@@ -301,9 +302,9 @@ public abstract class AbstractIndyFunctionalTest
         }
     }
 
-    private String getKeyspace()
+    private String getKeyspace( String prefix )
     {
-        String keyspace = getClass().getSimpleName();
+        String keyspace = prefix + getClass().getSimpleName();
         if ( keyspace.length() > 48 )
         {
             keyspace = keyspace.substring( 0, 48 ); // keyspace has to be less than 48 characters

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
@@ -88,8 +88,6 @@ public class CassandraClient
         cluster = builder.build();
     }
 
-    Session session;
-
     public Session getSession( String keyspace )
     {
         return sessions.computeIfAbsent( keyspace, key -> {

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
@@ -67,40 +67,43 @@ public class CassandraClient
             logger.info( "Cassandra client not enabled" );
             return;
         }
-        try
-        {
-            host = config.getCassandraHost();
-            port = config.getCassandraPort();
-            SocketOptions socketOptions = new SocketOptions();
-            socketOptions.setConnectTimeoutMillis( 30000 );
-            socketOptions.setReadTimeoutMillis( 30000 );
-            Cluster.Builder builder = Cluster.builder()
-                                             .withoutJMXReporting()
-                                             .addContactPoint( host )
-                                             .withPort( port )
-                                             .withSocketOptions( socketOptions );
-            username = config.getCassandraUser();
-            String password = config.getCassandraPass();
-            if ( isNotBlank( username ) && isNotBlank( password ) )
-            {
-                logger.info( "Build with credentials, user: {}, pass: ****", username );
-                builder.withCredentials( username, password );
-            }
 
-            cluster = builder.build();
-        }
-        catch ( Exception e )
+        host = config.getCassandraHost();
+        port = config.getCassandraPort();
+        SocketOptions socketOptions = new SocketOptions();
+        socketOptions.setConnectTimeoutMillis( 30000 );
+        socketOptions.setReadTimeoutMillis( 30000 );
+        Cluster.Builder builder = Cluster.builder()
+                                         .withoutJMXReporting()
+                                         .addContactPoint( host )
+                                         .withPort( port )
+                                         .withSocketOptions( socketOptions );
+        username = config.getCassandraUser();
+        String password = config.getCassandraPass();
+        if ( isNotBlank( username ) && isNotBlank( password ) )
         {
-            logger.error( "Connecting to Cassandra failed", e );
+            logger.info( "Build with credentials, user: {}, pass: ****", username );
+            builder.withCredentials( username, password );
         }
+        cluster = builder.build();
     }
+
+    Session session;
 
     public Session getSession( String keyspace )
     {
         return sessions.computeIfAbsent( keyspace, key -> {
             logger.info( "Connect to Cassandra, host: {}, port: {}, user: {}, keyspace: {}", host, port, username,
                          key );
-            return cluster.connect();
+            try
+            {
+                return cluster.connect();
+            }
+            catch ( Exception e )
+            {
+                logger.error( "Connecting to Cassandra failed", e );
+            }
+            return null;
         } );
     }
 

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
@@ -26,6 +26,9 @@ import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 @ApplicationScoped
@@ -36,7 +39,13 @@ public class CassandraClient
     @Inject
     private CassandraConfig config;
 
-    private Session session;
+    private String host;
+
+    private int port;
+
+    private String username;
+
+    final private Map<String, Session> sessions = new ConcurrentHashMap<>();
 
     private Cluster cluster;
 
@@ -60,8 +69,8 @@ public class CassandraClient
         }
         try
         {
-            String host = config.getCassandraHost();
-            int port = config.getCassandraPort();
+            host = config.getCassandraHost();
+            port = config.getCassandraPort();
             SocketOptions socketOptions = new SocketOptions();
             socketOptions.setConnectTimeoutMillis( 30000 );
             socketOptions.setReadTimeoutMillis( 30000 );
@@ -70,7 +79,7 @@ public class CassandraClient
                                              .addContactPoint( host )
                                              .withPort( port )
                                              .withSocketOptions( socketOptions );
-            String username = config.getCassandraUser();
+            username = config.getCassandraUser();
             String password = config.getCassandraPass();
             if ( isNotBlank( username ) && isNotBlank( password ) )
             {
@@ -79,9 +88,6 @@ public class CassandraClient
             }
 
             cluster = builder.build();
-
-            logger.info( "Connecting to Cassandra, host:{}, port:{}, user:{}", host, port, username );
-            session = cluster.connect();
         }
         catch ( Exception e )
         {
@@ -89,21 +95,25 @@ public class CassandraClient
         }
     }
 
-    public Session getSession()
+    public Session getSession( String keyspace )
     {
-        return session;
+        return sessions.computeIfAbsent( keyspace, key -> {
+            logger.info( "Connect to Cassandra, host: {}, port: {}, user: {}, keyspace: {}", host, port, username,
+                         key );
+            return cluster.connect();
+        } );
     }
 
     private volatile boolean closed;
 
     public void close()
     {
-        if ( !closed && cluster != null && session != null )
+        if ( !closed && cluster != null && sessions != null )
         {
             logger.info( "Close cassandra client" );
-            session.close();
+            sessions.entrySet().forEach( e -> e.getValue().close() );
+            sessions.clear();
             cluster.close();
-            session = null;
             cluster = null;
             closed = true;
         }


### PR DESCRIPTION
Create Cassandra sessions for each keyspace. In current situation, we use 2 sessions for indycache and indystorage. This helps to seperate concerns when it comes to connection problems. I expect this will help performance as well because each session manages its own connection pool.