### PR TITLE
Fine control pathDB metrics

### DIFF
--- a/subsys/metrics/core/src/main/conf/conf.d/metrics.conf
+++ b/subsys/metrics/core/src/main/conf/conf.d/metrics.conf
@@ -19,6 +19,14 @@ ispn.enabled = true
 #ispn.gauges = CurrentNumberOfEntries,CurrentNumberOfEntriesInMemory,\
 #TotalNumberOfEntries,Hits,Misses,Retrievals,Evictions
 
+# Enable pathDB metrics. Default true.
+#
+#pathdb.enabled = true
+
+# Specify pathDB operations. Default all.
+#
+#pathdb.operations = exists,getStorageFile,getFileSystemContaining
+
 # Enable Galley to measure artifact downloading time. Default false.
 #
 measure.transport = true

--- a/subsys/metrics/reporter/src/main/conf/conf.d/metrics.conf
+++ b/subsys/metrics/reporter/src/main/conf/conf.d/metrics.conf
@@ -19,6 +19,14 @@ ispn.enabled = true
 #ispn.gauges = CurrentNumberOfEntries,CurrentNumberOfEntriesInMemory,\
 #TotalNumberOfEntries,Hits,Misses,Retrievals,Evictions
 
+# Enable pathDB metrics. Default true.
+#
+#pathdb.enabled = true
+
+# Specify pathDB operations. Default all.
+#
+#pathdb.operations = exists,getStorageFile,getFileSystemContaining
+
 # Enable Galley to measure artifact downloading time. Default false.
 #
 measure.transport = true

--- a/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/conf/IndyMetricsConfig.java
+++ b/subsys/metrics/reporter/src/main/java/org/commonjava/indy/metrics/conf/IndyMetricsConfig.java
@@ -102,9 +102,17 @@ public class IndyMetricsConfig
 
     private final static String INDY_METRICS_KOJI_ENABLED = "koji.enabled";
 
+    private final static String INDY_METRICS_PATH_DB_ENABLED = "pathdb.enabled";
+
+    private final static String INDY_METRICS_PATH_DB_OPERATIONS = "pathdb.operations";
+
     private static final int DEFAULT_METER_RATIO = 1;
 
     private boolean ispnMetricsEnabled;
+
+    private boolean pathDBMetricsEnabled = true; // default
+
+    private String pathDBMetricsOperations;
 
     private String ispnGauges;
 
@@ -508,6 +516,28 @@ public class IndyMetricsConfig
     public boolean isKojiMetricEnabled()
     {
         return kojiMetricEnabled;
+    }
+
+    public boolean isPathDBMetricsEnabled()
+    {
+        return pathDBMetricsEnabled;
+    }
+
+    @ConfigName( INDY_METRICS_PATH_DB_ENABLED )
+    public void setPathDBMetricsEnabled( boolean pathDBMetricsEnabled )
+    {
+        this.pathDBMetricsEnabled = pathDBMetricsEnabled;
+    }
+
+    public String getPathDBMetricsOperations()
+    {
+        return pathDBMetricsOperations;
+    }
+
+    @ConfigName( INDY_METRICS_PATH_DB_OPERATIONS )
+    public void setPathDBMetricsOperations( String pathDBMetricsOperations )
+    {
+        this.pathDBMetricsOperations = pathDBMetricsOperations;
     }
 
     @ConfigName( INDY_METRICS_ISPN_ENABLED )

--- a/subsys/metrics/reporter/src/main/resources/default-metrics.conf
+++ b/subsys/metrics/reporter/src/main/resources/default-metrics.conf
@@ -19,6 +19,14 @@ ispn.enabled = true
 #ispn.gauges = CurrentNumberOfEntries,CurrentNumberOfEntriesInMemory,\
 #TotalNumberOfEntries,Hits,Misses,Retrievals,Evictions
 
+# Enable pathDB metrics. Default true.
+#
+#pathdb.enabled = true
+
+# Specify pathDB operations. Default all.
+#
+#pathdb.operations = exists,getStorageFile,getFileSystemContaining
+
 # Enable Galley to measure artifact downloading time. Default false.
 #
 measure.transport = true


### PR DESCRIPTION
This pr allows us to enable/disable pathDB metrics. If needed, we can also specify which method to measure. 