### PR TITLE
Use the injected objectMapper

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMerger.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMerger.java
@@ -51,18 +51,21 @@ public class PackageMetadataMerger
     @Inject
     private PackageSerializerModule packageSerializerModule;
 
+    @Inject
+    private IndyObjectMapper mapper;
+
     private List<PackageMetadataProvider> metadataProviders;
 
     public PackageMetadataMerger()
     {
     }
 
-    public PackageMetadataMerger( Iterable<PackageMetadataProvider> providers, PackageSerializerModule module )
+    public PackageMetadataMerger( Iterable<PackageMetadataProvider> providers, IndyObjectMapper mapper )
     {
         metadataProviders = new ArrayList<>();
         providers.forEach( provider -> metadataProviders.add( provider ) );
 
-        packageSerializerModule = module;
+        this.mapper = mapper;
     }
 
     @PostConstruct
@@ -73,6 +76,8 @@ public class PackageMetadataMerger
         {
             metadataProviderInstances.forEach( provider -> metadataProviders.add( provider ) );
         }
+
+        mapper.registerModule( packageSerializerModule );
     }
 
     public byte[] merge( final Collection<Transfer> sources, final Group group, final String path )
@@ -85,8 +90,6 @@ public class PackageMetadataMerger
         boolean merged = false;
 
         final PackageMetadata packageMetadata = new PackageMetadata();
-        final IndyObjectMapper mapper = new IndyObjectMapper( true );
-        mapper.registerModule( packageSerializerModule );
 
         for ( final Transfer src : sources )
         {
@@ -164,8 +167,7 @@ public class PackageMetadataMerger
         InputStream stream = null;
 
         final PackageMetadata packageMetadata = new PackageMetadata();
-        final IndyObjectMapper mapper = new IndyObjectMapper( true );
-        mapper.registerModule( packageSerializerModule );
+
         for ( final Transfer src : sources )
         {
             if ( !src.exists() )

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
@@ -70,7 +70,7 @@ public class PackageMetadataMergerTest
 
     private CacheProvider cacheProvider;
 
-    private PackageSerializerModule module;
+    private IndyObjectMapper mapper;
 
     @Before
     public void setup()
@@ -80,7 +80,9 @@ public class PackageMetadataMergerTest
                 Collections.singleton( new NPMStoragePathCalculator() ) ), new NoOpFileEventManager(),
                                                new TransferDecoratorManager( new NoOpTransferDecorator() ), false );
 
-        module = new PackageSerializerModule();
+        mapper = new IndyObjectMapper( true );
+        mapper.registerModule( new PackageSerializerModule() );
+
     }
 
     @Test
@@ -100,8 +102,8 @@ public class PackageMetadataMergerTest
 
         List<Transfer> sources = Arrays.asList( t1, t2 );
 
-        byte[] output = new PackageMetadataMerger( Collections.emptyList(), module ).merge( sources, g, path );
-        IndyObjectMapper mapper = new IndyObjectMapper( true );
+        byte[] output = new PackageMetadataMerger( Collections.emptyList(), mapper ).merge( sources, g, path );
+
         PackageMetadata merged = mapper.readValue( IOUtils.toString( new ByteArrayInputStream( output ) ),
                                                    PackageMetadata.class );
 
@@ -170,8 +172,8 @@ public class PackageMetadataMergerTest
 
         List<Transfer> sources = Arrays.asList( t1, t2 );
 
-        byte[] output = new PackageMetadataMerger( Collections.emptyList(), module ).merge( sources, g, path );
-        IndyObjectMapper mapper = new IndyObjectMapper( true );
+        byte[] output = new PackageMetadataMerger( Collections.emptyList(), mapper ).merge( sources, g, path );
+
         PackageMetadata merged = mapper.readValue( IOUtils.toString( new ByteArrayInputStream( output ) ),
                                                    PackageMetadata.class );
 
@@ -213,8 +215,8 @@ public class PackageMetadataMergerTest
 
         List<Transfer> sources = Arrays.asList( t1, t2 );
 
-        byte[] output = new PackageMetadataMerger( Collections.emptyList(), module ).merge( sources, g, path );
-        IndyObjectMapper mapper = new IndyObjectMapper( true );
+        byte[] output = new PackageMetadataMerger( Collections.emptyList(), mapper ).merge( sources, g, path );
+
         PackageMetadata merged = mapper.readValue( IOUtils.toString( new ByteArrayInputStream( output ) ),
                                                    PackageMetadata.class );
 
@@ -265,9 +267,8 @@ public class PackageMetadataMergerTest
         provided.setMaintainers( added );
         TestPackageMetadataProvider testProvider = new TestPackageMetadataProvider( provided );
 
-        byte[] output = new PackageMetadataMerger( Collections.singletonList( testProvider ), module ).merge( sources, g,
+        byte[] output = new PackageMetadataMerger( Collections.singletonList( testProvider ), mapper ).merge( sources, g,
                                                                                                       path );
-        IndyObjectMapper mapper = new IndyObjectMapper( true );
         PackageMetadata merged = mapper.readValue( IOUtils.toString( new ByteArrayInputStream( output ) ),
                                                    PackageMetadata.class );
 
@@ -312,9 +313,8 @@ public class PackageMetadataMergerTest
 
         TestPackageMetadataProvider testProvider = new TestPackageMetadataProvider( provided );
 
-        byte[] output = new PackageMetadataMerger( Collections.singletonList( testProvider ), module ).merge( sources, g,
+        byte[] output = new PackageMetadataMerger( Collections.singletonList( testProvider ), mapper ).merge( sources, g,
                                                                                                       path );
-        IndyObjectMapper mapper = new IndyObjectMapper( true );
         PackageMetadata merged = mapper.readValue( IOUtils.toString( new ByteArrayInputStream( output ) ),
                                                    PackageMetadata.class );
 
@@ -343,9 +343,8 @@ public class PackageMetadataMergerTest
 
         TestPackageMetadataProvider testProvider = new TestPackageMetadataProvider( provided );
 
-        byte[] output = new PackageMetadataMerger( Collections.singletonList( testProvider ), module ).merge( sources, g,
+        byte[] output = new PackageMetadataMerger( Collections.singletonList( testProvider ), mapper ).merge( sources, g,
                                                                                                       path );
-        IndyObjectMapper mapper = new IndyObjectMapper( true );
         PackageMetadata merged = mapper.readValue( IOUtils.toString( new ByteArrayInputStream( output ) ),
                                                    PackageMetadata.class );
 
@@ -369,9 +368,8 @@ public class PackageMetadataMergerTest
         TestPackageMetadataProvider testProvider = new TestPackageMetadataProvider(
                         new IndyWorkflowException( "Failed to get provider content" ) );
 
-        byte[] output = new PackageMetadataMerger( Collections.singletonList( testProvider ), module ).merge( sources, g,
+        byte[] output = new PackageMetadataMerger( Collections.singletonList( testProvider ), mapper ).merge( sources, g,
                                                                                                       path );
-        IndyObjectMapper mapper = new IndyObjectMapper( true );
         PackageMetadata merged = mapper.readValue( IOUtils.toString( new ByteArrayInputStream( output ) ),
                                                    PackageMetadata.class );
 


### PR DESCRIPTION
NPM builds are consuming this merge method heavily, to save the time to construct the objectMapper for each request, let's use the injected one instead. 