### PR TITLE
Fix the swagger missing issue

### DIFF
--- a/deployments/launcher/pom.xml
+++ b/deployments/launcher/pom.xml
@@ -131,6 +131,17 @@
     </dependency>
 
     <dependency>
+      <groupId>org.commonjava.indy.rest</groupId>
+      <artifactId>indy-rest-api</artifactId>
+      <type>yaml</type>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy.rest</groupId>
+      <artifactId>indy-rest-api</artifactId>
+      <type>json</type>
+    </dependency>
+
+    <dependency>
       <groupId>com.internetitem</groupId>
       <artifactId>logback-elasticsearch-appender</artifactId>
     </dependency>


### PR DESCRIPTION
I saw the following dependencies had been removed in the pr:
https://github.com/Commonjava/indy/pull/1507/files

We need that to export swagger.json 