### PR TITLE
Support mounting legacy storage to different path

### DIFF
--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -227,7 +227,9 @@ public class DefaultGalleyStorageProvider
             }
         }
 
-        PhysicalStore physicalStore = new LegacyReadonlyPhysicalStore( storeRoot );
+        File legacyStorageBasedir = config.getLegacyStorageBasedir();
+        logger.info( "Create physical store, storeRoot: {}, legacyStorageBasedir: {}", storeRoot, legacyStorageBasedir );
+        PhysicalStore physicalStore = new LegacyReadonlyPhysicalStore( storeRoot, legacyStorageBasedir );
 
         logger.info( "Create cacheProviderFactory, pathDB: {}, physicalStore: {}", pathDB, physicalStore );
         cacheProviderFactory =

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
@@ -42,6 +42,8 @@ public class DefaultStorageProviderConfiguration
 
     private File storageBasedir;
 
+    private File legacyStorageBasedir;
+
     private File nfsStoreBasedir;
 
     public DefaultStorageProviderConfiguration()
@@ -81,6 +83,17 @@ public class DefaultStorageProviderConfiguration
     public void setNFSStorageRootDirectory( final File nfsStorageRootDirectory )
     {
         this.nfsStoreBasedir = nfsStorageRootDirectory;
+    }
+
+    public File getLegacyStorageBasedir()
+    {
+        return legacyStorageBasedir;
+    }
+
+    @ConfigName( "storage.legacy.dir" )
+    public void setLegacyStorageBasedir( File legacyStorageBasedir )
+    {
+        this.legacyStorageBasedir = legacyStorageBasedir;
     }
 
     @Override


### PR DESCRIPTION
We found the storage dir on indy-perf is not right. There is another 'storage' folder under the '/opt/indy/var/lib/indy/storage'. And the content under the 'maven' seems only contain some test folders. See http://pastebin.test.redhat.com/865855
@ligangty make an idea that this may because the r/w because the snapshot is read-only. 
The read-only storage volume will block testing.
This pr will enable us to mount the legacy snapshot to other directory, e.g, /opt/indy/var/lib/indy/storage_legacy.
