### PR TITLE
Filter affected groups from initAffectedBy

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/DefaultContentIndexManager.java
@@ -322,7 +322,7 @@ public class DefaultContentIndexManager
                                                       .toBuilder()
                                                       .build() );
 
-        logger.trace( "Cleared all indices with group: {}, size: {}", sk, total );
+        logger.debug( "Cleared all indices with group: {}, size: {}", sk, total );
     }
 
     @Override
@@ -350,7 +350,7 @@ public class DefaultContentIndexManager
                                                       .toBuilder()
                                                       .build() );
 
-        logger.trace( "Cleared all indices with origin: {}, size: {}", osk, total );
+        logger.debug( "Cleared all indices with origin: {}, size: {}", osk, total );
     }
 
     private long iterateRemove( final Supplier<Query> queryFunction )
@@ -362,7 +362,7 @@ public class DefaultContentIndexManager
         {
             query = queryFunction.get();
 
-                    List<IndexedStorePath> all = query.list();
+            List<IndexedStorePath> all = query.list();
             all.forEach( ( key ) -> {
                 logger.debug("Removing from content index: {}", key);
                 contentIndex.remove( key );

--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/change/StoreChangeListener.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/change/StoreChangeListener.java
@@ -48,10 +48,10 @@ public class StoreChangeListener
     {
         final StoreKey key = store.getKey();
 
-        logger.trace( "Clean index for: {}", key );
+        logger.info( "Clean index for: {}", key );
         contentIndexManager.clearAllIndexedPathInStore( store );
 
-        logger.trace( "Clean index with origin: {}", key );
+        logger.info( "Clean index with origin: {}", key );
         contentIndexManager.clearAllIndexedPathWithOriginalStore( store );
     }
 

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -18,7 +18,6 @@ package org.commonjava.indy.db.common;
 import org.apache.commons.lang.StringUtils;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.Locker;
-import org.commonjava.cdi.util.weft.NamedThreadFactory;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.change.event.ArtifactStoreUpdateType;
@@ -54,7 +53,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
@@ -64,6 +62,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptySet;
 import static org.apache.commons.lang.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.commonjava.indy.db.common.StoreUpdateAction.DELETE;
 import static org.commonjava.indy.db.common.StoreUpdateAction.STORE;
 import static org.commonjava.indy.model.core.StoreType.group;
@@ -570,7 +569,7 @@ public abstract class AbstractStoreDataManager
     /**
      * Filter unnecessary affected groups in clean-up process. Most likely to exclude all the temp groups.
      */
-    protected Set<Group> filterAffectedGroups( Set<Group> affectedGroups )
+    public Set<Group> filterAffectedGroups( Set<Group> affectedGroups )
     {
         if ( affectedGroups == null )
         {
@@ -589,6 +588,12 @@ public abstract class AbstractStoreDataManager
         return affectedGroups.stream()
                              .filter( s -> !s.getName().matches( excludeFilter ) )
                              .collect( Collectors.toSet() );
+    }
+
+    public boolean isExcludedGroup( Group group )
+    {
+        String filter = indyConfiguration.getAffectedGroupsExcludeFilter();
+        return isNotBlank( filter ) && group.getName().matches( filter );
     }
 
 }

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -219,6 +219,7 @@ public class InfinispanStoreDataManager
     @Override
     public Set<Group> affectedBy( final Collection<StoreKey> keys )
     {
+        logger.debug( "Calculate affectedBy for keys: {}", keys );
         checkAffectedByCacheHealth();
 
         final Set<Group> result = new HashSet<>();
@@ -240,6 +241,7 @@ public class InfinispanStoreDataManager
                 Set<StoreKey> affected = affectedByStores.get( key );
                 if ( affected != null )
                 {
+                    logger.debug( "Get affectedByStores, key: {}, affected: {}", key, affected );
                     affected = affected.stream().filter( k -> k.getType() == group ).collect( Collectors.toSet() );
                     for ( StoreKey gKey : affected )
                     {
@@ -278,6 +280,12 @@ public class InfinispanStoreDataManager
     {
         if ( store == null )
         {
+            return;
+        }
+
+        if ( store instanceof Group && isExcludedGroup( (Group) store ) )
+        {
+            logger.info( "Skip affectedBy calculation of group: {}", store.getName() );
             return;
         }
 


### PR DESCRIPTION
Based on what I found in the log, the last log before reboot was pasted at http://pastebin.test.redhat.com/844790
From this log, the failure might happened at: 
1. PromotionManager (because the info log not printed out)
affectedGroups = storeManager.query().getGroupsAffectedBy( targetKey );
logger.info( "Calculate affected groups, target: {}, affected-groups: {}", targetKey, affectedGroups );
2. StoreChangeListener. The last info log was from here.

This pr:
1. add filter to affectedby from the beginning init. So we can see getGroupsAffectedBy return quickly.
2. a few log level change.

If CI is happy, I will merge it and open debug level for indy stage, and test again.