### PR TITLE
Repository proxy addon part 2 - Controlling NPM metadata content

### DIFF
--- a/addons/repo-proxy/common/src/main/conf/conf.d/repo-proxy.conf
+++ b/addons/repo-proxy/common/src/main/conf/conf.d/repo-proxy.conf
@@ -8,3 +8,6 @@
 
 # Define the api http methods that the proxy will be applied with, use comma to split
 # api.methods=GET,HEAD
+
+# Control if to enable npm metadata content rewriting, which replace repo path based on proxy-rule
+# npm.meta.rewrite.enabled=true

--- a/addons/repo-proxy/common/src/main/data/default-rule.groovy
+++ b/addons/repo-proxy/common/src/main/data/default-rule.groovy
@@ -21,7 +21,7 @@ import org.commonjava.indy.model.core.*;
 class DefaultRule extends AbstractProxyRepoCreateRule {
     @Override
     boolean matches(StoreKey storeKey) {
-        return "maven".equals(storeKey.getPackageType()) && (StoreType.group == storeKey.getType() || StoreType.hosted == storeKey.getType())
+        return StoreType.group == storeKey.getType() || StoreType.hosted == storeKey.getType()
     }
 
     @Override
@@ -29,7 +29,8 @@ class DefaultRule extends AbstractProxyRepoCreateRule {
         def pkgType = key.getPackageType()
         def type = key.getType().singularEndpointName()
         def name = key.getName()
-        return new RemoteRepository(key.getPackageType(), key.getName(), String.format("http://some.indy/api/content/%s/%s/%s", pkgType, type, name))
+        return new RemoteRepository(pkgType, String.format("%s-%s", type, name), String.format("http://some.indy/api/content/%s/%s/%s", pkgType, type, name))
     }
+
 
 }

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/NPMMetadtaRewriteResponseDecorator.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/NPMMetadtaRewriteResponseDecorator.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor;
+import org.commonjava.indy.repo.proxy.conf.RepoProxyConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.extractPath;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getProxyToStoreKey;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.keyToPath;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.trace;
+
+/**
+ * This response decorator will do following
+ * <ul>
+ *     <li>Intercept NPM metadata path, like /jquery, /@angular/core or /jquery/package.json</li>
+ *     <li>Replacing url which is using the proxy-to repo path with the request repo path in the metadata content, like "tarball:"</li>
+ *     <li>And this decorator can be disabled by config "npm.meta.rewrite.enabled", default is enabled</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class NPMMetadtaRewriteResponseDecorator
+        implements RepoProxyResponseDecorator
+{
+    private static final Logger logger = LoggerFactory.getLogger( NPMMetadtaRewriteResponseDecorator.class );
+
+    @Inject
+    private RepoProxyConfig config;
+
+    private static final String METADATA_NAME = "package.json";
+
+    @Override
+    public HttpServletResponse decoratingResponse( HttpServletRequest request, HttpServletResponse response )
+            throws IOException
+    {
+        if ( !config.isEnabled() || !config.isNpmMetaRewriteEnabled() )
+        {
+            trace( logger,
+                   "Addon not enabled or npm meta rewrite not allowed, will not decorate the response for NPM metadata rewriting." );
+            return response;
+        }
+
+        final String pathInfo = request.getPathInfo();
+        final Optional<String> originalRepo = RepoProxyUtils.getOriginalStoreKeyFromPath( pathInfo );
+        if ( !originalRepo.isPresent() )
+        {
+            trace( logger, "No matched repo path in request path {}, will not rewrite.", pathInfo );
+            return response;
+        }
+
+        final String originalRepoStr = originalRepo.get();
+
+        final StoreKey originalKey = StoreKey.fromString( originalRepoStr );
+        if ( !NPMPackageTypeDescriptor.NPM_PKG_KEY.equals( originalKey.getPackageType() ) )
+        {
+            trace( logger, "Not a NPM content request for path {}, will not rewrite.", pathInfo );
+            return response;
+        }
+
+        final String originalRepoPath = keyToPath( originalRepoStr );
+
+        final String path = extractPath( pathInfo, originalRepoPath );
+        if ( isNPMMetaPath( path ) )
+        {
+            final Optional<StoreKey> proxyToKey = getProxyToStoreKey( pathInfo );
+            if ( proxyToKey.isPresent() )
+            {
+                final String proxyToKeyPath = keyToPath( proxyToKey.get() );
+                trace( logger, "NPM rewriting replacement: from {} to {}", proxyToKeyPath, originalRepoPath );
+                return new NPMMetadataRewriteResponseWrapper( request, response,
+                                                              Collections.singletonMap( originalRepoPath,
+                                                                                        proxyToKeyPath ) );
+            }
+        }
+        else
+        {
+            trace( logger, "NPM meta rewrite: {} is not a metadata path", path );
+        }
+
+        return response;
+    }
+
+    private boolean isNPMMetaPath( final String path )
+    {
+        if ( StringUtils.isBlank( path ) )
+        {
+            return false;
+        }
+        String checkingPath = path;
+        if ( path.startsWith( "/" ) )
+        {
+            checkingPath = path.substring( 1 );
+        }
+        // This is considering the single path for npm standard like "/jquery"
+        final boolean isSinglePath = checkingPath.split( "/" ).length < 2;
+        // This is considering the scoped path for npm standard like "/@type/jquery"
+        final boolean isScopedPath = checkingPath.startsWith( "@" ) && checkingPath.split( "/" ).length < 3;
+        // This is considering the package.json file itself
+        final boolean isPackageJson = checkingPath.trim().endsWith( "/" + METADATA_NAME );
+
+        trace( logger, "path: {}, isSinglePath: {}, isScopedPath: {}, isPackageJson: {}", path, isSinglePath,
+               isScopedPath, isPackageJson );
+        return isSinglePath || isScopedPath || isPackageJson;
+    }
+
+    private static class NPMMetadataRewriteResponseWrapper
+            extends HttpServletResponseWrapper
+    {
+        private HttpServletRequest request;
+
+        private NPMMetadataRewriteOutputStream out;
+
+        /**
+         * Constructs a response adaptor wrapping the given response.
+         * @throws IllegalArgumentException if the response is null
+         * @param response -
+         * @throws IOException -
+         */
+        public NPMMetadataRewriteResponseWrapper( final HttpServletRequest request, final HttpServletResponse response,
+                                                  final Map<String, String> reposReplacing )
+                throws IOException
+        {
+            super( response );
+            this.request = request;
+            this.out = new NPMMetadataRewriteOutputStream( response.getOutputStream(), reposReplacing );
+        }
+
+        @Override
+        public PrintWriter getWriter()
+                throws IOException
+        {
+            return new PrintWriter( this.getResponse().getWriter() );
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream()
+        {
+            return this.out;
+        }
+
+    }
+
+    private static class NPMMetadataRewriteOutputStream
+            extends ServletOutputStream
+    {
+        private StringBuffer buffer = new StringBuffer();
+
+        private ServletOutputStream originalStream;
+
+        private Map<String, String> reposReplacing;
+
+        private NPMMetadataRewriteOutputStream( final ServletOutputStream originalStream,
+                                                final Map<String, String> reposReplacing )
+        {
+            this.originalStream = originalStream;
+            this.reposReplacing = reposReplacing;
+        }
+
+        @Override
+        public void write( int b )
+        {
+            buffer.append( (char) b );
+        }
+
+        @Override
+        public void flush()
+                throws IOException
+        {
+            try
+            {
+                String content = buffer.toString();
+                for ( Map.Entry<String, String> repoReplacing : reposReplacing.entrySet() )
+                {
+                    final String origin = repoReplacing.getKey();
+                    final String proxyTo = repoReplacing.getValue();
+                    trace( logger, "NPM metadata rewriting: Replacing {} to {}", proxyTo, origin );
+                    content = content.replaceAll( proxyTo, origin );
+                }
+                originalStream.write( content.getBytes() );
+                originalStream.flush();
+            }
+            finally
+            {
+                buffer = new StringBuffer();
+            }
+        }
+
+        @Override
+        public void close()
+                throws IOException
+        {
+            flush();
+            IOUtils.closeQuietly( originalStream );
+        }
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/NPMMetadtaRewriteResponseDecorator.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/NPMMetadtaRewriteResponseDecorator.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.extractPath;
-import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getProxyToStoreKey;
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.keyToPath;
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.trace;
 
@@ -60,7 +59,8 @@ public class NPMMetadtaRewriteResponseDecorator
     private static final String METADATA_NAME = "package.json";
 
     @Override
-    public HttpServletResponse decoratingResponse( HttpServletRequest request, HttpServletResponse response )
+    public HttpServletResponse decoratingResponse( final HttpServletRequest request, final HttpServletResponse response,
+                                                   final StoreKey proxyToStoreKey )
             throws IOException
     {
         if ( !config.isEnabled() || !config.isNpmMetaRewriteEnabled() )
@@ -88,19 +88,13 @@ public class NPMMetadtaRewriteResponseDecorator
         }
 
         final String originalRepoPath = keyToPath( originalRepoStr );
-
         final String path = extractPath( pathInfo, originalRepoPath );
         if ( isNPMMetaPath( path ) )
         {
-            final Optional<StoreKey> proxyToKey = getProxyToStoreKey( pathInfo );
-            if ( proxyToKey.isPresent() )
-            {
-                final String proxyToKeyPath = keyToPath( proxyToKey.get() );
-                trace( logger, "NPM rewriting replacement: from {} to {}", proxyToKeyPath, originalRepoPath );
-                return new NPMMetadataRewriteResponseWrapper( request, response,
-                                                              Collections.singletonMap( originalRepoPath,
-                                                                                        proxyToKeyPath ) );
-            }
+            final String proxyToKeyPath = keyToPath( proxyToStoreKey );
+            trace( logger, "NPM rewriting replacement: from {} to {}", proxyToKeyPath, originalRepoPath );
+            return new NPMMetadataRewriteResponseWrapper( request, response, Collections.singletonMap( originalRepoPath,
+                                                                                                       proxyToKeyPath ) );
         }
         else
         {

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyResponseDecorator.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyResponseDecorator.java
@@ -1,11 +1,14 @@
 package org.commonjava.indy.repo.proxy;
 
+import org.commonjava.indy.model.core.StoreKey;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public interface RepoProxyResponseDecorator
 {
-    HttpServletResponse decoratingResponse( final HttpServletRequest request, final HttpServletResponse response )
+    HttpServletResponse decoratingResponse( final HttpServletRequest request, final HttpServletResponse response,
+                                            final StoreKey proxyToStoreKey )
             throws IOException;
 }

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyResponseDecorator.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyResponseDecorator.java
@@ -1,0 +1,11 @@
+package org.commonjava.indy.repo.proxy;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public interface RepoProxyResponseDecorator
+{
+    HttpServletResponse decoratingResponse( final HttpServletRequest request, final HttpServletResponse response )
+            throws IOException;
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
@@ -56,19 +56,6 @@ public class RepoProxyUtils
         return empty();
     }
 
-    public static Optional<StoreKey> getProxyToStoreKey( final String originalPath )
-    {
-        final Optional<String> origStoreKey = getOriginalStoreKeyFromPath( originalPath );
-        if ( origStoreKey.isPresent() )
-        {
-            final String originStoreKeyStr = origStoreKey.get();
-            final String[] parts = originStoreKeyStr.split( ":" );
-            final String proxyToStoreString = parts[0] + ":" + StoreType.remote.singularEndpointName() + ":" + parts[2];
-            return of( StoreKey.fromString( proxyToStoreString ) );
-        }
-        return empty();
-    }
-
     public static Optional<String> getOriginalStoreKeyFromPath( final String originalPath )
     {
         final Pattern pat = Pattern.compile( STORE_PATH_PATTERN );

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2013 Red Hat, Inc.
+ <<<<<<< HEAD
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -7,6 +8,15 @@
  * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
  * <p>
+ =======
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ >>>>>>> f3674f198... Controlling NPM metadata content by repo-proxy
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,7 +58,7 @@ public class RepoProxyUtils
             final String[] parts = originStoreKeyStr.split( ":" );
             final String proxyToStorePathString = keyToPath( proxyToKey );
             final String proxyTo =
-                    originalPath.replaceAll( originStoreKeyStr.replaceAll( ":", "/" ), proxyToStorePathString );
+                    originalPath.replaceAll( keyToPath( originStoreKeyStr), proxyToStorePathString );
             logger.trace( "Found proxy to store rule: from {} to {}", originStoreKeyStr, proxyToStorePathString );
             return of( proxyTo );
         }

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
@@ -1,14 +1,5 @@
 /**
  * Copyright (C) 2013 Red Hat, Inc.
- <<<<<<< HEAD
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- =======
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +7,6 @@
  *
  *         http://www.apache.org/licenses/LICENSE-2.0
  *
- >>>>>>> f3674f198... Controlling NPM metadata content by repo-proxy
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
@@ -50,6 +50,8 @@ public class RepoProxyConfig
 
     private static final String API_METHODS_PARAM = "api.methods";
 
+    private static final String NPM_META_REWRITE_ENABLE_PARAM = "npm.meta.rewrite.enabled";
+
     private static final Boolean DEFAULT_ENABLED = Boolean.FALSE;
 
     private static final String DEFAULT_API_PATTERNS = "/api/content/*, /api/folo/track/*";
@@ -68,6 +70,8 @@ public class RepoProxyConfig
 
     private Boolean enabled;
 
+    private Boolean npmMetaRewriteEnabled;
+
     public RepoProxyConfig()
     {
     }
@@ -82,6 +86,16 @@ public class RepoProxyConfig
         return StringUtils.isBlank( repoCreatorRuleBaseDir ) ?
                 DEFAULT_REPO_CREATE_RULE_BASEDIR :
                 repoCreatorRuleBaseDir;
+    }
+
+    public Boolean getNpmMetaRewriteEnabled()
+    {
+        return this.npmMetaRewriteEnabled == null ? DEFAULT_NPM_META_REWRITE_ENABLE : this.npmMetaRewriteEnabled;
+    }
+
+    public Boolean isNpmMetaRewriteEnabled()
+    {
+        return getNpmMetaRewriteEnabled();
     }
 
     public Set<String> getApiPatterns()
@@ -133,6 +147,9 @@ public class RepoProxyConfig
                 {
                     apiMethods.add( method.trim().toUpperCase() );
                 }
+                break;
+            case NPM_META_REWRITE_ENABLE_PARAM:
+                this.npmMetaRewriteEnabled = Boolean.valueOf( value.trim() );
                 break;
             default:
                 break;

--- a/addons/repo-proxy/common/src/main/resources/default-repo-proxy.conf
+++ b/addons/repo-proxy/common/src/main/resources/default-repo-proxy.conf
@@ -8,3 +8,6 @@
 
 # Define the api http methods that the proxy will be applied with, use comma to split
 # api.methods=GET,HEAD
+
+# Control if to enable npm metadata content rewriting, which replace repo path based on proxy-rule
+# npm.meta.rewrite.enabled=true

--- a/addons/repo-proxy/common/src/test/java/RepoProxyUtilsTest.java
+++ b/addons/repo-proxy/common/src/test/java/RepoProxyUtilsTest.java
@@ -83,27 +83,4 @@ public class RepoProxyUtilsTest
         assertThat( proxyTo.get(), equalTo( "/api/folo/track/npm/remote/hosted-jkl/@react/core" ) );
     }
 
-    @Test
-    public void testProxyToStoreKey()
-    {
-        String fullPath = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
-        Optional<StoreKey> proxyTo = RepoProxyUtils.getProxyToStoreKey( fullPath );
-        assertTrue( proxyTo.isPresent() );
-        assertThat( proxyTo.get(), equalTo( fromString( "maven:remote:abc" ) ) );
-
-        fullPath = "/api/browse/content/maven/hosted/def/org/commonjava/indy/1.0/";
-        proxyTo = RepoProxyUtils.getProxyToStoreKey( fullPath );
-        assertTrue( proxyTo.isPresent() );
-        assertThat( proxyTo.get(), equalTo( fromString( "maven:remote:def" ) ) );
-
-        fullPath = "/api/folo/track/npm/group/ghi/jquery";
-        proxyTo = RepoProxyUtils.getProxyToStoreKey( fullPath );
-        assertTrue( proxyTo.isPresent() );
-        assertThat( proxyTo.get(), equalTo( fromString( "npm:remote:ghi" ) ) );
-
-        fullPath = "/api/folo/track/npm/hosted/jkl/@react/core";
-        proxyTo = RepoProxyUtils.getProxyToStoreKey( fullPath );
-        assertTrue( proxyTo.isPresent() );
-        assertThat( proxyTo.get(), equalTo( fromString( "npm:remote:jkl" ) ) );
-    }
 }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDefaultTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDefaultTest.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -77,7 +78,7 @@ public class RepoProxyDefaultTest
         server.expect( server.formatUrl( REPO_NAME, PATH1 ), 200, new ByteArrayInputStream( CONTENT1.getBytes() ) );
 
         remote = client.stores()
-                       .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
+                       .create( new RemoteRepository( PKG_TYPE_MAVEN, REPO_NAME,
                                                       server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
                                 RemoteRepository.class );
     }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDisableTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDisableTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -80,12 +81,12 @@ public class RepoProxyDisableTest
         server.expect( server.formatUrl( REPO_NAME, PATH1 ), 200, new ByteArrayInputStream( CONTENT1.getBytes() ) );
 
         remote = client.stores()
-                       .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
+                       .create( new RemoteRepository( PKG_TYPE_MAVEN, REPO_NAME,
                                                       server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
                                 RemoteRepository.class );
 
         hosted = client.stores()
-                       .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
+                       .create( new HostedRepository( PKG_TYPE_MAVEN, REPO_NAME ),
                                 "hosted pnc-builds", HostedRepository.class );
         client.content().store( hosted.getKey(), PATH2, new ByteArrayInputStream( CONTENT2.getBytes() ) );
     }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyMethodsTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyMethodsTest.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -75,7 +76,7 @@ public class RepoProxyMethodsTest
         server.expect( server.formatUrl( REPO_NAME, PATH1 ), 200, new ByteArrayInputStream( CONTENT1.getBytes() ) );
 
         remote = client.stores()
-                       .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
+                       .create( new RemoteRepository( PKG_TYPE_MAVEN, REPO_NAME,
                                                       server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
                                 RemoteRepository.class );
 

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMHugeMetaContentRewriteTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMHugeMetaContentRewriteTest.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the NPM metadata rewritting feature can work well with some huge NPM metadata content
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Hosted and Remote NPM Repo</li>
+ *     <li>Path for NPM metadata and the metadata content is huge (> 2MB with more than 8000 versions)</li>
+ *     <li>Hosted does not have path but Remote does</li>
+ *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request path through hosted</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of path can be returned correctly from hosted</li>
+ *     <li>The url in the content which points to Remote for the returned path has been rewritten to point to Hosted</li>
+ * </ul>
+ */
+public class RepoProxyNPMHugeMetaContentRewriteTest
+        extends AbstractContentManagementTest
+{
+    private static final String REPO_NAME = "npmjs";
+
+    private HostedRepository hosted;
+
+    private static final String PATH_ROOT = "jquery";
+
+    private String CONTENT_ANGULAR_CORE;
+
+    private String REMOTE_REPO_PATH;
+
+    private String HOSTED_REPO_PATH;
+
+    private int expectRepoUrlCountMatch;
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+        String CONTENT_JQUERY = getHugeMetaContent( server.formatUrl( REPO_NAME ) );
+        server.expect( server.formatUrl( REPO_NAME, PATH_ROOT ), 200,
+                       new ByteArrayInputStream( CONTENT_JQUERY.getBytes() ) );
+
+        RemoteRepository remote = client.stores()
+                                        .create( new RemoteRepository( PKG_TYPE_NPM, REPO_NAME,
+                                                                       server.formatUrl( REPO_NAME ) ), "remote npmjs",
+                                                 RemoteRepository.class );
+
+        hosted = new HostedRepository( PKG_TYPE_NPM, REPO_NAME );
+
+        REMOTE_REPO_PATH = normalize( fixture.getUrl(), "content/npm/remote", remote.getName() );
+        HOSTED_REPO_PATH = normalize( fixture.getUrl(), "content/npm/hosted", hosted.getName() );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        try (InputStream result = client.content().get( hosted.getKey(), PATH_ROOT ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            logger.debug( "NPM Rewrite content: {}", content );
+            assertThat( expectRepoUrlCountMatch, equalTo( StringUtils.countMatches( content, HOSTED_REPO_PATH ) ) );
+            assertThat( content.contains( REMOTE_REPO_PATH ), equalTo( false ) );
+        }
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true" );
+    }
+
+    private String getHugeMetaContent( final String repoUrl )
+    {
+        final StringBuilder buffer = new StringBuilder(
+                "{\"_id\": \"jquery\",\"_rev\": \"650-60d066f00248b6c41ab11151ed05d37e\",  \"name\": \"jquery\",  \"description\": \"JavaScript library for DOM operations\"" );
+
+        buffer.append( "\"versions\":{" );
+        int majorMax = 10, minorMax = 40, relMax = 20;
+        expectRepoUrlCountMatch = majorMax * minorMax * relMax;
+        for ( int major = 1; major <= majorMax; major++ )
+        {
+            for ( int minor = 0; minor < minorMax; minor++ )
+            {
+                for ( int rel = 0; rel < relMax; rel++ )
+                {
+                    final String version = String.format( "%s.%s.%s", major, minor, rel );
+                    buffer.append( quoted( version ) )
+                          .append( ": {" )
+                          .append( " \"name\": \"jquery\"," )
+                          .append( "\"title\": \"jQuery\"," )
+                          .append( "\"description\": \"JavaScript library for DOM operations\"," )
+                          .append( "\"version\": " )
+                          .append( quoted( version ) )
+                          .append( "," )
+                          .append( "\"main\": \"dist/jquery.js\"," )
+                          .append( "\"dist\": {\"shasum\": " )
+                          .append( fakeShasum( version ) )
+                          .append( "," )
+                          .append( "\"tarball\": \"" )
+                          .append( repoUrl )
+                          .append( "/jquery/-/jquery-" )
+                          .append( version )
+                          .append( ".tgz\"" + "}" + "}," );
+                }
+            }
+        }
+        buffer.deleteCharAt( buffer.length() - 1 );
+
+        buffer.append( "}}" );
+
+        logger.info( "The content size is {} kB", buffer.length() / 1024 );
+
+        return buffer.toString();
+    }
+
+    private String quoted( final String content )
+    {
+        return "\"" + content + "\"";
+    }
+
+    private String fakeShasum( final String version )
+    {
+        final String base = "2ae2d661e906c1a01e044a71bb5b274394";
+        final String gen = version.replaceAll( "\\.", "" );
+        return base + gen;
+    }
+
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMMetaRewriteDisableTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMMetaRewriteDisableTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the NPM metadata rewritting features can be disabled when addon can work itself
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Hosted and Remote NPM Repo</li>
+ *     <li>Path for NPM metadata</li>
+ *     <li>Hosted does not have path but Remote does</li>
+ *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ *     <li>Configured the "npm.meta.rewrite.enabled" to disabled</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request path through hosted</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of path can be returned correctly from hosted</li>
+ *     <li>The url in the content which points to Remote for the returned path has not been rewritten to point to Hosted</li>
+ * </ul>
+ */
+public class RepoProxyNPMMetaRewriteDisableTest
+        extends AbstractContentManagementTest
+{
+    private static final String REPO_NAME = "npmjs";
+
+    private HostedRepository hosted;
+
+    private RemoteRepository remote;
+
+    private static final String PATH_ROOT = "jquery";
+
+    private static final String PATH_SCOPED = "@angular/core";
+
+    private static final String PATH_PACKAGE_JSON = "jquery/package.json";
+
+    //@formatter:off
+    private static final String CONTENT_JQUERY_TEMPLATE = "{"
+            + "\"_id\": \"jquery\","
+            + "\"versions\":{"
+            + "\"1.5.1\": {"
+            + "\"dist\": {"
+            + "\"shasum\": \"2ae2d661e906c1a01e044a71bb5b2743942183e5\","
+            + "\"tarball\": \"%s/jquery/-/jquery-1.5.1.tgz\""
+            + "}"
+            + "}"
+            + "}"
+            + "}";
+
+    private static final String CONTENT_ANGULAR_CORE_TEMPLATE = "{"
+            + "\"_id\": \"@angular/core\","
+            + "\"versions\": {"
+            + "\"9.0.1\": {"
+            + "\"dist\": {"
+            + "\"shasum\": \"8908112ce6bb22aa1ae537230240ef9a324409ad\","
+            + "\"tarball\": \"%s/@angular/core/-/core-9.0.1.tgz\""
+            + "}"
+            + "}"
+            + "}"
+            + "}";
+    //@formatter:on
+
+    private String CONTENT_JQUERY;
+
+    private String CONTENT_ANGULAR_CORE;
+
+    private String REMOTE_REPO_PATH;
+
+    private String HOSTED_REPO_PATH;
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+        CONTENT_JQUERY = String.format( CONTENT_JQUERY_TEMPLATE, server.formatUrl( REPO_NAME ) );
+        server.expect( server.formatUrl( REPO_NAME, PATH_ROOT ), 200,
+                       new ByteArrayInputStream( CONTENT_JQUERY.getBytes() ) );
+        server.expect( server.formatUrl( REPO_NAME, PATH_PACKAGE_JSON ), 200,
+                       new ByteArrayInputStream( CONTENT_JQUERY.getBytes() ) );
+
+        CONTENT_ANGULAR_CORE = String.format( CONTENT_ANGULAR_CORE_TEMPLATE, server.formatUrl( REPO_NAME ) );
+        server.expect( server.formatUrl( REPO_NAME, PATH_SCOPED ), 200,
+                       new ByteArrayInputStream( CONTENT_ANGULAR_CORE.getBytes() ) );
+
+        remote = client.stores()
+                       .create( new RemoteRepository( PKG_TYPE_NPM, REPO_NAME, server.formatUrl( REPO_NAME ) ),
+                                "remote npmjs", RemoteRepository.class );
+
+        hosted = client.stores()
+                       .create( new HostedRepository( PKG_TYPE_NPM, REPO_NAME ), "hosted npmjs",
+                                HostedRepository.class );
+
+        REMOTE_REPO_PATH = normalize( fixture.getUrl(), "content/npm/remote", remote.getName() );
+        HOSTED_REPO_PATH = normalize( fixture.getUrl(), "content/npm/hosted", hosted.getName() );
+
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        try (InputStream result = client.content().get( hosted.getKey(), PATH_ROOT ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            logger.debug( "NPM Rewrite content: {}", content );
+            assertThat( content, containsString( REMOTE_REPO_PATH ) );
+            assertThat( content.contains( HOSTED_REPO_PATH ), equalTo( false ) );
+        }
+
+        try (InputStream result = client.content().get( hosted.getKey(), PATH_SCOPED ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            logger.debug( "NPM Rewrite content: {}", content );
+            assertThat( content, containsString( REMOTE_REPO_PATH ) );
+            assertThat( content.contains( HOSTED_REPO_PATH ), equalTo( false ) );
+        }
+
+        try (InputStream result = client.content().get( hosted.getKey(), PATH_PACKAGE_JSON ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            logger.debug( "NPM Rewrite content: {}", content );
+            assertThat( content, containsString( REMOTE_REPO_PATH ) );
+            assertThat( content.contains( HOSTED_REPO_PATH ), equalTo( false ) );
+        }
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true\nnpm.meta.rewrite.enabled=false" );
+    }
+
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMMetaRewriteTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMMetaRewriteTest.java
@@ -1,0 +1,172 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the NPM metadata rewritting features can work well for this proxy addon
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Hosted and Remote NPM Repo</li>
+ *     <li>Path for NPM metadata</li>
+ *     <li>Hosted does not have path but Remote does</li>
+ *     <li>Configured proxy rule with mapping hosted proxy to remote</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request path through hosted</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of path can be returned correctly from hosted</li>
+ *     <li>The url in the content which points to Remote for the returned path has been rewritten to point to Hosted</li>
+ * </ul>
+ */
+public class RepoProxyNPMMetaRewriteTest
+        extends AbstractContentManagementTest
+{
+    private static final String REPO_NAME = "npmjs";
+
+    private HostedRepository hosted;
+
+    private RemoteRepository remote;
+
+    private static final String PATH_ROOT = "jquery";
+
+    private static final String PATH_SCOPED = "@angular/core";
+
+    private static final String PATH_PACKAGE_JSON = "jquery/package.json";
+
+    //@formatter:off
+    private static final String CONTENT_JQUERY_TEMPLATE = "{"
+            + "\"_id\": \"jquery\","
+            + "\"versions\":{"
+            + "\"1.5.1\": {"
+            + "\"dist\": {"
+            + "\"shasum\": \"2ae2d661e906c1a01e044a71bb5b2743942183e5\","
+            + "\"tarball\": \"%s/jquery/-/jquery-1.5.1.tgz\""
+            + "}"
+            + "}"
+            + "}"
+            + "}";
+
+    private static final String CONTENT_ANGULAR_CORE_TEMPLATE = "{"
+            + "\"_id\": \"@angular/core\","
+            + "\"versions\": {"
+            + "\"9.0.1\": {"
+            + "\"dist\": {"
+            + "\"shasum\": \"8908112ce6bb22aa1ae537230240ef9a324409ad\","
+            + "\"tarball\": \"%s/@angular/core/-/core-9.0.1.tgz\""
+            + "}"
+            + "}"
+            + "}"
+            + "}";
+    //@formatter:on
+
+    private String CONTENT_JQUERY;
+
+    private String CONTENT_ANGULAR_CORE;
+
+    private String REMOTE_REPO_PATH;
+
+    private String HOSTED_REPO_PATH;
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+        CONTENT_JQUERY = String.format( CONTENT_JQUERY_TEMPLATE, server.formatUrl( REPO_NAME ) );
+        server.expect( server.formatUrl( REPO_NAME, PATH_ROOT ), 200,
+                       new ByteArrayInputStream( CONTENT_JQUERY.getBytes() ) );
+        server.expect( server.formatUrl( REPO_NAME, PATH_PACKAGE_JSON ), 200,
+                       new ByteArrayInputStream( CONTENT_JQUERY.getBytes() ) );
+
+        CONTENT_ANGULAR_CORE = String.format( CONTENT_ANGULAR_CORE_TEMPLATE, server.formatUrl( REPO_NAME ) );
+        server.expect( server.formatUrl( REPO_NAME, PATH_SCOPED ), 200,
+                       new ByteArrayInputStream( CONTENT_ANGULAR_CORE.getBytes() ) );
+
+        remote = client.stores()
+                       .create( new RemoteRepository( PKG_TYPE_NPM, REPO_NAME, server.formatUrl( REPO_NAME ) ),
+                                "remote npmjs", RemoteRepository.class );
+
+        hosted = new HostedRepository( PKG_TYPE_NPM, REPO_NAME );
+
+        REMOTE_REPO_PATH = normalize( fixture.getUrl(), "content/npm/remote", remote.getName() );
+        HOSTED_REPO_PATH = normalize( fixture.getUrl(), "content/npm/hosted", hosted.getName() );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        try (InputStream result = client.content().get( hosted.getKey(), PATH_ROOT ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            logger.debug( "NPM Rewrite content: {}", content );
+            assertThat( content, containsString( HOSTED_REPO_PATH ) );
+            assertThat( content.contains( REMOTE_REPO_PATH ), equalTo( false ) );
+        }
+
+        try (InputStream result = client.content().get( hosted.getKey(), PATH_SCOPED ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            logger.debug( "NPM Rewrite content: {}", content );
+            assertThat( content, containsString( HOSTED_REPO_PATH ) );
+            assertThat( content.contains( REMOTE_REPO_PATH ), equalTo( false ) );
+        }
+
+        try (InputStream result = client.content().get( hosted.getKey(), PATH_PACKAGE_JSON ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            logger.debug( "NPM Rewrite content: {}", content );
+            assertThat( content, containsString( HOSTED_REPO_PATH ) );
+            assertThat( content.contains( REMOTE_REPO_PATH ), equalTo( false ) );
+        }
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true" );
+    }
+
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyPatternsTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyPatternsTest.java
@@ -29,6 +29,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -85,13 +86,13 @@ public class RepoProxyPatternsTest
         server.expect( server.formatUrl( REPO_NAME, PATH1 ), 200, new ByteArrayInputStream( CONTENT1.getBytes() ) );
 
         remote = client.stores()
-                       .create( new RemoteRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME,
+                       .create( new RemoteRepository( PKG_TYPE_MAVEN, REPO_NAME,
                                                       server.formatUrl( REPO_NAME ) ), "remote pnc-builds",
                                 RemoteRepository.class );
 
         //        hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
         hosted = client.stores()
-                       .create( new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME ),
+                       .create( new HostedRepository( PKG_TYPE_MAVEN, REPO_NAME ),
                                 "hosted pnc-builds", HostedRepository.class );
         client.content().store( hosted.getKey(), PATH2, new ByteArrayInputStream( CONTENT2.getBytes() ) );
     }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorWithNPMContentRewriteTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorWithNPMContentRewriteTest.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest.create;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the repo proxy addon can proxy a npm group repo automatically with no remote setup, and npm metadata with huge content can be replaced correctly
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>A external npm repo with specified metadata path of huge content </li>
+ *     <li>Configured the repo-proxy enabled</li>
+ *     <li>Deployed a repo creator script whose rule to create remote repo which points to the external repo</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request npm metadata path through a group repo</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content of path can be returned correctly from group</li>
+ *     <li>The remote repo from creator script has been set up.</li>
+ *     <li>The url which points to remote repo has been replaced to the group repo</li>
+ * </ul>
+ */
+
+public class RepoProxyCreatorWithNPMContentRewriteTest
+        extends AbstractContentManagementTest
+{
+    private static final String REPO_NAME = "npmjs";
+
+    private static final String PATH_ROOT = "jquery";
+
+    private int expectRepoUrlCountMatch;
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+        String CONTENT_JQUERY = getHugeMetaContent( server.formatUrl( REPO_NAME ) );
+        server.expect( server.formatUrl( REPO_NAME, PATH_ROOT ), 200,
+                       new ByteArrayInputStream( CONTENT_JQUERY.getBytes() ) );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final String remoteName = String.format( "%s-%s", StoreType.group, REPO_NAME );
+        final StoreKey remoteKey =
+                new StoreKey( NPMPackageTypeDescriptor.NPM_PKG_KEY, StoreType.remote, remoteName );
+        RemoteRepository remote = client.stores().load( remoteKey, RemoteRepository.class );
+        assertThat( remote, nullValue() );
+
+        final String REMOTE_REPO_PATH = normalize( fixture.getUrl(), "content/npm/remote", remoteName );
+        final String GROUP_REPO_PATH = normalize( fixture.getUrl(), "content/npm/group", REPO_NAME );
+
+        final Group group = new Group( PKG_TYPE_NPM, REPO_NAME );
+        try (InputStream result = client.content().get( group.getKey(), PATH_ROOT ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            logger.debug( "NPM Rewrite content: {}", content );
+            assertThat( expectRepoUrlCountMatch, equalTo( StringUtils.countMatches( content, GROUP_REPO_PATH ) ) );
+            assertThat( content.contains( REMOTE_REPO_PATH ), equalTo( false ) );
+        }
+
+        remote = client.stores().load( remoteKey, RemoteRepository.class );
+        assertThat( remote, notNullValue() );
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true" );
+    }
+
+    private String getHugeMetaContent( final String repoUrl )
+    {
+        final StringBuilder buffer = new StringBuilder(
+                "{\"_id\": \"jquery\",\"_rev\": \"650-60d066f00248b6c41ab11151ed05d37e\",  \"name\": \"jquery\",  \"description\": \"JavaScript library for DOM operations\"" );
+
+        buffer.append( "\"versions\":{" );
+        int majorMax = 10, minorMax = 40, relMax = 20;
+        expectRepoUrlCountMatch = majorMax * minorMax * relMax;
+        for ( int major = 1; major <= majorMax; major++ )
+        {
+            for ( int minor = 0; minor < minorMax; minor++ )
+            {
+                for ( int rel = 0; rel < relMax; rel++ )
+                {
+                    final String version = String.format( "%s.%s.%s", major, minor, rel );
+                    buffer.append( quoted( version ) )
+                          .append( ": {" )
+                          .append( " \"name\": \"jquery\"," )
+                          .append( "\"title\": \"jQuery\"," )
+                          .append( "\"description\": \"JavaScript library for DOM operations\"," )
+                          .append( "\"version\": " )
+                          .append( quoted( version ) )
+                          .append( "," )
+                          .append( "\"main\": \"dist/jquery.js\"," )
+                          .append( "\"dist\": {\"shasum\": " )
+                          .append( fakeShasum( version ) )
+                          .append( "," )
+                          .append( "\"tarball\": \"" )
+                          .append( repoUrl )
+                          .append( "/jquery/-/jquery-" )
+                          .append( version )
+                          .append( ".tgz\"" + "}" + "}," );
+                }
+            }
+        }
+        buffer.deleteCharAt( buffer.length() - 1 );
+
+        buffer.append( "}}" );
+
+        logger.info( "The content size is {} kB", buffer.length() / 1024 );
+
+        return buffer.toString();
+    }
+
+    private String quoted( final String content )
+    {
+        return "\"" + content + "\"";
+    }
+
+    private String fakeShasum( final String version )
+    {
+        final String base = "2ae2d661e906c1a01e044a71bb5b274394";
+        final String gen = version.replaceAll( "\\.", "" );
+        return base + gen;
+    }
+
+    private String getRuleScriptContent()
+    {
+        final String targetBase = server.formatUrl( REPO_NAME );
+        // @formatter:off
+        return
+                "import org.commonjava.indy.repo.proxy.create.*\n" +
+                        "import org.commonjava.indy.model.core.*\n" +
+                        "class DefaultRule extends AbstractProxyRepoCreateRule {\n" +
+                        "    @Override\n" +
+                        "    boolean matches(StoreKey storeKey) {\n" +
+                        "        return \"npm\".equals(storeKey.getPackageType()) && StoreType.group==storeKey.getType()\n" +
+                        "    }\n" +
+                        "    @Override\n" +
+                        "    RemoteRepository createRemote(StoreKey key) {\n" +
+                        "        return new RemoteRepository(key.getPackageType(), String.format(\"%s-%s\", StoreType.group, key.getName()), \"" + targetBase + "\")\n" +
+                        "    }\n" +
+                        "}";
+        // @formatter:on;
+    }
+
+    @Override
+    public void initTestData( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeDataFile( "repo-proxy/default-rule.groovy", getRuleScriptContent() );
+
+        super.initTestData( fixture );
+    }
+}


### PR DESCRIPTION
   As NPM meatadata contains url which points to the npm package, we need to rewrite these urls to replace the repo path by proxy-rules.This commit did following:
   * Intercept NPM metadata path, like /jquery, /@angular/core or /jquery/package.json
   * Replacing url which is using the proxy-to repo path with the request repo path in the metadata content, like "tarball:"
   * And this feature can be disabled by config "npm.meta.rewrite.enabled", default is enabled