### PR TITLE
Enhance the NPM package object

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGenerator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGenerator.java
@@ -307,7 +307,10 @@ public class PackageMetadataGenerator
                     packageMetadata.setName( versionMetadata.getName() );
                     packageMetadata.setDescription( versionMetadata.getDescription() );
                     packageMetadata.setAuthor( versionMetadata.getAuthor() );
-                    packageMetadata.setLicense( versionMetadata.getLicense() );
+                    if ( versionMetadata.getLicense() != null )
+                    {
+                        packageMetadata.setLicense( versionMetadata.getLicense().getType() );
+                    }
                     packageMetadata.setRepository( versionMetadata.getRepository() );
                     packageMetadata.setBugs( versionMetadata.getBugs() );
                     distTags.setLatest( versionMetadata.getVersion() );

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Engines.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Engines.java
@@ -37,6 +37,25 @@ public class Engines
     {
     }
 
+    protected Engines( String engine )
+    {
+        String[] strings = engine.split( String.valueOf( Character.SPACE_SEPARATOR ) );
+
+        if ( strings.length != 2  )
+        {
+            return;
+        }
+
+        if ( NPM.equals( strings[0] ) )
+        {
+            enginesMap.put( NPM, strings[1] );
+        }
+        else if ( NODE.equals( strings[0] ) )
+        {
+            enginesMap.put( NODE, strings[1] );
+        }
+    }
+
     public String getNode()
     {
         return enginesMap.get( NODE );

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/License.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/License.java
@@ -30,6 +30,12 @@ public class License
         this.url = null;
     }
 
+    public License( final String type )
+    {
+        this.type = type;
+        this.url = null;
+    }
+
     public License( final String type, final String url )
     {
         this.type = type;

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmJsonOpts.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/NpmJsonOpts.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.indy.pkg.npm.model;
 
+import java.util.List;
+
 public class NpmJsonOpts
 {
 
@@ -22,7 +24,7 @@ public class NpmJsonOpts
 
     private final Boolean wscript;
 
-    private final Boolean contributors;
+    private final List<String> contributors;
 
     private final Boolean serverjs;
 
@@ -34,7 +36,7 @@ public class NpmJsonOpts
         this.serverjs = null;
     }
 
-    public NpmJsonOpts( final String file, final Boolean wscript, final Boolean contributors, final Boolean serverjs )
+    public NpmJsonOpts( final String file, final Boolean wscript, final List<String> contributors, final Boolean serverjs )
     {
         this.file = file;
         this.wscript = wscript;
@@ -52,7 +54,7 @@ public class NpmJsonOpts
         return wscript;
     }
 
-    public Boolean getContributors()
+    public List<String> getContributors()
     {
         return contributors;
     }

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Repository.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/Repository.java
@@ -32,6 +32,12 @@ public class Repository
         this.url = null;
     }
 
+    public Repository( final String url )
+    {
+        this.type = null;
+        this.url = url;
+    }
+
     public Repository( final String type, final String url )
     {
         this.type = type;

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/VersionMetadata.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/VersionMetadata.java
@@ -65,7 +65,7 @@ public class VersionMetadata
     @ApiModelProperty( value = "These styles are now deprecated. Instead, use SPDX expressions." )
     private List<License> licenses;
 
-    private String license;
+    private License license;
 
     private Map<String, String> dependencies;
 
@@ -74,7 +74,7 @@ public class VersionMetadata
     private Map<String, String> jsdomVersions;
 
     @ApiModelProperty( required = false, dataType = "Map", allowableValues = "prepare:<script>, build:<script>, start:<script>, test:<script>, precommit:<script>, commitmsg:<script>, etc." )
-    private Map<String, String> scripts;
+    private Map<String, Object> scripts;
 
     private Dist dist;
 
@@ -82,7 +82,7 @@ public class VersionMetadata
 
     private Commitplease commitplease;
 
-    private Engines engines;
+    private List<Engines> engines;
 
     @JsonProperty( "_engineSupported" )
     private Boolean engineSupported;
@@ -270,12 +270,12 @@ public class VersionMetadata
         this.licenses = licenses;
     }
 
-    public String getLicense()
+    public License getLicense()
     {
         return license;
     }
 
-    public void setLicense( String license )
+    public void setLicense( License license )
     {
         this.license = license;
     }
@@ -310,12 +310,12 @@ public class VersionMetadata
         this.jsdomVersions = jsdomVersions;
     }
 
-    public Map<String, String> getScripts()
+    public Map<String, Object> getScripts()
     {
         return scripts;
     }
 
-    public void setScripts( Map<String, String> scripts )
+    public void setScripts( Map<String, Object> scripts )
     {
         this.scripts = scripts;
     }
@@ -350,12 +350,12 @@ public class VersionMetadata
         this.commitplease = commitplease;
     }
 
-    public Engines getEngines()
+    public List<Engines> getEngines()
     {
         return engines;
     }
 
-    public void setEngines( Engines engines )
+    public void setEngines( List<Engines> engines )
     {
         this.engines = engines;
     }

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/IndyObjectMapper.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/IndyObjectMapper.java
@@ -122,6 +122,7 @@ public class IndyObjectMapper
     {
         setSerializationInclusion( Include.NON_EMPTY );
         configure( Feature.AUTO_CLOSE_JSON_CONTENT, true );
+        configure( DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
 
         enable( SerializationFeature.INDENT_OUTPUT, SerializationFeature.USE_EQUALITY_FOR_OBJECT_ID );
 


### PR DESCRIPTION
There are some errors when parsing the version metadata, for example:
the metadata engines of some package are object while some others are array:
`"engines":["node >=0.6.0"]`
`"engines":{"node":"*"}`

So I enable the configuration as follows to handle the above issue:
`configure( DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);`







