### PR TITLE
Add custom deserializer for VersionMetadata

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMerger.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMerger.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.pkg.npm.model.PackageMetadata;
+import org.commonjava.indy.pkg.npm.model.io.PackageSerializerModule;
 import org.commonjava.maven.galley.model.Transfer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +47,9 @@ public class PackageMetadataMerger
 
     @Inject
     private Instance<PackageMetadataProvider> metadataProviderInstances;
+
+    @Inject
+    private PackageSerializerModule packageSerializerModule;
 
     private List<PackageMetadataProvider> metadataProviders;
 
@@ -158,7 +162,7 @@ public class PackageMetadataMerger
 
         final PackageMetadata packageMetadata = new PackageMetadata();
         final IndyObjectMapper mapper = new IndyObjectMapper( true );
-
+        mapper.registerModule( packageSerializerModule );
         for ( final Transfer src : sources )
         {
             if ( !src.exists() )

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/io/PackageSerializerModule.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/io/PackageSerializerModule.java
@@ -1,0 +1,18 @@
+package org.commonjava.indy.pkg.npm.model.io;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.commonjava.indy.pkg.npm.model.VersionMetadata;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class PackageSerializerModule extends SimpleModule
+{
+
+    public PackageSerializerModule()
+    {
+        super( "Indy Package Metadata API" );
+        addDeserializer( VersionMetadata.class, new VersionMetadataDeserializer() );
+    }
+
+}

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/io/VersionMetadataDeserializer.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/io/VersionMetadataDeserializer.java
@@ -1,0 +1,99 @@
+package org.commonjava.indy.pkg.npm.model.io;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.commonjava.indy.pkg.npm.model.Bugs;
+import org.commonjava.indy.pkg.npm.model.Directories;
+import org.commonjava.indy.pkg.npm.model.Dist;
+import org.commonjava.indy.pkg.npm.model.Engines;
+import org.commonjava.indy.pkg.npm.model.License;
+import org.commonjava.indy.pkg.npm.model.Repository;
+import org.commonjava.indy.pkg.npm.model.UserInfo;
+import org.commonjava.indy.pkg.npm.model.VersionMetadata;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class VersionMetadataDeserializer extends StdDeserializer<VersionMetadata>
+{
+
+    public VersionMetadataDeserializer()
+    {
+        this(null);
+    }
+
+    protected VersionMetadataDeserializer( Class<?> vc )
+    {
+        super( vc );
+    }
+
+    @Override
+    public VersionMetadata deserialize( JsonParser jsonParser, DeserializationContext deserializationContext )
+                    throws IOException
+    {
+        final ObjectMapper mapper = (ObjectMapper) jsonParser.getCodec();
+        final JsonNode vNode = mapper.readTree( jsonParser );
+
+        VersionMetadata vm = new VersionMetadata( parseValue( vNode, "name" ), parseValue( vNode, "version" ) );
+        vm.setDescription( parseValue( vNode, "description" ) );
+
+        JsonNode repoNode = vNode.get( "repository" );
+        if ( repoNode instanceof ArrayNode )
+        {
+            repoNode = repoNode.get( 0 );
+        }
+        vm.setRepository( new Repository( parseValue( repoNode, "type"), parseValue( repoNode, "url") ) );
+
+        vm.setAuthor( parseObject( mapper, vNode.get( "author" ), UserInfo.class ));
+        vm.setBugs( parseObject( mapper, vNode.get( "bugs" ), Bugs.class ) );
+        vm.setDist( parseObject( mapper, vNode.get( "dist" ), Dist.class ) );
+        vm.setDirectories( parseObject( mapper, vNode.get( "directories" ), Directories.class ) );
+        vm.setKeywords( parseList( mapper, vNode.get( "keywords" ), String.class ) );
+        vm.setLicense( parseObject( mapper, vNode.get( "license" ), License.class ) );
+        vm.setMain( parseValue( vNode, "main" ) );
+
+        vm.setContributors( parseList( mapper, vNode.get( "contributors" ), UserInfo.class ));
+        vm.setEngines( parseList( mapper, vNode.get( "engines" ), Engines.class ));
+
+        vm.setDependencies( parseObject( mapper, vNode.get( "dependencies" ), Map.class ) );
+        vm.setDevDependencies( parseObject( mapper, vNode.get( "devDependencies" ), Map.class ) );
+
+        vm.setMaintainers( parseList( mapper, vNode.get( "maintainers" ), UserInfo.class));
+        vm.setLicenses( parseList( mapper, vNode.get( "licenses" ), License.class ) );
+
+        vm.setScripts( parseObject( mapper, vNode.get( "scripts" ), Map.class ) );
+
+        return vm;
+    }
+
+    private <T> T parseObject( ObjectMapper mapper, JsonNode node, Class<T> tClass ) throws JsonProcessingException
+    {
+        return mapper.treeToValue( node, tClass );
+    }
+
+    public <T> List<T> parseList( ObjectMapper mapper, JsonNode node, Class<T> tClass ) throws IOException
+    {
+        if ( node == null )
+        {
+            return null;
+        }
+
+        return mapper.readValue( mapper.treeAsTokens( node ),
+                                 mapper.getTypeFactory().constructCollectionType( List.class, tClass ) );
+    }
+
+    private String parseValue( JsonNode repoNode, String key )
+    {
+        if ( repoNode!=null && repoNode.get( key ) != null )
+        {
+            return repoNode.get( key ).asText();
+        }
+        return null;
+    }
+}

--- a/addons/pkg-npm/model-java/src/test/java/org/commonjava/indy/pkg/npm/model/VersionMetadataTest.java
+++ b/addons/pkg-npm/model-java/src/test/java/org/commonjava/indy/pkg/npm/model/VersionMetadataTest.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.pkg.npm.model;
 
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.pkg.npm.model.io.PackageSerializerModule;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -52,5 +53,27 @@ public class VersionMetadataTest
 
         assertThat( jsonResult.contains( "_id" ), equalTo( false ) );
 
+    }
+
+    @Test
+    public void customDeserializerTest() throws Exception
+    {
+        final IndyObjectMapper mapper = new IndyObjectMapper( true );
+        mapper.registerModule( new PackageSerializerModule() );
+        String json = IOUtils.toString(
+                        Thread.currentThread().getContextClassLoader().getResourceAsStream( "test-package-tmp.json" ) );
+
+        final PackageMetadata result = mapper.readValue( json, PackageMetadata.class );
+        final VersionMetadata version = result.getVersions().get( "0.0.4" );
+
+        assertThat( result.getVersions().size(), equalTo( 5 ) );
+
+        assertThat( version.getName(), equalTo( "tmp" ) );
+        assertThat( version.getVersion(), equalTo( "0.0.4" ) );
+        assertThat( version.getRepository().getType(), equalTo("git"));
+        assertThat( version.getEngines().get( 0 ).getNode(), equalTo( "0.4.10" ) );
+        assertThat( version.getScripts().get( "test" ), equalTo( "vows test/*-test.js" ) );
+        assertThat( version.getLicenses().get( 0 ).getType(), equalTo( "GPLv2" ) );
+        assertThat( version.getDist().getTarball(), equalTo( "https://registry.npmjs.org/tmp/-/tmp-0.0.4.tgz" ) );
     }
 }

--- a/addons/pkg-npm/model-java/src/test/resources/test-package-tmp.json
+++ b/addons/pkg-npm/model-java/src/test/resources/test-package-tmp.json
@@ -1,0 +1,407 @@
+{
+  "_id": "tmp",
+  "_rev": "110-999eb1f875db4ea25b96f9dbbe8f53dc",
+  "name": "tmp",
+  "description": "Temporary file and directory creator",
+  "dist-tags": {
+    "latest": "0.1.0"
+  },
+  "versions": {
+    "0.0.1": {
+      "name": "tmp",
+      "version": "0.0.1",
+      "description": "Temporary file and directory creator",
+      "preferGlobal": true,
+      "keywords": [
+        "temporary",
+        "tmp",
+        "temp",
+        "tempdir",
+        "tempfile",
+        "tmpdir",
+        "tmpfile"
+      ],
+      "author": "",
+      "contributors": [
+        {
+          "name": "KARASZI Istvan",
+          "email": "github@spam.raszi.hu"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/raszi/tmp/issues"
+      },
+      "main": "lib/tmp.js",
+      "scripts": {
+        "test": "vows test/*-test.js"
+      },
+      "engines": {
+        "node": "0.4.10"
+      },
+      "dependencies": {
+        "underscore": "~1.1.7"
+      },
+      "devDependencies": {
+        "vows": "~0.5.11"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/raszi/.npm/tmp/0.0.1/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "tmp@0.0.1",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.25",
+      "_nodeVersion": "v0.4.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "2b488c532ed9738a95ff96ccfe7e6234ac484ba9",
+        "tarball": "https://registry.npmjs.org/tmp/-/tmp-0.0.1.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "raszi",
+          "email": "npm@spam.raszi.hu"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.2": {
+      "name": "tmp",
+      "version": "0.0.2",
+      "description": "Temporary file and directory creator",
+      "homepage": "http://github.com/raszi/tmp",
+      "keywords": [
+        "temporary",
+        "tmp",
+        "temp",
+        "tempdir",
+        "tempfile",
+        "tmpdir",
+        "tmpfile"
+      ],
+      "author": "",
+      "contributors": [
+        {
+          "name": "KARASZI Istvan",
+          "email": "github@spam.raszi.hu",
+          "url": "http://raszi.hu/"
+        }
+      ],
+      "licenses": [
+        {
+          "type": "GPLv2",
+          "url": "http://www.example.com/licenses/gpl.html"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/raszi/tmp.git"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/raszi/tmp/issues"
+      },
+      "main": "lib/tmp.js",
+      "scripts": {
+        "test": "vows test/*-test.js"
+      },
+      "engines": {
+        "node": "0.4.10"
+      },
+      "dependencies": {
+        "underscore": "~1.1.7"
+      },
+      "devDependencies": {
+        "vows": "~0.5.11"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/raszi/.npm/tmp/0.0.2/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "tmp@0.0.2",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.25",
+      "_nodeVersion": "v0.4.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "f32d3bb73f3a405fb3f85ead63838189e516dad9",
+        "tarball": "https://registry.npmjs.org/tmp/-/tmp-0.0.2.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "raszi",
+          "email": "npm@spam.raszi.hu"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.3": {
+      "name": "tmp",
+      "version": "0.0.3",
+      "description": "Temporary file and directory creator",
+      "homepage": "http://github.com/raszi/tmp",
+      "keywords": [
+        "temporary",
+        "tmp",
+        "temp",
+        "tempdir",
+        "tempfile",
+        "tmpdir",
+        "tmpfile"
+      ],
+      "author": "",
+      "contributors": [
+        {
+          "name": "KARASZI Istvan",
+          "email": "github@spam.raszi.hu",
+          "url": "http://raszi.hu/"
+        }
+      ],
+      "licenses": [
+        {
+          "type": "GPLv2",
+          "url": "http://www.example.com/licenses/gpl.html"
+        }
+      ],
+      "repositories": [
+        {
+          "type": "git",
+          "url": "git://github.com/raszi/tmp.git"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/raszi/tmp/issues"
+      },
+      "main": "lib/tmp.js",
+      "scripts": {
+        "test": "vows test/*-test.js"
+      },
+      "engines": {
+        "node": "0.4.10"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "vows": "~0.5.11"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/raszi/.npm/tmp/0.0.3/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "tmp@0.0.3",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.25",
+      "_nodeVersion": "v0.4.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "72035c83ba264668aa3393364f79ae1201b5ca6f",
+        "tarball": "https://registry.npmjs.org/tmp/-/tmp-0.0.3.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "raszi",
+          "email": "npm@spam.raszi.hu"
+        }
+      ],
+      "directories": {}
+    },
+    "0.0.4": {
+      "name": "tmp",
+      "version": "0.0.4",
+      "description": "Temporary file and directory creator",
+      "author": {
+        "name": "KARASZI István",
+        "email": "github@spam.raszi.hu",
+        "url": "http://raszi.hu/"
+      },
+      "homepage": "http://github.com/raszi/tmp",
+      "keywords": [
+        "temporary",
+        "tmp",
+        "temp",
+        "tempdir",
+        "tempfile",
+        "tmpdir",
+        "tmpfile"
+      ],
+      "licenses": [
+        {
+          "type": "GPLv2",
+          "url": "http://www.example.com/licenses/gpl.html"
+        }
+      ],
+      "repository": [
+        {
+          "type": "git",
+          "url": "git://github.com/raszi/tmp.git"
+        }
+      ],
+      "bugs": {
+        "url": "https://github.com/raszi/tmp/issues"
+      },
+      "main": "lib/tmp.js",
+      "scripts": {
+        "test": "vows test/*-test.js"
+      },
+      "engines": {
+        "node": "0.4.10"
+      },
+      "dependencies": {},
+      "devDependencies": {
+        "vows": "~0.5.11"
+      },
+      "_npmJsonOpts": {
+        "file": "/Users/raszi/.npm/tmp/0.0.4/package/package.json",
+        "wscript": false,
+        "contributors": false,
+        "serverjs": false
+      },
+      "_id": "tmp@0.0.4",
+      "_engineSupported": true,
+      "_npmVersion": "1.0.25",
+      "_nodeVersion": "v0.4.10",
+      "_defaultsLoaded": true,
+      "dist": {
+        "shasum": "744300c5b4bd7a0a6e8b451355b792961bd168e0",
+        "tarball": "https://registry.npmjs.org/tmp/-/tmp-0.0.4.tgz"
+      },
+      "maintainers": [
+        {
+          "name": "raszi",
+          "email": "npm@spam.raszi.hu"
+        }
+      ],
+      "directories": {}
+    },
+    "0.1.0": {
+      "name": "tmp",
+      "version": "0.1.0",
+      "description": "Temporary file and directory creator",
+      "author": {
+        "name": "KARASZI István",
+        "email": "github@spam.raszi.hu",
+        "url": "http://raszi.hu/"
+      },
+      "keywords": [
+        "temporary",
+        "tmp",
+        "temp",
+        "tempdir",
+        "tempfile",
+        "tmpdir",
+        "tmpfile"
+      ],
+      "license": "MIT",
+      "repository": {
+        "type": "git",
+        "url": "git+https://github.com/raszi/node-tmp.git"
+      },
+      "homepage": "http://github.com/raszi/node-tmp",
+      "bugs": {
+        "url": "http://github.com/raszi/node-tmp/issues"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "dependencies": {
+        "rimraf": "^2.6.3"
+      },
+      "devDependencies": {
+        "eslint": "^4.19.1",
+        "eslint-plugin-mocha": "^5.0.0",
+        "istanbul": "^0.4.5",
+        "mocha": "^5.1.1"
+      },
+      "main": "lib/tmp.js",
+      "scripts": {
+        "lint": "eslint lib --env mocha test",
+        "clean": "rm -Rf ./coverage",
+        "test": "npm run clean && istanbul cover ./node_modules/mocha/bin/_mocha --report none --print none --dir ./coverage/json -u exports -R test/*-test.js && istanbul report --root ./coverage/json html && istanbul report text-summary",
+        "doc": "jsdoc -c .jsdoc.json"
+      },
+      "gitHead": "05aba23f06aa62dc286bca4340849f475f862dc3",
+      "_id": "tmp@0.1.0",
+      "_nodeVersion": "11.12.0",
+      "_npmVersion": "6.7.0",
+      "dist": {
+        "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+        "shasum": "ee434a4e22543082e294ba6201dcc6eafefa2877",
+        "tarball": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+        "fileCount": 4,
+        "unpackedSize": 32466,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJcmRJJCRA9TVsSAnZWagAAc2UP/iF4CoApYjrSznP2b0fX\n3LzFV23KzKdpDOP18KW7FxGLcBKJaNA9SX2QifhFx6vJSoJJ667Cwderh9FJ\nncLq6TZk82dpHKQEmctFm3moXQ30V101tsLWFY5v2fa3Zz954+bH4NVhzpCJ\nqoberdyzVx6bA5Jr16s4iQjdSr2js5s4+D14xue99JFfcQ0v1x/2vRvA90aS\nZk1R4XD4Z8HCXz4CsRckk0j3sIDYwPQMAdtnfpc3wy0gCadJu4FpNl/x72ez\nkvQ/+KU7/IbqROHdM6rXur1jRVfmAEnUYXs2pl7/6C4nNVVXYSqBAsUdCLAP\n5pWxV7x0yrgWQQjYGkjCOl2YcMhmAJThRB4AxrDIpjcPw6OFlYd1YzO0mXWD\n2YbST+Km4S6Ky4mOMhk3Z1/b1uCuxmDo50PTw9N7aujahK/7UfkmFfiGtGxj\na1pCoBCEsdGJwObJXfm4sJ/zB2F24F1xdVkXDc1IgOoQ/UY5cHwS0CR4WQgE\ntOO0nWqYPSZxFPkpUD0E8mCiB4bskzCblOVV2/o9m8GsGXMg1GTWT10bU446\n8659h7BKqDyLIJbm+txt/fNVo4ObKcHfpMeiboZj7OOd/VJQpr3sEvfppd4Q\nsfUagp9+GgJZSlLEJc8yYJH46YsFHtSmY/tVrg2riFYDTzWBf2gwLIcnyEh4\n4IVZ\r\n=d9KA\r\n-----END PGP SIGNATURE-----\r\n"
+      },
+      "maintainers": [
+        {
+          "name": "raszi",
+          "email": "npm@spam.raszi.hu"
+        }
+      ],
+      "_npmUser": {
+        "name": "raszi",
+        "email": "npm@spam.raszi.hu"
+      },
+      "directories": {},
+      "_npmOperationalInternal": {
+        "host": "s3://npm-registry-packages",
+        "tmp": "tmp/tmp_0.1.0_1553535560800_0.2116124838769562"
+      },
+      "_hasShrinkwrap": false
+    }
+  },
+  "maintainers": [
+    {
+      "name": "raszi",
+      "email": "npm@spam.raszi.hu"
+    }
+  ],
+  "time": {
+    "modified": "2019-03-25T17:39:23.441Z",
+    "created": "2011-09-02T12:30:13.534Z",
+    "0.0.1": "2011-09-02T12:30:15.269Z",
+    "0.0.2": "2011-09-02T12:37:00.785Z",
+    "0.0.3": "2011-09-02T12:45:19.487Z",
+    "0.0.4": "2011-09-02T13:22:17.215Z",
+    "0.1.0": "2019-03-25T17:39:20.951Z"
+  },
+  "author": {
+    "name": "KARASZI István",
+    "email": "github@spam.raszi.hu",
+    "url": "http://raszi.hu/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/raszi/node-tmp.git"
+  },
+  "users": {
+    "bencevans": true,
+    "pid": true,
+    "julien-f": true,
+    "chyingp": true,
+    "sdolard": true,
+    "aw": true,
+    "gdbtek": true
+  },
+  "readme": "# Tmp\n\nA simple temporary file and directory creator for [node.js.][1]\n\n[![Build Status](https://travis-ci.org/raszi/node-tmp.svg?branch=master)](https://travis-ci.org/raszi/node-tmp)\n[![Dependencies](https://david-dm.org/raszi/node-tmp.svg)](https://david-dm.org/raszi/node-tmp)\n[![npm version](https://badge.fury.io/js/tmp.svg)](https://badge.fury.io/js/tmp)\n[![API documented](https://img.shields.io/badge/API-documented-brightgreen.svg)](https://raszi.github.io/node-tmp/)\n[![Known Vulnerabilities](https://snyk.io/test/npm/tmp/badge.svg)](https://snyk.io/test/npm/tmp)\n\n## About\n\nThis is a [widely used library][2] to create temporary files and directories\nin a [node.js][1] environment.\n\nTmp offers both an asynchronous and a synchronous API. For all API calls, all\nthe parameters are optional. There also exists a promisified version of the\nAPI, see [tmp-promise][5].\n\nTmp uses crypto for determining random file names, or, when using templates,\na six letter random identifier. And just in case that you do not have that much\nentropy left on your system, Tmp will fall back to pseudo random numbers.\n\nYou can set whether you want to remove the temporary file on process exit or\nnot.\n\nIf you do not want to store your temporary directories and files in the\nstandard OS temporary directory, then you are free to override that as well.\n\n## An Important Note on Compatibility\n\n### Version 0.1.0\n\nSince version 0.1.0, all support for node versions < 0.10.0 has been dropped.\n\nMost importantly, any support for earlier versions of node-tmp was also dropped.\n\nIf you still require node versions < 0.10.0, then you must limit your node-tmp\ndependency to versions below 0.1.0.\n\n### Version 0.0.33\n\nSince version 0.0.33, all support for node versions < 0.8 has been dropped.\n\nIf you still require node version 0.8, then you must limit your node-tmp\ndependency to version 0.0.33.\n\nFor node versions < 0.8 you must limit your node-tmp dependency to\nversions < 0.0.33.\n\n### Node Versions < 8.12.0\n\nThe SIGINT handler will not work correctly with versions of NodeJS < 8.12.0.\n\n### Windows\n\nSignal handlers for SIGINT will not work. Pressing CTRL-C will leave behind\ntemporary files and directories.\n\n## How to install\n\n```bash\nnpm install tmp\n```\n\n## Usage\n\nPlease also check [API docs][4].\n\n### Asynchronous file creation\n\nSimple temporary file creation, the file will be closed and unlinked on process exit.\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.file(function _tempFileCreated(err, path, fd, cleanupCallback) {\n  if (err) throw err;\n\n  console.log('File: ', path);\n  console.log('Filedescriptor: ', fd);\n  \n  // If we don't need the file anymore we could manually call the cleanupCallback\n  // But that is not necessary if we didn't pass the keep option because the library\n  // will clean after itself.\n  cleanupCallback();\n});\n```\n\n### Synchronous file creation\n\nA synchronous version of the above.\n\n```javascript\nvar tmp = require('tmp');\n\nvar tmpobj = tmp.fileSync();\nconsole.log('File: ', tmpobj.name);\nconsole.log('Filedescriptor: ', tmpobj.fd);\n  \n// If we don't need the file anymore we could manually call the removeCallback\n// But that is not necessary if we didn't pass the keep option because the library\n// will clean after itself.\ntmpobj.removeCallback();\n```\n\nNote that this might throw an exception if either the maximum limit of retries\nfor creating a temporary name fails, or, in case that you do not have the permission\nto write to the directory where the temporary file should be created in.\n\n### Asynchronous directory creation\n\nSimple temporary directory creation, it will be removed on process exit.\n\nIf the directory still contains items on process exit, then it won't be removed.\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.dir(function _tempDirCreated(err, path, cleanupCallback) {\n  if (err) throw err;\n\n  console.log('Dir: ', path);\n  \n  // Manual cleanup\n  cleanupCallback();\n});\n```\n\nIf you want to cleanup the directory even when there are entries in it, then\nyou can pass the `unsafeCleanup` option when creating it.\n\n### Synchronous directory creation\n\nA synchronous version of the above.\n\n```javascript\nvar tmp = require('tmp');\n\nvar tmpobj = tmp.dirSync();\nconsole.log('Dir: ', tmpobj.name);\n// Manual cleanup\ntmpobj.removeCallback();\n```\n\nNote that this might throw an exception if either the maximum limit of retries\nfor creating a temporary name fails, or, in case that you do not have the permission\nto write to the directory where the temporary directory should be created in.\n\n### Asynchronous filename generation\n\nIt is possible with this library to generate a unique filename in the specified\ndirectory.\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.tmpName(function _tempNameGenerated(err, path) {\n    if (err) throw err;\n\n    console.log('Created temporary filename: ', path);\n});\n```\n\n### Synchronous filename generation\n\nA synchronous version of the above.\n\n```javascript\nvar tmp = require('tmp');\n\nvar name = tmp.tmpNameSync();\nconsole.log('Created temporary filename: ', name);\n```\n\n## Advanced usage\n\n### Asynchronous file creation\n\nCreates a file with mode `0644`, prefix will be `prefix-` and postfix will be `.txt`.\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.file({ mode: 0644, prefix: 'prefix-', postfix: '.txt' }, function _tempFileCreated(err, path, fd) {\n  if (err) throw err;\n\n  console.log('File: ', path);\n  console.log('Filedescriptor: ', fd);\n});\n```\n\n### Synchronous file creation\n\nA synchronous version of the above.\n\n```javascript\nvar tmp = require('tmp');\n\nvar tmpobj = tmp.fileSync({ mode: 0644, prefix: 'prefix-', postfix: '.txt' });\nconsole.log('File: ', tmpobj.name);\nconsole.log('Filedescriptor: ', tmpobj.fd);\n```\n\n### Controlling the Descriptor\n\nAs a side effect of creating a unique file `tmp` gets a file descriptor that is\nreturned to the user as the `fd` parameter.  The descriptor may be used by the\napplication and is closed when the `removeCallback` is invoked.\n\nIn some use cases the application does not need the descriptor, needs to close it\nwithout removing the file, or needs to remove the file without closing the\ndescriptor.  Two options control how the descriptor is managed:\n\n* `discardDescriptor` - if `true` causes `tmp` to close the descriptor after the file\n  is created.  In this case the `fd` parameter is undefined.\n* `detachDescriptor` - if `true` causes `tmp` to return the descriptor in the `fd`\n  parameter, but it is the application's responsibility to close it when it is no\n  longer needed.\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.file({ discardDescriptor: true }, function _tempFileCreated(err, path, fd, cleanupCallback) {\n  if (err) throw err;\n  // fd will be undefined, allowing application to use fs.createReadStream(path)\n  // without holding an unused descriptor open.\n});\n```\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.file({ detachDescriptor: true }, function _tempFileCreated(err, path, fd, cleanupCallback) {\n  if (err) throw err;\n\n  cleanupCallback();\n  // Application can store data through fd here; the space used will automatically\n  // be reclaimed by the operating system when the descriptor is closed or program\n  // terminates.\n});\n```\n\n### Asynchronous directory creation\n\nCreates a directory with mode `0755`, prefix will be `myTmpDir_`.\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.dir({ mode: 0750, prefix: 'myTmpDir_' }, function _tempDirCreated(err, path) {\n  if (err) throw err;\n\n  console.log('Dir: ', path);\n});\n```\n\n### Synchronous directory creation\n\nAgain, a synchronous version of the above.\n\n```javascript\nvar tmp = require('tmp');\n\nvar tmpobj = tmp.dirSync({ mode: 0750, prefix: 'myTmpDir_' });\nconsole.log('Dir: ', tmpobj.name);\n```\n\n### mkstemp like, asynchronously\n\nCreates a new temporary directory with mode `0700` and filename like `/tmp/tmp-nk2J1u`.\n\nIMPORTANT NOTE: template no longer accepts a path. Use the dir option instead if you\nrequire tmp to create your temporary filesystem object in a different place than the\ndefault `tmp.tmpdir`.\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.dir({ template: 'tmp-XXXXXX' }, function _tempDirCreated(err, path) {\n  if (err) throw err;\n\n  console.log('Dir: ', path);\n});\n```\n\n### mkstemp like, synchronously\n\nThis will behave similarly to the asynchronous version.\n\n```javascript\nvar tmp = require('tmp');\n\nvar tmpobj = tmp.dirSync({ template: 'tmp-XXXXXX' });\nconsole.log('Dir: ', tmpobj.name);\n```\n\n### Asynchronous filename generation\n\nUsing `tmpName()` you can create temporary file names asynchronously.\nThe function accepts all standard options, e.g. `prefix`, `postfix`, `dir`, and so on.\n\nYou can also leave out the options altogether and just call the function with a callback as first parameter.\n\n```javascript\nvar tmp = require('tmp');\n\nvar options = {};\n\ntmp.tmpName(options, function _tempNameGenerated(err, path) {\n    if (err) throw err;\n\n    console.log('Created temporary filename: ', path);\n});\n```\n\n### Synchronous filename generation\n\nThe `tmpNameSync()` function works similarly to `tmpName()`.\nAgain, you can leave out the options altogether and just invoke the function without any parameters.\n\n```javascript\nvar tmp = require('tmp');\nvar options = {};\nvar tmpname = tmp.tmpNameSync(options);\nconsole.log('Created temporary filename: ', tmpname);\n```\n\n## Graceful cleanup\n\nOne may want to cleanup the temporary files even when an uncaught exception\noccurs. To enforce this, you can call the `setGracefulCleanup()` method:\n\n```javascript\nvar tmp = require('tmp');\n\ntmp.setGracefulCleanup();\n```\n\n## Options\n\nAll options are optional :)\n\n  * `mode`: the file mode to create with, it fallbacks to `0600` on file creation and `0700` on directory creation\n  * `prefix`: the optional prefix, fallbacks to `tmp-` if not provided\n  * `postfix`: the optional postfix, fallbacks to `.tmp` on file creation\n  * `template`: [`mkstemp`][3] like filename template, no default\n  * `dir`: the optional temporary directory, fallbacks to system default (guesses from environment)\n  * `tries`: how many times should the function try to get a unique filename before giving up, default `3`\n  * `keep`: signals that the temporary file or directory should not be deleted on exit, default is `false`\n    * In order to clean up, you will have to call the provided `cleanupCallback` function manually.\n  * `unsafeCleanup`: recursively removes the created temporary directory, even when it's not empty. default is `false`\n\n[1]: http://nodejs.org/\n[2]: https://www.npmjs.com/browse/depended/tmp\n[3]: http://www.kernel.org/doc/man-pages/online/pages/man3/mkstemp.3.html\n[4]: https://raszi.github.io/node-tmp/\n[5]: https://github.com/benjamingr/tmp-promise\n",
+  "homepage": "http://github.com/raszi/node-tmp",
+  "keywords": [
+    "temporary",
+    "tmp",
+    "temp",
+    "tempdir",
+    "tempfile",
+    "tmpdir",
+    "tmpfile"
+  ],
+  "bugs": {
+    "url": "http://github.com/raszi/node-tmp/issues"
+  },
+  "readmeFilename": "README.md",
+  "license": "MIT"
+}


### PR DESCRIPTION
Adding this aims to handle the parsing stuff more flexible I hope,
seems the rules of package metadata template is loose/open, I see
most of the repository of version metadata is a object containing
"type" and "url",  but we ran into the pakcage "tmp" which the repository
is a array, and that appears only in one of their versions(e.g.: 0.0.4).
Details see: http://registry.npmjs.org/tmp

I don't think we need to update our model to adapt this type of data,
but we have to consider it because it will break our code and cause
no versions for the package.