### PR TITLE
Repo-proxy: Apply content rewriting for content browse api

### DIFF
--- a/addons/repo-proxy/common/pom.xml
+++ b/addons/repo-proxy/common/pom.xml
@@ -36,9 +36,20 @@
       <artifactId>indy-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-bindings-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.jboss.spec.javax.servlet</groupId>
+          <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.0_spec</artifactId>
     </dependency>
+
   </dependencies>
 
   <build>

--- a/addons/repo-proxy/common/src/main/conf/conf.d/repo-proxy.conf
+++ b/addons/repo-proxy/common/src/main/conf/conf.d/repo-proxy.conf
@@ -4,10 +4,13 @@
 #enabled=false
 
 # Define the pattern for the api url pattern that will use the proxy, use comma to split
-# api.url.patterns=/api/content/*, /api/folo/track/*
+#api.url.patterns=/api/content/*, /api/folo/track/*, /api/browse/*, /api/group/*, /api/hosted/*
 
 # Define the api http methods that the proxy will be applied with, use comma to split
-# api.methods=GET,HEAD
+#api.methods=GET,HEAD
 
-# Control if to enable npm metadata content rewriting, which replace repo path based on proxy-rule
-# npm.meta.rewrite.enabled=true
+# Control if to enable npm metadata content rewriting, which replace repo path based on proxy-rule, default is true
+#npm.meta.rewrite.enabled=true
+
+# Control if to enable content browse(directory listing) content rewriting, which replace repo path based on proxy-rule, default is true
+#content-browse.rewrite.enabled

--- a/addons/repo-proxy/common/src/main/data/default-rule.groovy
+++ b/addons/repo-proxy/common/src/main/data/default-rule.groovy
@@ -28,7 +28,10 @@ class DefaultRule extends AbstractProxyRepoCreateRule {
         def pkgType = key.getPackageType()
         def type = key.getType().singularEndpointName()
         def name = key.getName()
-        return Optional.of(new RemoteRepository(pkgType, String.format("%s-%s", type, name), String.format("http://some.indy/api/content/%s/%s/%s", pkgType, type, name)))
+        def remoteRepository = new RemoteRepository(pkgType, String.format("%s-%s", type, name), String.format("http://some.indy/api/content/%s/%s/%s", pkgType, type, name))
+        remoteRepository.setMetadataTimeoutSeconds(12*3600)
+        remoteRepository.setCacheTimeoutSeconds(7*24*3600)
+        return Optional.of(remoteRepository)
     }
 
 

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingOutputStream.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingOutputStream.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletOutputStream;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * This output stream will cache the original stream and do replacing based on the passed
+ * in candidates in content of original stream during flushing
+ */
+class ContentReplacingOutputStream
+        extends ServletOutputStream
+{
+    private static final Logger logger = LoggerFactory.getLogger( ContentReplacingOutputStream.class );
+
+    private StringBuffer buffer = new StringBuffer();
+
+    private final ServletOutputStream originalStream;
+
+    private final Map<String, String> reposReplacing;
+
+    ContentReplacingOutputStream( final ServletOutputStream originalStream, final Map<String, String> reposReplacing )
+    {
+        this.originalStream = originalStream;
+        this.reposReplacing = reposReplacing;
+    }
+
+    @Override
+    public void write( int b )
+    {
+        buffer.append( (char) b );
+    }
+
+    @Override
+    public void flush()
+            throws IOException
+    {
+        try
+        {
+            String content = buffer.toString();
+            for ( Map.Entry<String, String> repoReplacing : reposReplacing.entrySet() )
+            {
+                final String replaceTo = repoReplacing.getKey();
+                final String origin = repoReplacing.getValue();
+                logger.trace( "Repository Proxy: Content rewriting: Replacing {} to {}", origin, replaceTo );
+                content = content.replaceAll( origin, replaceTo );
+            }
+            originalStream.write( content.getBytes() );
+            originalStream.flush();
+        }
+        finally
+        {
+            buffer = new StringBuffer();
+        }
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        flush();
+        IOUtils.closeQuietly( originalStream );
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingResponseWrapper.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingResponseWrapper.java
@@ -53,9 +53,7 @@ public class ContentReplacingResponseWrapper extends HttpServletResponseWrapper
 
     @Override
     public ServletOutputStream getOutputStream()
-            throws IOException
     {
-        final ServletOutputStream originalStream = this.getResponse().getOutputStream();
         return this.out;
     }
 }

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingResponseWrapper.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingResponseWrapper.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2013 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+public class ContentReplacingResponseWrapper extends HttpServletResponseWrapper
+{
+    private final HttpServletRequest request;
+
+    private final ContentReplacingOutputStream out;
+
+    /**
+     * Constructs a response adaptor wrapping the given response.
+     * @throws IllegalArgumentException if the response is null
+     * @param response -
+     * @throws IOException -
+     */
+    public ContentReplacingResponseWrapper( final HttpServletRequest request, final HttpServletResponse response,
+                                              final Map<String, String> reposReplacing )
+            throws IOException
+    {
+        super( response );
+        this.request = request;
+        this.out = new ContentReplacingOutputStream( response.getOutputStream(), reposReplacing );
+    }
+
+    @Override
+    public PrintWriter getWriter()
+            throws IOException
+    {
+        return new PrintWriter( this.getResponse().getWriter() );
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream()
+            throws IOException
+    {
+        final ServletOutputStream originalStream = this.getResponse().getOutputStream();
+        return this.out;
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
@@ -21,13 +21,17 @@ import org.commonjava.indy.model.core.StoreType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+import static org.commonjava.indy.model.core.StoreKey.fromString;
 import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
+import static org.commonjava.maven.galley.util.PathUtils.normalize;
 
 public class RepoProxyUtils
 {
@@ -35,7 +39,9 @@ public class RepoProxyUtils
 
     private static final String STORE_PATH_PATTERN = ".*/(maven|npm)/(group|hosted)/(.+?)(/.*)?";
 
-    public static Optional<String> getProxyTo( final String originalPath, final StoreKey proxyToKey )
+    private static final String NPM_METADATA_NAME = "package.json";
+
+    static Optional<String> getProxyTo( final String originalPath, final StoreKey proxyToKey )
     {
         if ( StoreType.remote != proxyToKey.getType() )
         {
@@ -55,7 +61,7 @@ public class RepoProxyUtils
         return empty();
     }
 
-    public static Optional<String> getOriginalStoreKeyFromPath( final String originalPath )
+    static Optional<String> getOriginalStoreKeyFromPath( final String originalPath )
     {
         final Pattern pat = Pattern.compile( STORE_PATH_PATTERN );
         final Matcher match = pat.matcher( originalPath );
@@ -70,20 +76,20 @@ public class RepoProxyUtils
             logger.trace( "There is not matched original store key in path {}", originalPath );
         }
 
-        return storeKeyString == null ? empty() : of( storeKeyString );
+        return ofNullable( storeKeyString );
     }
 
-    public static String keyToPath( final String keyString )
+    static String keyToPath( final String keyString )
     {
         return StringUtils.isNotBlank( keyString ) ? keyString.replaceAll( ":", "/" ) : "";
     }
 
-    public static String keyToPath( final StoreKey key )
+    static String keyToPath( final StoreKey key )
     {
         return keyToPath( key.toString() );
     }
 
-    public static String extractPath( final String fullPath, final String repoPath )
+    static String extractPath( final String fullPath, final String repoPath )
     {
         if ( StringUtils.isBlank( fullPath ) || !fullPath.contains( repoPath ) )
         {
@@ -108,9 +114,42 @@ public class RepoProxyUtils
         return path;
     }
 
+    static boolean isNPMMetaPath( final String path )
+    {
+        if ( StringUtils.isBlank( path ) )
+        {
+            return false;
+        }
+        String checkingPath = path;
+        if ( path.startsWith( "/" ) )
+        {
+            checkingPath = path.substring( 1 );
+        }
+        // This is considering the single path for npm standard like "/jquery"
+        final boolean isSinglePath = checkingPath.split( "/" ).length < 2;
+        // This is considering the scoped path for npm standard like "/@type/jquery"
+        final boolean isScopedPath = checkingPath.startsWith( "@" ) && checkingPath.split( "/" ).length < 3;
+        // This is considering the package.json file itself
+        final boolean isPackageJson = checkingPath.trim().endsWith( "/" + NPM_METADATA_NAME );
+
+        trace( logger, "path: {}, isSinglePath: {}, isScopedPath: {}, isPackageJson: {}", path, isSinglePath,
+               isScopedPath, isPackageJson );
+        return isSinglePath || isScopedPath || isPackageJson;
+    }
+
+    static String getRequestAbsolutePath( HttpServletRequest request )
+    {
+        final String pathInfo = request.getPathInfo();
+
+        return normalize( request.getServletPath(), request.getContextPath(), request.getPathInfo() );
+    }
+
     public static void trace( final Logger logger, final String template, final Object... params )
     {
-        final String finalTemplate = ADDON_NAME + ": " + template;
-        logger.trace( finalTemplate, params );
+        if ( logger.isTraceEnabled() )
+        {
+            final String finalTemplate = ADDON_NAME + ": " + template;
+            logger.trace( finalTemplate, params );
+        }
     }
 }

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
@@ -52,15 +52,19 @@ public class RepoProxyConfig
 
     private static final String NPM_META_REWRITE_ENABLE_PARAM = "npm.meta.rewrite.enabled";
 
+    private static final String CONTENT_BROWSE_REWRITE_ENABLE_PARAM = "content-browse.rewrite.enabled";
+
     private static final Boolean DEFAULT_ENABLED = Boolean.FALSE;
 
-    private static final String DEFAULT_API_PATTERNS = "/api/content/*, /api/folo/track/*";
+    private static final String DEFAULT_API_PATTERNS = "/api/content/*, /api/folo/track/*, /api/browse/*, /api/group/*, /api/hosted/*";
 
     private static final String DEFAULT_API_METHODS = "GET,HEAD";
 
     private static final Boolean DEFAULT_NPM_META_REWRITE_ENABLE = Boolean.TRUE;
 
     private static final String DEFAULT_REPO_CREATE_RULE_BASEDIR = "repo-proxy";
+
+    private static final Boolean DEFAULT_CONTENT_BROWSE_REWRITE_ENABLE = Boolean.TRUE;
 
     private String repoCreatorRuleBaseDir;
 
@@ -71,6 +75,8 @@ public class RepoProxyConfig
     private Boolean enabled;
 
     private Boolean npmMetaRewriteEnabled;
+
+    private Boolean contentBrowseRewriteEnabled;
 
     public RepoProxyConfig()
     {
@@ -88,14 +94,16 @@ public class RepoProxyConfig
                 repoCreatorRuleBaseDir;
     }
 
-    public Boolean getNpmMetaRewriteEnabled()
+    public Boolean isNpmMetaRewriteEnabled()
     {
         return this.npmMetaRewriteEnabled == null ? DEFAULT_NPM_META_REWRITE_ENABLE : this.npmMetaRewriteEnabled;
     }
 
-    public Boolean isNpmMetaRewriteEnabled()
+    public Boolean isContentBrowseRewriteEnabled()
     {
-        return getNpmMetaRewriteEnabled();
+        return this.contentBrowseRewriteEnabled == null ?
+                DEFAULT_CONTENT_BROWSE_REWRITE_ENABLE :
+                this.contentBrowseRewriteEnabled;
     }
 
     public Set<String> getApiPatterns()
@@ -150,6 +158,9 @@ public class RepoProxyConfig
                 break;
             case NPM_META_REWRITE_ENABLE_PARAM:
                 this.npmMetaRewriteEnabled = Boolean.valueOf( value.trim() );
+                break;
+            case CONTENT_BROWSE_REWRITE_ENABLE_PARAM:
+                this.contentBrowseRewriteEnabled = Boolean.valueOf( value.trim() );
                 break;
             default:
                 break;

--- a/addons/repo-proxy/common/src/main/resources/default-repo-proxy.conf
+++ b/addons/repo-proxy/common/src/main/resources/default-repo-proxy.conf
@@ -4,10 +4,13 @@
 #enabled=false
 
 # Define the pattern for the api url pattern that will use the proxy, use comma to split
-# api.url.patterns=/api/content/*, /api/folo/track/*
+# api.url.patterns=/api/content/*, /api/folo/track/*, /api/browse/*, /api/group/*, /api/hosted/*
 
 # Define the api http methods that the proxy will be applied with, use comma to split
 # api.methods=GET,HEAD
 
 # Control if to enable npm metadata content rewriting, which replace repo path based on proxy-rule
 # npm.meta.rewrite.enabled=true
+
+# Control if to enable content browse(directory listing) content rewriting, which replace repo path based on proxy-rule, default is true
+#content-browse.rewrite.enabled

--- a/addons/repo-proxy/common/src/test/java/org/commonjava/indy/repo/proxy/RepoProxyUtilsTest.java
+++ b/addons/repo-proxy/common/src/test/java/org/commonjava/indy/repo/proxy/RepoProxyUtilsTest.java
@@ -1,10 +1,13 @@
+package org.commonjava.indy.repo.proxy;
+
 import org.commonjava.indy.model.core.StoreKey;
-import org.commonjava.indy.repo.proxy.RepoProxyUtils;
 import org.junit.Test;
 
 import java.util.Optional;
 
-import static org.commonjava.indy.model.core.StoreKey.fromString;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.extractPath;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getOriginalStoreKeyFromPath;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getProxyTo;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -16,22 +19,22 @@ public class RepoProxyUtilsTest
     public void testGetOriginalStoreKeyFromPath()
     {
         String path = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
-        Optional<String> storeKeyStr = RepoProxyUtils.getOriginalStoreKeyFromPath( path );
+        Optional<String> storeKeyStr = getOriginalStoreKeyFromPath( path );
         assertTrue( storeKeyStr.isPresent() );
         assertThat( storeKeyStr.get(), equalTo( "maven:group:abc" ) );
 
         path = "/api/content/maven/hosted/def";
-        storeKeyStr = RepoProxyUtils.getOriginalStoreKeyFromPath( path );
+        storeKeyStr = getOriginalStoreKeyFromPath( path );
         assertTrue( storeKeyStr.isPresent() );
         assertThat( storeKeyStr.get(), equalTo( "maven:hosted:def" ) );
 
         path = "/api/content/npm/group/ghi/";
-        storeKeyStr = RepoProxyUtils.getOriginalStoreKeyFromPath( path );
+        storeKeyStr = getOriginalStoreKeyFromPath( path );
         assertTrue( storeKeyStr.isPresent() );
         assertThat( storeKeyStr.get(), equalTo( "npm:group:ghi" ) );
 
         path = "/api/content/npm/groupe/ghi/";
-        storeKeyStr = RepoProxyUtils.getOriginalStoreKeyFromPath( path );
+        storeKeyStr = getOriginalStoreKeyFromPath( path );
         assertFalse( storeKeyStr.isPresent() );
     }
 
@@ -40,32 +43,32 @@ public class RepoProxyUtilsTest
     {
         String fullPath = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
         String repoPath = "maven/group/abc";
-        String path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        String path = extractPath( fullPath, repoPath );
         assertThat( path, equalTo( "/org/commonjava/indy/maven-metadata.xml" ) );
 
         fullPath = "/api/content/maven/hosted/def/org/commonjava/indy/1.0/";
         repoPath = "/maven/hosted/def";
-        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        path = extractPath( fullPath, repoPath );
         assertThat( path, equalTo( "/org/commonjava/indy/1.0/" ) );
 
         fullPath = "/api/content/npm/group/ghi/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom";
         repoPath = "npm/group/ghi/";
-        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        path = extractPath( fullPath, repoPath );
         assertThat( path, equalTo( "/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
 
         fullPath = "/api/content/npm/hosted/jkl/org/commonjava/indy/indy-api/2.0/indy-api-2.0.jar";
         repoPath = "/npm/hosted/jkl/";
-        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        path = extractPath( fullPath, repoPath );
         assertThat( path, equalTo( "/org/commonjava/indy/indy-api/2.0/indy-api-2.0.jar" ) );
 
         fullPath = "/api/content/npm/hosted/jkl/";
         repoPath = "/npm/hosted/jkl/";
-        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        path = extractPath( fullPath, repoPath );
         assertThat( path, equalTo( "" ) );
 
         fullPath = "/api/content/npm/hosted/jkl";
         repoPath = "/npm/hosted/jkl/";
-        path = RepoProxyUtils.extractPath( fullPath, repoPath );
+        path = extractPath( fullPath, repoPath );
         assertThat( path, equalTo( "" ) );
     }
 
@@ -73,22 +76,22 @@ public class RepoProxyUtilsTest
     public void testProxyTo()
     {
         String fullPath = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
-        Optional<String> proxyTo = RepoProxyUtils.getProxyTo( fullPath, StoreKey.fromString( "maven:remote:group-abc" ) );
+        Optional<String> proxyTo = getProxyTo( fullPath, StoreKey.fromString( "maven:remote:group-abc" ) );
         assertTrue( proxyTo.isPresent() );
         assertThat( proxyTo.get(), equalTo( "/api/content/maven/remote/group-abc/org/commonjava/indy/maven-metadata.xml" ) );
 
         fullPath = "/api/browse/content/maven/hosted/def/org/commonjava/indy/1.0/";
-        proxyTo = RepoProxyUtils.getProxyTo( fullPath, StoreKey.fromString( "maven:remote:hosted-def" ) );
+        proxyTo = getProxyTo( fullPath, StoreKey.fromString( "maven:remote:hosted-def" ) );
         assertTrue( proxyTo.isPresent() );
         assertThat( proxyTo.get(), equalTo( "/api/browse/content/maven/remote/hosted-def/org/commonjava/indy/1.0/" ) );
 
         fullPath = "/api/folo/track/npm/group/ghi/jquery";
-        proxyTo = RepoProxyUtils.getProxyTo( fullPath, StoreKey.fromString( "npm:remote:group-ghi" ) );
+        proxyTo = getProxyTo( fullPath, StoreKey.fromString( "npm:remote:group-ghi" ) );
         assertTrue( proxyTo.isPresent() );
         assertThat( proxyTo.get(), equalTo( "/api/folo/track/npm/remote/group-ghi/jquery" ) );
 
         fullPath = "/api/folo/track/npm/hosted/jkl/@react/core";
-        proxyTo = RepoProxyUtils.getProxyTo( fullPath, StoreKey.fromString( "npm:remote:hosted-jkl") );
+        proxyTo = getProxyTo( fullPath, StoreKey.fromString( "npm:remote:hosted-jkl") );
         assertTrue( proxyTo.isPresent() );
         assertThat( proxyTo.get(), equalTo( "/api/folo/track/npm/remote/hosted-jkl/@react/core" ) );
     }

--- a/addons/repo-proxy/ftests/pom.xml
+++ b/addons/repo-proxy/ftests/pom.xml
@@ -66,5 +66,10 @@
       <artifactId>hamcrest-core</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-browse-client-java</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDefaultTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDefaultTest.java
@@ -56,7 +56,7 @@ import static org.junit.Assert.assertThat;
 public class RepoProxyDefaultTest
         extends AbstractContentManagementTest
 {
-    private static final String REPO_NAME = "pnc-builds";
+    private static final String REPO_NAME = "test";
 
     private HostedRepository hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
 

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDisableTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyDisableTest.java
@@ -59,7 +59,7 @@ import static org.junit.Assert.assertThat;
 public class RepoProxyDisableTest
         extends AbstractContentManagementTest
 {
-    private static final String REPO_NAME = "pnc-builds";
+    private static final String REPO_NAME = "test";
 
     private HostedRepository hosted;
 

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyMethodsTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyMethodsTest.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.fail;
 public class RepoProxyMethodsTest
         extends AbstractContentManagementTest
 {
-    private static final String REPO_NAME = "pnc-builds";
+    private static final String REPO_NAME = "test";
 
     private HostedRepository hosted;
 

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMHugeMetaContentRewriteTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMHugeMetaContentRewriteTest.java
@@ -36,7 +36,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
- * Check if the NPM metadata rewritting feature can work well with some huge NPM metadata content
+ * Check if the NPM metadata rewriting feature can work well with some huge NPM metadata content
  * <br/>
  * GIVEN:
  * <ul>

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMMetaRewriteDisableTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMMetaRewriteDisableTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
- * Check if the NPM metadata rewritting features can be disabled when addon can work itself
+ * Check if the NPM metadata rewriting features can be disabled when addon can work itself
  * <br/>
  * GIVEN:
  * <ul>

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMMetaRewriteTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyNPMMetaRewriteTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 /**
- * Check if the NPM metadata rewritting features can work well for this proxy addon
+ * Check if the NPM metadata rewriting features can work well for this proxy addon
  * <br/>
  * GIVEN:
  * <ul>

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyPatternsTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyPatternsTest.java
@@ -64,7 +64,7 @@ import static org.junit.Assert.assertThat;
 public class RepoProxyPatternsTest
         extends AbstractContentManagementTest
 {
-    private static final String REPO_NAME = "pnc-builds";
+    private static final String REPO_NAME = "test";
 
     private HostedRepository hosted;
 

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorContentBrowseTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorContentBrowseTest.java
@@ -15,7 +15,9 @@
  */
 package org.commonjava.indy.repo.proxy.ftest.create;
 
-import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.content.browse.client.IndyContentBrowseClientModule;
+import org.commonjava.indy.content.browse.model.ContentBrowseResult;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
@@ -23,20 +25,20 @@ import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
+import java.util.Collection;
+import java.util.Collections;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 /**
- * Check if the repo proxy addon can proxy a hosted repo automatically with no remote setup
+ * Check if the content browse rewriting features can work well for this proxy addon
  * <br/>
  * GIVEN:
  * <ul>
@@ -47,16 +49,16 @@ import static org.junit.Assert.assertThat;
  * <br/>
  * WHEN:
  * <ul>
- *     <li>Request path through a Hosted repo</li>
+ *     <li>Request directory path through content-browse api for a hosted repo</li>
  * </ul>
  * <br/>
  * THEN:
  * <ul>
- *     <li>The content of path can be returned correctly from hosted, but pathB can not</li>
- *     <li>The remote repo which is same-named as hosted has been set up.</li>
+ *     <li>The content for this request can be returned correctly.</li>
+ *     <li>The content should include hosted repo info for both store key and key path.</li>
  * </ul>
  */
-public class RepoProxyCreatorDefaultTest
+public class RepoProxyCreatorContentBrowseTest
         extends AbstractContentManagementTest
 
 {
@@ -64,16 +66,6 @@ public class RepoProxyCreatorDefaultTest
 
     private HostedRepository hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
 
-    private static final String PATH = "foo/bar/1.0/foo-bar-1.0.txt";
-
-    private static final String CONTENT = "This is content";
-
-    @Before
-    public void setupRepos()
-            throws Exception
-    {
-        server.expect( server.formatUrl( REPO_NAME, PATH ), 200, new ByteArrayInputStream( CONTENT.getBytes() ) );
-    }
 
     @Test
     public void run()
@@ -84,22 +76,24 @@ public class RepoProxyCreatorDefaultTest
         RemoteRepository remote = client.stores().load( remoteKey, RemoteRepository.class );
         assertThat( remote, nullValue() );
 
-        try (InputStream result = client.content().get( hosted.getKey(), PATH ))
-        {
-            assertThat( result, notNullValue() );
-            final String content = IOUtils.toString( result );
-            assertThat( content, equalTo( CONTENT ) );
-        }
+        ContentBrowseResult result = client.module( IndyContentBrowseClientModule.class ).getContentList( hosted.getKey(), "foo" );
+        assertThat( result, notNullValue() );
 
         remote = client.stores().load( remoteKey, RemoteRepository.class );
         assertThat( remote, notNullValue() );
+
+        assertThat( result.getStoreKey(), equalTo( hosted.getKey() ) );
+        assertThat( result.getParentUrl(), containsString( "maven/hosted/test" ) );
+        assertThat( result.getStoreBrowseUrl(), containsString( "maven/hosted/test" ) );
+        assertThat( result.getStoreContentUrl(), containsString( "maven/hosted/test" ) );
+
     }
 
     @Override
     protected void initTestConfig( CoreServerFixture fixture )
             throws IOException
     {
-        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true" );
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true\n\n[content-browse]\nenabled=true\n" );
     }
 
     @Override
@@ -129,5 +123,11 @@ public class RepoProxyCreatorDefaultTest
             "    }\n" +
             "}";
         // @formatter:on;
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Collections.singletonList( new IndyContentBrowseClientModule() );
     }
 }

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorMavenContentBrowseTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorMavenContentBrowseTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -38,18 +39,18 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 /**
- * Check if the content browse rewriting features can work well for this proxy addon
+ * Check if the content browse rewriting features in maven can work well for this proxy addon
  * <br/>
  * GIVEN:
  * <ul>
- *     <li>A external repo with specified path </li>
+ *     <li>An external repo with specified path </li>
  *     <li>Configured the repo-proxy enabled</li>
- *     <li>Deployed a repo creator script whose rule to create remote repo which points to the external repo</li>
+ *     <li>Deployed a repo creator script whose rule to create maven remote repo which points to the external repo</li>
  * </ul>
  * <br/>
  * WHEN:
  * <ul>
- *     <li>Request directory path through content-browse api for a hosted repo</li>
+ *     <li>Request directory path through content-browse api for a maven hosted repo</li>
  * </ul>
  * <br/>
  * THEN:
@@ -58,13 +59,13 @@ import static org.junit.Assert.assertThat;
  *     <li>The content should include hosted repo info for both store key and key path.</li>
  * </ul>
  */
-public class RepoProxyCreatorContentBrowseTest
+public class RepoProxyCreatorMavenContentBrowseTest
         extends AbstractContentManagementTest
 
 {
     private static final String REPO_NAME = "test";
 
-    private HostedRepository hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
+    private HostedRepository hosted = new HostedRepository( MAVEN_PKG_KEY, REPO_NAME );
 
 
     @Test
@@ -72,7 +73,7 @@ public class RepoProxyCreatorContentBrowseTest
             throws Exception
     {
         final StoreKey remoteKey =
-                new StoreKey( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, StoreType.remote, REPO_NAME );
+                new StoreKey( MAVEN_PKG_KEY, StoreType.remote, REPO_NAME );
         RemoteRepository remote = client.stores().load( remoteKey, RemoteRepository.class );
         assertThat( remote, nullValue() );
 

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorNPMContentBrowseTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorNPMContentBrowseTest.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest.create;
+
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.content.browse.client.IndyContentBrowseClientModule;
+import org.commonjava.indy.content.browse.model.ContentBrowseResult;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the content browse rewriting features in npm can work well for this proxy addon
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>A external repo with specified path </li>
+ *     <li>Configured the repo-proxy enabled</li>
+ *     <li>Deployed a repo creator script whose rule to create npm remote repo which points to the external repo</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request directory path through content-browse api for a npm hosted repo</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>The content for this request can be returned correctly.</li>
+ *     <li>The content should include hosted repo info for both store key and key path.</li>
+ * </ul>
+ */
+public class RepoProxyCreatorNPMContentBrowseTest
+        extends AbstractContentManagementTest
+
+{
+    private static final String REPO_NAME = "test";
+
+    private HostedRepository hosted = new HostedRepository( NPM_PKG_KEY, REPO_NAME );
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        final StoreKey remoteKey =
+                new StoreKey( NPM_PKG_KEY, StoreType.remote, REPO_NAME );
+        RemoteRepository remote = client.stores().load( remoteKey, RemoteRepository.class );
+        assertThat( remote, nullValue() );
+
+        ContentBrowseResult result = client.module( IndyContentBrowseClientModule.class ).getContentList( hosted.getKey(), "" );
+        assertThat( result, notNullValue() );
+
+        remote = client.stores().load( remoteKey, RemoteRepository.class );
+        assertThat( remote, notNullValue() );
+
+        assertThat( result.getStoreKey(), equalTo( hosted.getKey() ) );
+        assertThat( result.getStoreBrowseUrl(), containsString( "npm/hosted/test" ) );
+        assertThat( result.getStoreContentUrl(), containsString( "npm/hosted/test" ) );
+
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true\n\n[content-browse]\nenabled=true\n" );
+    }
+
+    @Override
+    public void initTestData( CoreServerFixture fixture )
+            throws IOException
+    {
+        writeDataFile( "repo-proxy/default-rule.groovy", getRuleScriptContent() );
+
+        super.initTestData( fixture );
+    }
+
+    private String getRuleScriptContent()
+    {
+        final String targetBase = server.formatUrl( REPO_NAME );
+        // @formatter:off
+        return
+            "import org.commonjava.indy.repo.proxy.create.*\n" +
+            "import org.commonjava.indy.model.core.*\n" +
+            "class DefaultRule extends AbstractProxyRepoCreateRule {\n" +
+            "    @Override\n" +
+            "    boolean matches(StoreKey storeKey) {\n" +
+            "        return \"npm\".equals(storeKey.getPackageType())\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    Optional<RemoteRepository> createRemote(StoreKey key) {\n" +
+            "        return Optional.of(new RemoteRepository(key.getPackageType(), key.getName(), \"" + targetBase + "\"))\n" +
+            "    }\n" +
+            "}";
+        // @formatter:on;
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Collections.singletonList( new IndyContentBrowseClientModule() );
+    }
+}

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorNotMatchTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/create/RepoProxyCreatorNotMatchTest.java
@@ -60,7 +60,7 @@ public class RepoProxyCreatorNotMatchTest
         extends AbstractContentManagementTest
 
 {
-    private static final String REPO_NAME_1 = "pnc-builds";
+    private static final String REPO_NAME_1 = "test";
 
     private static final String REPO_NAME_2 = "not-matched";
 
@@ -138,7 +138,7 @@ public class RepoProxyCreatorNotMatchTest
             "class DefaultRule extends AbstractProxyRepoCreateRule {\n" +
             "    @Override\n" +
             "    boolean matches(StoreKey storeKey) {\n" +
-            "        return \"maven\".equals(storeKey.getPackageType()) && \"pnc-builds\".equals(storeKey.getName())\n" +
+            "        return \"maven\".equals(storeKey.getPackageType()) && \"" + REPO_NAME_1 + "\".equals(storeKey.getName())\n" +
             "    }\n" +
             "    @Override\n" +
             "    Optional<RemoteRepository> createRemote(StoreKey key) {\n" +

--- a/addons/repo-proxy/jaxrs/src/main/java/org/commonjava/indy/repo/proxy/servlet/RepositoryProxyFilter.java
+++ b/addons/repo-proxy/jaxrs/src/main/java/org/commonjava/indy/repo/proxy/servlet/RepositoryProxyFilter.java
@@ -15,9 +15,7 @@
  */
 package org.commonjava.indy.repo.proxy.servlet;
 
-import jnr.ffi.annotations.In;
-import org.commonjava.indy.repo.proxy.RepoProxyContoller;
-import org.commonjava.indy.repo.proxy.conf.RepoProxyConfig;
+import org.commonjava.indy.repo.proxy.RepoProxyController;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -27,7 +25,6 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 
 @ApplicationScoped
@@ -37,7 +34,7 @@ public class RepositoryProxyFilter
     public static final String FILTER_NAME = "RepositoryProxyFilter";
 
     @Inject
-    private RepoProxyContoller contoller;
+    private RepoProxyController contoller;
 
     @Override
     public void init( FilterConfig filterConfig )

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/RequestUtils.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/RequestUtils.java
@@ -94,7 +94,19 @@ public final class RequestUtils
      */
     public static boolean isDirectoryPath( final String path, final HttpServletRequest request )
     {
-        return path == null || path.equals( "" ) || request.getPathInfo().endsWith( "/" ) || path.endsWith(
+        return path == null || path.equals( "" ) || isDirectoryPathForRequest( request ) || path.endsWith(
                 LISTING_HTML_FILE );
+    }
+
+    /**
+     * Check if http request is accessing directory listing
+     *
+     * @param request
+     * @return
+     */
+    public static boolean isDirectoryPathForRequest( final HttpServletRequest request )
+    {
+        final String pathInfo = request.getPathInfo().trim();
+        return pathInfo.endsWith( "/" ) || pathInfo.endsWith( LISTING_HTML_FILE );
     }
 }


### PR DESCRIPTION
  This pr will replace all original repo info to its proxy to repo for content browse api, including both path info and store key info.