### PR TITLE
Static-proxy: Enable remote indy listing content rewriting

### DIFF
--- a/addons/repo-proxy/common/pom.xml
+++ b/addons/repo-proxy/common/pom.xml
@@ -37,6 +37,14 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-client-core-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-browse-client-java</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-bindings-jaxrs</artifactId>
       <exclusions>
         <exclusion>

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentBrowseRemoteIndyListingRewriteManager.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentBrowseRemoteIndyListingRewriteManager.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy;
+
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.indy.client.core.Indy;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.content.browse.client.IndyContentBrowseClientModule;
+import org.commonjava.indy.content.browse.model.ContentBrowseResult;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.repo.proxy.conf.RepoProxyConfig;
+import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
+
+import static org.commonjava.indy.repo.proxy.RepoProxyAddon.ADDON_NAME;
+import static org.commonjava.indy.repo.proxy.RepoProxyUtils.getRequestAbsolutePath;
+
+/**
+ * This rewrite manager handles the content listing request for case that is with a indy remote target. It will
+ * call remote indy content listing api instead of local listing request to get the real content listing result.
+ */
+@ApplicationScoped
+public class ContentBrowseRemoteIndyListingRewriteManager
+
+{
+    private static final Logger logger = LoggerFactory.getLogger( ContentBrowseRemoteIndyListingRewriteManager.class );
+
+    @Inject
+    private RepoProxyConfig config;
+
+    @Inject
+    private IndyObjectMapper mapper;
+
+    private Indy indyClient;
+
+    @PostConstruct
+    public void initIndyClient()
+    {
+        if ( !config.isEnabled() || !config.isRemoteIndyListingRewriteEnabled() )
+        {
+            logger.debug(
+                    "[{}] Addon not enabled or not allowed to use remote indy listing rewriting, will not init indy client.",
+                    ADDON_NAME );
+            return;
+        }
+        final String remoteIndyUrl = config.getDefaultRemoteIndyUrl();
+        if ( remoteIndyUrl != null )
+        {
+            SiteConfig siteConfig =
+                    new SiteConfigBuilder( "indy-static", remoteIndyUrl + "api/" ).withRequestTimeoutSeconds(
+                            config.getRemoteIndyRequestTimeout() ).build();
+            try
+            {
+                //FIXME: Here we used a MemPassMgr for simple. Maybe some changes in future for more complex cases.
+                indyClient =
+                        new Indy( siteConfig, new MemoryPasswordManager(), mapper, new IndyContentBrowseClientModule() );
+            }
+            catch ( IndyClientException e )
+            {
+                logger.error(
+                        String.format( "[%s] Cannot init indy client successfully for remote indy access", ADDON_NAME ),
+                        e );
+            }
+        }
+        else
+        {
+            logger.warn(
+                    "[{}] remote indy listing rewriting enabled but no remote indy supplied, please check your configuration to add remote indy url.",
+                    ADDON_NAME );
+        }
+    }
+
+    public boolean rewriteResponse( HttpServletRequest request, HttpServletResponse response )
+            throws IOException
+    {
+        if ( !config.isEnabled() || !config.isRemoteIndyListingRewriteEnabled() )
+        {
+            logger.debug(
+                    "[{}] Addon not enabled or not allowed to use remote indy listing rewriting, will not decorate the response by remote indy listing rewriting.",
+                    ADDON_NAME );
+            return false;
+        }
+
+        final String absolutePath = getRequestAbsolutePath( request );
+        if ( !absolutePath.startsWith( "/api/browse/" ) )
+        {
+            logger.debug(
+                    "[{}] Remote indy listing rewriting: {} is not a content browse request, will not decorate the response. ",
+                    ADDON_NAME, absolutePath );
+            return false;
+        }
+
+        final String pathInfo = request.getPathInfo();
+        final Optional<String> originalRepo = RepoProxyUtils.getOriginalStoreKeyFromPath( pathInfo );
+        if ( !originalRepo.isPresent() )
+        {
+            logger.debug( "[{}] No matched repo path in request path {}, will not rewrite.", ADDON_NAME, pathInfo );
+            return false;
+        }
+
+        final String path = RepoProxyUtils.extractPath( absolutePath );
+        final String remoteIndyUrl = config.getDefaultRemoteIndyUrl();
+
+        logger.trace( "Start to get remote indy content list for indy {} and path {}", remoteIndyUrl, path );
+
+        URL remoteIndyURL = new URL( remoteIndyUrl );
+        String remoteIndyHost = remoteIndyURL.getHost();
+        int remotePort = remoteIndyURL.getPort();
+        // 80 or 443 can be ignored in http(s) url
+        if ( remotePort != 80 && remotePort != 443 && remotePort > 0 )
+        {
+            remoteIndyHost = remoteIndyHost + ":" + remotePort;
+        }
+        String localProxyHost = request.getServerName();
+        int localPort = request.getServerPort();
+        if ( localPort != 80 && localPort != 443 && localPort > 0 )
+        {
+            localProxyHost = localProxyHost + ":" + localPort;
+        }
+        final StoreKey originalStoreKey = StoreKey.fromString( originalRepo.get() );
+        final String remoteContentResult = getRemoteIndyListingContent( originalStoreKey, path );
+
+        if ( StringUtils.isNotBlank( remoteContentResult ) )
+        {
+            logger.trace( "Start replacing original host {} to target host {}", remoteIndyHost, localProxyHost );
+            final String replaced =
+                    RepoProxyUtils.replaceAllWithNoRegex( remoteContentResult, remoteIndyHost, localProxyHost );
+            logger.trace( "Replaced result for remote indy content list: {}", replaced );
+            response.getWriter().write( replaced );
+            return true;
+        }
+        return false;
+    }
+
+    private String getRemoteIndyListingContent( final StoreKey key, final String path )
+            throws IOException
+    {
+        if ( indyClient == null )
+        {
+            initIndyClient();
+            if ( indyClient == null )
+            {
+                throw new IOException( "Failed to init indy client to access remote indy" );
+            }
+        }
+        try
+        {
+            ContentBrowseResult result =
+                    indyClient.module( IndyContentBrowseClientModule.class ).getContentList( key, path );
+            return mapper.writeValueAsString( result );
+        }
+        catch ( IndyClientException e )
+        {
+            throw new IOException( e );
+        }
+    }
+
+}
+
+

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentBrowseRewriteResponseDecorator.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentBrowseRewriteResponseDecorator.java
@@ -56,11 +56,19 @@ public class ContentBrowseRewriteResponseDecorator
             return response;
         }
 
+        if ( config.isRemoteIndyListingRewriteEnabled() )
+        {
+            logger.debug(
+                    "[{}] Will use remote indy content listing instead, so will not decorate the response for remote proxy type of content browse rewriting.",
+                    ADDON_NAME );
+            return response;
+        }
+
         final String absolutePath = getRequestAbsolutePath( request );
         if ( !absolutePath.startsWith( "/api/browse/" ) )
         {
             logger.debug(
-                    "[{}] Content browse rewrite: {} is not a content browse request, will not decorate the response for content browse rewriting. ",
+                    "[{}] Content browse rewrite: {} is not a content browse request, will not decorate the response. ",
                     ADDON_NAME, absolutePath );
             return response;
         }

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
@@ -56,6 +56,12 @@ public class RepoProxyConfig
 
     private static final String REPO_PROXY_BLOCK_LIST = "block.path.patterns";
 
+    private static final String REMOTE_INDY_URL = "remote.indy.url";
+
+    private static final String REMOTE_INDY_REQUEST_TIMEOUT = "remote.indy.request.timeout";
+
+    private static final String REMOTE_INDY_LISTING_REWRITE_ENABLED = "remote.indy.listing.rewrite.enabled";
+
     private static final Boolean DEFAULT_ENABLED = Boolean.FALSE;
 
     private static final String DEFAULT_API_PATTERNS = "/api/content/*, /api/folo/track/*, /api/browse/*, /api/group/*, /api/hosted/*";
@@ -67,6 +73,8 @@ public class RepoProxyConfig
     private static final String DEFAULT_REPO_CREATE_RULE_BASEDIR = "repo-proxy";
 
     private static final Boolean DEFAULT_CONTENT_BROWSE_REWRITE_ENABLE = Boolean.TRUE;
+
+    private static final Integer DEFAULT_REMOTE_INDY_REQUEST_TIMEOUT = 60;
 
     private String repoCreatorRuleBaseDir;
 
@@ -81,6 +89,12 @@ public class RepoProxyConfig
     private Boolean npmMetaRewriteEnabled;
 
     private Boolean contentBrowseRewriteEnabled;
+
+    private String defaultRemoteIndyUrl;
+
+    private Boolean remoteIndyListingRewriteEnabled;
+
+    private Integer remoteIndyRequestTimeout;
 
     public RepoProxyConfig()
     {
@@ -139,6 +153,25 @@ public class RepoProxyConfig
         return blockListPatterns;
     }
 
+    public String getDefaultRemoteIndyUrl()
+    {
+        if ( defaultRemoteIndyUrl != null && !defaultRemoteIndyUrl.endsWith( "/" ) )
+        {
+            return defaultRemoteIndyUrl + "/";
+        }
+        return defaultRemoteIndyUrl;
+    }
+
+    public Boolean isRemoteIndyListingRewriteEnabled()
+    {
+        return remoteIndyListingRewriteEnabled == null ? DEFAULT_ENABLED : this.remoteIndyListingRewriteEnabled;
+    }
+
+    public Integer getRemoteIndyRequestTimeout()
+    {
+        return remoteIndyRequestTimeout == null ? DEFAULT_REMOTE_INDY_REQUEST_TIMEOUT : remoteIndyRequestTimeout;
+    }
+
     @Override
     public void parameter( final String name, final String value )
     {
@@ -177,6 +210,15 @@ public class RepoProxyConfig
                 {
                     blockListPatterns.add( pattern.trim() );
                 }
+                break;
+            case REMOTE_INDY_URL:
+                this.defaultRemoteIndyUrl = value.trim();
+                break;
+            case REMOTE_INDY_LISTING_REWRITE_ENABLED:
+                this.remoteIndyListingRewriteEnabled = Boolean.valueOf( value.trim() );
+                break;
+            case REMOTE_INDY_REQUEST_TIMEOUT:
+                this.remoteIndyRequestTimeout = Integer.parseInt( value.trim() );
                 break;
             default:
                 break;

--- a/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyRemoteIndyListingRewriteTest.java
+++ b/addons/repo-proxy/ftests/src/main/java/org/commonjava/indy/repo/proxy/ftest/RepoProxyRemoteIndyListingRewriteTest.java
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.repo.proxy.ftest;
+
+import org.apache.commons.io.IOUtils;
+import org.commonjava.indy.content.browse.model.ContentBrowseResult;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
+import org.commonjava.indy.repo.proxy.RepoProxyUtils;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+import org.commonjava.maven.galley.util.PathUtils;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.hamcrest.CoreMatchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check if the repo proxy addon can correcly handle the remote indy listing rewrite function
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>Repo-proxy add-on enabled</li>
+ *     <li>"Remote indy listing content rewrite" configuration enabled</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Request path of directory listing</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>Response is from the configured remote indy with same direcoty path</li>
+ *     <li>Response content is using replaced host info for url related info</li>
+ * </ul>
+ */
+public class RepoProxyRemoteIndyListingRewriteTest
+        extends AbstractIndyFunctionalTest
+{
+    private static final String REPO_NAME = "test";
+
+    private final HostedRepository hosted = new HostedRepository( MavenPackageTypeDescriptor.MAVEN_PKG_KEY, REPO_NAME );
+
+    private static final String PATH = "/foo/bar/";
+
+    private static final String PATH_WITHOUT_LAST_SLASH = "/foo/bar";
+
+    private final IndyObjectMapper mapper = new IndyObjectMapper( true );
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "" );
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+        server.expect( server.formatUrl( "api/browse/maven/hosted", REPO_NAME, PATH_WITHOUT_LAST_SLASH ), 200,
+                       new ByteArrayInputStream( getExpectedRemoteContent().getBytes() ) );
+    }
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        try (InputStream result = client.content().get( hosted.getKey(), PATH ))
+        {
+            assertThat( result, notNullValue() );
+            final String content = IOUtils.toString( result );
+            ContentBrowseResult rewrittenResult = mapper.readValue( content, ContentBrowseResult.class );
+            final String originalContent = getExpectedRemoteContent();
+            ContentBrowseResult originalResult = mapper.readValue( originalContent, ContentBrowseResult.class );
+            assertThat( rewrittenResult.getStoreKey(), equalTo( originalResult.getStoreKey() ) );
+            assertThat( rewrittenResult.getPath(), equalTo( originalResult.getPath() ) );
+            assertThat( rewrittenResult.getParentPath(), equalTo( originalResult.getParentPath() ) );
+
+            assertThat( rewrittenResult.getStoreBrowseUrl(), not( originalResult.getStoreBrowseUrl() ) );
+            assertThat( rewrittenResult.getStoreContentUrl(), not( originalResult.getStoreContentUrl() ) );
+        }
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        final String url = server.formatUrl( "" );
+        logger.debug( "Remote url: {}", url );
+        writeConfigFile( "conf.d/repo-proxy.conf", "[repo-proxy]\nenabled=true\napi.methods=GET,HEAD\n"
+                + "remote.indy.listing.rewrite.enabled=true\nremote.indy.url=" + url );
+    }
+
+    private String getExpectedRemoteContent()
+            throws IOException
+    {
+        final String url = server.formatUrl( "" );
+        ContentBrowseResult result = new ContentBrowseResult();
+        result.setStoreKey( hosted.getKey() );
+        final String rootStorePath =
+                PathUtils.normalize( url, "api/browse", hosted.getKey().toString().replaceAll( ":", "/" ) );
+        result.setParentUrl( PathUtils.normalize( rootStorePath, "foo", "/" ) );
+        result.setParentPath( "foo/" );
+        result.setPath( "foo/bar/" );
+        result.setStoreBrowseUrl( rootStorePath );
+        result.setStoreContentUrl(
+                PathUtils.normalize( url, "api/content", hosted.getKey().toString().replaceAll( ":", "/" ) ) );
+        result.setSources( Collections.singletonList( rootStorePath ) );
+        ContentBrowseResult.ListingURLResult listResult = new ContentBrowseResult.ListingURLResult();
+        final String path = PATH + "foo-bar.txt";
+        listResult.setListingUrl( PathUtils.normalize( rootStorePath, path ) );
+        listResult.setPath( path );
+        Set<String> sources = new HashSet<>();
+        sources.add( "indy:" + hosted.getKey().toString() + path );
+        listResult.setSources( sources );
+        result.setListingUrls( Collections.singletonList( listResult ) );
+
+        return mapper.writeValueAsString( result );
+
+    }
+}

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
@@ -164,7 +164,6 @@ public class IndyClientHttp
      */
     @Deprecated
     public void connect( final HttpClientConnectionManager connectionManager )
-            throws IndyClientException
     {
         // NOP, now that we've moved to HttpFactory.
     }
@@ -309,9 +308,8 @@ public class IndyClientHttp
             }
 
             final String json = entityToString( response );
-            final T value = objectMapper.readValue( json, typeRef );
 
-            return value;
+            return objectMapper.readValue( json, typeRef );
         }
         catch ( final IOException e )
         {
@@ -329,7 +327,7 @@ public class IndyClientHttp
         connect();
 
         addLoggingMDCToHeaders(req);
-        CloseableHttpResponse response = null;
+        CloseableHttpResponse response;
         try
         {
             final CloseableHttpClient client = newClient();
@@ -366,7 +364,7 @@ public class IndyClientHttp
             addLoggingMDCToHeaders(req);
             if ( headers != null )
             {
-                headers.forEach( (k, v) -> { req.setHeader( k, v );} );
+                headers.forEach( req::setHeader );
             }
             final CloseableHttpClient client = newClient();
 
@@ -416,7 +414,7 @@ public class IndyClientHttp
         catch ( final ClientProtocolException e )
         {
             final Throwable cause = e.getCause();
-            if ( cause != null && ( cause instanceof IndyClientException ) )
+            if ( cause instanceof IndyClientException )
             {
                 throw (IndyClientException) cause;
             }
@@ -483,7 +481,7 @@ public class IndyClientHttp
         connect();
 
         addLoggingMDCToHeaders(request);
-        CloseableHttpResponse response = null;
+        CloseableHttpResponse response;
         try
         {
             final CloseableHttpClient client = newClient();
@@ -514,7 +512,7 @@ public class IndyClientHttp
         checkRequestValue( value );
         connect();
 
-        CloseableHttpResponse response = null;
+        CloseableHttpResponse response;
         try
         {
             final HttpPost req = newRawPost( buildUrl( baseUrl, path ) );
@@ -852,8 +850,7 @@ public class IndyClientHttp
 
     public HttpGet newRawGet( final String url )
     {
-        final HttpGet req = new HttpGet( url );
-        return req;
+        return new HttpGet( url );
     }
 
     public HttpGet newJsonGet( final String url )
@@ -872,8 +869,7 @@ public class IndyClientHttp
 
     public HttpDelete newDelete( final String url )
     {
-        final HttpDelete req = new HttpDelete( url );
-        return req;
+        return new HttpDelete( url );
     }
 
     public HttpPut newJsonPut( final String url )
@@ -885,8 +881,7 @@ public class IndyClientHttp
 
     public HttpPut newRawPut( final String url )
     {
-        final HttpPut req = new HttpPut( url );
-        return req;
+        return new HttpPut( url );
     }
 
     public HttpPost newJsonPost( final String url )


### PR DESCRIPTION
  For static-proxy, current static instance uses its own proxy remote to
  render directory listing content, which is all located in the remote
  cache itself. This brings problem, especially if the remote target is
  also indy instance. So this commit will enable a feature that uses
  remote indy listing content api instead for directory content listing
  request.