### PR TITLE
Update to pathmap 1.4 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <honeycombVersion>1.1.0</honeycombVersion>
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.7.2</datastaxVersion>
-    <pathmappedStorageVersion>1.3-SNAPSHOT</pathmappedStorageVersion>
+    <pathmappedStorageVersion>1.4-SNAPSHOT</pathmappedStorageVersion>
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.0</atlasVersion>


### PR DESCRIPTION
Pathmap 1.4 contains two fixes: Skip physicalStore.exists; Lower addToReverseMap ConsistencyLevel to ONE. We will need them in next indy 2.1.x release.