### PR TITLE
Fix a small bug of extract path from full http request path

### DIFF
--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
@@ -47,8 +47,7 @@ public class RepoProxyUtils
             final String originStoreKeyStr = origStoreKey.get();
             final String[] parts = originStoreKeyStr.split( ":" );
             final String proxyToStorePathString = keyToPath( proxyToKey );
-            final String proxyTo =
-                    originalPath.replaceAll( keyToPath( originStoreKeyStr), proxyToStorePathString );
+            final String proxyTo = originalPath.replaceAll( keyToPath( originStoreKeyStr ), proxyToStorePathString );
             logger.trace( "Found proxy to store rule: from {} to {}", originStoreKeyStr, proxyToStorePathString );
             return of( proxyTo );
         }
@@ -96,7 +95,12 @@ public class RepoProxyUtils
             checkingRepoPath = repoPath.substring( 0, repoPath.length() - 1 );
         }
         final int pos = fullPath.indexOf( checkingRepoPath );
-        String path = fullPath.substring( pos + checkingRepoPath.length() + 1 );
+        final int pathStartPos = pos + checkingRepoPath.length() + 1;
+        if ( pathStartPos >= fullPath.length() )
+        {
+            return "";
+        }
+        String path = fullPath.substring( pathStartPos );
         if ( StringUtils.isNotBlank( path ) && !path.startsWith( "/" ) )
         {
             path = "/" + path;

--- a/addons/repo-proxy/common/src/test/java/org/commonjava/indy/repo/proxy/RepoProxyUtilsTest.java
+++ b/addons/repo-proxy/common/src/test/java/org/commonjava/indy/repo/proxy/RepoProxyUtilsTest.java
@@ -57,6 +57,16 @@ public class RepoProxyUtilsTest
         repoPath = "/npm/hosted/jkl/";
         path = RepoProxyUtils.extractPath( fullPath, repoPath );
         assertThat( path, equalTo( "/org/commonjava/indy/indy-api/2.0/indy-api-2.0.jar" ) );
+
+        fullPath = "/api/content/npm/hosted/jkl/";
+        repoPath = "/npm/hosted/jkl/";
+        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        assertThat( path, equalTo( "" ) );
+
+        fullPath = "/api/content/npm/hosted/jkl";
+        repoPath = "/npm/hosted/jkl/";
+        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        assertThat( path, equalTo( "" ) );
     }
 
     @Test


### PR DESCRIPTION
When testing, I found there is a bug of extract path from a full http request path. This is a fix for it.