### PR TITLE
Fix bug: wrong use of String.replaceAll(regex,replacement)

### DIFF
--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentBrowseRewriteResponseDecorator.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentBrowseRewriteResponseDecorator.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.extractPath;
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getRequestAbsolutePath;
-import static org.commonjava.indy.repo.proxy.RepoProxyUtils.keyToPath;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.noPkgStorePath;
 
 @ApplicationScoped
 public class ContentBrowseRewriteResponseDecorator
@@ -77,12 +77,12 @@ public class ContentBrowseRewriteResponseDecorator
 
         final StoreKey originalKey = StoreKey.fromString( originalRepoStr );
 
-        final String originalRepoPath = keyToPath( originalRepoStr );
-        final String path = extractPath( pathInfo, originalRepoPath );
+        final String originalRepoPath = noPkgStorePath( originalRepoStr );
+        final String path = extractPath( pathInfo );
         final boolean ruleInPath = pathInfo.contains( originalRepoPath );
         if ( ruleInPath )
         {
-            final String proxyToKeyPath = keyToPath( proxyToStoreKey );
+            final String proxyToKeyPath = noPkgStorePath( proxyToStoreKey );
             final Map<String, String> replacingMap = new HashMap<>(2);
             replacingMap.put( originalRepoPath, proxyToKeyPath );
             replacingMap.put( originalRepoStr, proxyToStoreKey.toString() );

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingOutputStream.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingOutputStream.java
@@ -62,7 +62,7 @@ class ContentReplacingOutputStream
                 final String replaceTo = repoReplacing.getKey();
                 final String origin = repoReplacing.getValue();
                 logger.trace( "Repository Proxy: Content rewriting: Replacing {} to {}", origin, replaceTo );
-                content = content.replaceAll( origin, replaceTo );
+                content = RepoProxyUtils.replaceAllWithNoRegex( content, origin, replaceTo );
             }
             originalStream.write( content.getBytes() );
             originalStream.flush();

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/NPMMetadtaRewriteResponseDecorator.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/NPMMetadtaRewriteResponseDecorator.java
@@ -32,8 +32,7 @@ import java.util.Optional;
 import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.extractPath;
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.isNPMMetaPath;
-import static org.commonjava.indy.repo.proxy.RepoProxyUtils.keyToPath;
-import static org.commonjava.indy.repo.proxy.RepoProxyUtils.trace;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.noPkgStorePath;
 
 /**
  * This response decorator will do following
@@ -82,11 +81,11 @@ public class NPMMetadtaRewriteResponseDecorator
             return response;
         }
 
-        final String originalRepoPath = keyToPath( originalRepoStr );
-        final String path = extractPath( pathInfo, originalRepoPath );
+        final String originalRepoPath = noPkgStorePath( originalRepoStr );
+        final String path = extractPath( pathInfo );
         if ( isNPMMetaPath( path ) )
         {
-            final String proxyToKeyPath = keyToPath( proxyToStoreKey );
+            final String proxyToKeyPath = noPkgStorePath( proxyToStoreKey );
             logger.debug( "[{}] NPM rewriting replacement: from {} to {}", ADDON_NAME, proxyToKeyPath,
                           originalRepoPath );
             return new ContentReplacingResponseWrapper( request, response,

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyController.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyController.java
@@ -44,7 +44,6 @@ import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getRequestAbsolutePa
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getOriginalStoreKeyFromPath;
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getProxyTo;
 import static org.commonjava.indy.repo.proxy.RepoProxyUtils.isNPMMetaPath;
-import static org.commonjava.indy.repo.proxy.RepoProxyUtils.keyToPath;
 
 @ApplicationScoped
 public class RepoProxyController
@@ -223,7 +222,7 @@ public class RepoProxyController
                 {
                     // For npm metadata request with trailing /, it's still a normal content request even
                     // if it's a content browse liked request, so we still need to do proxy
-                    final String path = extractPath( absoluteOriginalPath, keyToPath( storeKeyStr ) );
+                    final String path = extractPath( absoluteOriginalPath );
                     if ( isNPMMetaPath( path ) )
                     {
                         trace( "This is a npm metadata request with trailing / {}, will do proxy", absoluteOriginalPath );

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/RepoProxyUtils.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.repo.proxy;
 import org.apache.commons.lang3.StringUtils;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.PackageTypeConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +30,6 @@ import java.util.regex.Pattern;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
-import static org.commonjava.indy.model.core.StoreKey.fromString;
 import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 
@@ -38,6 +38,9 @@ public class RepoProxyUtils
     private static final Logger logger = LoggerFactory.getLogger( RepoProxyUtils.class );
 
     private static final String STORE_PATH_PATTERN = ".*/(maven|npm)/(group|hosted)/(.+?)(/.*)?";
+
+    // For legacy indy content api: /api/$repoType/$name/*
+    private static final String STORE_PATH_PATTERN_NO_PKG = ".*/(group|hosted)/(.+?)(/.*)?";
 
     private static final String NPM_METADATA_NAME = "package.json";
 
@@ -51,20 +54,38 @@ public class RepoProxyUtils
         if ( origStoreKey.isPresent() )
         {
             final String originStoreKeyStr = origStoreKey.get();
-            final String[] parts = originStoreKeyStr.split( ":" );
-            final String proxyToStorePathString = keyToPath( proxyToKey );
-            final String proxyTo = originalPath.replaceAll( keyToPath( originStoreKeyStr ), proxyToStorePathString );
-            logger.trace( "Found proxy to store rule: from {} to {}", originStoreKeyStr, proxyToStorePathString );
+            final StoreKey originStoreKey = StoreKey.fromString( originStoreKeyStr );
+            if ( !originStoreKey.getPackageType().equals( proxyToKey.getPackageType() ) )
+            {
+                logger.warn(
+                        "The proxy to store has different package type with original store: original: {}, proxyTo: {}",
+                        originStoreKey.getPackageType(), proxyToKey.getPackageType() );
+                return empty();
+            }
+            final String proxyTo = replaceAllWithNoRegex( originalPath, noPkgStorePath( originStoreKeyStr ),
+                                                          noPkgStorePath( proxyToKey ) );
+            logger.trace( "Found proxy to store rule: from {} to {}", originStoreKeyStr, proxyToKey );
             return of( proxyTo );
         }
 
         return empty();
     }
 
+    static String noPkgStorePath( StoreKey key )
+    {
+        return String.format( "%s/%s", key.getType(), key.getName() );
+    }
+
+    static String noPkgStorePath( String keyString )
+    {
+        final StoreKey key = StoreKey.fromString( keyString );
+        return noPkgStorePath( key );
+    }
+
     static Optional<String> getOriginalStoreKeyFromPath( final String originalPath )
     {
-        final Pattern pat = Pattern.compile( STORE_PATH_PATTERN );
-        final Matcher match = pat.matcher( originalPath );
+        Pattern pat = Pattern.compile( STORE_PATH_PATTERN );
+        Matcher match = pat.matcher( originalPath );
         String storeKeyString = null;
         if ( match.matches() )
         {
@@ -73,45 +94,58 @@ public class RepoProxyUtils
         }
         else
         {
-            logger.trace( "There is not matched original store key in path {}", originalPath );
+            // Tweak for legacy content path: the legacy content path is like /api/$type/$name/* which does not contain package type, so
+            // here we treat this type of content patch specially.
+            pat = Pattern.compile( STORE_PATH_PATTERN_NO_PKG );
+            match = pat.matcher( originalPath );
+            if ( match.matches() )
+            {
+                final String pkgType = PackageTypeConstants.PKG_TYPE_MAVEN;
+                storeKeyString = String.format( "%s:%s:%s", pkgType, match.group( 1 ), match.group( 2 ) );
+                logger.trace( "Found matched original store key {} by legacy content path in path {}", storeKeyString,
+                              originalPath );
+            }
+            else
+            {
+                logger.trace( "There is not matched original store key in path {}", originalPath );
+            }
         }
 
         return ofNullable( storeKeyString );
     }
 
-    static String keyToPath( final String keyString )
+    static String extractPath( final String fullPath )
     {
-        return StringUtils.isNotBlank( keyString ) ? keyString.replaceAll( ":", "/" ) : "";
-    }
-
-    static String keyToPath( final StoreKey key )
-    {
-        return keyToPath( key.toString() );
-    }
-
-    static String extractPath( final String fullPath, final String repoPath )
-    {
-        if ( StringUtils.isBlank( fullPath ) || !fullPath.contains( repoPath ) )
+        if ( StringUtils.isBlank( fullPath ) )
         {
             return "";
         }
-        String checkingRepoPath = repoPath;
-        if ( repoPath.endsWith( "/" ) )
+
+        final Pattern pat = Pattern.compile( STORE_PATH_PATTERN_NO_PKG );
+        final Matcher match = pat.matcher( fullPath );
+        if ( match.matches() )
         {
-            checkingRepoPath = repoPath.substring( 0, repoPath.length() - 1 );
+            final String pkgType = PackageTypeConstants.PKG_TYPE_MAVEN;
+            final String repoPath = String.format( "%s/%s", match.group( 1 ), match.group( 2 ) );
+            String checkingRepoPath = repoPath;
+            if ( repoPath.endsWith( "/" ) )
+            {
+                checkingRepoPath = repoPath.substring( 0, repoPath.length() - 1 );
+            }
+            final int pos = fullPath.indexOf( checkingRepoPath );
+            final int pathStartPos = pos + checkingRepoPath.length() + 1;
+            if ( pathStartPos >= fullPath.length() )
+            {
+                return "";
+            }
+            String path = fullPath.substring( pathStartPos );
+            if ( StringUtils.isNotBlank( path ) && !path.startsWith( "/" ) )
+            {
+                path = "/" + path;
+            }
+            return path;
         }
-        final int pos = fullPath.indexOf( checkingRepoPath );
-        final int pathStartPos = pos + checkingRepoPath.length() + 1;
-        if ( pathStartPos >= fullPath.length() )
-        {
-            return "";
-        }
-        String path = fullPath.substring( pathStartPos );
-        if ( StringUtils.isNotBlank( path ) && !path.startsWith( "/" ) )
-        {
-            path = "/" + path;
-        }
-        return path;
+        return "";
     }
 
     static boolean isNPMMetaPath( final String path )
@@ -151,5 +185,15 @@ public class RepoProxyUtils
             final String finalTemplate = ADDON_NAME + ": " + template;
             logger.trace( finalTemplate, params );
         }
+    }
+
+    public static String replaceAllWithNoRegex( String originalStr, String target, String replacement )
+    {
+        String result = originalStr;
+        while ( result.indexOf( target ) > 0 )
+        {
+            result = result.replace( target, replacement );
+        }
+        return result;
     }
 }

--- a/addons/repo-proxy/common/src/test/java/org/commonjava/indy/repo/proxy/RepoProxyUtilsTest.java
+++ b/addons/repo-proxy/common/src/test/java/org/commonjava/indy/repo/proxy/RepoProxyUtilsTest.java
@@ -38,6 +38,11 @@ public class RepoProxyUtilsTest
         assertTrue( storeKeyStr.isPresent() );
         assertThat( storeKeyStr.get(), equalTo( "maven:group:abc" ) );
 
+        path = "/api/content/maven/group/builds-untested+shared-imports/org/commonjava/indy/maven-metadata.xml";
+        storeKeyStr = getOriginalStoreKeyFromPath( path );
+        assertTrue( storeKeyStr.isPresent() );
+        assertThat( storeKeyStr.get(), equalTo( "maven:group:builds-untested+shared-imports" ) );
+
         path = "/api/content/maven/hosted/def";
         storeKeyStr = getOriginalStoreKeyFromPath( path );
         assertTrue( storeKeyStr.isPresent() );
@@ -54,37 +59,69 @@ public class RepoProxyUtilsTest
     }
 
     @Test
+    public void testGetOriginalStoreKeyFromLegacyPath(){
+        String path = "/api/group/abc/org/commonjava/indy/maven-metadata.xml";
+        Optional<String> storeKeyStr = getOriginalStoreKeyFromPath( path );
+        assertTrue( storeKeyStr.isPresent() );
+        assertThat( storeKeyStr.get(), equalTo( "maven:group:abc" ) );
+
+        path = "/api/group/builds-untested+shared-imports/org/commonjava/indy/maven-metadata.xml";
+        storeKeyStr = getOriginalStoreKeyFromPath( path );
+        assertTrue( storeKeyStr.isPresent() );
+        assertThat( storeKeyStr.get(), equalTo( "maven:group:builds-untested+shared-imports" ) );
+
+        path = "/api/hosted/def";
+        storeKeyStr = getOriginalStoreKeyFromPath( path );
+        assertTrue( storeKeyStr.isPresent() );
+        assertThat( storeKeyStr.get(), equalTo( "maven:hosted:def" ) );
+    }
+
+    @Test
     public void testExtractPath()
     {
         String fullPath = "/api/content/maven/group/abc/org/commonjava/indy/maven-metadata.xml";
-        String repoPath = "maven/group/abc";
-        String path = extractPath( fullPath, repoPath );
+        String path = extractPath( fullPath );
+        assertThat( path, equalTo( "/org/commonjava/indy/maven-metadata.xml" ) );
+
+        fullPath = "/api/content/maven/group/builds-untested+shared-imports/org/commonjava/indy/maven-metadata.xml";
+        path = extractPath( fullPath );
         assertThat( path, equalTo( "/org/commonjava/indy/maven-metadata.xml" ) );
 
         fullPath = "/api/content/maven/hosted/def/org/commonjava/indy/1.0/";
-        repoPath = "/maven/hosted/def";
-        path = extractPath( fullPath, repoPath );
+        path = extractPath( fullPath );
         assertThat( path, equalTo( "/org/commonjava/indy/1.0/" ) );
 
         fullPath = "/api/content/npm/group/ghi/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom";
-        repoPath = "npm/group/ghi/";
-        path = extractPath( fullPath, repoPath );
+        path = extractPath( fullPath );
         assertThat( path, equalTo( "/org/commonjava/indy/indy-api/1.0/indy-api-1.0.pom" ) );
 
         fullPath = "/api/content/npm/hosted/jkl/org/commonjava/indy/indy-api/2.0/indy-api-2.0.jar";
-        repoPath = "/npm/hosted/jkl/";
-        path = extractPath( fullPath, repoPath );
+        path = extractPath( fullPath );
         assertThat( path, equalTo( "/org/commonjava/indy/indy-api/2.0/indy-api-2.0.jar" ) );
 
         fullPath = "/api/content/npm/hosted/jkl/";
-        repoPath = "/npm/hosted/jkl/";
-        path = extractPath( fullPath, repoPath );
+        path = extractPath( fullPath );
         assertThat( path, equalTo( "" ) );
 
         fullPath = "/api/content/npm/hosted/jkl";
-        repoPath = "/npm/hosted/jkl/";
-        path = extractPath( fullPath, repoPath );
+        path = extractPath( fullPath );
         assertThat( path, equalTo( "" ) );
+    }
+
+    @Test
+    public void testExtractPathFromLegacy()
+    {
+        String fullPath = "/api/group/abc/org/commonjava/indy/maven-metadata.xml";
+        String path = extractPath( fullPath );
+        assertThat( path, equalTo( "/org/commonjava/indy/maven-metadata.xml" ) );
+
+        fullPath = "/api/group/builds-untested+shared-imports/org/commonjava/indy/maven-metadata.xml";
+        path = extractPath( fullPath );
+        assertThat( path, equalTo( "/org/commonjava/indy/maven-metadata.xml" ) );
+
+        fullPath = "/api/hosted/def/org/commonjava/indy/1.0/";
+        path = extractPath( fullPath );
+        assertThat( path, equalTo( "/org/commonjava/indy/1.0/" ) );
     }
 
     @Test
@@ -94,6 +131,11 @@ public class RepoProxyUtilsTest
         Optional<String> proxyTo = getProxyTo( fullPath, StoreKey.fromString( "maven:remote:group-abc" ) );
         assertTrue( proxyTo.isPresent() );
         assertThat( proxyTo.get(), equalTo( "/api/content/maven/remote/group-abc/org/commonjava/indy/maven-metadata.xml" ) );
+
+        fullPath = "/api/content/maven/group/builds-untested+shared-imports/org/commonjava/indy/maven-metadata.xml";
+        proxyTo = getProxyTo( fullPath, StoreKey.fromString( "maven:remote:group-builds-untested+shared-imports" ) );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( "/api/content/maven/remote/group-builds-untested+shared-imports/org/commonjava/indy/maven-metadata.xml" ) );
 
         fullPath = "/api/browse/content/maven/hosted/def/org/commonjava/indy/1.0/";
         proxyTo = getProxyTo( fullPath, StoreKey.fromString( "maven:remote:hosted-def" ) );
@@ -109,6 +151,21 @@ public class RepoProxyUtilsTest
         proxyTo = getProxyTo( fullPath, StoreKey.fromString( "npm:remote:hosted-jkl") );
         assertTrue( proxyTo.isPresent() );
         assertThat( proxyTo.get(), equalTo( "/api/folo/track/npm/remote/hosted-jkl/@react/core" ) );
+    }
+
+    @Test
+    public void testProxyToFromLegacy()
+    {
+        String fullPath = "/api/group/abc/org/commonjava/indy/maven-metadata.xml";
+        Optional<String> proxyTo = getProxyTo( fullPath, StoreKey.fromString( "maven:remote:group-abc" ) );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo( "/api/remote/group-abc/org/commonjava/indy/maven-metadata.xml" ) );
+
+        fullPath = "/api/group/builds-untested+shared-imports/org/commonjava/indy/maven-metadata.xml";
+        proxyTo = getProxyTo( fullPath, StoreKey.fromString( "maven:remote:group-builds-untested+shared-imports" ) );
+        assertTrue( proxyTo.isPresent() );
+        assertThat( proxyTo.get(), equalTo(
+                "/api/remote/group-builds-untested+shared-imports/org/commonjava/indy/maven-metadata.xml" ) );
     }
 
 }


### PR DESCRIPTION
   I've used a wrong API when do replacement based on the static-proxy route rule, seems some group/hosted name contains "+", which is a valid char in regex, and so when using replaceAll these chars are treated as regex but not normal charsequence. This is not correct.