### PR TITLE
Repository proxy addon part 1 - automatic proxy 

### DIFF
--- a/addons/repo-proxy/common/pom.xml
+++ b/addons/repo-proxy/common/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-repo-proxy</artifactId>
+    <version>2.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>indy-repo-proxy-common</artifactId>
+  <name>Indy :: Add-Ons :: Repository-Proxy :: Common</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.servlet</groupId>
+      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>confset</id>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <descriptorRefs>
+                <descriptorRef>confset</descriptorRef>
+                <!-- <descriptorRef>dataset</descriptorRef> -->
+              </descriptorRefs>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/addons/repo-proxy/common/pom.xml
+++ b/addons/repo-proxy/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-repo-proxy-common</artifactId>
   <name>Indy :: Add-Ons :: Repository-Proxy :: Common</name>

--- a/addons/repo-proxy/common/src/main/conf/conf.d/repo-proxy.conf
+++ b/addons/repo-proxy/common/src/main/conf/conf.d/repo-proxy.conf
@@ -1,0 +1,13 @@
+[repo-proxy]
+# enabled: By default, the repo-proxy add-on is disabled.
+#
+#enabled=false
+
+# proxy: define the proxy rule for the repos. A valid rule is like this: proxy.$packageType.$type.$name=$packageType:$type:$name.
+# proxy.maven.hosted.from=maven:remote:to
+
+# Define the pattern for the api url pattern that will use the proxy, use comma to split
+# api.url.patterns=/api/content/*, /api/folo/track/*
+
+# Define the api http methods that the proxy will be applied with, use comma to split
+# api.methods=GET,HEAD

--- a/addons/repo-proxy/common/src/main/conf/conf.d/repo-proxy.conf
+++ b/addons/repo-proxy/common/src/main/conf/conf.d/repo-proxy.conf
@@ -3,9 +3,6 @@
 #
 #enabled=false
 
-# proxy: define the proxy rule for the repos. A valid rule is like this: proxy.$packageType.$type.$name=$packageType:$type:$name.
-# proxy.maven.hosted.from=maven:remote:to
-
 # Define the pattern for the api url pattern that will use the proxy, use comma to split
 # api.url.patterns=/api/content/*, /api/folo/track/*
 

--- a/addons/repo-proxy/common/src/main/data/default-rule.groovy
+++ b/addons/repo-proxy/common/src/main/data/default-rule.groovy
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2011 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.commonjava.indy.repo.proxy.create.*
+
+import org.commonjava.indy.model.core.*;
+
+class DefaultRule extends AbstractProxyRepoCreateRule {
+    @Override
+    boolean matches(StoreKey storeKey) {
+        return "maven".equals(storeKey.getPackageType()) && (StoreType.group == storeKey.getType() || StoreType.hosted == storeKey.getType())
+    }
+
+    @Override
+    RemoteRepository createRemote(StoreKey key) {
+        def pkgType = key.getPackageType()
+        def type = key.getType().singularEndpointName()
+        def name = key.getName()
+        return new RemoteRepository(key.getPackageType(), key.getName(), String.format("http://some.indy/api/content/%s/%s/%s", pkgType, type, name))
+    }
+
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyAddon.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyAddon.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy;
+
+import org.commonjava.indy.model.spi.IndyAddOnID;
+import org.commonjava.indy.spi.IndyAddOn;
+
+public class RepoProxyAddon
+        implements IndyAddOn
+{
+    private IndyAddOnID id;
+
+    public static final String ADDON_NAME = "Repository Proxy";
+
+    @Override
+    public IndyAddOnID getId()
+    {
+        if ( id == null )
+        {
+            id = new IndyAddOnID().withName( ADDON_NAME );
+        }
+
+        return id;
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyContoller.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyContoller.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy;
+
+import org.commonjava.indy.repo.proxy.conf.RepoProxyConfig;
+import org.commonjava.maven.galley.util.PathUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+
+import static javax.servlet.http.HttpServletResponse.SC_MOVED_PERMANENTLY;
+import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
+
+@ApplicationScoped
+public class RepoProxyContoller
+{
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    @Inject
+    private RepoProxyConfig config;
+
+    protected RepoProxyContoller()
+    {
+    }
+
+    public RepoProxyContoller( RepoProxyConfig config )
+    {
+        this.config = config;
+    }
+
+    public boolean doProxy( ServletRequest request, ServletResponse response )
+            throws IOException, ServletException
+    {
+        if ( !config.isEnabled() )
+        {
+            trace( "addon not enabled, will not do any proxy." );
+            return false;
+        }
+        final HttpServletRequest httpRequest = (HttpServletRequest) request;
+        final String method = httpRequest.getMethod().trim().toUpperCase();
+        if ( !config.getApiMethods().contains( method ) )
+        {
+            trace( "http method {} not allowed for the request, no proxy action will be performed", method );
+            return false;
+        }
+        final String pathInfo = httpRequest.getPathInfo();
+
+        final String absoluteOriginalPath =
+                PathUtils.normalize( httpRequest.getServletPath(), httpRequest.getContextPath(),
+                                     httpRequest.getPathInfo() );
+        trace( "absolute path {}", absoluteOriginalPath );
+        final String proxyTo = proxyTo( absoluteOriginalPath );
+        if ( proxyTo == null )
+        {
+            return false;
+        }
+        trace( "proxied to path info {}", proxyTo );
+        // Here we do not use redirect but forward.
+        // doRedirect( (HttpServletResponse)response, proxyTo );
+        doForward( httpRequest, response, proxyTo );
+        return true;
+    }
+
+    //TODO: not used but just leave here for reference
+    private void doRedirect( final HttpServletResponse httpResponse, final String directTo )
+            throws IOException
+    {
+        trace( "will redirect to {}", directTo );
+        httpResponse.setStatus( SC_MOVED_PERMANENTLY );
+        httpResponse.setHeader( "Location", directTo );
+        httpResponse.sendRedirect( directTo );
+    }
+
+    private void doForward( final HttpServletRequest httpRequest, final ServletResponse response,
+                            final String forwardTo )
+            throws IOException, ServletException
+    {
+        trace( "will redirect to {}",  forwardTo );
+        httpRequest.getRequestDispatcher( forwardTo ).forward( httpRequest, response );
+    }
+
+    private String proxyTo( final String originalPath )
+    {
+        for ( Map.Entry<String, String> rule : config.getProxyRules().entrySet() )
+        {
+            trace( "rule key ({}), rule value ({})", rule.getKey(), rule.getValue() );
+            if ( originalPath.indexOf( rule.getKey() ) > 0 )
+            {
+
+                trace( "found proxy rules for path {}: from {} to {}", originalPath, rule.getKey(), rule.getValue() );
+                return originalPath.replace( rule.getKey(), rule.getValue() );
+
+            }
+        }
+        trace( "no proxy rules for path {}, will not do any proxy", originalPath );
+        return null;
+    }
+
+    private void trace( final String template, final Object... params )
+    {
+        final String finalTemplate = ADDON_NAME + ": " + template;
+        logger.trace( finalTemplate, params );
+    }
+
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyException.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyException.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy;
+
+import java.text.MessageFormat;
+import java.util.IllegalFormatException;
+
+public class RepoProxyException
+        extends Exception
+{
+    private static final long serialVersionUID = 1L;
+
+    private Object[] params;
+
+    public RepoProxyException( final String message, final Throwable error, final Object... params )
+    {
+        super( message, error );
+        this.params = params;
+    }
+
+    public RepoProxyException( final String message, final Object... params )
+    {
+        super( message );
+        this.params = params;
+    }
+
+    @Override
+    public String getLocalizedMessage()
+    {
+        return getMessage();
+    }
+
+    @Override
+    public String getMessage()
+    {
+        String message = super.getMessage();
+
+        if ( params != null )
+        {
+            try
+            {
+                message = String.format( message.replaceAll( "\\{}", "%s" ), params );
+            }
+            catch ( final IllegalFormatException ife )
+            {
+                try
+                {
+                    message = MessageFormat.format( message, params );
+                }
+                catch ( final IllegalArgumentException iae )
+                {
+                }
+            }
+        }
+
+        return message;
+    }
+
+    private Object writeReplace()
+    {
+        final Object[] newParams = new Object[params.length];
+        int i = 0;
+        for ( final Object object : params )
+        {
+            newParams[i] = String.valueOf( object );
+            i++;
+        }
+
+        this.params = newParams;
+        return this;
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy;
+
+import org.apache.commons.lang3.StringUtils;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
+
+public class RepoProxyUtils
+{
+    private static final Logger logger = LoggerFactory.getLogger( RepoProxyUtils.class );
+
+    private static final String STORE_PATH_PATTERN = ".*/(maven|npm)/(group|hosted)/(.+?)(/.*)?";
+
+    public static Optional<String> getProxyTo( final String originalPath, final StoreKey proxyToKey )
+    {
+        if ( StoreType.remote != proxyToKey.getType() )
+        {
+            return empty();
+        }
+        final Optional<String> origStoreKey = getOriginalStoreKeyFromPath( originalPath );
+        if ( origStoreKey.isPresent() )
+        {
+            final String originStoreKeyStr = origStoreKey.get();
+            final String[] parts = originStoreKeyStr.split( ":" );
+            final String proxyToStorePathString = keyToPath( proxyToKey );
+            final String proxyTo =
+                    originalPath.replaceAll( originStoreKeyStr.replaceAll( ":", "/" ), proxyToStorePathString );
+            logger.trace( "Found proxy to store rule: from {} to {}", originStoreKeyStr, proxyToStorePathString );
+            return of( proxyTo );
+        }
+
+        return empty();
+    }
+
+    public static Optional<StoreKey> getProxyToStoreKey( final String originalPath )
+    {
+        final Optional<String> origStoreKey = getOriginalStoreKeyFromPath( originalPath );
+        if ( origStoreKey.isPresent() )
+        {
+            final String originStoreKeyStr = origStoreKey.get();
+            final String[] parts = originStoreKeyStr.split( ":" );
+            final String proxyToStoreString = parts[0] + ":" + StoreType.remote.singularEndpointName() + ":" + parts[2];
+            return of( StoreKey.fromString( proxyToStoreString ) );
+        }
+        return empty();
+    }
+
+    public static Optional<String> getOriginalStoreKeyFromPath( final String originalPath )
+    {
+        final Pattern pat = Pattern.compile( STORE_PATH_PATTERN );
+        final Matcher match = pat.matcher( originalPath );
+        String storeKeyString = null;
+        if ( match.matches() )
+        {
+            storeKeyString = String.format( "%s:%s:%s", match.group( 1 ), match.group( 2 ), match.group( 3 ) );
+            logger.trace( "Found matched original store key {} in path {}", storeKeyString, originalPath );
+        }
+        else
+        {
+            logger.trace( "There is not matched original store key in path {}", originalPath );
+        }
+
+        return storeKeyString == null ? empty() : of( storeKeyString );
+    }
+
+    public static String keyToPath( final String keyString )
+    {
+        return StringUtils.isNotBlank( keyString ) ? keyString.replaceAll( ":", "/" ) : "";
+    }
+
+    public static String keyToPath( final StoreKey key )
+    {
+        return keyToPath( key.toString() );
+    }
+
+    public static String extractPath( final String fullPath, final String repoPath )
+    {
+        if ( StringUtils.isBlank( fullPath ) || !fullPath.contains( repoPath ) )
+        {
+            return "";
+        }
+        String checkingRepoPath = repoPath;
+        if ( repoPath.endsWith( "/" ) )
+        {
+            checkingRepoPath = repoPath.substring( 0, repoPath.length() - 1 );
+        }
+        final int pos = fullPath.indexOf( checkingRepoPath );
+        String path = fullPath.substring( pos + checkingRepoPath.length() + 1 );
+        if ( StringUtils.isNotBlank( path ) && !path.startsWith( "/" ) )
+        {
+            path = "/" + path;
+        }
+        return path;
+    }
+
+    public static void trace( final Logger logger, final String template, final Object... params )
+    {
+        final String finalTemplate = ADDON_NAME + ": " + template;
+        logger.trace( finalTemplate, params );
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
@@ -1,0 +1,170 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.conf;
+
+import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.indy.repo.proxy.RepoProxyAddon;
+import org.commonjava.propulsor.config.ConfigurationException;
+import org.commonjava.propulsor.config.annotation.SectionName;
+import org.commonjava.propulsor.config.section.MapSectionListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.File;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
+
+@SectionName( RepoProxyConfig.SECTION )
+@ApplicationScoped
+public class RepoProxyConfig
+        extends MapSectionListener
+        implements IndyConfigInfo
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final String DEFAULT_CONFIG_FILE_NAME = "default-repo-proxy.conf";
+
+    public static final String SECTION = "repo-proxy";
+
+    private static final String ENABLED_PARAM = "enabled";
+
+    private static final String API_PATTERNS_PARAM = "api.url.patterns";
+
+    private static final String API_METHODS_PARAM = "api.methods";
+
+    private static final Boolean DEFAULT_ENABLED = Boolean.FALSE;
+
+    private static final String DEFAULT_API_PATTERNS = "/api/content/*, /api/folo/track/*";
+
+    private static final String DEFAULT_API_METHODS = "GET,HEAD";
+
+    private static final String PROXY_KEY_PREFIX = "proxy.";
+
+    private final Map<String, String> proxyRules = new LinkedHashMap<>();
+
+    private final Set<String> apiPatterns = new HashSet<>();
+
+    private final Set<String> apiMethods = new HashSet<>();
+
+    private Boolean enabled;
+
+    public RepoProxyConfig()
+    {
+    }
+
+    public boolean getEnabled()
+    {
+        return this.enabled == null ? DEFAULT_ENABLED : this.enabled;
+    }
+
+    public boolean isEnabled()
+    {
+        return getEnabled();
+    }
+
+    public void setEnabled( Boolean enabled )
+    {
+        this.enabled = enabled;
+    }
+
+    public Map<String, String> getProxyRules()
+    {
+        return proxyRules;
+    }
+
+    public Set<String> getApiPatterns()
+    {
+        if ( apiPatterns.isEmpty() )
+        {
+            for ( String pattern : DEFAULT_API_PATTERNS.split( "," ) )
+            {
+                apiPatterns.add( pattern.trim() );
+            }
+        }
+        return apiPatterns;
+    }
+
+    public Set<String> getApiMethods()
+    {
+        if ( apiMethods.isEmpty() )
+        {
+            for ( String method : DEFAULT_API_METHODS.split( "," ) )
+            {
+                apiMethods.add( method.trim().toUpperCase() );
+            }
+        }
+        return apiMethods;
+    }
+
+    @Override
+    public void parameter( final String name, final String value )
+            throws ConfigurationException
+    {
+        logger.trace( "{}: config tracing: name({})-value({}) ", ADDON_NAME, name, value );
+        switch ( name )
+        {
+            case ENABLED_PARAM:
+                this.enabled = Boolean.valueOf( value.trim() );
+                break;
+            case API_PATTERNS_PARAM:
+                apiPatterns.clear();
+                for ( String pattern : value.split( "," ) )
+                {
+                    apiPatterns.add( pattern.trim() );
+                }
+                break;
+            case API_METHODS_PARAM:
+                apiMethods.clear();
+                for ( String method : value.split( "," ) )
+                {
+                    apiMethods.add( method.trim().toUpperCase() );
+                }
+                break;
+            default:
+            {
+                if ( name.startsWith( PROXY_KEY_PREFIX ) && name.length() > PROXY_KEY_PREFIX.length() )
+                {
+                    String source = name.substring( PROXY_KEY_PREFIX.length() );
+                    String sourceRepoPath = source.replaceAll( "\\.", "/" );
+                    logger.trace( "{}: Repo {} proxy target is repo {}", ADDON_NAME, source, value );
+                    proxyRules.put( sourceRepoPath, value.replaceAll( ":", "/" ) );
+                }
+                else
+                {
+                    throw new ConfigurationException( "Invalid parameter: '%s'.", value, name, SECTION );
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return new File( IndyConfigInfo.CONF_INCLUDES_DIR, DEFAULT_CONFIG_FILE_NAME ).getPath();
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream( DEFAULT_CONFIG_FILE_NAME );
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/AbstractProxyRepoCreateRule.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/AbstractProxyRepoCreateRule.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.create;
+
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+
+
+public abstract class AbstractProxyRepoCreateRule
+        implements ProxyRepoCreateRule
+{
+
+    @Override
+    public boolean matches( final StoreKey key )
+    {
+        return false;
+    }
+
+    @Override
+    public RemoteRepository createRemote( final StoreKey key )
+    {
+        return null;
+    }
+
+    public String getTargetIndyUrl(){
+        return "";
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/ProxyRepoCreateManager.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/ProxyRepoCreateManager.java
@@ -1,0 +1,208 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.create;
+
+import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.repo.proxy.RepoProxyAddon;
+import org.commonjava.indy.repo.proxy.RepoProxyException;
+import org.commonjava.indy.repo.proxy.conf.RepoProxyConfig;
+import org.commonjava.indy.subsys.datafile.DataFile;
+import org.commonjava.indy.subsys.datafile.DataFileManager;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+@ApplicationScoped
+public class ProxyRepoCreateManager
+{
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    private static final String REPO_PROXY_ORIGIN = RepoProxyAddon.ADDON_NAME;
+
+    @Inject
+    private RepoProxyConfig config;
+
+    @Inject
+    private DataFileManager ffManager;
+
+    @Inject
+    private ScriptRuleParser ruleParser;
+
+    @Inject
+    private StoreDataManager storeManager;
+
+    private List<ProxyRepoCreateRule> rules;
+
+    @PostConstruct
+    public void init()
+    {
+        try
+        {
+            parseRules();
+        }
+        catch ( final RepoProxyException e )
+        {
+            logger.error( "Failed to parse repo creator rule: " + e.getMessage(), e );
+        }
+    }
+
+    public Optional<RemoteRepository> createProxyRemote( final StoreKey origKey )
+            throws RepoProxyException
+    {
+        if ( !enabled() )
+        {
+            throw new RepoProxyException( "Repo proxy addon is disabled" );
+        }
+        if ( rules != null )
+        {
+            for ( ProxyRepoCreateRule rule : rules )
+            {
+                if ( rule.matches( origKey ) )
+                {
+                    logger.info( "[{}] Found rule {} to create repo {}", RepoProxyAddon.ADDON_NAME, rule, origKey );
+                    try
+                    {
+                        RemoteRepository repo = rule.createRemote( origKey );
+                        if ( repo != null )
+                        {
+                            Optional<RemoteRepository> existedRepo =
+                                    existsAndGetStore( repo.getKey(), RemoteRepository.class );
+                            if ( existedRepo.isPresent() )
+                            {
+                                return existedRepo;
+                            }
+                            repo.setMetadata( ArtifactStore.METADATA_ORIGIN, REPO_PROXY_ORIGIN );
+                            boolean created = storeManager.storeArtifactStore( repo, new ChangeSummary(
+                                                                                       ChangeSummary.SYSTEM_USER, "[Repository proxy] create remote proxy" ), true, false,
+                                                                               new EventMetadata() );
+                            if ( created )
+                            {
+                                logger.info( "[{}] Repo {} found or created to do proxy to", RepoProxyAddon.ADDON_NAME,
+                                             repo.getKey() );
+                                return Optional.of( repo );
+                            }
+                            else
+                            {
+                                logger.warn( "[{}] Repo {} not created successfully to do proxy to",
+                                             RepoProxyAddon.ADDON_NAME, repo.getKey() );
+                            }
+                        }
+                        else
+                        {
+                            logger.warn( "[{}] Repo creation from rule {} not succeed.", RepoProxyAddon.ADDON_NAME,
+                                         rule );
+                        }
+                    }
+                    catch ( MalformedURLException | IndyDataException e )
+                    {
+                        logger.warn( "Repo creation failed for key {} with rule {}, Reason: {}", origKey, rule,
+                                     e.getMessage() );
+                    }
+                }
+            }
+        }
+
+        //Tweak: will find and check a same-named remote repo for the original one if all other rules failed to get the matched remote
+        final StoreKey sameNamedRemoteKey = StoreKey.fromString(
+                String.format( "%s:%s:%s", origKey.getPackageType(), StoreType.remote.singularEndpointName(),
+                               origKey.getName() ) );
+        return existsAndGetStore( sameNamedRemoteKey, RemoteRepository.class );
+    }
+
+    private <S extends ArtifactStore> Optional<S> existsAndGetStore( final StoreKey key, Class<S> repoType )
+    {
+        ArtifactStore repo = null;
+        try
+        {
+            repo = storeManager.getArtifactStore( key );
+            if ( repo == null )
+            {
+                logger.debug( "Store {} not found for repo-proxy", key );
+            }
+        }
+        catch ( IndyDataException e )
+        {
+            logger.debug( "Cannot find store {} for pre-check with exception: {}", key, e.getMessage() );
+        }
+        return repo == null ? empty() : of( (S) repo );
+    }
+
+    public synchronized void parseRules()
+            throws RepoProxyException
+    {
+        if ( !enabled() )
+        {
+            return;
+        }
+
+        final List<ProxyRepoCreateRule> rules = new ArrayList<>();
+
+        final DataFile dataDir = ffManager.getDataFile( config.getRepoCreatorRuleBaseDir() );
+        logger.info( "Scanning {} for repo creator rules...", dataDir );
+        if ( dataDir.exists() )
+        {
+            final DataFile[] scripts = dataDir.listFiles( pathname -> {
+                logger.debug( "Checking for repo creator script in: {}", pathname );
+                return pathname.getName().endsWith( ".groovy" );
+            } );
+
+            for ( final DataFile script : scripts )
+            {
+                logger.info( "Reading repo creator rule from: {}", script );
+                final ProxyRepoCreateRule rule = ruleParser.parseRule( script );
+                if ( rule != null )
+                {
+                    rules.add( rule );
+                }
+            }
+        }
+        else
+        {
+            logger.info( "Datadir {} not found, no rule scripts scanned", dataDir );
+        }
+
+        this.rules = rules;
+    }
+
+    private boolean enabled()
+    {
+        if ( !config.isEnabled() )
+        {
+            this.rules = new ArrayList<>();
+            logger.debug( "Autoprox is disabled." );
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/ProxyRepoCreateRule.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/ProxyRepoCreateRule.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.create;
+
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+
+import java.net.MalformedURLException;
+
+public interface ProxyRepoCreateRule
+{
+    boolean matches( final StoreKey origKey );
+
+    RemoteRepository createRemote( final StoreKey origKey )
+            throws MalformedURLException;
+
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/ScriptRuleParser.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/ScriptRuleParser.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.create;
+
+import org.apache.commons.io.FileUtils;
+import org.commonjava.indy.repo.proxy.RepoProxyAddon;
+import org.commonjava.indy.repo.proxy.RepoProxyException;
+import org.commonjava.indy.subsys.datafile.DataFile;
+import org.commonjava.indy.subsys.template.IndyGroovyException;
+import org.commonjava.indy.subsys.template.ScriptEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+
+import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
+
+@ApplicationScoped
+public class ScriptRuleParser
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private ScriptEngine scriptEngine;
+
+    protected ScriptRuleParser()
+    {
+    }
+
+    public ScriptRuleParser( final ScriptEngine scriptEngine )
+    {
+        this.scriptEngine = scriptEngine;
+    }
+
+    public ProxyRepoCreateRule parseRule( final DataFile script )
+            throws RepoProxyException
+    {
+        String spec = null;
+        try
+        {
+            spec = script.readString();
+        }
+        catch ( final IOException e )
+        {
+            logger.error( String.format( "[%s] Cannot load repo proxy factory from: %s. Reason: %s", ADDON_NAME, script,
+                                         e.getMessage() ), e );
+        }
+
+        return parseRule( spec, script.getName() );
+    }
+
+    public ProxyRepoCreateRule parseRule( final File script )
+            throws RepoProxyException
+    {
+        String spec = null;
+        try
+        {
+            spec = FileUtils.readFileToString( script );
+        }
+        catch ( final IOException e )
+        {
+            logger.error( String.format( "[%s] Cannot load repo proxy factory from: %s. Reason: %s", ADDON_NAME, script,
+                                         e.getMessage() ), e );
+        }
+
+        return parseRule( spec, script.getName() );
+    }
+
+    public ProxyRepoCreateRule parseRule( final String spec, final String scriptName )
+            throws RepoProxyException
+    {
+        if ( spec == null )
+        {
+            return null;
+        }
+
+        ProxyRepoCreateRule rule;
+        try
+        {
+            rule = scriptEngine.parseScriptInstance( spec, ProxyRepoCreateRule.class );
+        }
+        catch ( final IndyGroovyException e )
+        {
+            throw new RepoProxyException(
+                    "[{}] Cannot load repo-proxy factory from: {} as an instance of: {}. Reason: {}", e, ADDON_NAME,
+                    scriptName, ProxyRepoCreateRule.class.getSimpleName(), e.getMessage() );
+        }
+
+        if ( rule != null )
+        {
+            return rule;
+        }
+
+        logger.warn( "Rule named: {} parsed to null ProxyRepoCreateRule instance. Spec was:\n\n{}\n\n", scriptName,
+                     spec );
+        return null;
+    }
+
+}
+

--- a/addons/repo-proxy/common/src/main/resources/META-INF/beans.xml
+++ b/addons/repo-proxy/common/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2014 Red Hat, Inc..
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the GNU Public License v3.0
+  which accompanies this distribution, and is available at
+  http://www.gnu.org/licenses/gpl.html
+  
+  Contributors:
+      Red Hat, Inc. - initial API and implementation
+-->
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
+       version="1.1" bean-discovery-mode="all">
+      
+  
+</beans>

--- a/addons/repo-proxy/common/src/main/resources/default-repo-proxy.conf
+++ b/addons/repo-proxy/common/src/main/resources/default-repo-proxy.conf
@@ -1,0 +1,13 @@
+[repo-proxy]
+# enabled: By default, the repo-proxy add-on is disabled.
+#
+#enabled=false
+
+# proxy: define the proxy rule for the repos. A valid rule is like this: proxy.$packageType.$type.$name=$packageType:$type:$name.
+# proxy.maven.hosted.from=maven:remote:to
+
+# Define the pattern for the api url pattern that will use the proxy, use comma to split
+# api.url.patterns=/api/content/*, /api/folo/track/*
+
+# Define the api http methods that the proxy will be applied with, use comma to split
+# api.methods=GET,HEAD

--- a/addons/repo-proxy/common/src/main/resources/default-repo-proxy.conf
+++ b/addons/repo-proxy/common/src/main/resources/default-repo-proxy.conf
@@ -3,9 +3,6 @@
 #
 #enabled=false
 
-# proxy: define the proxy rule for the repos. A valid rule is like this: proxy.$packageType.$type.$name=$packageType:$type:$name.
-# proxy.maven.hosted.from=maven:remote:to
-
 # Define the pattern for the api url pattern that will use the proxy, use comma to split
 # api.url.patterns=/api/content/*, /api/folo/track/*
 

--- a/addons/repo-proxy/common/src/test/java/RepoProxyUtilsTest.java
+++ b/addons/repo-proxy/common/src/test/java/RepoProxyUtilsTest.java
@@ -1,0 +1,109 @@
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.repo.proxy.RepoProxyUtils;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.commonjava.indy.model.core.StoreKey.fromString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class RepoProxyUtilsTest
+{
+    @Test
+    public void testGetOriginalStoreKeyFromPath()
+    {
+        String path = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
+        Optional<String> storeKeyStr = RepoProxyUtils.getOriginalStoreKeyFromPath( path );
+        assertTrue( storeKeyStr.isPresent() );
+        assertThat( storeKeyStr.get(), equalTo( "maven:group:abc" ) );
+
+        path = "/api/content/maven/hosted/def";
+        storeKeyStr = RepoProxyUtils.getOriginalStoreKeyFromPath( path );
+        assertTrue( storeKeyStr.isPresent() );
+        assertThat( storeKeyStr.get(), equalTo( "maven:hosted:def" ) );
+
+        path = "/api/content/npm/group/ghi/";
+        storeKeyStr = RepoProxyUtils.getOriginalStoreKeyFromPath( path );
+        assertTrue( storeKeyStr.isPresent() );
+        assertThat( storeKeyStr.get(), equalTo( "npm:group:ghi" ) );
+
+        path = "/api/content/npm/groupe/ghi/";
+        storeKeyStr = RepoProxyUtils.getOriginalStoreKeyFromPath( path );
+        assertFalse( storeKeyStr.isPresent() );
+    }
+
+    @Test
+    public void testExtractPath()
+    {
+        String fullPath = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
+        String repoPath = "maven/group/abc";
+        String path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        assertThat( path, equalTo( "/org/commonjava/indy/maven-metadata.xml" ) );
+
+        fullPath = "/api/content/maven/hosted/def/org/commonjava/indy/1.0/";
+        repoPath = "/maven/hosted/def";
+        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        assertThat( path, equalTo( "/org/commonjava/indy/1.0/" ) );
+
+        fullPath = "/api/content/npm/group/ghi/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom";
+        repoPath = "npm/group/ghi/";
+        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        assertThat( path, equalTo( "/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
+
+        fullPath = "/api/content/npm/hosted/jkl/org/commonjava/indy/indy-api/2.0/indy-api-2.0.jar";
+        repoPath = "/npm/hosted/jkl/";
+        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        assertThat( path, equalTo( "/org/commonjava/indy/indy-api/2.0/indy-api-2.0.jar" ) );
+    }
+
+    @Test
+    public void testProxyTo()
+    {
+        String fullPath = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
+        Optional<String> proxyTo = RepoProxyUtils.getProxyTo( fullPath, StoreKey.fromString( "maven:remote:group-abc" ) );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( "/api/content/maven/remote/group-abc/org/commonjava/indy/maven-metadata.xml" ) );
+
+        fullPath = "/api/browse/content/maven/hosted/def/org/commonjava/indy/1.0/";
+        proxyTo = RepoProxyUtils.getProxyTo( fullPath, StoreKey.fromString( "maven:remote:hosted-def" ) );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( "/api/browse/content/maven/remote/hosted-def/org/commonjava/indy/1.0/" ) );
+
+        fullPath = "/api/folo/track/npm/group/ghi/jquery";
+        proxyTo = RepoProxyUtils.getProxyTo( fullPath, StoreKey.fromString( "npm:remote:group-ghi" ) );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( "/api/folo/track/npm/remote/group-ghi/jquery" ) );
+
+        fullPath = "/api/folo/track/npm/hosted/jkl/@react/core";
+        proxyTo = RepoProxyUtils.getProxyTo( fullPath, StoreKey.fromString( "npm:remote:hosted-jkl") );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( "/api/folo/track/npm/remote/hosted-jkl/@react/core" ) );
+    }
+
+    @Test
+    public void testProxyToStoreKey()
+    {
+        String fullPath = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
+        Optional<StoreKey> proxyTo = RepoProxyUtils.getProxyToStoreKey( fullPath );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( fromString( "maven:remote:abc" ) ) );
+
+        fullPath = "/api/browse/content/maven/hosted/def/org/commonjava/indy/1.0/";
+        proxyTo = RepoProxyUtils.getProxyToStoreKey( fullPath );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( fromString( "maven:remote:def" ) ) );
+
+        fullPath = "/api/folo/track/npm/group/ghi/jquery";
+        proxyTo = RepoProxyUtils.getProxyToStoreKey( fullPath );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( fromString( "npm:remote:ghi" ) ) );
+
+        fullPath = "/api/folo/track/npm/hosted/jkl/@react/core";
+        proxyTo = RepoProxyUtils.getProxyToStoreKey( fullPath );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( fromString( "npm:remote:jkl" ) ) );
+    }
+}

--- a/addons/repo-proxy/ftests/pom.xml
+++ b/addons/repo-proxy/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-repo-proxy</artifactId>

--- a/addons/repo-proxy/ftests/pom.xml
+++ b/addons/repo-proxy/ftests/pom.xml
@@ -1,0 +1,70 @@
+<!--
+
+    Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-repo-proxy</artifactId>
+    <version>2.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>indy-ftests-repo-proxy</artifactId>
+  <name>Indy :: Repository-Proxy :: Functional Tests</name>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-repo-proxy-jaxrs</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-repo-proxy-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-client-core-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-ftests-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-test-fixtures-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>http-testserver</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDefaultTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDefaultTest.java
@@ -1,0 +1,130 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the repo proxy addon can proxy a hosted repo to a remote repo
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Hosted and Remote Repo</li>
+ *     <li>Hosted does not contain pathA but remote does</li>
+ *     <li>Hosted contains pathB but remote does not</li>
+ *     <li>Configured the repo-proxy disabled</li>
+ *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request pathA and pathB through hosted</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of pathA can be returned correctly from hosted, but pathB can not</li>
+ * </ul>
+ */
+public class RepoProxyDefaultTest
+        extends AbstractContentManagementTest
+{
+    private static final String REPO_NAME = "pnc-builds";
+
+    private HostedRepository hosted;
+
+    private RemoteRepository remote;
+
+    private static final String PATH1 = "foo/bar/1.0/foo-bar-1.0.txt";
+
+    private static final String PATH2 = "foo/bar/2.0/foo-bar-2.0.txt";
+
+    private static final String CONTENT1 = "This is content 1";
+
+    private static final String CONTENT2 = "This is content 2";
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+
+        server.expect( server.formatUrl( REPO_NAME, PATH1 ), 200, new ByteArrayInputStream( CONTENT1.getBytes() ) );
+
+        remote = client.stores()
+                       .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
+                                                      server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
+                                RemoteRepository.class );
+
+        hosted = client.stores()
+                       .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
+                                "hosted pnc-builds", HostedRepository.class );
+        client.content().store( hosted.getKey(), PATH2, new ByteArrayInputStream( CONTENT2.getBytes() ) );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        try (InputStream result = client.content().get( remote.getKey(), PATH1 ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            assertThat( content, equalTo( CONTENT1 ) );
+        }
+
+        try (InputStream result = client.content().get( hosted.getKey(), PATH1 ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            assertThat( content, equalTo( CONTENT1 ) );
+        }
+
+        InputStream result = client.content().get( remote.getKey(), PATH2 );
+        assertThat( result, nullValue() );
+
+        result = client.content().get( hosted.getKey(), PATH2 );
+        assertThat( result, nullValue() );
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf",
+                         "[repo-proxy]\nenabled=true\nproxy.maven.hosted.pnc-builds=maven:remote:pnc-builds" );
+    }
+
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDefaultTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDefaultTest.java
@@ -21,11 +21,7 @@ import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
-import org.commonjava.test.http.expect.ExpectationServer;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -38,20 +34,17 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 /**
- * Check if the repo proxy addon can proxy a hosted repo to a remote repo
+ * Check if the repo proxy addon can proxy a hosted repo to a same-named remote repo if no creator rules defined
  * <br/>
  * GIVEN:
  * <ul>
- *     <li>Hosted and Remote Repo</li>
- *     <li>Hosted does not contain pathA but remote does</li>
- *     <li>Hosted contains pathB but remote does not</li>
- *     <li>Configured the repo-proxy disabled</li>
- *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ *     <li>Remote Repo and contains pathA, but does not contain pathB</li>
+ *     <li>Configured the repo-proxy enabled</li>
  * </ul>
  * <br/>
  * WHEN:
  * <ul>
- *     <li>Request pathA and pathB through hosted</li>
+ *     <li>Request pathA and pathB through a Hosted repo which is same-named as Remote</li>
  * </ul>
  * <br/>
  * THEN:
@@ -64,7 +57,7 @@ public class RepoProxyDefaultTest
 {
     private static final String REPO_NAME = "pnc-builds";
 
-    private HostedRepository hosted;
+    private HostedRepository hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
 
     private RemoteRepository remote;
 
@@ -87,11 +80,6 @@ public class RepoProxyDefaultTest
                        .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
                                                       server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
                                 RemoteRepository.class );
-
-        hosted = client.stores()
-                       .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
-                                "hosted pnc-builds", HostedRepository.class );
-        client.content().store( hosted.getKey(), PATH2, new ByteArrayInputStream( CONTENT2.getBytes() ) );
     }
 
     @Test
@@ -123,8 +111,7 @@ public class RepoProxyDefaultTest
     protected void initTestConfig( CoreServerFixture fixture )
             throws IOException
     {
-        writeConfigFile( "conf.d/repo-proxy.conf",
-                         "[repo-proxy]\nenabled=true\nproxy.maven.hosted.pnc-builds=maven:remote:pnc-builds" );
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true" );
     }
 
 }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDisableTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDisableTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the repo proxy addon will stop working when disabled.
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Hosted and Remote Repo</li>
+ *     <li>Hosted does not contain pathA but remote does</li>
+ *     <li>Hosted contains pathB but remote does not</li>
+ *     <li>Configured the repo-proxy disabled</li>
+ *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request pathA and pathB through hosted</li>
+ *     <li>Request pathA and pathB through remote</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of pathA can not be returned correctly from hosted, but pathB can</li>
+ *     <li>The content of pathA can not be returned correctly from remote, but pathB can not</li>
+ * </ul>
+ */
+public class RepoProxyDisableTest
+        extends AbstractContentManagementTest
+{
+    private static final String REPO_NAME = "pnc-builds";
+
+    private HostedRepository hosted;
+
+    private RemoteRepository remote;
+
+    private static final String PATH1 = "foo/bar/1.0/foo-bar-1.0.txt";
+
+    private static final String PATH2 = "foo/bar/2.0/foo-bar-2.0.txt";
+
+    private static final String CONTENT1 = "This is content 1";
+
+    private static final String CONTENT2 = "This is content 2";
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+
+        server.expect( server.formatUrl( REPO_NAME, PATH1 ), 200, new ByteArrayInputStream( CONTENT1.getBytes() ) );
+
+        remote = client.stores()
+                       .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
+                                                      server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
+                                RemoteRepository.class );
+
+        hosted = client.stores()
+                       .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
+                                "hosted pnc-builds", HostedRepository.class );
+        client.content().store( hosted.getKey(), PATH2, new ByteArrayInputStream( CONTENT2.getBytes() ) );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        InputStream result = client.content().get( hosted.getKey(), PATH1 );
+        assertThat( result, nullValue() );
+
+        try (InputStream result2 = client.content().get( hosted.getKey(), PATH2 ))
+        {
+            assertThat( result2, notNullValue() );
+            final String content = IOUtils.toString( result2 );
+            assertThat( content, equalTo( CONTENT2 ) );
+        }
+
+        try (InputStream result3 = client.content().get( remote.getKey(), PATH1 ))
+        {
+            assertThat( result3, notNullValue() );
+            final String content = IOUtils.toString( result3 );
+            assertThat( content, equalTo( CONTENT1 ) );
+        }
+
+        result = client.content().get( remote.getKey(), PATH2 );
+        assertThat( result, nullValue() );
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf",
+                         "[repo-proxy]\nproxy.maven.hosted.pnc-builds=maven:remote:pnc-builds" );
+    }
+
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDisableTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDisableTest.java
@@ -20,12 +20,10 @@ import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
-import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -116,14 +114,6 @@ public class RepoProxyDisableTest
         result = client.content().get( remote.getKey(), PATH2 );
         assertThat( result, nullValue() );
 
-    }
-
-    @Override
-    protected void initTestConfig( CoreServerFixture fixture )
-            throws IOException
-    {
-        writeConfigFile( "conf.d/repo-proxy.conf",
-                         "[repo-proxy]\nproxy.maven.hosted.pnc-builds=maven:remote:pnc-builds" );
     }
 
 }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyMethodsTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyMethodsTest.java
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Check if the repo proxy addon can proxy a hosted repo to a remote repo with specific api methods
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Hosted and Remote Repo</li>
+ *     <li>Hosted does not contain pathA but remote does</li>
+ *     <li>Configured the repo-proxy disabled</li>
+ *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ *     <li>Configured api methods</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request pathA through hosted with specified api methods</li>
+ *     <li>Request pathA through hosted without specified api methods</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of pathA can be returned correctly from hosted when methods applied</li>
+ *     <li>The content of pathA can be returned correctly from hosted when methods not applied</li>
+ * </ul>
+ */
+public class RepoProxyMethodsTest
+        extends AbstractContentManagementTest
+{
+    private static final String REPO_NAME = "pnc-builds";
+
+    private HostedRepository hosted;
+
+    private RemoteRepository remote;
+
+    private static final String PATH1 = "foo/bar/1.0/foo-bar-1.0.txt";
+
+    private static final String CONTENT1 = "This is content 1";
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+
+        server.expect( server.formatUrl( REPO_NAME, PATH1 ), 200, new ByteArrayInputStream( CONTENT1.getBytes() ) );
+
+        remote = client.stores()
+                       .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
+                                                      server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
+                                RemoteRepository.class );
+
+        hosted = client.stores()
+                       .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
+                                "hosted pnc-builds", HostedRepository.class );
+    }
+
+    @Test(expected = IndyClientException.class)
+    public void runPUTWithError()
+            throws Exception
+    {
+        client.content().store( hosted.getKey(), PATH1, new ByteArrayInputStream( CONTENT1.getBytes() ) );
+        fail( "Should not store successfully: proxy remote does not support deployment!" );
+    }
+
+    @Test
+    public void runNoContentStored()
+            throws Exception
+    {
+        InputStream result = client.content().get( hosted.getKey(), PATH1 );
+        assertThat( result, nullValue() );
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf",
+                         "[repo-proxy]\nenabled=true\nproxy.maven.hosted.pnc-builds=maven:remote:pnc-builds\napi.methods=PUT" );
+    }
+
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyMethodsTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyMethodsTest.java
@@ -15,14 +15,12 @@
  */
 package org.commonjava.indy.repo.proxy.ftest;
 
-import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
-import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,8 +28,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -41,17 +37,15 @@ import static org.junit.Assert.fail;
  * <br/>
  * GIVEN:
  * <ul>
- *     <li>Hosted and Remote Repo</li>
- *     <li>Hosted does not contain pathA but remote does</li>
- *     <li>Configured the repo-proxy disabled</li>
- *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ *     <li>Remote Repo and contains pathA</li>
+ *     <li>Configured the repo-proxy enabled</li>
  *     <li>Configured api methods</li>
  * </ul>
  * <br/>
  * WHEN:
  * <ul>
- *     <li>Request pathA through hosted with specified api methods</li>
- *     <li>Request pathA through hosted without specified api methods</li>
+ *     <li>Request pathA through a hosted repo which is same-named as Remote with specified api methods</li>
+ *     <li>Request pathA through the hosted without specified api methods</li>
  * </ul>
  * <br/>
  * THEN:
@@ -85,12 +79,10 @@ public class RepoProxyMethodsTest
                                                       server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
                                 RemoteRepository.class );
 
-        hosted = client.stores()
-                       .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
-                                "hosted pnc-builds", HostedRepository.class );
+        hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
     }
 
-    @Test(expected = IndyClientException.class)
+    @Test( expected = IndyClientException.class )
     public void runPUTWithError()
             throws Exception
     {
@@ -110,8 +102,7 @@ public class RepoProxyMethodsTest
     protected void initTestConfig( CoreServerFixture fixture )
             throws IOException
     {
-        writeConfigFile( "conf.d/repo-proxy.conf",
-                         "[repo-proxy]\nenabled=true\nproxy.maven.hosted.pnc-builds=maven:remote:pnc-builds\napi.methods=PUT" );
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true\napi.methods=PUT" );
     }
 
 }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyPatternsTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyPatternsTest.java
@@ -40,22 +40,24 @@ import static org.junit.Assert.assertThat;
  * GIVEN:
  * <ul>
  *     <li>Hosted and Remote Repo</li>
- *     <li>Hosted does not contain pathA but remote does</li>
- *     <li>Configured the repo-proxy disabled</li>
+ *     <li>Hosted does not contain path1 but remote does</li>
+ *     <li>Hosted contain path2 but remote does not</li>
+ *     <li>Configured the repo-proxy enabled</li>
  *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
- *     <li>Configured api url patterns</li>
+ *     <li>Configured api url patterns as /api/admin/stores/* with only GET methods allowed (means enable store load proxy)</li>
  * </ul>
  * <br/>
  * WHEN:
  * <ul>
- *     <li>Request pathA through hosted with specific url patterns</li>
- *     <li>Request pathA through hosted without specific url patterns</li>
+ *     <li>Load hosted with specific url patterns</li>
+ *     <li>Request path1 and path2 through hosted without specific url patterns</li>
  * </ul>
  * <br/>
  * THEN:
  * <ul>
- *     <li>The content of pathA can be returned correctly from hosted when patterns applied</li>
- *     <li>The content of pathA can be returned correctly from hosted when patterns not applied</li>
+ *     <li>Loaded store is remote but not hosted</li>
+ *     <li>The content of path1 can not be returned correctly from hosted as no proxy happened</li>
+ *     <li>The content of pathA can be returned correctly from hosted as no proxy happened</li>
  * </ul>
  */
 public class RepoProxyPatternsTest
@@ -87,6 +89,7 @@ public class RepoProxyPatternsTest
                                                       server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
                                 RemoteRepository.class );
 
+        //        hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
         hosted = client.stores()
                        .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
                                 "hosted pnc-builds", HostedRepository.class );
@@ -118,7 +121,7 @@ public class RepoProxyPatternsTest
             throws IOException
     {
         writeConfigFile( "conf.d/repo-proxy.conf",
-                         "[repo-proxy]\nenabled=true\nproxy.maven.hosted.pnc-builds=maven:remote:pnc-builds\napi.url.patterns=/api/admin/stores/*\napi.methods=GET,HEAD" );
+                         "[repo-proxy]\nenabled=true\napi.url.patterns=/api/admin/stores/*\napi.methods=GET,HEAD" );
     }
 
 }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyPatternsTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyPatternsTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the repo proxy addon can proxy a hosted repo to a remote repo with specific api patterns
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Hosted and Remote Repo</li>
+ *     <li>Hosted does not contain pathA but remote does</li>
+ *     <li>Configured the repo-proxy disabled</li>
+ *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ *     <li>Configured api url patterns</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request pathA through hosted with specific url patterns</li>
+ *     <li>Request pathA through hosted without specific url patterns</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of pathA can be returned correctly from hosted when patterns applied</li>
+ *     <li>The content of pathA can be returned correctly from hosted when patterns not applied</li>
+ * </ul>
+ */
+public class RepoProxyPatternsTest
+        extends AbstractContentManagementTest
+{
+    private static final String REPO_NAME = "pnc-builds";
+
+    private HostedRepository hosted;
+
+    private RemoteRepository remote;
+
+    private static final String PATH1 = "foo/bar/1.0/foo-bar-1.0.txt";
+
+    private static final String PATH2 = "foo/bar/2.0/foo-bar-2.0.txt";
+
+    private static final String CONTENT1 = "This is content 1";
+
+    private static final String CONTENT2 = "This is content 2";
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+
+        server.expect( server.formatUrl( REPO_NAME, PATH1 ), 200, new ByteArrayInputStream( CONTENT1.getBytes() ) );
+
+        remote = client.stores()
+                       .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
+                                                      server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
+                                RemoteRepository.class );
+
+        hosted = client.stores()
+                       .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
+                                "hosted pnc-builds", HostedRepository.class );
+        client.content().store( hosted.getKey(), PATH2, new ByteArrayInputStream( CONTENT2.getBytes() ) );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        ArtifactStore store = client.stores().load( hosted.getKey(), ArtifactStore.class );
+        assertThat( store, notNullValue() );
+        assertThat( store.getKey(), equalTo( remote.getKey() ) );
+
+        InputStream result = client.content().get( hosted.getKey(), PATH1 );
+        assertThat( result, nullValue() );
+
+        try (InputStream result2 = client.content().get( hosted.getKey(), PATH2 ))
+        {
+            assertThat( result2, notNullValue() );
+            final String content = IOUtils.toString( result2 );
+            assertThat( content, equalTo( CONTENT2 ) );
+        }
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf",
+                         "[repo-proxy]\nenabled=true\nproxy.maven.hosted.pnc-builds=maven:remote:pnc-builds\napi.url.patterns=/api/admin/stores/*\napi.methods=GET,HEAD" );
+    }
+
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorDefaultTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorDefaultTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest.create;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the repo proxy addon can proxy a hosted repo automatically with no remote setup
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>A external repo with specified path </li>
+ *     <li>Configured the repo-proxy enabled</li>
+ *     <li>Deployed a repo creator script whose rule to create remote repo which points to the external repo</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request path through a Hosted repo</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of path can be returned correctly from hosted, but pathB can not</li>
+ *     <li>The remote repo which is same-named as hosted has been set up.</li>
+ * </ul>
+ */
+public class RepoProxyCreatorDefaultTest
+        extends AbstractContentManagementTest
+
+{
+    private static final String REPO_NAME = "pnc-builds";
+
+    private HostedRepository hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
+
+    private static final String PATH = "foo/bar/1.0/foo-bar-1.0.txt";
+
+    private static final String CONTENT = "This is content";
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+        server.expect( server.formatUrl( REPO_NAME, PATH ), 200, new ByteArrayInputStream( CONTENT.getBytes() ) );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final StoreKey remoteKey =
+                new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, REPO_NAME );
+        RemoteRepository remote = client.stores().load( remoteKey, RemoteRepository.class );
+        assertThat( remote, nullValue() );
+
+        try (InputStream result = client.content().get( hosted.getKey(), PATH ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            assertThat( content, equalTo( CONTENT ) );
+        }
+
+        remote = client.stores().load( remoteKey, RemoteRepository.class );
+        assertThat( remote, notNullValue() );
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true" );
+    }
+
+    @Override
+    public void initTestData( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeDataFile( "repo-proxy/default-rule.groovy", getRuleScriptContent() );
+
+        super.initTestData( fixture );
+    }
+
+    private String getRuleScriptContent()
+    {
+        final String targetBase = server.formatUrl( REPO_NAME );
+        // @formatter:off
+        return
+            "import org.commonjava.indy.repo.proxy.create.*\n" +
+            "import org.commonjava.indy.model.core.*\n" +
+            "class DefaultRule extends AbstractProxyRepoCreateRule {\n" +
+            "    @Override\n" +
+            "    boolean matches(StoreKey storeKey) {\n" +
+            "        return \"maven\".equals(storeKey.getPackageType())\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    RemoteRepository createRemote(StoreKey key) {\n" +
+            "        return new RemoteRepository(key.getPackageType(), key.getName(), \"" + targetBase + "\")\n" +
+            "    }\n" +
+            "}";
+        // @formatter:on;
+    }
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorNotMatchTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorNotMatchTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest.create;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the repo proxy addon can proxy a hosted repo automatically based on matched script rules
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>A external repo with specified path </li>
+ *     <li>Configured the repo-proxy enabled</li>
+ *     <li>Deployed a repo creator script rule. This rule will match specified repo name then create same-named repo. If not matched, do nothing.</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request path through two Hosted repos, one with matched name in rule and the other not</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of path can be returned correctly from hosted which name matches the rule, and related remote will be set up.</li>
+ *     <li>The content of path can not be returned correctly from hosted which name does not match the rule, and related remote will not be set up.</li>
+ * </ul>
+ */
+public class RepoProxyCreatorNotMatchTest
+        extends AbstractContentManagementTest
+
+{
+    private static final String REPO_NAME_1 = "pnc-builds";
+
+    private static final String REPO_NAME_2 = "not-matched";
+
+    private HostedRepository hosted1 = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME_1 );
+
+    private HostedRepository hosted2 = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME_2 );
+
+    private static final String PATH = "foo/bar/1.0/foo-bar-1.0.txt";
+
+    private static final String CONTENT = "This is content";
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+        server.expect( server.formatUrl( REPO_NAME_1, PATH ), 200, new ByteArrayInputStream( CONTENT.getBytes() ) );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final StoreKey remoteKey1 =
+                new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, REPO_NAME_1 );
+        RemoteRepository remote1 = client.stores().load( remoteKey1, RemoteRepository.class );
+        assertThat( remote1, nullValue() );
+
+        try (InputStream result = client.content().get( hosted1.getKey(), PATH ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            assertThat( content, equalTo( CONTENT ) );
+        }
+
+        remote1 = client.stores().load( remoteKey1, RemoteRepository.class );
+        assertThat( remote1, notNullValue() );
+
+        final StoreKey remoteKey2 =
+                new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, REPO_NAME_2 );
+        RemoteRepository remote2 = client.stores().load( remoteKey2, RemoteRepository.class );
+        assertThat( remote2, nullValue() );
+
+        try (InputStream result = client.content().get( hosted2.getKey(), PATH ))
+        {
+            assertThat( result, nullValue() );
+        }
+
+        remote2 = client.stores().load( remoteKey2, RemoteRepository.class );
+        assertThat( remote2, nullValue() );
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true" );
+    }
+
+    @Override
+    public void initTestData( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeDataFile( "repo-proxy/default-rule.groovy", getRuleScriptContent() );
+
+        super.initTestData( fixture );
+    }
+
+    private String getRuleScriptContent()
+    {
+        final String targetBase = server.formatUrl( REPO_NAME_1 );
+        // @formatter:off
+        return
+            "import org.commonjava.indy.repo.proxy.create.*\n" +
+            "import org.commonjava.indy.model.core.*\n" +
+            "class DefaultRule extends AbstractProxyRepoCreateRule {\n" +
+            "    @Override\n" +
+            "    boolean matches(StoreKey storeKey) {\n" +
+            "        return \"maven\".equals(storeKey.getPackageType()) && \"pnc-builds\".equals(storeKey.getName())\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    RemoteRepository createRemote(StoreKey key) {\n" +
+            "        return new RemoteRepository(key.getPackageType(), key.getName(), \"" + targetBase + "\")\n" +
+            "    }\n" +
+            "}";
+        // @formatter:on;
+    }
+}

--- a/addons/repo-proxy/ftests/src/main/resources/beans.xml
+++ b/addons/repo-proxy/ftests/src/main/resources/beans.xml
@@ -5,7 +5,7 @@
   are made available under the terms of the GNU Public License v3.0
   which accompanies this distribution, and is available at
   http://www.gnu.org/licenses/gpl.html
-
+  
   Contributors:
       Red Hat, Inc. - initial API and implementation
 -->

--- a/addons/repo-proxy/jaxrs/pom.xml
+++ b/addons/repo-proxy/jaxrs/pom.xml
@@ -1,0 +1,62 @@
+<!--
+
+    Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.commonjava.indy</groupId>
+    <artifactId>indy-repo-proxy</artifactId>
+    <version>2.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>indy-repo-proxy-jaxrs</artifactId>
+
+  <name>Indy :: Add-Ons :: Repository-Proxy :: JAX-RS Bindings</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-repo-proxy-common</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-bindings-jaxrs</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.jboss.weld.se</groupId>
+      <artifactId>weld-se-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.resteasy</groupId>
+      <artifactId>resteasy-jaxrs</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
+  </dependencies>
+  
+</project>

--- a/addons/repo-proxy/jaxrs/pom.xml
+++ b/addons/repo-proxy/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-repo-proxy-jaxrs</artifactId>

--- a/addons/repo-proxy/jaxrs/src/main/java/org/commonjava/indy/repo/proxy/jaxrs/RepoProxyAdminResource.java
+++ b/addons/repo-proxy/jaxrs/src/main/java/org/commonjava/indy/repo/proxy/jaxrs/RepoProxyAdminResource.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.jaxrs;
+
+import io.swagger.annotations.Api;
+import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.REST;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.Path;
+
+@Api( value = "Repository Proxy administration REST interface" )
+@Path( "/api/repoproxy/admin" )
+@ApplicationScoped
+@REST
+public class RepoProxyAdminResource implements IndyResources
+{
+}

--- a/addons/repo-proxy/jaxrs/src/main/java/org/commonjava/indy/repo/proxy/servlet/RepoProxyDeploymentProvider.java
+++ b/addons/repo-proxy/jaxrs/src/main/java/org/commonjava/indy/repo/proxy/servlet/RepoProxyDeploymentProvider.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.servlet;
+
+import io.undertow.servlet.Servlets;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.FilterInfo;
+import io.undertow.servlet.api.ServletInfo;
+import io.undertow.servlet.util.ImmediateInstanceFactory;
+import jnr.ffi.annotations.In;
+import org.commonjava.indy.bind.jaxrs.IndyDeploymentProvider;
+import org.commonjava.indy.repo.proxy.conf.RepoProxyConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.DispatcherType;
+import javax.servlet.Filter;
+import javax.servlet.Servlet;
+import javax.ws.rs.core.Application;
+
+import static org.commonjava.indy.repo.proxy.servlet.RepositoryProxyFilter.FILTER_NAME;
+
+@ApplicationScoped
+public class RepoProxyDeploymentProvider
+        extends IndyDeploymentProvider
+{
+    @Inject
+    private RepositoryProxyFilter filter;
+
+    @Inject
+    private RepoProxyConfig config;
+
+    @Override
+    public DeploymentInfo getDeploymentInfo( String contextRoot, Application application )
+    {
+        if ( !config.isEnabled() )
+        {
+            final Logger logger = LoggerFactory.getLogger( getClass() );
+            logger.info( "Repository Proxy: addon not enabled, will not register the filter of the addon." );
+            return null;
+        }
+        final FilterInfo filterInfo = Servlets.filter( FILTER_NAME, RepositoryProxyFilter.class );
+
+        filterInfo.setInstanceFactory( new ImmediateInstanceFactory<Filter>( filter ) );
+        DeploymentInfo deploymentInfo = new DeploymentInfo().addFilter( filterInfo );
+        for ( final String urlPattern : config.getApiPatterns() )
+        {
+            deploymentInfo =
+                    deploymentInfo.addFilterUrlMapping( filterInfo.getName(), urlPattern, DispatcherType.REQUEST );
+        }
+
+        return deploymentInfo;
+    }
+}

--- a/addons/repo-proxy/jaxrs/src/main/java/org/commonjava/indy/repo/proxy/servlet/RepositoryProxyFilter.java
+++ b/addons/repo-proxy/jaxrs/src/main/java/org/commonjava/indy/repo/proxy/servlet/RepositoryProxyFilter.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.servlet;
+
+import jnr.ffi.annotations.In;
+import org.commonjava.indy.repo.proxy.RepoProxyContoller;
+import org.commonjava.indy.repo.proxy.conf.RepoProxyConfig;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@ApplicationScoped
+public class RepositoryProxyFilter
+        implements Filter
+{
+    public static final String FILTER_NAME = "RepositoryProxyFilter";
+
+    @Inject
+    private RepoProxyContoller contoller;
+
+    @Override
+    public void init( FilterConfig filterConfig )
+    {
+
+    }
+
+    @Override
+    public void doFilter( ServletRequest request, ServletResponse response, FilterChain chain )
+            throws IOException, ServletException
+    {
+        if ( !contoller.doProxy( request, response ) )
+        {
+            chain.doFilter( request, response );
+        }
+    }
+
+    @Override
+    public void destroy()
+    {
+
+    }
+}

--- a/addons/repo-proxy/pom.xml
+++ b/addons/repo-proxy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-repo-proxy</artifactId>
   <name>Indy :: Add-Ons :: Repository-Proxy :: Parent</name>

--- a/addons/repo-proxy/pom.xml
+++ b/addons/repo-proxy/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <!--
 
     Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
@@ -18,37 +18,19 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.commonjava.indy</groupId>
-    <artifactId>indy-parent</artifactId>
-    <version>2.1.0-SNAPSHOT</version>
+    <artifactId>indy-addons</artifactId>
+    <version>2.0-SNAPSHOT</version>
   </parent>
-  
-  <artifactId>indy-addons</artifactId>
+  <artifactId>indy-repo-proxy</artifactId>
+  <name>Indy :: Add-Ons :: Repository-Proxy :: Parent</name>
   <packaging>pom</packaging>
 
-  <name>Indy :: Add-Ons :: Parent</name>
-  
   <modules>
-    <module>content-index</module>
-    <module>dot-maven</module>
-    <module>folo</module>
-    <module>httprox</module>
-    <module>implied-repos</module>
-    <module>koji</module>
-    <module>promote</module>
-    <module>revisions</module>
-    <module>pkg-maven</module>
-    <module>diagnostics</module>
-    <module>pkg-npm</module>
-    <module>hosted-by-archive</module>
-    <module>content-browse</module>
-    <module>changelog</module>
-    <module>event-audit</module>
-    <module>sli</module>
-    <module>path-mapped</module>
-    <module>repo-proxy</module>
-    <!-- DO NOT REMOVE: append::addon -->
+    <module>common</module>
+    <module>jaxrs</module>
+    <module>ftests</module>
   </modules>
+
 </project>

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -222,6 +222,14 @@
       <artifactId>indy-event-audit-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-repo-proxy-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-repo-proxy-jaxrs</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.commonjava.atlas</groupId>
@@ -351,6 +359,10 @@
       <artifactId>cassandra-unit</artifactId>
     </dependency>
 -->
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-ftests-repo-proxy</artifactId>
+    </dependency>
   </dependencies>
   
   <build>
@@ -457,6 +469,7 @@
               <dependency>org.commonjava.indy:indy-ftests-hosted-by-archive</dependency>
               <dependency>org.commonjava.indy:indy-ftests-content-browse</dependency>
               <dependency>org.commonjava.indy:indy-ftests-changelog</dependency>
+              <dependency>org.commonjava.indy:indy-ftests-repo-proxy</dependency>
             </dependenciesToScan>
           </configuration>
           <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -944,6 +944,30 @@
         <version>${jgroupsVersion}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-repo-proxy-common</artifactId>
+        <version>2.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-repo-proxy-jaxrs</artifactId>
+        <version>2.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-ftests-repo-proxy</artifactId>
+        <version>2.0-SNAPSHOT</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-repo-proxy-common</artifactId>
+        <version>2.0-SNAPSHOT</version>
+        <classifier>confset</classifier>
+        <type>tar.gz</type>
+      </dependency>
+
       <!-- DO NOT REMOVE: append::depMgmt -->
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -947,17 +947,17 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-repo-proxy-common</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-repo-proxy-jaxrs</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-repo-proxy</artifactId>
-        <version>2.0-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This pr focus the first part of the repository proxy addon: do the automatic proxy for the hosted/group repository. Includes:
    * Rewrites api url and forwards to new one.(from hosted/group repo to remote)
    * Includes repo creator script way to create proxy to remote automatically
    * Controls which apis will be handled in rewriting, based on api url patterns in configuration
    * Controls which http methods can be included in rewriting, based on configuration
    * Can be enabled/disabled
