### PR TITLE
Change connection pool implementation to Agroal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -822,9 +822,14 @@
       </dependency>
 
       <dependency>
-        <groupId>com.zaxxer</groupId>
-        <artifactId>HikariCP</artifactId>
-        <version>2.7.8</version>
+        <groupId>io.agroal</groupId>
+        <artifactId>agroal-api</artifactId>
+        <version>1.8</version>
+      </dependency>
+      <dependency>
+        <groupId>io.agroal</groupId>
+        <artifactId>agroal-pool</artifactId>
+        <version>1.8</version>
       </dependency>
 
       <dependency>

--- a/subsys/cpool/pom.xml
+++ b/subsys/cpool/pom.xml
@@ -34,8 +34,13 @@
       <artifactId>indy-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.zaxxer</groupId>
-      <artifactId>HikariCP</artifactId>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.agroal</groupId>
+      <artifactId>agroal-pool</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/subsys/cpool/src/main/conf/conf.d/connection-pools.conf
+++ b/subsys/cpool/src/main/conf/conf.d/connection-pools.conf
@@ -7,11 +7,14 @@
 # If you end a connection specification with the '\' character, this config file may not be read correctly! It may
 # also prevent correct parsing of other parts of the Indy configuration files.
 #
-# The property names used here follow the properties file format explained in:
-#      https://github.com/brettwooldridge/HikariCP#configuration-knobs-baby 
+# The property names used here follow the keys available in:
+#      https://github.com/agroal/agroal/blob/master/agroal-api/src/main/java/io/agroal/api/configuration/supplier/AgroalPropertiesReader.java
+#
+# The values are described in detail in:
+#      https://agroal.github.io/docs.html#configuration
 #
 # Everything specified in a connection pool entry is split into a java.util.Properties
-# object and passed to HikariConfig(props), with the exceptions of 'metrics' and
+# object and passed to AgroalPropertiesReader(props), with the exceptions of 'metrics' and
 # 'healthchecks', which are pulled out separately and parsed as booleans. If true,
 # the pool metrics / healthchecks are initialized to use the Indy-wide metrics 
 # registry.

--- a/subsys/cpool/src/main/conf/conf.d/connection-pools.conf
+++ b/subsys/cpool/src/main/conf/conf.d/connection-pools.conf
@@ -20,12 +20,16 @@
 # registry.
 #
 # You can specify a new datasource with:
-# pool-jndi-name = dataSourceClassName=org.postgresql.ds.PGSimpleDataSource,\
-#                  dataSource.user=db_user,\
-#                  dataSource.password=mySpecialPassword,\
-#                  dataSource.serverName=postgresql.myco.com,\
-#                  dataSource.portNumber=5432,\
-#                  dataSource.databaseName=dbName,\
+# pool-jndi-name = dataSource.providerClassName=org.postgresql.ds.PGSimpleDataSource,\
+#                  dataSource.jdbcUrl=jdbc:postgresql://localhost:5432/test,\
+#                  dataSource.principal=db_user,\
+#                  dataSource.credential=mySpecialPassword,\
+#                  dataSource.minSize=10,\
+#                  dataSource.initialSize=10,\
+#                  dataSource.maxSize=100,\
+#                  dataSource.reapTimeout_m=10,\
+#                  dataSource.maxLifetime_m=28,\
+#                  dataSource.leakTimeout_s=5,\
 #                  metrics=true,\
 #                  healthChecks=true
 

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolConfig.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolConfig.java
@@ -34,28 +34,18 @@ import static java.lang.Boolean.TRUE;
 import static org.commonjava.indy.subsys.cpool.ConnectionPoolConfig.SECTION;
 
 @ApplicationScoped
-@SectionName( SECTION)
+@SectionName( SECTION )
 public class ConnectionPoolConfig
         extends MapSectionListener
         implements IndyConfigInfo
 {
     public static final String SECTION = "connection-pools";
 
-    public static final String URL_SUBKEY = "url";
-
-    private static final String USER_SUBKEY = "user";
-
-    private static final String PASSWORD_SUBKEY = "password";
-
-    private static final String DS_CLASS_SUBKEY = "datasource.class";
-
-    private static final String DS_PROPERTY_PREFIX = "datasource.";
+    public static final String DS_PROPERTY_PREFIX = "datasource.";
 
     private static final String METRICS_SUBKEY = "metrics";
 
     private static final String HEALTH_CHECKS_SUBKEY = "healthChecks";
-
-    private static final String DRIVER_CLASS_SUBKEY = "driver.class";
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolProvider.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolProvider.java
@@ -15,10 +15,15 @@
  */
 package org.commonjava.indy.subsys.cpool;
 
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
+import io.agroal.api.AgroalDataSource;
+import io.agroal.api.AgroalDataSourceListener;
+import io.agroal.api.AgroalDataSourceMetrics;
+import io.agroal.api.configuration.AgroalDataSourceConfiguration;
+import io.agroal.api.configuration.supplier.AgroalPropertiesReader;
 import org.commonjava.indy.action.IndyLifecycleException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +32,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
 
@@ -36,9 +44,6 @@ import static javax.naming.Context.INITIAL_CONTEXT_FACTORY;
 public class ConnectionPoolProvider
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
-
-//    private Registry registry;
-//    private int registryPort;
 
     @Inject
     private ConnectionPoolConfig config;
@@ -53,36 +58,9 @@ public class ConnectionPoolProvider
             throws IndyLifecycleException
     {
         logger.info( "Starting connection pool binding..." );
-//        if ( registry == null )
-//        {
-//            AtomicReference<IndyLifecycleException> err = new AtomicReference<>();
-//            registryPort = PortFinder.findPortFor( 16, (port)->{
-//                try
-//                {
-//                    registry = LocateRegistry.createRegistry( port );
-//                    logger.info( "Started RMI Registry on port: {} (for JNDI connection-pool bindings)", port );
-//                    return port;
-//                }
-//                catch ( RemoteException e )
-//                {
-//                    err.set( new IndyLifecycleException( "Failed to start RMI / JNDI registry on port 1099",
-//                                                         e ) );
-//                }
-//
-//                return -1;
-//            } );
-//
-//            if ( err.get() != null )
-//            {
-//                throw err.get();
-//            }
-//        }
-//
-//        logger.info( "RMI / JNDI Registry running on port: {}", registryPort );
 
         Properties properties = System.getProperties();
         properties.setProperty( INITIAL_CONTEXT_FACTORY, CPInitialContextFactory.class.getName() );
-//        properties.setProperty( "java.naming.provider.url", "rmi://127.0.0.1:" + registryPort );
         System.setProperties( properties );
 
         InitialContext ctx;
@@ -99,22 +77,21 @@ public class ConnectionPoolProvider
         logger.info( "Creating bindings for {} pools from config: {}", poolConfigs.size(), config );
         for ( ConnectionPoolInfo poolInfo : poolConfigs.values() )
         {
-            HikariConfig cfg = new HikariConfig( poolInfo.getProperties() );
-            cfg.setPoolName( poolInfo.getName() );
-
-            if ( poolInfo.isUseMetrics() )
-            {
-                cfg.setMetricRegistry( metricRegistry );
-            }
-
-            if ( poolInfo.isUseHealthChecks() )
-            {
-                cfg.setHealthCheckRegistry( healthCheckRegistry );
-            }
-
-            HikariDataSource ds = new HikariDataSource( cfg );
             try
             {
+                AgroalDataSourceConfiguration config = new AgroalPropertiesReader().readProperties( poolInfo.getProperties() ).get();
+                config.setMetricsEnabled( poolInfo.isUseMetrics() );
+                AgroalDataSource ds = AgroalDataSource.from( config, new AgroalDataSourceLogger( poolInfo.getName() ) );
+
+                if ( poolInfo.isUseMetrics() )
+                {
+                    registerMetrics(ds.getMetrics(), poolInfo.getName());
+                }
+                if ( poolInfo.isUseHealthChecks() )
+                {
+                    registerHealthChecks(ds, poolInfo.getName());
+                }
+
                 String jndiName = "java:/comp/env/jdbc/" + poolInfo.getName();
                 logger.info( "Binding datasource: {}", jndiName );
                 ctx.rebind( jndiName, ds );
@@ -123,7 +100,117 @@ public class ConnectionPoolProvider
             {
                 throw new IndyLifecycleException( "Failed to bind datasource: " + poolInfo.getName(), e );
             }
+            catch ( SQLException e )
+            {
+                throw new IndyLifecycleException( "Failed to start datasource: " + poolInfo.getName(), e );
+            }
         }
     }
 
+
+    private void registerMetrics(AgroalDataSourceMetrics agroalMetrics, String name) {
+        metricRegistry.register(MetricRegistry.name(name, "acquireCount"), (Gauge<Long>) agroalMetrics::acquireCount);
+        metricRegistry.register(MetricRegistry.name(name, "creationCount"), (Gauge<Long>) agroalMetrics::creationCount);
+        metricRegistry.register(MetricRegistry.name(name, "leakDetectionCount"), (Gauge<Long>) agroalMetrics::leakDetectionCount);
+        metricRegistry.register(MetricRegistry.name(name, "destroyCount"), (Gauge<Long>) agroalMetrics::destroyCount);
+        metricRegistry.register(MetricRegistry.name(name, "flushCount"), (Gauge<Long>) agroalMetrics::flushCount);
+        metricRegistry.register(MetricRegistry.name(name, "invalidCount"), (Gauge<Long>) agroalMetrics::invalidCount);
+        metricRegistry.register(MetricRegistry.name(name, "reapCount"), (Gauge<Long>) agroalMetrics::reapCount);
+
+        metricRegistry.register(MetricRegistry.name(name, "activeCount"), (Gauge<Long>) agroalMetrics::activeCount);
+        metricRegistry.register(MetricRegistry.name(name, "availableCount"), (Gauge<Long>) agroalMetrics::availableCount);
+        metricRegistry.register(MetricRegistry.name(name, "maxUsedCount"), (Gauge<Long>) agroalMetrics::maxUsedCount);
+        metricRegistry.register(MetricRegistry.name(name, "awaitingCount"), (Gauge<Long>) agroalMetrics::awaitingCount);
+        metricRegistry.register(MetricRegistry.name(name, "blockingTimeAverage"), (Gauge<Duration>) agroalMetrics::blockingTimeAverage);
+        metricRegistry.register(MetricRegistry.name(name, "blockingTimeMax"), (Gauge<Duration>) agroalMetrics::blockingTimeMax);
+        metricRegistry.register(MetricRegistry.name(name, "blockingTimeTotal"), (Gauge<Duration>) agroalMetrics::blockingTimeTotal);
+        metricRegistry.register(MetricRegistry.name(name, "creationTimeAverage"), (Gauge<Duration>) agroalMetrics::creationTimeAverage);
+        metricRegistry.register(MetricRegistry.name(name, "creationTimeMax"), (Gauge<Duration>) agroalMetrics::creationTimeMax);
+        metricRegistry.register(MetricRegistry.name(name, "creationTimeTotal"), (Gauge<Duration>) agroalMetrics::creationTimeTotal);
+    }
+
+    private void registerHealthChecks(AgroalDataSource ds, String name)
+    {
+        healthCheckRegistry.register(name, new HealthCheck()
+        {
+            @Override protected Result check()
+            {
+                try ( Connection con = ds.getConnection() )
+                {
+                    if ( con.isValid(5) )
+                    {
+                        return Result.healthy();
+                    }
+                    else
+                    {
+                        return Result.unhealthy( "validation check failed for DataSource %s", name );
+                    }
+                }
+                catch ( SQLException e )
+                {
+                    return Result.unhealthy( e );
+                }
+            }
+        });
+    }
+
+    private static class AgroalDataSourceLogger implements AgroalDataSourceListener
+    {
+        private final Logger logger;
+
+        public AgroalDataSourceLogger(String name)
+        {
+            logger = LoggerFactory.getLogger( AgroalDataSource.class.getName() + ".'" + name + "'" );
+        }
+
+        @Override public void onConnectionPooled(Connection connection)
+        {
+            logger.debug( "Added connection {} to the pool", connection );
+        }
+
+        @Override public void onConnectionAcquire(Connection connection)
+        {
+            logger.debug( "Connection {} acquired", connection );
+        }
+
+        @Override public void onConnectionReturn(Connection connection)
+        {
+            logger.debug( "Connection {} return", connection );
+        }
+
+        @Override public void onConnectionLeak(Connection connection, Thread thread)
+        {
+            logger.info( "Connection {} leak. Acquired by {}", connection, thread );
+        }
+
+        @Override public void beforeConnectionValidation(Connection connection)
+        {
+            logger.debug( "Connection {} about to be validated", connection );
+        }
+
+        @Override public void beforeConnectionFlush(Connection connection)
+        {
+            logger.debug( "Connection {} removed from the pool", connection );
+        }
+
+        @Override public void beforeConnectionReap(Connection connection)
+        {
+            logger.debug( "Connection {} idle", connection );
+        }
+
+        @Override public void onWarning(String message)
+        {
+            logger.warn( message );
+        }
+
+        @Override public void onWarning(Throwable throwable)
+        {
+            logger.warn( "Exception", throwable );
+        }
+
+        @Override public void onInfo(String message)
+        {
+            logger.info( message );
+        }
+    }
 }

--- a/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolProvider.java
+++ b/subsys/cpool/src/main/java/org/commonjava/indy/subsys/cpool/ConnectionPoolProvider.java
@@ -79,7 +79,8 @@ public class ConnectionPoolProvider
         {
             try
             {
-                AgroalDataSourceConfiguration config = new AgroalPropertiesReader().readProperties( poolInfo.getProperties() ).get();
+                AgroalPropertiesReader propertiesReader = new AgroalPropertiesReader( ConnectionPoolConfig.DS_PROPERTY_PREFIX );
+                AgroalDataSourceConfiguration config = propertiesReader.readProperties( poolInfo.getProperties() ).get();
                 config.setMetricsEnabled( poolInfo.isUseMetrics() );
                 AgroalDataSource ds = AgroalDataSource.from( config, new AgroalDataSourceLogger( poolInfo.getName() ) );
 


### PR DESCRIPTION
I used `AgroalPropertiesReader` for convenience, but can have a custom builder of the Agroal configuration that doesn't break compatibility so much.