### PR TITLE
Update NPM pathCalculator to support metadata and checksum files

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
@@ -54,6 +54,15 @@ public class NPMStoragePathCalculator
     @Inject
     SpecialPathManager specialPathManager;
 
+    protected NPMStoragePathCalculator()
+    {
+    }
+
+    public NPMStoragePathCalculator( SpecialPathManager specialPathManager )
+    {
+        this.specialPathManager = specialPathManager;
+    }
+
     @Override
     public String calculateStoragePath( final StoreKey key, final String path )
     {

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/data/NPMSpecialPathProducer.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/data/NPMSpecialPathProducer.java
@@ -56,6 +56,12 @@ public class NPMSpecialPathProducer
                                                 .setMergable( true )
                                                 .setMetadata( true )
                                                 .build() );
+
+            npmSpecialPaths.add( SpecialPathInfo.from( new FilePatternMatcher( ".*(\\.md5|\\.sha[\\d]+)$" ) )
+                                                .setDecoratable( false )
+                                                .setMergable( true )
+                                                .setMetadata( true )
+                                                .build() );
         }
 
         @Override

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGeneratorTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGeneratorTest.java
@@ -23,10 +23,12 @@ import org.commonjava.maven.galley.GalleyCore;
 import org.commonjava.maven.galley.GalleyCoreBuilder;
 import org.commonjava.maven.galley.cache.FileCacheProviderFactory;
 import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
 import org.commonjava.maven.galley.maven.internal.type.StandardTypeMapper;
 import org.commonjava.maven.galley.maven.spi.type.TypeMapper;
 import org.commonjava.maven.galley.model.Transfer;
 import org.commonjava.maven.galley.nfc.MemoryNotFoundCache;
+import org.commonjava.maven.galley.spi.io.SpecialPathManager;
 import org.commonjava.maven.galley.spi.transport.LocationExpander;
 import org.junit.Before;
 import org.junit.Rule;
@@ -58,6 +60,8 @@ public class PackageMetadataGeneratorTest
 
     private GalleyCore core;
 
+    private SpecialPathManager specialPathManager;
+
     @Before
     public void setup() throws Exception
     {
@@ -86,8 +90,12 @@ public class PackageMetadataGeneratorTest
 
         final GroupMergeHelper helper = new GroupMergeHelper( downloads );
 
+        specialPathManager = new SpecialPathManagerImpl(  );
         fileManager = new DefaultDownloadManager( stores, core.getTransferManager(), core.getLocationExpander(), rescanService );
-        generator = new PackageMetadataGenerator( contentAccess, stores, downloads, types, merger, helper, new MemoryNotFoundCache(), new IndyPathGenerator( Collections.singleton( new NPMStoragePathCalculator() ) ), new NPMStoragePathCalculator() );
+        generator = new PackageMetadataGenerator( contentAccess, stores, downloads, types, merger, helper,
+                                                  new MemoryNotFoundCache(), new IndyPathGenerator(
+                        Collections.singleton( new NPMStoragePathCalculator( specialPathManager ) ) ),
+                                                  new NPMStoragePathCalculator( specialPathManager ) );
 
     }
 

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMergerTest.java
@@ -34,6 +34,7 @@ import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.cache.FileCacheProvider;
 import org.commonjava.maven.galley.event.NoOpFileEventManager;
 import org.commonjava.maven.galley.io.NoOpTransferDecorator;
+import org.commonjava.maven.galley.io.SpecialPathManagerImpl;
 import org.commonjava.maven.galley.io.TransferDecoratorManager;
 import org.commonjava.maven.galley.model.ConcreteResource;
 import org.commonjava.maven.galley.model.Transfer;
@@ -77,7 +78,7 @@ public class PackageMetadataMergerTest
             throws Exception
     {
         cacheProvider = new FileCacheProvider( temp.newFolder( "cache" ), new IndyPathGenerator(
-                Collections.singleton( new NPMStoragePathCalculator() ) ), new NoOpFileEventManager(),
+                Collections.singleton( new NPMStoragePathCalculator( new SpecialPathManagerImpl(  ) ) ) ), new NoOpFileEventManager(),
                                                new TransferDecoratorManager( new NoOpTransferDecorator() ), false );
 
         mapper = new IndyObjectMapper( true );

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMHttpMetaDeleteTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMHttpMetaDeleteTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.junit.Test;
+
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This case tests the http-meta json deletion when the package is removed.
+ * when: <br />
+ * <ul>
+ *      <li>creates a hosted repo, stores files in the hosted repo</li>
+ *      <li>*.http-metadata.json file will be generated correspondingly</li>
+ *      <li>remove the files from the hosted repo</li>
+ * </ul>
+ * then: <br />
+ * <ul>
+ *     <li>*.http-metadata.json file will be removed correspondingly</li>
+ * </ul>
+ */
+
+public class NPMHttpMetaDeleteTest
+        extends AbstractContentManagementTest
+{
+
+    private static final String HOSTED = "HOSTED";
+
+    private static final String PATH = "jquery";
+
+    private static final String PACKAGE_HTTP_META_PATH = "jquery/package.json.http-metadata.json";
+
+    @Test
+    public void test()
+            throws Exception
+    {
+        final InputStream content =
+                Thread.currentThread().getContextClassLoader().getResourceAsStream( "package-1.5.1.json" );
+
+        final HostedRepository hosted = new HostedRepository( NPM_PKG_KEY, HOSTED );
+        client.stores().create( hosted, "adding npm hosted repo", HostedRepository.class );
+        client.content().store( hosted.getKey(), PATH, content );
+        assertThat(client.content().exists( hosted.getKey(), PACKAGE_HTTP_META_PATH ), equalTo( true ));
+
+        client.content().delete( hosted.getKey(), PATH );
+        assertThat(client.content().exists( hosted.getKey(), PACKAGE_HTTP_META_PATH ), equalTo( false ));
+
+        content.close();
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
I found the following logs when checking NPM stuff in indy.log:

```
Modifying target path: immediate.http-metadata.json, appending 'package.json'
immediate.http-metadata.json/package.json not exists in fileSystem npm:remote:npmjs
Modifying target path: immediate.md5, appending 'package.json'
immediate.md5/package.json not exists in fileSystem npm:remote:npmjs
Modifying target path: immediate.sha256, appending 'package.json'
```

The correct path should be:
  "immediate/package.json.md5" rather than "immediate.md5/package.json"