### PR TITLE
Set thread defaults on Xnio to avoid overwhelming jvm.

### DIFF
--- a/boot/jaxrs/src/main/conf/conf.d/rest.conf
+++ b/boot/jaxrs/src/main/conf/conf.d/rest.conf
@@ -2,8 +2,8 @@
 
 # Specify a set number of threads used by XNIO to handle I/O for REST requests.
 # By default, this is set by Undertow itself, and is set to either 2 or the number of CPU-cores, whichever is greater
-#io.threads=
+io.threads=2
 
 # Specify a set number of threads used by the XNIO workers to serve REST requests.
 # By default, this is set by Undertow itself, and is set to 8X [CPU-cores]
-#worker.threads=
+worker.threads=40

--- a/boot/jaxrs/src/main/resources/default-rest.conf
+++ b/boot/jaxrs/src/main/resources/default-rest.conf
@@ -2,8 +2,8 @@
 
 # Specify a set number of threads used by XNIO to handle I/O for REST requests.
 # By default, this is set by Undertow itself, and is set to either 2 or the number of CPU-cores, whichever is greater
-#io.threads=
+io.threads=2
 
 # Specify a set number of threads used by the XNIO workers to serve REST requests.
 # By default, this is set by Undertow itself, and is set to 8X [CPU-cores]
-#worker.threads=
+worker.threads=40


### PR DESCRIPTION
 This PR sets the IO threads to 2. Worker threads set to 40. This PR looks to resolve the issue identified in #1569 