### PR TITLE
Refactor the getDeprecated to use Optional instead of returning null

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/stats/IndyDeprecatedApis.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/stats/IndyDeprecatedApis.java
@@ -23,9 +23,12 @@ import javax.enterprise.inject.Alternative;
 import javax.inject.Named;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.apache.commons.lang.StringUtils.isBlank;
 
 @Alternative
@@ -82,11 +85,11 @@ public class IndyDeprecatedApis
         logger.debug( "Parsed deprecatedApis:{}, minApiVersion:{}", deprecatedApis, minApiVersion );
     }
 
-    public DeprecatedApiEntry getDeprecated( String reqApiVersion )
+    public Optional<DeprecatedApiEntry> getDeprecated( String reqApiVersion )
     {
         if ( isBlank( reqApiVersion ))
         {
-            return null;
+            return empty();
         }
         Float reqVer;
         try
@@ -96,7 +99,7 @@ public class IndyDeprecatedApis
         catch ( NumberFormatException e )
         {
             logger.warn( "Unknown api version: {}", reqApiVersion );
-            return null;
+            return empty();
         }
 
         // the scopes may overlap, we go through range entries first and other entries next
@@ -104,7 +107,7 @@ public class IndyDeprecatedApis
         {
             if ( et.range != null && et.range.containsFloat( reqVer ) )
             {
-                return et;
+                return of( et );
             }
         }
 
@@ -112,11 +115,11 @@ public class IndyDeprecatedApis
         {
             if ( et.endVersion != null && reqVer <= et.endVersion )
             {
-                return et;
+                return of( et );
             }
         }
 
-        return null;
+        return empty();
     }
 
     public String getMinApiVersion()

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ApiVersioningFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ApiVersioningFilter.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 
 import static io.undertow.util.StatusCodes.GONE;
 import static org.apache.commons.lang.StringUtils.isBlank;
@@ -107,20 +108,21 @@ public class ApiVersioningFilter
         httpServletResponse.addHeader( HEADER_INDY_CUR_API_VERSION, indyVersioning.getApiVersion() );
         httpServletResponse.addHeader( HEADER_INDY_MIN_API_VERSION, indyDeprecatedApis.getMinApiVersion() );
 
-        IndyDeprecatedApis.DeprecatedApiEntry deprecatedApiEntry = indyDeprecatedApis.getDeprecated( reqApiVersion );
+        Optional<IndyDeprecatedApis.DeprecatedApiEntry>
+                deprecatedApiEntry = indyDeprecatedApis.getDeprecated( reqApiVersion );
 
         String deprecatedApiVersion = null;
 
-        if ( deprecatedApiEntry != null )
+        if ( deprecatedApiEntry.isPresent() )
         {
-            if (deprecatedApiEntry.isOff() )
+            if ( deprecatedApiEntry.get().isOff() )
             {
                 httpServletResponse.setStatus( GONE ); // Return 410
                 return;
             }
             else
             {
-                deprecatedApiVersion = deprecatedApiEntry.getValue();
+                deprecatedApiVersion = deprecatedApiEntry.get().getValue();
             }
         }
 


### PR DESCRIPTION
In java 8, we have better way now to solve "null-return" problem by using java.util.Optional, which makes the "null-return" more like some code smell. This pr is to refactor the api version problem by this way.