### PR TITLE
Add debug log to DefaultContentDigester

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
@@ -123,12 +123,14 @@ public class DefaultContentDigester
         final Transfer transfer = directContentAccess.getTransfer( key, path );
         if ( transfer == null || !transfer.exists() )
         {
+            logger.error( "No transfer to digest, store: {}, path: {}, transfer: {}", key, path, transfer );
             return new TransferMetadata( Collections.emptyMap(), 0L );
         }
 
         TransferMetadata meta = getContentMetadata( transfer );
         if ( meta != null )
         {
+            logger.debug( "Get transferMetadata: {}", meta );
             return meta;
         }
 


### PR DESCRIPTION
Add debug log to catch folo 0-sized artifact problem. The problem is fixed in path-mapped storage. Adding those logs is just in case.