### PR TITLE
Version bump Galley and Path-mapped-storage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,11 +82,11 @@
     <honeycombVersion>1.1.0</honeycombVersion>
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.7.2</datastaxVersion>
-    <pathmappedStorageVersion>1.6</pathmappedStorageVersion>
+    <pathmappedStorageVersion>1.7-SNAPSHOT</pathmappedStorageVersion>
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.0</atlasVersion>
-    <galleyVersion>1.3</galleyVersion>
+    <galleyVersion>1.4-SNAPSHOT</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.16</partylineVersion>


### PR DESCRIPTION
This PR bumps Galley to

1.4-SNAPSHOT

and path-mapped-storage to

1.7-SNAPSHOT.

To take advantage of the more efficient stream handling changes in.