### PR TITLE
[maint] Disable bearer token debug

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/keycloak/KeycloakProxyAuthenticator.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/keycloak/KeycloakProxyAuthenticator.java
@@ -184,7 +184,7 @@ public class KeycloakProxyAuthenticator
         AccessToken token;
         try
         {
-            KeycloakBearerTokenDebug.debugToken( tokenString );
+//            KeycloakBearerTokenDebug.debugToken( tokenString );
 
             logger.debug( "Verifying token: '{}'", tokenString );
             token = RSATokenVerifier.verifyToken( tokenString, getHardcodedRealmKey( deployment ), deployment.getRealmInfoUrl() );

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/BasicAuthenticationOAuthTranslator.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/BasicAuthenticationOAuthTranslator.java
@@ -169,7 +169,7 @@ public class BasicAuthenticationOAuthTranslator
                             "BASIC authentication translated into OAuth 2.0 bearer token. Handing off to Keycloak." );
                     resultValues.add( value );
 
-                    KeycloakBearerTokenDebug.debugToken( encodedToken );
+//                    KeycloakBearerTokenDebug.debugToken( encodedToken );
                     exchange.getResponseHeaders().add( new HttpString( INDY_BEARER_TOKEN ), encodedToken );
                 }
             }


### PR DESCRIPTION
This debugger class actually has some code that throws two different kinds of RuntimeException, which is very dangerous considering its function is to help debug the authentication process (not change it).