### PR TITLE
Revert "Add a new flag in RemoteRepository to identify if remote host is a indy instance"

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/RemoteRepository.java
@@ -121,11 +121,6 @@ public class RemoteRepository
     @JsonProperty( "prefetch_rescan_time" )
     private String prefetchRescanTimestamp;
 
-    @ApiModelProperty(
-            value = "Indicate if the remote host is a indy instance, default is false." )
-    @JsonProperty("indy_remote")
-    private boolean indyRemote = false;
-
     public RemoteRepository()
     {
         super();
@@ -464,16 +459,6 @@ public class RemoteRepository
         this.prefetchRescanTimestamp = prefetchRescanTimestamp;
     }
 
-    public boolean isIndyRemote()
-    {
-        return indyRemote;
-    }
-
-    public void setIndyRemote( boolean indyRemote )
-    {
-        this.indyRemote = indyRemote;
-    }
-
     @Override
     public RemoteRepository copyOf()
     {
@@ -507,7 +492,6 @@ public class RemoteRepository
         repo.setPrefetchPriority( getPrefetchPriority() );
         repo.setPrefetchRescan( isPrefetchRescan() );
         repo.setPrefetchRescanTimestamp( getPrefetchRescanTimestamp() );
-        repo.setIndyRemote( isIndyRemote() );
 
         copyRestrictions( repo );
         copyBase( repo );
@@ -546,7 +530,6 @@ public class RemoteRepository
         out.writeBoolean( prefetchRescan );
         out.writeObject( prefetchListingType );
         out.writeObject( prefetchRescanTimestamp );
-        out.writeBoolean( indyRemote );
     }
 
     @Override
@@ -586,7 +569,6 @@ public class RemoteRepository
         this.prefetchRescan = in.readBoolean();
         this.prefetchListingType = (String) in.readObject();
         this.prefetchRescanTimestamp = (String) in.readObject();
-        this.indyRemote = in.readBoolean();
     }
 
 }


### PR DESCRIPTION


   Seems this commit will break current repository data store
   deserilization. As it is not needed now, I'll revert it.

This reverts commit c05504b260d0daeea73ef5aec3a840842c9e222b.