### PR TITLE
Fix a metadata timeout reset problem

### DIFF
--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataRevisitTimeoutTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataRevisitTimeoutTest.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.pkg.npm.model.DistTag;
+import org.commonjava.indy.pkg.npm.model.PackageMetadata;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This case tests if remote package.json will timeout correctly based on the first time retrieval
+ * Given: <br />
+ * <ul>
+ *      <li>remote repo A contains package.json for a given package</li>
+ *      <li>package.json metadata timeout is scheduled</li>
+ * </ul>
+ * When: <br />
+ * <ul>
+ *      <li>package.json is retrieved via remote repo A by client</li>
+ *      <li>wait for a period which does not pass the timeout window</li>
+ *      <li>retrieved the package.json again</li>
+ *      <li>wait for another period which passed the first accessed timeout window, but not the second</li>
+ * </ul>
+ * Then: <br />
+ * <ul>
+ *     <li>package.json expires with metadata timeout based on the first retrieval but not the second</li>
+ * </ul>
+ */
+public class NPMMetadataRevisitTimeoutTest
+        extends AbstractContentManagementTest
+{
+
+    private static final String REPO = "A";
+
+    private static final String PATH = "jquery";
+
+    @Test
+    public void test()
+            throws Exception
+    {
+        IndyObjectMapper mapper = new IndyObjectMapper( true );
+
+        final PackageMetadata src = new PackageMetadata();
+        final DistTag dts = new DistTag();
+        dts.setBeta( "1" );
+        src.setDistTags( dts );
+
+        server.expect( "GET", server.formatUrl( REPO, PATH ), ( req, resp ) -> {
+            resp.setStatus( 200 );
+            mapper.writeValue( resp.getWriter(), src );
+            resp.getWriter().flush();
+        } );
+
+        //FIXME: After using galley-0.16.8, I'm not sure the second retrieval of npm metadata will get path of
+        //       "A/jquery/package.json" while the first retrieval is "A/jquery". So I add a new expectation here
+        //       to let the second retrieval can work. Need further checking.
+        //        server.expect( "GET", server.formatUrl( REPO, PATH+"/package.json" ), (req, resp)->{
+        //            resp.setStatus( 200 );
+        //            mapper.writeValue( resp.getWriter(), src );
+        //            resp.getWriter().flush();
+        //        } );
+
+        final int METADATA_TIMEOUT_SECOND = 3;
+        final int TIMEOUT_WAIT_MILLI_S = 1000;
+
+        final RemoteRepository repo = new RemoteRepository( NPM_PKG_KEY, REPO, server.formatUrl( REPO ) );
+        logger.info( "\n\nCreate repo: {}\n\n", repo );
+        repo.setMetadataTimeoutSeconds( METADATA_TIMEOUT_SECOND );
+
+        client.stores().create( repo, "adding npm remote repo", RemoteRepository.class );
+
+        logger.info( "\n\nFirst retrieval\n\n" );
+        // First retrieval
+        verifyMetadataBetaTag( "1", repo );
+
+        dts.setBeta( "2" );
+        // wait for repo metadata timeout
+        Thread.sleep( TIMEOUT_WAIT_MILLI_S * 2 );
+
+        logger.info( "\n\nSecond retrieval: try to reset timeout\n\n" );
+        // Second retrieval when not timeout for first
+        verifyMetadataBetaTag( "1", repo );
+
+        // wait for repo metadata timeout
+        Thread.sleep( TIMEOUT_WAIT_MILLI_S * 2 );
+
+        assertThat( "Metadata not cleaned up!", client.content().exists( repo.getKey(), PATH + "/package.json", true ),
+                    equalTo( false ) );
+
+        logger.info( "\n\nThird retrieval: check if timeout happened\n\n" );
+        // Third retrieval
+        verifyMetadataBetaTag( "2", repo );
+    }
+
+    private void verifyMetadataBetaTag( final String betaTag, RemoteRepository repo )
+            throws IndyClientException, IOException
+    {
+        try (InputStream remote = client.content().get( repo.getKey(), PATH ))
+        {
+            assertThat( remote, notNullValue() );
+
+            PackageMetadata merged =
+                    new IndyObjectMapper( true ).readValue( IOUtils.toString( remote ), PackageMetadata.class );
+
+            assertThat( merged.getDistTags().getBeta(), equalTo( betaTag ) );
+        }
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/honeycomb.conf", "[honeycomb]\nenabled=false" );
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleKey.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleKey.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
+import java.util.Objects;
 
 public class ScheduleKey implements Externalizable, Serializable
 {
@@ -72,14 +73,14 @@ public class ScheduleKey implements Externalizable, Serializable
     @Override
     public boolean equals( Object obj )
     {
-        if ( obj == null || !( obj instanceof ScheduleKey ) )
+        if ( !( obj instanceof ScheduleKey ) )
         {
             return false;
         }
 
         final ScheduleKey that = (ScheduleKey) obj;
-        return equalsWithNull( this.storeKey, that.storeKey ) && equalsWithNull( this.type, that.type )
-                && equalsWithNull( this.name, that.name );
+        return Objects.equals( this.storeKey, that.storeKey ) && Objects.equals( this.type, that.type )
+                && Objects.equals( this.name, that.name );
     }
 
     @Override
@@ -91,11 +92,6 @@ public class ScheduleKey implements Externalizable, Serializable
         result = prime * result + ( ( type == null ) ? 0 : type.hashCode() );
         result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
         return result;
-    }
-
-    private boolean equalsWithNull( final Object one, final Object two )
-    {
-        return one == two || ( one != null && two != null && one.equals( two ) );
     }
 
     public String toStringKey()

--- a/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/TimeoutEventListener.java
@@ -189,7 +189,7 @@ public class TimeoutEventListener
                 }
                 else if ( type == StoreType.remote )
                 {
-                    SpecialPathInfo info = specialPathManager.getSpecialPathInfo( transfer );
+                    SpecialPathInfo info = specialPathManager.getSpecialPathInfo( transfer, key.getPackageType() );
                     if ( info == null || !info.isMetadata() )
                     {
                         logger.debug( "Accessed resource {} timeout will be reset.", transfer );

--- a/embedder/src/test/resources/logback-test.xml
+++ b/embedder/src/test/resources/logback-test.xml
@@ -42,11 +42,28 @@
       </encoder>
     </appender>
 
+  <logger name="org.xnio.nio" level="WARN"/>
+  <logger name="io.undertow" level="WARN"/>
+  <logger name="org.jboss" level="WARN"/>
+  <logger name="org.keycloak" level="WARN"/>
+  <logger name="org.infinispan" level="WARN"/>
+  <logger name="io.netty" level="WARN"/>
+  <logger name="com.datastax" level="WARN" />
+  <logger name="org.apache.http" level="WARN"/>
+  <logger name="org.jboss.weld" level="ERROR"/>
+
+
   <logger name="org.commonjava.indy" level="TRACE"/>
   <logger name="org.commonjava.maven.galley" level="TRACE"/>
+
+  <logger name="org.commonjava.propulsor" level="INFO" />
+  <logger name="org.commonjava.atlas" level="INFO" />
+  <logger name="org.commonjava.util.jhttpc" level="INFO" />
+
   <logger name="org.commonjava.indy.model.core.StoreKey" level="INFO" />
   <logger name="org.commonjava.indy.pkg.npm.content.NPMStoragePathCalculator" level="INFO" />
   <logger name="org.commonjava.indy.metrics" level="INFO" />
+  <logger name="org.commonjava.indy.subsys.honeycomb" level="INFO" />
 
   <root level="DEBUG">
     <appender-ref ref="STDOUT" />

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRevisitTimeoutTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/MetadataRevisitTimeoutTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.ftest.core.content;
+
+import org.commonjava.indy.ftest.core.category.TimingDependent;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+
+import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This case tests if remote maven metadata will timeout correctly based on the first time retrieval
+ * Given: <br />
+ * <ul>
+ *      <li>remote repo A contains maven-metadata.xml</li>
+ *      <li>metadata timeout is scheduled</li>
+ * </ul>
+ * When: <br />
+ * <ul>
+ *      <li>metadata retrieved via remote repo A by client</li>
+ *      <li>wait for a period which does not pass the timeout window</li>
+ *      <li>retrieved the package.json again</li>
+ *      <li>wait for another period which passed the first accessed timeout window, but not the second</li>
+ * </ul>
+ * Then: <br />
+ * <ul>
+ *     <li>metadta expires with metadata timeout based on the first retrieval but not the second</li>
+ * </ul>
+ */
+public class MetadataRevisitTimeoutTest
+        extends AbstractMetadataTimeoutWorkingTest
+{
+    private final int METADATA_TIMEOUT_SECONDS = 3;
+
+    private final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 1000;
+
+    @Test
+    @Category( TimingDependent.class )
+    public void timeout()
+            throws Exception
+    {
+        // make the metadata.xml timeout
+        sleepAndRunFileGC( METADATA_TIMEOUT_WAITING_MILLISECONDS * 4 );
+        assertThat( "Metadata not removed when timeout", metadataFile.exists(), equalTo( false ) );
+
+        // retrieve it again
+        client.content().get( new StoreKey( MAVEN_PKG_KEY, remote, repoId ), metadataPath ).close();
+
+        sleepAndRunFileGC( METADATA_TIMEOUT_WAITING_MILLISECONDS * 2 );
+        //retrieve again
+        client.content().get( new StoreKey( MAVEN_PKG_KEY, remote, repoId ), metadataPath ).close();
+        sleepAndRunFileGC( METADATA_TIMEOUT_WAITING_MILLISECONDS * 2 );
+        assertThat( "(Second) Metadata not removed when timeout", metadataFile.exists(), equalTo( false ) );
+    }
+
+    @Override
+    protected RemoteRepository createRemoteRepository()
+    {
+        RemoteRepository repository = new RemoteRepository( MAVEN_PKG_KEY, repoId, server.formatUrl( repoId ) );
+        repository.setMetadataTimeoutSeconds( METADATA_TIMEOUT_SECONDS );
+        return repository;
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/honeycomb.conf", "[honeycomb]\nenabled=false" );
+    }
+}


### PR DESCRIPTION
   We found that the npm metadata timeout for remote repo does not work
   correctly. It is not working based on the initial access time, but on
   the last access time, which is totally wrong way. This commit is
   addressing the problem.