### PR TITLE
Executor thread pool should live for the duration of the Application lifetime.

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyTransfersExecutor.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyTransfersExecutor.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.httprox.handler;
+
+import static org.commonjava.cdi.util.weft.ExecutorConfig.BooleanLiteral.FALSE;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.commonjava.cdi.util.weft.ExecutorConfig;
+import org.commonjava.cdi.util.weft.WeftExecutorService;
+import org.commonjava.cdi.util.weft.WeftManaged;
+
+/**
+ * Provides a Weft managed Executor to allocate managed threads for each proxy request.
+ */
+@ApplicationScoped
+public class ProxyTransfersExecutor {
+
+    @Inject
+    @WeftManaged
+    @ExecutorConfig( named = "mitm-transfers", threads = 0, priority = 5, loadSensitive = FALSE )
+    private WeftExecutorService executor;
+
+    protected ProxyTransfersExecutor() 
+    {
+    }
+
+    public ProxyTransfersExecutor(WeftExecutorService exec)
+    {
+        this.executor = exec;
+    }
+
+    public WeftExecutorService getExecutor()
+    {
+        return executor;
+    }
+}

--- a/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
+++ b/addons/httprox/common/src/test/java/org/commonjava/indy/httprox/HttpProxyTest.java
@@ -47,6 +47,7 @@ import org.commonjava.indy.core.ctl.ContentController;
 import org.commonjava.indy.core.inject.ExpiringMemoryNotFoundCache;
 import org.commonjava.indy.httprox.conf.HttproxConfig;
 import org.commonjava.indy.httprox.handler.ProxyAcceptHandler;
+import org.commonjava.indy.httprox.handler.ProxyTransfersExecutor;
 import org.commonjava.indy.httprox.keycloak.KeycloakProxyAuthenticator;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
 import org.commonjava.indy.model.core.RemoteRepository;
@@ -204,10 +205,15 @@ public class HttpProxyTest
 
         ScriptEngine scriptEngine = new ScriptEngine( dfm );
 
+        WeftExecutorService transferService =
+              new PoolWeftExecutorService( "test-mitm-transfers", (ThreadPoolExecutor) Executors.newCachedThreadPool(), 2, 10f, false,null, null );
+        ProxyTransfersExecutor handler = new ProxyTransfersExecutor( transferService );
+
         proxy = new HttpProxy( config, bootOpts,
                                new ProxyAcceptHandler( config, storeManager, contentController, auth, core.getCache(),
                                                        scriptEngine, new MDCManager(), null, null,
-                                                       new CacheProducer( null, cacheManager, null ) ) );
+                                                       new CacheProducer( null, cacheManager, null ),
+                                                       handler ) );
         proxy.start();
     }
 

--- a/addons/httprox/ftests/pom.xml
+++ b/addons/httprox/ftests/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-core</artifactId>
-      <scope>test</scope>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>

--- a/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/ProxyHttpsTest.java
+++ b/addons/httprox/ftests/src/main/java/org/commonjava/indy/httprox/ProxyHttpsTest.java
@@ -22,6 +22,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.commonjava.indy.client.core.helper.HttpResources;
+import org.commonjava.indy.core.conf.IndyWeftConfig;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.dto.StoreListingDTO;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
@@ -154,5 +155,7 @@ public class ProxyHttpsTest
         copyToConfigFile( "ssl/ca.der", "ssl/ca.der" );
         copyToConfigFile( "ssl/ca.crt", "ssl/ca.crt" );
         copyToConfigFile( "ssl/ca.jks", "ssl/ca.jks" );
+        String threadPools = new IndyWeftConfig().getDefaultConfigFileName();
+        copyToConfigFile( threadPools, threadPools );
     }
 }

--- a/addons/httprox/ftests/src/main/resources/conf.d/threadpools.conf
+++ b/addons/httprox/ftests/src/main/resources/conf.d/threadpools.conf
@@ -1,0 +1,25 @@
+[threadpools]
+#
+# This configures the Weft threadpool-injector. It is used to initialize 
+# threadpools with custom names, sizes, and thread priorities, and inject
+# them via the CDI annotation: @ExecutorConfig
+# (class name is: org.commonjava.cdi.util.weft.ExecutorConfig)
+#
+# defaultThreads=NN # Default for this is calculated by: Runtime.getRuntime().availableProcessors() * 2
+# defaultPriority=8
+# For a custom threadpool called 'mypool' you might configure it using:
+# mypool.threads=NN
+# mypool.priority=N
+
+# By default, weft is enabled
+#
+#enabled=false
+
+# Metric name prefix for clustering environment
+#
+#node.prefix = node-1
+
+# MITM proxy
+mitm-transfers.threads=20
+mitm-transfers.priority=5
+mitm-transfers.maxLoadFactor=99999


### PR DESCRIPTION
 This PR solves the issue identified in #1613 

 The change ensures only one Executor is used to create threads for requests. Instead of an Executor per request.