### PR TITLE
Switch to use the cached version for thread metrics

### DIFF
--- a/subsys/metrics/core/src/main/java/org/commonjava/indy/metrics/jvm/IndyJVMInstrumentation.java
+++ b/subsys/metrics/core/src/main/java/org/commonjava/indy/metrics/jvm/IndyJVMInstrumentation.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.metrics.jvm;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jvm.BufferPoolMetricSet;
+import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
 import com.codahale.metrics.jvm.ClassLoadingGaugeSet;
 import com.codahale.metrics.jvm.FileDescriptorRatioGauge;
 import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
@@ -24,6 +25,7 @@ import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 
 import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -48,7 +50,7 @@ public class IndyJVMInstrumentation
     {
         registry.register( name( nodePrefix, JVM_MEMORY ), new MemoryUsageGaugeSet() );
         registry.register( name( nodePrefix, JVM_GARBAGE ), new GarbageCollectorMetricSet() );
-        registry.register( name( nodePrefix, JVM_THREADS ), new ThreadStatesGaugeSet() );
+        registry.register( name( nodePrefix, JVM_THREADS ), new CachedThreadStatesGaugeSet( 60, TimeUnit.SECONDS ));
         registry.register( name( nodePrefix, JVM_FILES ), new FileDescriptorRatioGauge() );
         registry.register( name( nodePrefix, JVM_CLASSLOADING ), new ClassLoadingGaugeSet() );
         registry.register( name( nodePrefix, JVM_BUFFERS ),


### PR DESCRIPTION
Since the thread metric requires traversing all threads and can be a little
more expensive than some other metrics, and the cached version can cache
the information for the given interval and time unit.

https://github.com/dropwizard/metrics/issues/508