### PR TITLE
Fix NPM package metadata parsing error

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGenerator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGenerator.java
@@ -309,7 +309,7 @@ public class PackageMetadataGenerator
                     packageMetadata.setAuthor( versionMetadata.getAuthor() );
                     if ( versionMetadata.getLicense() != null )
                     {
-                        packageMetadata.setLicense( versionMetadata.getLicense().getType() );
+                        packageMetadata.setLicense( versionMetadata.getLicense() );
                     }
                     packageMetadata.setRepository( versionMetadata.getRepository() );
                     packageMetadata.setBugs( versionMetadata.getBugs() );

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
@@ -115,7 +115,7 @@ public class PackageMetadataMergerTest
         assertThat( merged.getReadmeFilename(), equalTo( "README.md" ) );
         assertThat( merged.getHomepage(), equalTo( "https://jquery.com" ) );
         assertThat( merged.getBugs().getUrl(), equalTo( "https://github.com/jquery/jquery/issues" ) );
-        assertThat( merged.getLicense(), equalTo( "MIT" ) );
+        assertThat( merged.getLicense().getType(), equalTo( "MIT" ) );
 
         // dist-tags object merging verification
         assertThat( merged.getDistTags().getBeta(), equalTo( "3.2.1-beta.1" ) );
@@ -185,7 +185,7 @@ public class PackageMetadataMergerTest
         assertThat( merged.getReadmeFilename(), equalTo( "README1.md" ) );
         assertThat( merged.getHomepage(), equalTo( "https://jquery1.com" ) );
         assertThat( merged.getBugs().getUrl(), equalTo( "https://github.com/jquery1/jquery1/issues" ) );
-        assertThat( merged.getLicense(), equalTo( "MIT1" ) );
+        assertThat( merged.getLicense().getType(), equalTo( "MIT1" ) );
 
         // dist-tags object merging verification
         assertThat( merged.getDistTags().getBeta(), equalTo( "2.2.1" ) );
@@ -228,7 +228,7 @@ public class PackageMetadataMergerTest
         assertThat( merged.getReadmeFilename(), equalTo( "README1.md" ) );
         assertThat( merged.getHomepage(), equalTo( "https://jquery1.com" ) );
         assertThat( merged.getBugs().getUrl(), equalTo( "https://github.com/jquery1/jquery1/issues" ) );
-        assertThat( merged.getLicense(), equalTo( "MIT1" ) );
+        assertThat( merged.getLicense().getType(), equalTo( "MIT1" ) );
 
         // dist-tags object merging verification
         assertThat( merged.getDistTags().getBeta(), equalTo( "2.2.1" ) );
@@ -381,7 +381,7 @@ public class PackageMetadataMergerTest
         assertThat( merged.getReadmeFilename(), equalTo( "README1.md" ) );
         assertThat( merged.getHomepage(), equalTo( "https://jquery1.com" ) );
         assertThat( merged.getBugs().getUrl(), equalTo( "https://github.com/jquery1/jquery1/issues" ) );
-        assertThat( merged.getLicense(), equalTo( "MIT1" ) );
+        assertThat( merged.getLicense().getType(), equalTo( "MIT1" ) );
 
         // dist-tags object merging verification
         assertThat( merged.getDistTags().getBeta(), equalTo( "2.2.1" ) );

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupContentMergeRetrieveTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMGroupContentMergeRetrieveTest.java
@@ -107,7 +107,7 @@ public class NPMGroupContentMergeRetrieveTest
         assertThat( merged.getReadmeFilename(), equalTo( "README.md" ) );
         assertThat( merged.getHomepage(), equalTo( "https://jquery.com" ) );
         assertThat( merged.getBugs().getUrl(), equalTo( "https://github.com/jquery/jquery/issues" ) );
-        assertThat( merged.getLicense(), equalTo( "MIT" ) );
+        assertThat( merged.getLicense().getType(), equalTo( "MIT" ) );
 
         // dist-tags object merging verification
         assertThat( merged.getDistTags().getBeta(), equalTo( "3.2.1-beta.1" ) );

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/PackageMetadata.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/PackageMetadata.java
@@ -80,7 +80,7 @@ public class PackageMetadata
     @ApiModelProperty( required = false, dataType = "Bugs", value = "The issue tracker and / or the email address to which issues should be reported." )
     private Bugs bugs;
 
-    private String license;
+    private License license;
 
     public PackageMetadata()
     {
@@ -231,12 +231,12 @@ public class PackageMetadata
         this.bugs = bugs;
     }
 
-    public String getLicense()
+    public License getLicense()
     {
         return license;
     }
 
-    public void setLicense( String license )
+    public void setLicense( License license )
     {
         this.license = license;
     }


### PR DESCRIPTION
Use "Licence" object instead to adapt some package metadata, e.g.: http://registry.npmjs.org/deep-is