### PR TITLE
Update undertow and xnio versions

### DIFF
--- a/api/src/main/java/org/commonjava/indy/model/galley/RepositoryLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/RepositoryLocation.java
@@ -20,7 +20,11 @@ import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.model.Location;
 import org.commonjava.maven.galley.transport.htcli.model.HttpLocation;
 import org.commonjava.maven.galley.transport.htcli.model.LocationTrustType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -131,10 +135,39 @@ public class RepositoryLocation
         {
             return type.cast( value );
         }
-        else
+        else if ( value.getClass() == String.class && Number.class.isAssignableFrom( type ) )
         {
-            return defaultValue;
+            Number n = null;
+            try
+            {
+                n = NumberFormat.getInstance().parse( (String) value );
+            }
+            catch ( ParseException e )
+            {
+                Logger logger = LoggerFactory.getLogger( getClass() );
+                logger.error( "Failed to get attribute, key: {}, value: {}", key, value, e );
+            }
+            // convert, e.g., n might be Long while the T is Integer
+            Object ret;
+            if ( type == Long.TYPE )
+            {
+                ret = new Long( n.longValue() );
+            }
+            else if ( type == Float.TYPE )
+            {
+                ret = new Float( n.floatValue() );
+            }
+            else if ( type == Double.TYPE )
+            {
+                ret = new Double( n.doubleValue() );
+            }
+            else
+            {
+                ret = new Integer( n.intValue() ); // default int
+            }
+            return (T) ret;
         }
+        return defaultValue;
     }
 
     @Override

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractRemoteRepoTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/AbstractRemoteRepoTimeoutTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractRemoteRepoTimeoutTest extends AbstractContentManag
             {
             }
 
-            return 0;
+            return -1;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,8 @@
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <hibernateVersion>5.8.1.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>
-    <undertowVersion>2.0.1.Final</undertowVersion>
-    <xnioVersion>3.3.0.Final</xnioVersion>
+    <undertowVersion>2.1.0.Final</undertowVersion>
+    <xnioVersion>3.8.0.Final</xnioVersion>
     <keycloakVersion>7.0.1</keycloakVersion>
     <bouncycastleVersion>1.64</bouncycastleVersion>
     <bytemanVersion>3.0.6</bytemanVersion>


### PR DESCRIPTION
Besides the Undertow/Xnio version update, there are two fixes:
1. DelayInputStream read returning -1. The @Rule expectedServer will hang on there if the stream is not complete. This cased six xxxTimeoutTest hang and eventually timeout.
2. The artifact store metadata is map<string, string> but the attributes in Location is map<string,object>. This discrepancy will miss the connection-timeout set by artifactstore.setMetadata(). 