### PR TITLE
Version bump parent pom version.

### DIFF
--- a/deployments/docker/pom.xml
+++ b/deployments/docker/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-deployments</artifactId>
-    <version>1.9.4-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.docker</groupId>


### PR DESCRIPTION
 This brings the docker kit to the same version as other sub-projects.