### PR TITLE
Use executeAsync in maint op

### DIFF
--- a/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/cache/PathMappedMavenGACache.java
+++ b/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/cache/PathMappedMavenGACache.java
@@ -261,7 +261,7 @@ public class PathMappedMavenGACache
         if ( !deleted.isEmpty() )
         {
             logger.info( "Find deleted stores, deleted: {}", deleted );
-            reduce( SCANNED_STORES, deleted );
+            reduce( SCANNED_STORES, deleted, false );
         }
     }
 
@@ -308,12 +308,19 @@ public class PathMappedMavenGACache
         inMemoryCache.remove( ga ); // clear to force reloading
     }
 
-    public void reduce( String ga, Set<String> set )
+    public void reduce( String ga, Set<String> set, boolean isAsync )
     {
         BoundStatement bound = preparedStoresReduction.bind();
         bound.setSet( 0, set );
         bound.setString( 1, ga );
-        session.execute( bound );
+        if ( isAsync )
+        {
+            session.executeAsync( bound );
+        }
+        else
+        {
+            session.execute( bound );
+        }
         inMemoryCache.remove( ga ); // clear to force reloading
     }
 

--- a/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/inject/PathMappedMavenGACacheGroupRepositoryFilter.java
+++ b/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/inject/PathMappedMavenGACacheGroupRepositoryFilter.java
@@ -128,7 +128,7 @@ public class PathMappedMavenGACacheGroupRepositoryFilter
         if ( !staled.isEmpty() )
         {
             logger.info( "Clean staled stores, gaPath: {}, staled: {}", gaPath, staled );
-            gaCache.reduce( gaPath, staled );
+            gaCache.reduce( gaPath, staled, true );
         }
     }
 


### PR DESCRIPTION
We do maintanance when using ga cache to find out the stale stores. Here we can use async to reduce the impact on the retrieval logic. Async does not check if the operation success, but in this case, it is good enough.