### PR TITLE
Fix bug for firefox mis-actions of tar.gz with Content-Encoding:gzip response headers

### DIFF
--- a/api/src/main/java/org/commonjava/indy/util/ApplicationContent.java
+++ b/api/src/main/java/org/commonjava/indy/util/ApplicationContent.java
@@ -30,6 +30,18 @@ public final class ApplicationContent
 
     public static final String application_zip = "application/zip";
 
+    public static final String application_gzip = "application/x-gzip";
+
+    public static final String application_jar = "application/java-archive";
+
+    public static final String application_tar = "application/x-tar";
+
+    public static final String application_ar = "application/x-archive";
+
+    public static final String application_7z = "application/x-7z-compressed";
+
+    public static final String application_rar = "application/x-rar-compressed";
+
     public static final String text_css = "text/css";
 
     public static final String text_html = "text/html";

--- a/api/src/main/resources/extra-mime.types
+++ b/api/src/main/resources/extra-mime.types
@@ -1,1 +1,10 @@
-application/maven+xml       pom
+application/maven+xml         pom
+application/java-archive      jar
+application/x-gzip            gz
+application/x-gzip            tgz
+application/x-tar             tar
+application/x-archive         a
+application/x-archive         ar
+application/x-7z-compressed   7z
+application/x-rar-compressed  rar
+application/zip               zip

--- a/boot/jaxrs/pom.xml
+++ b/boot/jaxrs/pom.xml
@@ -68,6 +68,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-jaxrs</artifactId>

--- a/boot/jaxrs/src/main/java/org/commonjava/indy/boot/jaxrs/IndyDeployer.java
+++ b/boot/jaxrs/src/main/java/org/commonjava/indy/boot/jaxrs/IndyDeployer.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.boot.jaxrs;
 import io.undertow.Undertow;
 import io.undertow.predicate.Predicate;
 import io.undertow.predicate.Predicates;
+import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.encoding.ContentEncodingRepository;
 import io.undertow.server.handlers.encoding.DeflateEncodingProvider;
 import io.undertow.server.handlers.encoding.EncodingHandler;
@@ -26,6 +27,8 @@ import io.undertow.servlet.Servlets;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
 import org.commonjava.indy.bind.jaxrs.IndyDeployment;
+import org.commonjava.indy.util.ApplicationContent;
+import org.commonjava.indy.util.MimeTyper;
 import org.commonjava.propulsor.boot.BootOptions;
 import org.commonjava.propulsor.boot.PortFinder;
 import org.commonjava.propulsor.deploy.DeployException;
@@ -37,6 +40,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.servlet.ServletException;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 @ApplicationScoped
@@ -57,6 +62,9 @@ public class IndyDeployer
 
     @Inject
     private RestConfig restConfig;
+
+    @Inject
+    private MimeTyper mimeTyper;
 
     @Override
     public void stop()
@@ -136,18 +144,32 @@ public class IndyDeployer
         return t;
     }
 
+    private static final Set<String> NO_NEED_GZIPPED_CONTENT = new HashSet<>();
+
+    static
+    {
+        NO_NEED_GZIPPED_CONTENT.add( ApplicationContent.application_gzip );
+    }
+
     private EncodingHandler getGzipEncodeHandler( final DeploymentManager dm )
             throws ServletException
     {
         // FROM: https://stackoverflow.com/questions/28295752/compressing-undertow-server-responses#28329810
         final Predicate sizePredicate = Predicates.parse( "max-content-size[" + Long.toString( 5 * 1024 ) + "]" );
 
+        // For firefox bug: https://bugzilla.mozilla.org/show_bug.cgi?id=610679
+        final Predicate fileTypePredicate = v -> {
+            final String path = v.getRequestPath();
+            return !NO_NEED_GZIPPED_CONTENT.contains( mimeTyper.getContentType( path ).toLowerCase() );
+        };
+
+        final Predicate mixePredicate = v -> sizePredicate.resolve( v ) && fileTypePredicate.resolve( v );
+
         EncodingHandler eh = new EncodingHandler(
                 new ContentEncodingRepository().addEncodingHandler( "gzip", new GzipEncodingProvider(), 50,
-                                                                    sizePredicate ) ).setNext( dm.start() );
+                                                                    mixePredicate ) ).setNext( dm.start() );
 //                                               .addEncodingHandler( "deflate", new DeflateEncodingProvider(), 51,
 //                                                                    sizePredicate ) ).setNext( dm.start() );
         return eh;
     }
-
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/SetContentTypeNotExistsTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/SetContentTypeNotExistsTest.java
@@ -59,7 +59,7 @@ public class SetContentTypeNotExistsTest
     public void run() throws Exception
     {
         final String content = "This is some content " + System.currentTimeMillis() + "." + System.nanoTime();
-        final String path = "org/foo/foo-project/1/foo-1.jar";
+        final String path = "org/foo/foo-project/1/foo-1.nodefine";
 
         server.expect( "GET", server.formatUrl( STORE, path ), ( request, response ) -> {
             response.setStatus( 200 );


### PR DESCRIPTION
As Firefox or some curl or wget in old version centos will do dounble-gzip for .gz and .tgz files if the response header "Content-Encoding" is set to "gzip", it will cause chaos. This fix is addressing the problem.