### PR TITLE
Use gaCache.matchAny to reduce unnecessary filtering

### DIFF
--- a/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/inject/PathMappedMavenGACacheGroupRepositoryFilter.java
+++ b/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/inject/PathMappedMavenGACacheGroupRepositoryFilter.java
@@ -82,6 +82,12 @@ public class PathMappedMavenGACacheGroupRepositoryFilter
             return concreteStores;
         }
 
+        if ( !gaCache.matchAny( concreteStores ) )
+        {
+            logger.debug( "No matched candidate, skip" );
+            return concreteStores;
+        }
+
         Set<String> storesContaining = gaCache.getStoresContaining( gaPath );
         logger.debug( "Get from GA cache, gaPath: {}, containing: {}", gaPath, storesContaining );
 


### PR DESCRIPTION
a minor improvement. If no candidate match the cache pattern, skip GA cache filtering earlier.