### PR TITLE
Add metrics in the honeycomb event post processor 

### DIFF
--- a/subsys/honeycomb/pom.xml
+++ b/subsys/honeycomb/pom.xml
@@ -44,6 +44,10 @@
       <groupId>org.jboss.spec.javax.servlet</groupId>
       <artifactId>jboss-servlet-api_3.0_spec</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-metrics-reporter</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/HoneycombManager.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/HoneycombManager.java
@@ -66,6 +66,9 @@ public class HoneycombManager
     @Inject
     private IndyTracingContext tracingContext;
 
+    @Inject
+    private IndyEventPostProcessor eventPostProcessor;
+
     public HoneycombManager()
     {
     }
@@ -79,7 +82,8 @@ public class HoneycombManager
             String dataset = configuration.getDataset();
 
             logger.debug( "Init Honeycomb manager, dataset: {}", dataset );
-            client = new HoneyClient( LibHoney.options().setDataset( dataset ).setWriteKey( writeKey ).build() ); //, new ConsoleTransport( new ResponseObservable() ) );
+            client = new HoneyClient( LibHoney.options().setDataset( dataset ).setWriteKey( writeKey )
+                                              .setEventPostProcessor( eventPostProcessor ).build() ); //, new ConsoleTransport( new ResponseObservable() ) );
             LibHoney.setDefault( client );
 
             SpanPostProcessor postProcessor = Tracing.createSpanProcessor( client, Sampling.alwaysSampler() );

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyEventPostProcessor.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyEventPostProcessor.java
@@ -1,0 +1,21 @@
+package org.commonjava.indy.subsys.honeycomb;
+
+import io.honeycomb.libhoney.EventPostProcessor;
+import io.honeycomb.libhoney.eventdata.EventData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class IndyEventPostProcessor implements EventPostProcessor
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Override
+    public void process( EventData<?> eventData )
+    {
+        //TODO
+    }
+}

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyEventPostProcessor.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyEventPostProcessor.java
@@ -1,11 +1,19 @@
 package org.commonjava.indy.subsys.honeycomb;
 
+import com.codahale.metrics.Meter;
 import io.honeycomb.libhoney.EventPostProcessor;
 import io.honeycomb.libhoney.eventdata.EventData;
+import org.commonjava.indy.metrics.IndyMetricsManager;
+import org.commonjava.indy.metrics.conf.IndyMetricsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import static org.commonjava.indy.metrics.IndyMetricsConstants.METER;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.getDefaultName;
+import static org.commonjava.indy.metrics.IndyMetricsConstants.getName;
 
 @ApplicationScoped
 public class IndyEventPostProcessor implements EventPostProcessor
@@ -13,9 +21,23 @@ public class IndyEventPostProcessor implements EventPostProcessor
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
+    @Inject
+    private IndyMetricsManager metricsManager;
+
+    @Inject
+    private IndyMetricsConfig metricsConfig;
+
+    private final static String TRANSFER_HONEYCOMB_EVENT = "indy.transferred.honeycomb.event";
+
     @Override
     public void process( EventData<?> eventData )
     {
-        //TODO
+        if ( metricsConfig != null && metricsManager != null )
+        {
+            String name = getName( metricsConfig.getNodePrefix(), TRANSFER_HONEYCOMB_EVENT,
+                                   getDefaultName( IndyEventPostProcessor.class, "process" ), METER );
+            Meter meter = metricsManager.getMeter( name );
+            meter.mark();
+        }
     }
 }


### PR DESCRIPTION
As mentioned in https://projects.engineering.redhat.com/browse/MMENG-398, It would be good if we could monitor the rate at which we're sending events from each Indy instance, up to Honeycomb. After researching, I think we can put the stuff into the method "process" of the class 
https://honeycombio.github.io/libhoney-java/io/honeycomb/libhoney/EventPostProcessor.html


