### PR TITLE
Performance optimizations.

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxySSLTunnel.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxySSLTunnel.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.conduits.ConduitStreamSinkChannel;
 
+import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -80,7 +81,7 @@ public class ProxySSLTunnel implements Runnable
                     throws IOException
     {
         targetChannel.socket().setSoTimeout( (int) TimeUnit.MINUTES.toMillis( config.getMITMSoTimeoutMinutes() ) );
-        InputStream inStream = targetChannel.socket().getInputStream();
+        InputStream inStream = new BufferedInputStream( targetChannel.socket().getInputStream() );
         ReadableByteChannel wrappedChannel = Channels.newChannel( inStream );
 
         ByteBuffer byteBuffer = ByteBuffer.allocate( DEFAULT_READ_BUF_SIZE );


### PR DESCRIPTION
 These optimizations improve execution times and overhead on the jvm process. To solve the issues in #1611 
 Using a simple benchmark to drive load at the proxy these results were obtained for identical testing duration:




before: commit 8ed2ff91d3fb9ee1868fefee383b0b5033064bc7
memory allocations, total requests
231MB per second, 326 requests

after: commit 78dcb66e85123e755457354323c72a85790596e7
memory allocations, total requests
41MB per second, 338 requests

 Overall CPU utilization was reduced as well.
