### PR TITLE
Cache storekey created by repo-creator

### DIFF
--- a/addons/repo-proxy/common/src/main/data/default-rule.groovy
+++ b/addons/repo-proxy/common/src/main/data/default-rule.groovy
@@ -15,8 +15,7 @@
  */
 
 import org.commonjava.indy.repo.proxy.create.*
-
-import org.commonjava.indy.model.core.*;
+import org.commonjava.indy.model.core.*
 
 class DefaultRule extends AbstractProxyRepoCreateRule {
     @Override
@@ -25,11 +24,11 @@ class DefaultRule extends AbstractProxyRepoCreateRule {
     }
 
     @Override
-    RemoteRepository createRemote(StoreKey key) {
+    Optional<RemoteRepository> createRemote(StoreKey key) {
         def pkgType = key.getPackageType()
         def type = key.getType().singularEndpointName()
         def name = key.getName()
-        return new RemoteRepository(pkgType, String.format("%s-%s", type, name), String.format("http://some.indy/api/content/%s/%s/%s", pkgType, type, name))
+        return Optional.of(new RemoteRepository(pkgType, String.format("%s-%s", type, name), String.format("http://some.indy/api/content/%s/%s/%s", pkgType, type, name)))
     }
 
 

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/AbstractProxyRepoCreateRule.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/AbstractProxyRepoCreateRule.java
@@ -18,6 +18,9 @@ package org.commonjava.indy.repo.proxy.create;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 
+import java.util.Optional;
+
+import static java.util.Optional.empty;
 
 public abstract class AbstractProxyRepoCreateRule
         implements ProxyRepoCreateRule
@@ -30,9 +33,9 @@ public abstract class AbstractProxyRepoCreateRule
     }
 
     @Override
-    public RemoteRepository createRemote( final StoreKey key )
+    public Optional<RemoteRepository> createRemote( final StoreKey key )
     {
-        return null;
+        return empty();
     }
 
     public String getTargetIndyUrl(){

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/ProxyRepoCreateRule.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/create/ProxyRepoCreateRule.java
@@ -19,12 +19,13 @@ import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 
 import java.net.MalformedURLException;
+import java.util.Optional;
 
 public interface ProxyRepoCreateRule
 {
     boolean matches( final StoreKey origKey );
 
-    RemoteRepository createRemote( final StoreKey origKey )
+    Optional<RemoteRepository> createRemote( final StoreKey origKey )
             throws MalformedURLException;
 
 }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorDefaultTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorDefaultTest.java
@@ -124,8 +124,8 @@ public class RepoProxyCreatorDefaultTest
             "        return \"maven\".equals(storeKey.getPackageType())\n" +
             "    }\n" +
             "    @Override\n" +
-            "    RemoteRepository createRemote(StoreKey key) {\n" +
-            "        return new RemoteRepository(key.getPackageType(), key.getName(), \"" + targetBase + "\")\n" +
+            "    Optional<RemoteRepository> createRemote(StoreKey key) {\n" +
+            "        return Optional.of(new RemoteRepository(key.getPackageType(), key.getName(), \"" + targetBase + "\"))\n" +
             "    }\n" +
             "}";
         // @formatter:on;

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorNotMatchTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorNotMatchTest.java
@@ -141,8 +141,8 @@ public class RepoProxyCreatorNotMatchTest
             "        return \"maven\".equals(storeKey.getPackageType()) && \"pnc-builds\".equals(storeKey.getName())\n" +
             "    }\n" +
             "    @Override\n" +
-            "    RemoteRepository createRemote(StoreKey key) {\n" +
-            "        return new RemoteRepository(key.getPackageType(), key.getName(), \"" + targetBase + "\")\n" +
+            "    Optional<RemoteRepository> createRemote(StoreKey key) {\n" +
+            "        return Optional.of(new RemoteRepository(key.getPackageType(), key.getName(), \"" + targetBase + "\"))\n" +
             "    }\n" +
             "}";
         // @formatter:on;

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorWithNPMContentRewriteTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorWithNPMContentRewriteTest.java
@@ -182,8 +182,8 @@ public class RepoProxyCreatorWithNPMContentRewriteTest
                         "        return \"npm\".equals(storeKey.getPackageType()) && StoreType.group==storeKey.getType()\n" +
                         "    }\n" +
                         "    @Override\n" +
-                        "    RemoteRepository createRemote(StoreKey key) {\n" +
-                        "        return new RemoteRepository(key.getPackageType(), String.format(\"%s-%s\", StoreType.group, key.getName()), \"" + targetBase + "\")\n" +
+                        "    Optional<RemoteRepository> createRemote(StoreKey key) {\n" +
+                        "        return Optional.of(new RemoteRepository(key.getPackageType(), String.format(\"%s-%s\", StoreType.group, key.getName()), \"" + targetBase + "\"))\n" +
                         "    }\n" +
                         "}";
         // @formatter:on;


### PR DESCRIPTION
In current code, when each request goes in proxy, the process needs to retrieve the proxy-to remote repo from the repo-creator script, which means needs to execute the groovy code for each request. This is not good for performance if the request number is huge. 
So this fix will cache the remote key for the group/hosted key in the request to avoid to run the groovy again for the following same hosted/hosted request, which will improve the performance.