### PR TITLE
Changed to use bulk read method.

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
@@ -108,6 +108,8 @@ public class NPMPackageMaskingTransferDecorator
 
         boolean masked;
 
+        private static final int SIZE = 1024;
+
         private PackageMaskingInputStream( final InputStream stream, final String contextURL,
                                            final IndyMetricsManager metricsManager )
         {
@@ -164,9 +166,12 @@ public class NPMPackageMaskingTransferDecorator
             {
                 ByteArrayOutputStream bos = new ByteArrayOutputStream();
                 int read;
-                while ( ( read = super.read() ) >= 0 )
                 {
-                    bos.write( read );
+                    byte[] buffer = new byte[SIZE];
+                    while ( ( read = super.read(buffer, 0, buffer.length) ) >= 0 )
+                    {
+                        bos.write( buffer, 0, read );
+                    }
                 }
                 byte[] rawBytes = bos.toByteArray();
                 String raw = new String( rawBytes, UTF_8 );


### PR DESCRIPTION
This PR looks to improve the current situation. Improving the situation identified in issue #1685 .

 A micro benchmark shows the improvement using this change has these results.

```
Benchmark                            Mode  Cnt  Score   Error   Units
NPMPackageMaskBenchmark.bulk        thrpt    5  2.737 ± 1.103  ops/ms
NPMPackageMaskBenchmark.individual  thrpt    5  0.302 ± 0.003  ops/ms
```

An unsophisticated profiler shows

 this is the difference in the existing code. Test named "individual"

```
....[Thread state: RUNNABLE]........................................................................
  1.0%  90.0% java.io.FileInputStream.read0
  0.1%   4.7% java.lang.Object.wait
  0.0%   2.3% <stack is empty, everything is filtered?>
  0.0%   0.7% java.io.FileInputStream.open0
  0.0%   0.5% java.lang.Object.<init>
  0.0%   0.4% java.io.FileInputStream.available0
  0.0%   0.1% java.security.AccessController.getStackAccessControlContext
  0.0%   0.1% java.lang.StringCoding$StringEncoder.encode
  0.0%   0.1% java.lang.String.toLowerCase
  0.0%   0.1% java.lang.Thread.start0
  0.0%   0.9% <other>

```

and then the improved time spent in the stack with this commit. Test named "bulk"

```
....[Thread state: RUNNABLE]........................................................................
  0.1%  39.4% java.lang.Object.wait
  0.0%  18.0% <stack is empty, everything is filtered?>
  0.0%   6.5% java.io.FileInputStream.available0
  0.0%   5.7% java.io.FileInputStream.open0
  0.0%   5.1% java.lang.Object.<init>
  0.0%   4.4% java.io.FileInputStream.readBytes
  0.0%   3.2% java.lang.StringCoding$StringEncoder.encode
  0.0%   2.6% sun.nio.cs.UTF_8$Decoder.decodeArrayLoop
  0.0%   2.1% java.security.AccessController.getStackAccessControlContext
  0.0%   1.8% sun.nio.cs.StreamDecoder.implRead
  0.0%  11.3% <other>
```

