### PR TITLE
Config cassandra write retry

### DIFF
--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
@@ -75,7 +75,8 @@ public class CassandraClient
         socketOptions.setReadTimeoutMillis( config.getReadTimeoutMillis() );
         Cluster.Builder builder = Cluster.builder()
                                          .withoutJMXReporting()
-                                         .withRetryPolicy( new ConfigurableRetryPolicy( config.getReadRetries() ) )
+                                         .withRetryPolicy( new ConfigurableRetryPolicy( config.getReadRetries(),
+                                                                                        config.getWriteRetries() ) )
                                          .addContactPoint( host )
                                          .withPort( port )
                                          .withSocketOptions( socketOptions );

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/config/CassandraConfig.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/config/CassandraConfig.java
@@ -43,6 +43,8 @@ public class CassandraConfig
 
     private int readRetries = 3;
 
+    private int writeRetries = 3;
+
     public CassandraConfig()
     {
     }
@@ -137,6 +139,17 @@ public class CassandraConfig
     public void setReadRetries( int readRetries )
     {
         this.readRetries = readRetries;
+    }
+
+    public int getWriteRetries()
+    {
+        return writeRetries;
+    }
+
+    @ConfigName( "cassandra.write.retries" )
+    public void setWriteRetries( int writeRetries )
+    {
+        this.writeRetries = writeRetries;
     }
 
     @Override


### PR DESCRIPTION
This is another part of fix for issue 
com.datastax.driver.core.exceptions.WriteTimeoutException: Cassandra timeout during SIMPLE write query at consistency ALL (3 replica were required but only 2 acknowledged the write)
by config the write retry.