### PR TITLE
Disable content-index's NFCContentListener and move the clean ups to indexManager

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -73,9 +73,10 @@ public class DefaultContentIndexManager
     @Inject
     private CacheHandle<IndexedStorePath, IndexedStorePath> contentIndex;
 
-    //FIXME: Seems no cache register this listener?
+/*
     @Inject
     private NFCContentListener listener;
+*/
 
     @Inject
     private Instance<PackageIndexingStrategy> indexingStrategyComponents;
@@ -121,6 +122,14 @@ public class DefaultContentIndexManager
         }
 
         contentIndex.executeCache( (cache) -> {
+            /*
+             * The listener was meant to clean up NFC entries. But NFC is not per directory but per concrete path.
+             * This makes the clean-up Java thread like "store-affected-by-async-runner::ContentIndexNFCClean-store
+             * (maven:remote:central)-path(org/sonatype/spice/spice-parent/15/)" useless.
+             * Doing clean-up in the listener also makes it hard to share important information, e.g, the cached
+             * affected groups. The NFC cleanups has been moved to the ContentIndexManager.
+             * We can remove NFCContentListener class entirely next time if we find no problem. ruhan 2020 Mar 11
+             */
 //            cache.addListener( listener );
             queryFactory = Search.getQueryFactory( (Cache) cache ); // Obtain a query factory for the cache
 //            maxResultSetSize = config.getNfcMaxResultSetSize();

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -121,7 +121,7 @@ public class DefaultContentIndexManager
         }
 
         contentIndex.executeCache( (cache) -> {
-            cache.addListener( listener );
+//            cache.addListener( listener );
             queryFactory = Search.getQueryFactory( (Cache) cache ); // Obtain a query factory for the cache
 //            maxResultSetSize = config.getNfcMaxResultSetSize();
             return null;

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/NFCContentListener.java
@@ -61,6 +61,11 @@ class NFCContentListener
     @Inject
     private NotFoundCache nfc;
 
+/*
+ * Maven content index is by-directory which does not make sense for NFC because NFC is by concrete path.
+ * For other package types, we'd better to move the clean-up to content manager itself in order to share some thing
+ * important like the pre-loaded affected groups.
+ *
     @CacheEntryCreated
     public void newIndex( final CacheEntryCreatedEvent<IndexedStorePath, IndexedStorePath> e )
     {
@@ -85,6 +90,7 @@ class NFCContentListener
             }
         }
     }
+*/
 
     // Not sure if this entry modified event should be watched, need some further check
     //    @CacheEntryModified
@@ -114,7 +120,6 @@ class NFCContentListener
             }
         }
     }
-*/
 
     private void nfcClearByContaining( final ArtifactStore store, final String path )
     {
@@ -149,4 +154,5 @@ class NFCContentListener
             }
         } ) );
     }
+*/
 }


### PR DESCRIPTION
This is due to two reasons: 
1. NFC is not per directory but per concrete path. This makes the clean-up Java thread "store-affected-by-async-runner::ContentIndexNFCClean-store(maven:remote:central)-path(org/sonatype/spice/spice-parent/15/)" useless. And doing clean-up in the listener makes it hard to share some important information, e.g, the cached affected groups.
ps. depending on the ISPN event should be removed as we move to clustering.
2. I see lots of affected-by-async-runner threads blocking on NFC clean. This might be the cause of reboot when the load is suddenly high and the datastax connection pools are not warmed up. 
More detail is in nos-2424.
