### PR TITLE
Remove abandoned indy-subsys-pathmapped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -421,11 +421,6 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
-        <artifactId>indy-subsys-pathmapped</artifactId>
-        <version>2.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-infinispan</artifactId>
         <version>2.1.0-SNAPSHOT</version>
       </dependency>


### PR DESCRIPTION
Not sure why this is here. Path mapped is under indy/addon.