### PR TITLE
Model for schedules in cassandra

### DIFF
--- a/addons/changelog/client-java/pom.xml
+++ b/addons/changelog/client-java/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-changelog</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/changelog/client-java/pom.xml
+++ b/addons/changelog/client-java/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-changelog</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/changelog/common/pom.xml
+++ b/addons/changelog/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-changelog</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-changelog-common</artifactId>
   <name>Indy :: Add-Ons :: ChangeLog :: Common</name>

--- a/addons/changelog/common/pom.xml
+++ b/addons/changelog/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-changelog</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-changelog-common</artifactId>
   <name>Indy :: Add-Ons :: ChangeLog :: Common</name>

--- a/addons/changelog/ftests/pom.xml
+++ b/addons/changelog/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-changelog</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-changelog</artifactId>

--- a/addons/changelog/ftests/pom.xml
+++ b/addons/changelog/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-changelog</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-changelog</artifactId>

--- a/addons/changelog/jaxrs/pom.xml
+++ b/addons/changelog/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-changelog</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-changelog-jaxrs</artifactId>

--- a/addons/changelog/jaxrs/pom.xml
+++ b/addons/changelog/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-changelog</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-changelog-jaxrs</artifactId>

--- a/addons/changelog/pom.xml
+++ b/addons/changelog/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-changelog</artifactId>
   <name>Indy :: Add-Ons :: ChangeLog :: Parent</name>

--- a/addons/changelog/pom.xml
+++ b/addons/changelog/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-changelog</artifactId>
   <name>Indy :: Add-Ons :: ChangeLog :: Parent</name>

--- a/addons/content-browse/client-java/pom.xml
+++ b/addons/content-browse/client-java/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-content-browse</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/content-browse/client-java/pom.xml
+++ b/addons/content-browse/client-java/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-content-browse</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/content-browse/common/pom.xml
+++ b/addons/content-browse/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-content-browse</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-content-browse-common</artifactId>
   <name>Indy :: Add-Ons :: Directory Content Browse :: Common</name>

--- a/addons/content-browse/common/pom.xml
+++ b/addons/content-browse/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-content-browse</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-content-browse-common</artifactId>
   <name>Indy :: Add-Ons :: Directory Content Browse :: Common</name>

--- a/addons/content-browse/ftests/pom.xml
+++ b/addons/content-browse/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-content-browse</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-content-browse</artifactId>

--- a/addons/content-browse/ftests/pom.xml
+++ b/addons/content-browse/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-content-browse</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-content-browse</artifactId>

--- a/addons/content-browse/jaxrs/pom.xml
+++ b/addons/content-browse/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-content-browse</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-content-browse-jaxrs</artifactId>

--- a/addons/content-browse/jaxrs/pom.xml
+++ b/addons/content-browse/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-content-browse</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-content-browse-jaxrs</artifactId>

--- a/addons/content-browse/model-java/pom.xml
+++ b/addons/content-browse/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-content-browse</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-content-browse-model-java</artifactId>
   <name>Indy :: Add-Ons :: Directory Content Browse :: Java Domain Model</name>

--- a/addons/content-browse/model-java/pom.xml
+++ b/addons/content-browse/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-content-browse</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-content-browse-model-java</artifactId>
   <name>Indy :: Add-Ons :: Directory Content Browse :: Java Domain Model</name>

--- a/addons/content-browse/pom.xml
+++ b/addons/content-browse/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-content-browse</artifactId>
   <name>Indy :: Add-Ons :: Directory Content Browse :: Parent</name>

--- a/addons/content-browse/pom.xml
+++ b/addons/content-browse/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-content-browse</artifactId>
   <name>Indy :: Add-Ons :: Directory Content Browse :: Parent</name>

--- a/addons/content-browse/ui/package-lock.json
+++ b/addons/content-browse/ui/package-lock.json
@@ -2270,9 +2270,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
-      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",

--- a/addons/content-browse/ui/pom.xml
+++ b/addons/content-browse/ui/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-content-browse</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/content-browse/ui/pom.xml
+++ b/addons/content-browse/ui/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-content-browse</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/content-index/pom.xml
+++ b/addons/content-index/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-content-index</artifactId>

--- a/addons/content-index/pom.xml
+++ b/addons/content-index/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-content-index</artifactId>

--- a/addons/diagnostics/client-java/pom.xml
+++ b/addons/diagnostics/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-diagnostics</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-diagnostics-client-java</artifactId>
   <name>Indy :: Add-Ons :: Diagnostic Tools :: Java Client</name>

--- a/addons/diagnostics/client-java/pom.xml
+++ b/addons/diagnostics/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-diagnostics</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-diagnostics-client-java</artifactId>
   <name>Indy :: Add-Ons :: Diagnostic Tools :: Java Client</name>

--- a/addons/diagnostics/common/pom.xml
+++ b/addons/diagnostics/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-diagnostics</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-diagnostics-common</artifactId>
   <name>Indy :: Add-Ons :: Diagnostic Tools :: Common</name>

--- a/addons/diagnostics/common/pom.xml
+++ b/addons/diagnostics/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-diagnostics</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-diagnostics-common</artifactId>
   <name>Indy :: Add-Ons :: Diagnostic Tools :: Common</name>

--- a/addons/diagnostics/ftests/pom.xml
+++ b/addons/diagnostics/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-diagnostics</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-diagnostics</artifactId>

--- a/addons/diagnostics/ftests/pom.xml
+++ b/addons/diagnostics/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-diagnostics</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-diagnostics</artifactId>

--- a/addons/diagnostics/jaxrs/pom.xml
+++ b/addons/diagnostics/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-diagnostics</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-diagnostics-jaxrs</artifactId>

--- a/addons/diagnostics/jaxrs/pom.xml
+++ b/addons/diagnostics/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-diagnostics</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-diagnostics-jaxrs</artifactId>

--- a/addons/diagnostics/pom.xml
+++ b/addons/diagnostics/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-diagnostics</artifactId>
   <name>Indy :: Add-Ons :: Diagnostic Tools :: Parent</name>

--- a/addons/diagnostics/pom.xml
+++ b/addons/diagnostics/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-diagnostics</artifactId>
   <name>Indy :: Add-Ons :: Diagnostic Tools :: Parent</name>

--- a/addons/dot-maven/common/pom.xml
+++ b/addons/dot-maven/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-dot-maven</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-dot-maven-common</artifactId>
   <name>Indy :: Add-Ons :: Dot-Maven (.m2 WebDAV) :: Common Core</name>

--- a/addons/dot-maven/common/pom.xml
+++ b/addons/dot-maven/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-dot-maven</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-dot-maven-common</artifactId>
   <name>Indy :: Add-Ons :: Dot-Maven (.m2 WebDAV) :: Common Core</name>

--- a/addons/dot-maven/ftests/pom.xml
+++ b/addons/dot-maven/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-dot-maven</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-dot-maven</artifactId>

--- a/addons/dot-maven/ftests/pom.xml
+++ b/addons/dot-maven/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-dot-maven</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-dot-maven</artifactId>

--- a/addons/dot-maven/jaxrs/pom.xml
+++ b/addons/dot-maven/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-dot-maven</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-dot-maven-jaxrs</artifactId>

--- a/addons/dot-maven/jaxrs/pom.xml
+++ b/addons/dot-maven/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-dot-maven</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-dot-maven-jaxrs</artifactId>

--- a/addons/dot-maven/pom.xml
+++ b/addons/dot-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-dot-maven</artifactId>

--- a/addons/dot-maven/pom.xml
+++ b/addons/dot-maven/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-dot-maven</artifactId>

--- a/addons/event-audit/common/pom.xml
+++ b/addons/event-audit/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-event-audit</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>indy-event-audit-common</artifactId>

--- a/addons/event-audit/common/pom.xml
+++ b/addons/event-audit/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-event-audit</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>indy-event-audit-common</artifactId>

--- a/addons/event-audit/pom.xml
+++ b/addons/event-audit/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-addons</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>indy-event-audit</artifactId>

--- a/addons/event-audit/pom.xml
+++ b/addons/event-audit/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-addons</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>indy-event-audit</artifactId>

--- a/addons/folo/client-java/pom.xml
+++ b/addons/folo/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-folo-client-java</artifactId>
   <name>Indy :: Add-Ons :: Folo Usage Tracker :: Java Client</name>

--- a/addons/folo/client-java/pom.xml
+++ b/addons/folo/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-folo-client-java</artifactId>
   <name>Indy :: Add-Ons :: Folo Usage Tracker :: Java Client</name>

--- a/addons/folo/common/pom.xml
+++ b/addons/folo/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-folo-common</artifactId>
   <name>Indy :: Add-Ons :: Folo Usage Tracker :: Common</name>

--- a/addons/folo/common/pom.xml
+++ b/addons/folo/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-folo-common</artifactId>
   <name>Indy :: Add-Ons :: Folo Usage Tracker :: Common</name>

--- a/addons/folo/ftests/pom.xml
+++ b/addons/folo/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-folo</artifactId>

--- a/addons/folo/ftests/pom.xml
+++ b/addons/folo/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-folo</artifactId>

--- a/addons/folo/jaxrs/pom.xml
+++ b/addons/folo/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-folo-jaxrs</artifactId>

--- a/addons/folo/jaxrs/pom.xml
+++ b/addons/folo/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-folo-jaxrs</artifactId>

--- a/addons/folo/model-java/pom.xml
+++ b/addons/folo/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-folo-model-java</artifactId>
   <name>Indy :: Add-Ons :: Folo Usage Tracker :: Java Domain Model</name>

--- a/addons/folo/model-java/pom.xml
+++ b/addons/folo/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-folo</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-folo-model-java</artifactId>
   <name>Indy :: Add-Ons :: Folo Usage Tracker :: Java Domain Model</name>

--- a/addons/folo/pom.xml
+++ b/addons/folo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-folo</artifactId>
   <name>Indy :: Add-Ons :: Folo Usage Tracker :: Parent</name>

--- a/addons/folo/pom.xml
+++ b/addons/folo/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-folo</artifactId>
   <name>Indy :: Add-Ons :: Folo Usage Tracker :: Parent</name>

--- a/addons/hosted-by-archive/client-java/pom.xml
+++ b/addons/hosted-by-archive/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-hosted-by-archive</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-hosted-by-archive-client-java</artifactId>
   <name>Indy :: Add-Ons :: Hosted By Archive :: Java Client</name>

--- a/addons/hosted-by-archive/client-java/pom.xml
+++ b/addons/hosted-by-archive/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-hosted-by-archive</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-hosted-by-archive-client-java</artifactId>
   <name>Indy :: Add-Ons :: Hosted By Archive :: Java Client</name>

--- a/addons/hosted-by-archive/common/pom.xml
+++ b/addons/hosted-by-archive/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-hosted-by-archive</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-hosted-by-archive-common</artifactId>
   <name>Indy :: Add-Ons :: Hosted By Archive :: Common</name>

--- a/addons/hosted-by-archive/common/pom.xml
+++ b/addons/hosted-by-archive/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-hosted-by-archive</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-hosted-by-archive-common</artifactId>
   <name>Indy :: Add-Ons :: Hosted By Archive :: Common</name>

--- a/addons/hosted-by-archive/ftests/pom.xml
+++ b/addons/hosted-by-archive/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-hosted-by-archive</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-hosted-by-archive</artifactId>

--- a/addons/hosted-by-archive/ftests/pom.xml
+++ b/addons/hosted-by-archive/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-hosted-by-archive</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-hosted-by-archive</artifactId>

--- a/addons/hosted-by-archive/jaxrs/pom.xml
+++ b/addons/hosted-by-archive/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-hosted-by-archive</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-hosted-by-archive-jaxrs</artifactId>

--- a/addons/hosted-by-archive/jaxrs/pom.xml
+++ b/addons/hosted-by-archive/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-hosted-by-archive</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-hosted-by-archive-jaxrs</artifactId>

--- a/addons/hosted-by-archive/pom.xml
+++ b/addons/hosted-by-archive/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-hosted-by-archive</artifactId>
   <name>Indy :: Add-Ons :: Hosted By Archive :: Parent</name>

--- a/addons/hosted-by-archive/pom.xml
+++ b/addons/hosted-by-archive/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-hosted-by-archive</artifactId>
   <name>Indy :: Add-Ons :: Hosted By Archive :: Parent</name>

--- a/addons/httprox/common/pom.xml
+++ b/addons/httprox/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-httprox</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-httprox-common</artifactId>
   <name>Indy :: Add-Ons :: HTTProx (HTTP Proxy) :: Common Core</name>

--- a/addons/httprox/common/pom.xml
+++ b/addons/httprox/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-httprox</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-httprox-common</artifactId>
   <name>Indy :: Add-Ons :: HTTProx (HTTP Proxy) :: Common Core</name>

--- a/addons/httprox/ftests/pom.xml
+++ b/addons/httprox/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-httprox</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-httprox</artifactId>

--- a/addons/httprox/ftests/pom.xml
+++ b/addons/httprox/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-httprox</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-httprox</artifactId>

--- a/addons/httprox/jaxrs/pom.xml
+++ b/addons/httprox/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-httprox</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-httprox-jaxrs</artifactId>
   <name>Indy :: Add-Ons :: HTTProx (HTTP Proxy) :: JAX-RS Handlers</name>

--- a/addons/httprox/jaxrs/pom.xml
+++ b/addons/httprox/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-httprox</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-httprox-jaxrs</artifactId>
   <name>Indy :: Add-Ons :: HTTProx (HTTP Proxy) :: JAX-RS Handlers</name>

--- a/addons/httprox/pom.xml
+++ b/addons/httprox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-httprox</artifactId>

--- a/addons/httprox/pom.xml
+++ b/addons/httprox/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-httprox</artifactId>

--- a/addons/implied-repos/client-java/pom.xml
+++ b/addons/implied-repos/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-implied-repos</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-implied-repos-client-java</artifactId>
   <name>Indy :: Add-Ons :: Implied Repositories :: Java Client</name>

--- a/addons/implied-repos/client-java/pom.xml
+++ b/addons/implied-repos/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-implied-repos</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-implied-repos-client-java</artifactId>
   <name>Indy :: Add-Ons :: Implied Repositories :: Java Client</name>

--- a/addons/implied-repos/common/pom.xml
+++ b/addons/implied-repos/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-implied-repos</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-implied-repos-common</artifactId>
   <name>Indy :: Add-Ons :: Implied Repositories :: Common</name>

--- a/addons/implied-repos/common/pom.xml
+++ b/addons/implied-repos/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-implied-repos</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-implied-repos-common</artifactId>
   <name>Indy :: Add-Ons :: Implied Repositories :: Common</name>

--- a/addons/implied-repos/ftests/pom.xml
+++ b/addons/implied-repos/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-implied-repos</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-implied-repos</artifactId>

--- a/addons/implied-repos/ftests/pom.xml
+++ b/addons/implied-repos/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-implied-repos</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-implied-repos</artifactId>

--- a/addons/implied-repos/model-java/pom.xml
+++ b/addons/implied-repos/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-implied-repos</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-implied-repos-model-java</artifactId>
   <name>Indy :: Add-Ons :: Implied Repositories :: Java Domain Model</name>

--- a/addons/implied-repos/model-java/pom.xml
+++ b/addons/implied-repos/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-implied-repos</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-implied-repos-model-java</artifactId>
   <name>Indy :: Add-Ons :: Implied Repositories :: Java Domain Model</name>

--- a/addons/implied-repos/pom.xml
+++ b/addons/implied-repos/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-implied-repos</artifactId>
   <name>Indy :: Add-Ons :: Implied Repositories :: Parent</name>

--- a/addons/implied-repos/pom.xml
+++ b/addons/implied-repos/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-implied-repos</artifactId>
   <name>Indy :: Add-Ons :: Implied Repositories :: Parent</name>

--- a/addons/koji/client-java/pom.xml
+++ b/addons/koji/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-koji</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-koji-client-java</artifactId>
   <name>Indy :: Add-Ons :: Koji Integration :: Java Client</name>

--- a/addons/koji/client-java/pom.xml
+++ b/addons/koji/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-koji</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-koji-client-java</artifactId>
   <name>Indy :: Add-Ons :: Koji Integration :: Java Client</name>

--- a/addons/koji/common/pom.xml
+++ b/addons/koji/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-koji</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-koji-common</artifactId>
   <name>Indy :: Add-Ons :: Koji Integration :: Common</name>

--- a/addons/koji/common/pom.xml
+++ b/addons/koji/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-koji</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-koji-common</artifactId>
   <name>Indy :: Add-Ons :: Koji Integration :: Common</name>

--- a/addons/koji/jaxrs/pom.xml
+++ b/addons/koji/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-koji</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-koji-jaxrs</artifactId>

--- a/addons/koji/jaxrs/pom.xml
+++ b/addons/koji/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-koji</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-koji-jaxrs</artifactId>

--- a/addons/koji/model-java/pom.xml
+++ b/addons/koji/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-koji</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-koji-model-java</artifactId>
   <name>Indy :: Add-Ons :: Koji Integration :: Java Domain Model</name>

--- a/addons/koji/model-java/pom.xml
+++ b/addons/koji/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-koji</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-koji-model-java</artifactId>
   <name>Indy :: Add-Ons :: Koji Integration :: Java Domain Model</name>

--- a/addons/koji/pom.xml
+++ b/addons/koji/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-koji</artifactId>
   <name>Indy :: Add-Ons :: Koji Integration :: Parent</name>

--- a/addons/koji/pom.xml
+++ b/addons/koji/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-koji</artifactId>
   <name>Indy :: Add-Ons :: Koji Integration :: Parent</name>

--- a/addons/path-mapped/common/pom.xml
+++ b/addons/path-mapped/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-path-mapped</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>indy-path-mapped-common</artifactId>

--- a/addons/path-mapped/common/pom.xml
+++ b/addons/path-mapped/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-path-mapped</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
 
   <artifactId>indy-path-mapped-common</artifactId>

--- a/addons/path-mapped/jaxrs/pom.xml
+++ b/addons/path-mapped/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-path-mapped</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-path-mapped-jaxrs</artifactId>

--- a/addons/path-mapped/jaxrs/pom.xml
+++ b/addons/path-mapped/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-path-mapped</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-path-mapped-jaxrs</artifactId>

--- a/addons/path-mapped/model-java/pom.xml
+++ b/addons/path-mapped/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-path-mapped</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
 
   <artifactId>indy-path-mapped-model-java</artifactId>

--- a/addons/path-mapped/model-java/pom.xml
+++ b/addons/path-mapped/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-path-mapped</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>indy-path-mapped-model-java</artifactId>

--- a/addons/path-mapped/pom.xml
+++ b/addons/path-mapped/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-path-mapped</artifactId>
   <name>Indy :: Add-Ons :: Path Mapped :: Parent</name>

--- a/addons/path-mapped/pom.xml
+++ b/addons/path-mapped/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-path-mapped</artifactId>
   <name>Indy :: Add-Ons :: Path Mapped :: Parent</name>

--- a/addons/pkg-maven/common/pom.xml
+++ b/addons/pkg-maven/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-pkg-maven</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-maven/common/pom.xml
+++ b/addons/pkg-maven/common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-pkg-maven</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -1050,7 +1050,7 @@ public class MavenMetadataGenerator
             final Map<String, String> coordMap = new HashMap<>();
             coordMap.put( ARTIFACT_ID, info.getArtifactId() );
             coordMap.put( GROUP_ID, info.getGroupId() );
-            coordMap.put( VERSION, info.getVersion() );
+            coordMap.put( VERSION, info.getReleaseVersion() + LOCAL_SNAPSHOT_VERSION_PART );
 
             final String lastUpdated = SnapshotUtils.generateUpdateTimestamp( SnapshotUtils.getCurrentTimestamp() );
 

--- a/addons/pkg-maven/ftests/pom.xml
+++ b/addons/pkg-maven/ftests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-pkg-maven</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-maven/ftests/pom.xml
+++ b/addons/pkg-maven/ftests/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-pkg-maven</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-maven/jaxrs/pom.xml
+++ b/addons/pkg-maven/jaxrs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-pkg-maven</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-maven/jaxrs/pom.xml
+++ b/addons/pkg-maven/jaxrs/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-pkg-maven</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-maven/pom.xml
+++ b/addons/pkg-maven/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-addons</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-maven/pom.xml
+++ b/addons/pkg-maven/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-addons</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/common/pom.xml
+++ b/addons/pkg-npm/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>indy-pkg-npm</artifactId>
         <groupId>org.commonjava.indy</groupId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/common/pom.xml
+++ b/addons/pkg-npm/common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>indy-pkg-npm</artifactId>
         <groupId>org.commonjava.indy</groupId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackagePath.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackagePath.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.indy.pkg.npm.content;
 
+import java.util.Optional;
+
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 
 public class PackagePath
@@ -109,6 +111,21 @@ public class PackagePath
     public String getVersionPath()
     {
         return isScoped() ? normalize( scopedName, packageName, version ) : normalize( packageName, version );
+    }
+
+    public static Optional<PackagePath> parse( final String tarPath )
+    {
+        String[] parts = tarPath.split( "/" );
+        if ( parts.length < 3 )
+        {
+            return Optional.empty();
+        }
+        else if ( tarPath.startsWith( "@" ) && parts.length < 4 )
+        {
+            return Optional.empty();
+        }
+        PackagePath packagePath = new PackagePath( tarPath );
+        return Optional.of( packagePath );
     }
 
     @Override

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/PackagePathTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/PackagePathTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class PackagePathTest
+{
+    @Test
+    public void testNormal()
+    {
+        Optional<PackagePath> packagePath = PackagePath.parse( "jquery/-/jquery-1.2.3-redhat-1.tgz" );
+        assertTrue( packagePath.isPresent() );
+        PackagePath path = packagePath.get();
+        assertFalse( path.isScoped() );
+        assertThat( path.getPackageName(), equalTo( "jquery" ) );
+        assertThat( path.getVersionPath(), equalTo( "jquery/1.2.3-redhat-1" ) );
+        assertThat( path.getVersion(), equalTo( "1.2.3-redhat-1" ) );
+        packagePath = PackagePath.parse( "jquery/jquery-1.2.3-redhat-1.tgz" );
+        assertFalse( packagePath.isPresent() );
+    }
+
+    @Test
+    public void testScoped()
+    {
+        Optional<PackagePath> packagePath = PackagePath.parse( "@angular/core/-/core-1.2.3-redhat-1.tgz" );
+        assertTrue( packagePath.isPresent() );
+        PackagePath path = packagePath.get();
+        assertTrue( path.isScoped() );
+        assertThat( path.getPackageName(), equalTo( "core" ) );
+        assertThat( path.getScopedName(), equalTo( "@angular" ) );
+        assertThat( path.getVersionPath(), equalTo( "@angular/core/1.2.3-redhat-1" ) );
+        assertThat( path.getVersion(), equalTo( "1.2.3-redhat-1" ) );
+        packagePath = PackagePath.parse( "@angular/core/jquery-1.2.3-redhat-1.tgz" );
+        assertFalse( packagePath.isPresent() );
+    }
+}

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/PackagePathTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/PackagePathTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2020 Red Hat, Inc.
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/addons/pkg-npm/ftests/pom.xml
+++ b/addons/pkg-npm/ftests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>indy-pkg-npm</artifactId>
         <groupId>org.commonjava.indy</groupId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/ftests/pom.xml
+++ b/addons/pkg-npm/ftests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>indy-pkg-npm</artifactId>
         <groupId>org.commonjava.indy</groupId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/jaxrs/pom.xml
+++ b/addons/pkg-npm/jaxrs/pom.xml
@@ -20,7 +20,7 @@
    <parent>
     <artifactId>indy-pkg-npm</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/jaxrs/pom.xml
+++ b/addons/pkg-npm/jaxrs/pom.xml
@@ -20,7 +20,7 @@
    <parent>
     <artifactId>indy-pkg-npm</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -427,6 +427,12 @@ public class NPMContentAccessHandler
                 {
                     return null;
                 }
+                // remove scope if present
+                if ( tarball.startsWith( "@" ) && tarball.contains( "/" ) )
+                {
+                    tarball = tarball.split( "/", 2 )[1];
+                }
+
                 tarballPath = Paths.get( idnode.asText(), "-", tarball ).toString();
                 tarballContent = anode.findPath( "data" ).asText();
             }

--- a/addons/pkg-npm/model-java/pom.xml
+++ b/addons/pkg-npm/model-java/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-pkg-npm</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/model-java/pom.xml
+++ b/addons/pkg-npm/model-java/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-pkg-npm</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/pom.xml
+++ b/addons/pkg-npm/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-addons</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pkg-npm/pom.xml
+++ b/addons/pkg-npm/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-addons</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-addons</artifactId>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -49,6 +49,7 @@
     <module>sli</module>
     <module>path-mapped</module>
     <module>repo-proxy</module>
+    <module>schedule</module>
     <!-- DO NOT REMOVE: append::addon -->
   </modules>
 </project>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-addons</artifactId>

--- a/addons/promote/client-java/pom.xml
+++ b/addons/promote/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-promote-client-java</artifactId>
   <name>Indy :: Add-Ons :: Artifact Promotion :: Java Client</name>

--- a/addons/promote/client-java/pom.xml
+++ b/addons/promote/client-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-promote-client-java</artifactId>
   <name>Indy :: Add-Ons :: Artifact Promotion :: Java Client</name>

--- a/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteClientModule.java
+++ b/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteClientModule.java
@@ -53,6 +53,16 @@ public class IndyPromoteClientModule
         return result;
     }
 
+    public GroupPromoteResult promoteToGroup( final StoreKey src, final StoreKey target )
+            throws IndyClientException
+    {
+        final GroupPromoteRequest req = new GroupPromoteRequest( src, target );
+        final GroupPromoteResult
+                result = http.postWithResponse( GROUP_PROMOTE_PATH, req, GroupPromoteResult.class, HttpStatus.SC_OK );
+
+        return result;
+    }
+
     public GroupPromoteResult promoteToGroup( final GroupPromoteRequest request )
             throws IndyClientException
     {

--- a/addons/promote/common/pom.xml
+++ b/addons/promote/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-promote-common</artifactId>
   <name>Indy :: Add-Ons :: Artifact Promotion :: Common</name>

--- a/addons/promote/common/pom.xml
+++ b/addons/promote/common/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>indy-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-pkg-npm-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/addons/promote/common/pom.xml
+++ b/addons/promote/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-promote-common</artifactId>
   <name>Indy :: Add-Ons :: Artifact Promotion :: Common</name>

--- a/addons/promote/common/src/main/data/promote/rules/maven-artifact-refs-via.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/maven-artifact-refs-via.groovy
@@ -10,7 +10,7 @@ import org.commonjava.atlas.maven.ident.DependencyScope
 import org.commonjava.maven.galley.maven.rel.ModelProcessorConfig
 import org.slf4j.LoggerFactory
 
-class ArtifactRefAvailability implements ValidationRule {
+class MavenArtifactRefAvailability implements ValidationRule {
 
     String validate(ValidationRequest request) {
         def verifyStoreKeys = request.getTools().getValidationStoreKeys(request, true);

--- a/addons/promote/common/src/main/data/promote/rules/maven-no-pre-existing-paths.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/maven-no-pre-existing-paths.groovy
@@ -5,7 +5,7 @@ import org.commonjava.indy.promote.validate.PromotionValidationException
 import org.commonjava.indy.promote.validate.model.ValidationRequest
 import org.commonjava.indy.promote.validate.model.ValidationRule
 
-class NoPreExistingPaths implements ValidationRule {
+class MavenNoPreExistingPaths implements ValidationRule {
 
     String validate(ValidationRequest request) throws PromotionValidationException {
         def verifyStoreKeys = request.getTools().getValidationStoreKeys(request, false);

--- a/addons/promote/common/src/main/data/promote/rules/maven-no-snapshots.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/maven-no-snapshots.groovy
@@ -6,7 +6,7 @@ import org.commonjava.indy.promote.validate.model.ValidationRequest
 import org.commonjava.indy.promote.validate.model.ValidationRule
 import org.commonjava.maven.galley.maven.rel.ModelProcessorConfig
 
-class NoSnapshots implements ValidationRule {
+class MavenNoSnapshots implements ValidationRule {
 
     String validate(ValidationRequest request) {
         def verifyStoreKeys = request.getTools().getValidationStoreKeys(request, true)

--- a/addons/promote/common/src/main/data/promote/rules/maven-no-version-ranges.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/maven-no-version-ranges.groovy
@@ -5,7 +5,7 @@ import org.commonjava.indy.promote.validate.model.ValidationRequest
 import org.commonjava.indy.promote.validate.model.ValidationRule
 import org.commonjava.maven.galley.maven.rel.ModelProcessorConfig
 
-class NoVersionRanges implements ValidationRule {
+class MavenNoVersionRanges implements ValidationRule {
 
     String validate(ValidationRequest request) {
         def verifyStoreKeys = request.getTools().getValidationStoreKeys(request, true)

--- a/addons/promote/common/src/main/data/promote/rules/maven-parsable-pom.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/maven-parsable-pom.groovy
@@ -5,7 +5,7 @@ import org.commonjava.indy.promote.validate.model.ValidationRule
 import org.apache.commons.lang.StringUtils
 import org.slf4j.LoggerFactory
 
-class ParsablePom implements ValidationRule {
+class MavenParsablePom implements ValidationRule {
 
     String validate(ValidationRequest request) {
         def errors = Collections.synchronizedList(new ArrayList());

--- a/addons/promote/common/src/main/data/promote/rules/maven-project-artifacts.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/maven-project-artifacts.groovy
@@ -7,7 +7,7 @@ import org.apache.commons.lang.StringUtils
 import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
-class ProjectArtifacts implements ValidationRule {
+class MavenProjectArtifacts implements ValidationRule {
 
     String validate(ValidationRequest request) throws Exception {
         def classifierAndTypeSet = request.getValidationParameter("classifierAndTypeSet")

--- a/addons/promote/common/src/main/data/promote/rules/maven-project-version-pattern.groovy
+++ b/addons/promote/common/src/main/data/promote/rules/maven-project-version-pattern.groovy
@@ -5,7 +5,7 @@ import org.commonjava.indy.promote.validate.model.ValidationRequest
 import org.commonjava.indy.promote.validate.model.ValidationRule
 import org.slf4j.LoggerFactory
 
-class ProjectVersionPattern implements ValidationRule {
+class MavenProjectVersionPattern implements ValidationRule {
 
     String validate(ValidationRequest request) throws Exception {
         def versionPattern = request.getValidationParameter("versionPattern")

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang.StringUtils;
 import org.commonjava.cdi.util.weft.DrainingExecutorCompletionService;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.Locker;
+import org.commonjava.cdi.util.weft.ThreadContext;
 import org.commonjava.cdi.util.weft.WeftExecutorService;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.IndyWorkflowException;
@@ -659,7 +660,12 @@ public class PromotionManager
         List<Transfer> contents;
         if ( paths == null || paths.isEmpty() )
         {
+            // This is used to let galley ignore the NPMPathStorageCalculator handling,
+            // which will append package.json to a directory transfer and make listing not applicable.
+            ThreadContext context = ThreadContext.getContext( true );
+            context.put( RequestContextHelper.IS_RAW_VIEW, Boolean.TRUE );
             contents = downloadManager.listRecursively( source, DownloadManager.ROOT_PATH );
+            context.put( RequestContextHelper.IS_RAW_VIEW, Boolean.FALSE );
         }
         else
         {

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.promote.validate;
 
 import groovy.lang.Closure;
+import org.bouncycastle.util.Pack;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.PoolWeftExecutorService;
 import org.commonjava.cdi.util.weft.WeftExecutorService;
@@ -30,6 +31,8 @@ import org.commonjava.indy.data.ArtifactStoreQuery;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.PackageTypeConstants;
+import org.commonjava.indy.pkg.npm.content.PackagePath;
 import org.commonjava.indy.promote.conf.PromoteConfig;
 import org.commonjava.indy.promote.validate.model.ValidationRequest;
 import org.commonjava.indy.util.LocationUtils;
@@ -66,9 +69,11 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -336,6 +341,11 @@ public class PromotionValidationTools
     {
         ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
         return pathInfo == null ? null : pathInfo.getArtifact();
+    }
+
+    public Optional<PackagePath> getNPMPackagePath( final String tarPath )
+    {
+        return PackagePath.parse( tarPath );
     }
 
     public MavenMetadataView getMetadata( final ProjectRef ref, final List<? extends Location> locations )

--- a/addons/promote/ftests/pom.xml
+++ b/addons/promote/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-promote</artifactId>

--- a/addons/promote/ftests/pom.xml
+++ b/addons/promote/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-promote</artifactId>

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/AbstractValidationRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/AbstractValidationRuleTest.java
@@ -24,6 +24,7 @@ import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.PackageTypeConstants;
 import org.commonjava.indy.promote.client.IndyPromoteClientModule;
 import org.commonjava.indy.promote.model.ValidationRuleSet;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
@@ -62,7 +63,7 @@ public abstract class AbstractValidationRuleTest<T extends ArtifactStore> extend
 
         module = client.module( IndyPromoteClientModule.class );
 
-        HostedRepository shr = new HostedRepository( "source" );
+        HostedRepository shr = new HostedRepository( getPackageType(), "source" );
         shr.setAllowSnapshots( true );
 
         System.out.println("Validation rule test client:"+ client);
@@ -70,11 +71,13 @@ public abstract class AbstractValidationRuleTest<T extends ArtifactStore> extend
         source = client.stores().create( shr, "creating test source", HostedRepository.class );
         if ( Group.class.equals( targetCls ) )
         {
-            target = (T) client.stores().create( new Group( TARGET_NAME ), "creating test target", Group.class );
+            target = (T) client.stores()
+                               .create( new Group( getPackageType(), TARGET_NAME ), "creating test target",
+                                        Group.class );
         }
         else if ( HostedRepository.class.equals( targetCls ) )
         {
-            HostedRepository hr = new HostedRepository( TARGET_NAME );
+            HostedRepository hr = new HostedRepository( getPackageType(), TARGET_NAME );
             hr.setAllowSnapshots( true );
 
             target = (T) client.stores().create( hr, "creating test target", HostedRepository.class );
@@ -178,5 +181,10 @@ public abstract class AbstractValidationRuleTest<T extends ArtifactStore> extend
     {
         super.initTestConfig( fixture );
         writeConfigFile( "conf.d/threadpools.conf", "[threadpools]\nenabled=true" );
+    }
+
+    protected String getPackageType(){
+        //default is maven
+        return PackageTypeConstants.PKG_TYPE_MAVEN;
     }
 }

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_DependencyInAnotherRepoInGroup_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_DependencyInAnotherRepoInGroup_RuleTest.java
@@ -46,7 +46,7 @@ public class ArtifactRefs_DependencyInAnotherRepoInGroup_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "artifact-refs-via.groovy";
+    private static final String RULE = "maven-artifact-refs-via.groovy";
 
     private static final String PREFIX = "artifact-refs-via/";
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_DependencyTwoExtraGroups_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_DependencyTwoExtraGroups_RuleTest.java
@@ -45,7 +45,7 @@ public class ArtifactRefs_DependencyTwoExtraGroups_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "artifact-refs-via.groovy";
+    private static final String RULE = "maven-artifact-refs-via.groovy";
 
     private static final String PREFIX = "artifact-refs-via/";
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_PromoteWithParent_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ArtifactRefs_PromoteWithParent_RuleTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 public class ArtifactRefs_PromoteWithParent_RuleTest
     extends AbstractValidationRuleTest<HostedRepository>
 {
-    private static final String RULE = "artifact-refs-via.groovy";
+    private static final String RULE = "maven-artifact-refs-via.groovy";
 
     private static final String PREFIX = "artifact-refs-via/";
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/FullRuleStack_GroupWithOneOfTwoHosts_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/FullRuleStack_GroupWithOneOfTwoHosts_RuleTest.java
@@ -66,19 +66,19 @@ public class FullRuleStack_GroupWithOneOfTwoHosts_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "no-pre-existing-paths.groovy";
+    private static final String RULE = "maven-no-pre-existing-paths.groovy";
 
     private static final String PREFIX = "no-pre-existing-paths/";
 
     /* @formatter:off */
     private static final String[] RULES = {
-        "parsable-pom.groovy",
-        "artifact-refs-via.groovy",
-        "no-pre-existing-paths.groovy",
-        "no-snapshots.groovy",
-        "no-version-ranges.groovy",
-        "project-version-pattern.groovy",
-        "project-artifacts.groovy"
+        "maven-parsable-pom.groovy",
+        "maven-artifact-refs-via.groovy",
+        "maven-no-pre-existing-paths.groovy",
+        "maven-no-snapshots.groovy",
+        "maven-no-version-ranges.groovy",
+        "maven-project-version-pattern.groovy",
+        "maven-project-artifacts.groovy"
     };
     /* @formatter:on */
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoPreExistingPaths_GroupWithOneOfTwoHosts_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoPreExistingPaths_GroupWithOneOfTwoHosts_RuleTest.java
@@ -59,7 +59,7 @@ public class NoPreExistingPaths_GroupWithOneOfTwoHosts_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "no-pre-existing-paths.groovy";
+    private static final String RULE = "maven-no-pre-existing-paths.groovy";
 
     private static final String PREFIX = "no-pre-existing-paths/";
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoPreExistingPaths_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoPreExistingPaths_RuleTest.java
@@ -42,7 +42,7 @@ public class NoPreExistingPaths_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "no-pre-existing-paths.groovy";
+    private static final String RULE = "maven-no-pre-existing-paths.groovy";
 
     private static final String PREFIX = "no-pre-existing-paths/";
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_DependencyVersion_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_DependencyVersion_RuleTest.java
@@ -37,7 +37,7 @@ public class NoSnapshots_DependencyVersion_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "no-snapshots.groovy";
+    private static final String RULE = "maven-no-snapshots.groovy";
 
     @Test
     @Category( EventDependent.class )

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_PluginVersion_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_PluginVersion_RuleTest.java
@@ -37,7 +37,7 @@ public class NoSnapshots_PluginVersion_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "no-snapshots.groovy";
+    private static final String RULE = "maven-no-snapshots.groovy";
 
     @Test
     @Category( EventDependent.class )

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_ProjectVersion_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoSnapshots_ProjectVersion_RuleTest.java
@@ -37,7 +37,7 @@ public class NoSnapshots_ProjectVersion_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "no-snapshots.groovy";
+    private static final String RULE = "maven-no-snapshots.groovy";
 
     @Test
     @Category( EventDependent.class )

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoVersionRanges_DependencyVersion_RuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/NoVersionRanges_DependencyVersion_RuleTest.java
@@ -37,7 +37,7 @@ public class NoVersionRanges_DependencyVersion_RuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "no-version-ranges.groovy";
+    private static final String RULE = "maven-no-version-ranges.groovy";
 
     @Test
     @Category( EventDependent.class )

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ParsablePomRuleByPathTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ParsablePomRuleByPathTest.java
@@ -36,7 +36,7 @@ public class ParsablePomRuleByPathTest
                 extends AbstractValidationRuleTest<HostedRepository>
 {
 
-    private static final String RULE = "parsable-pom.groovy";
+    private static final String RULE = "maven-parsable-pom.groovy";
 
     @Test
     @Category( EventDependent.class )

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ParsablePomRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ParsablePomRuleTest.java
@@ -37,7 +37,7 @@ public class ParsablePomRuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "parsable-pom.groovy";
+    private static final String RULE = "maven-parsable-pom.groovy";
 
     @Test
     @Category( EventDependent.class )

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRuleTest.java
@@ -39,7 +39,7 @@ public class ProjectArtifactsRuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "project-artifacts.groovy";
+    private static final String RULE = "maven-project-artifacts.groovy";
 
     private static final String CONTENT = "this is some content";
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRule_PomDeploymentTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectArtifactsRule_PomDeploymentTest.java
@@ -40,7 +40,7 @@ public class ProjectArtifactsRule_PomDeploymentTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "project-artifacts.groovy";
+    private static final String RULE = "maven-project-artifacts.groovy";
 
     private static final String CONTENT = "this is some content";
 

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectVersionPatternRuleForTempBuildTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectVersionPatternRuleForTempBuildTest.java
@@ -57,7 +57,7 @@ public class ProjectVersionPatternRuleForTempBuildTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "project-version-pattern.groovy";
+    private static final String RULE = "maven-project-version-pattern.groovy";
 
     @Test
     @Category( EventDependent.class )

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectVersionPatternRuleTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/rule/ProjectVersionPatternRuleTest.java
@@ -39,7 +39,7 @@ public class ProjectVersionPatternRuleTest
         extends AbstractValidationRuleTest<Group>
 {
 
-    private static final String RULE = "project-version-pattern.groovy";
+    private static final String RULE = "maven-project-version-pattern.groovy";
 
     @Test
     @Category( EventDependent.class )

--- a/addons/promote/jaxrs/pom.xml
+++ b/addons/promote/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-promote-jaxrs</artifactId>

--- a/addons/promote/jaxrs/pom.xml
+++ b/addons/promote/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-promote-jaxrs</artifactId>

--- a/addons/promote/model-java/pom.xml
+++ b/addons/promote/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-promote-model-java</artifactId>
   <name>Indy :: Add-Ons :: Artifact Promotion :: Java Domain Model</name>

--- a/addons/promote/model-java/pom.xml
+++ b/addons/promote/model-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-promote</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-promote-model-java</artifactId>
   <name>Indy :: Add-Ons :: Artifact Promotion :: Java Domain Model</name>

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/GroupPromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/GroupPromoteRequest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.annotations.ApiModelProperty;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.PackageTypeConstants;
 
 /**
  * Configuration for promoting artifacts from one store to another (denoted by their corresponding {@link StoreKey}'s). If paths are provided, only
@@ -31,11 +32,15 @@ public class GroupPromoteRequest
                 extends AbstractPromoteRequest<GroupPromoteRequest>
 {
 
-    @ApiModelProperty( value="Indy store/repository key to promote FROM (formatted as: '{remote,hosted,group}:name')", required=true )
+    @ApiModelProperty( value="Indy store/repository key to promote FROM (formatted as: '{maven, npm}:{remote,hosted,group}:name')", required=true )
     private StoreKey source;
 
-    @ApiModelProperty( value="Name of the Indy target group to promote TO (MUST be pre-existing)", required=true )
+    @Deprecated
+    @ApiModelProperty( value="Name of the Indy target group to promote TO (MUST be pre-existing)" )
     private String targetGroup;
+
+    @ApiModelProperty( value="Indy store/repository key to promote TO (formatted as: '{maven, npm}:{hosted,group}:name')" )
+    private StoreKey target;
 
     @ApiModelProperty( value="Run validations, verify source and target locations ONLY, do not modify anything!" )
     private boolean dryRun;
@@ -44,10 +49,18 @@ public class GroupPromoteRequest
     {
     }
 
+    @Deprecated
     public GroupPromoteRequest( final StoreKey source, final String targetGroup )
     {
         this.source = source;
         this.targetGroup = targetGroup;
+        this.target = new StoreKey( PackageTypeConstants.PKG_TYPE_MAVEN, StoreType.group, targetGroup );
+    }
+
+    public GroupPromoteRequest( final StoreKey source, final StoreKey target )
+    {
+        this.source = source;
+        this.target = target;
     }
 
     public StoreKey getSource()
@@ -65,17 +78,22 @@ public class GroupPromoteRequest
     @JsonIgnore
     public StoreKey getTargetKey()
     {
-        return new StoreKey( StoreType.group, getTargetGroup() );
+        return target != null ?
+                target :
+                new StoreKey( PackageTypeConstants.PKG_TYPE_MAVEN, StoreType.group, getTargetGroup() );
     }
 
+    @Deprecated
     public String getTargetGroup()
     {
         return targetGroup;
     }
 
+    @Deprecated
     public GroupPromoteRequest setTargetGroup( final String targetGroup )
     {
         this.targetGroup = targetGroup;
+        this.target = StoreKey.fromString( "maven:group:" + targetGroup );
         return this;
     }
 
@@ -87,6 +105,17 @@ public class GroupPromoteRequest
     public GroupPromoteRequest setDryRun( final boolean dryRun )
     {
         this.dryRun = dryRun;
+        return this;
+    }
+
+    public StoreKey getTarget()
+    {
+        return target;
+    }
+
+    public GroupPromoteRequest setTarget( StoreKey target )
+    {
+        this.target = target;
         return this;
     }
 

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PathsPromoteRequest.java
@@ -109,7 +109,7 @@ public class PathsPromoteRequest
 
     public Set<String> getPaths()
     {
-        return paths == null ? Collections.<String> emptySet() : paths;
+        return paths == null ? Collections.emptySet() : paths;
     }
 
     public PathsPromoteRequest setPaths( final Set<String> paths )

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PromoteRequest.java
@@ -20,17 +20,17 @@ import org.commonjava.indy.model.core.StoreKey;
 /**
  * Created by jdcasey on 9/11/15.
  */
-public interface PromoteRequest<T extends PromoteRequest<T>>
+public interface PromoteRequest
 {
     StoreKey getSource();
 
-    T setSource( StoreKey source );
+    PromoteRequest setSource( StoreKey source );
 
     StoreKey getTargetKey();
 
     boolean isDryRun();
 
-    T setDryRun( boolean dryRun );
+    PromoteRequest setDryRun( boolean dryRun );
 
     boolean isFireEvents();
 

--- a/addons/promote/pom.xml
+++ b/addons/promote/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-promote</artifactId>
   <name>Indy :: Add-Ons :: Artifact Promotion :: Parent</name>

--- a/addons/promote/pom.xml
+++ b/addons/promote/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-promote</artifactId>
   <name>Indy :: Add-Ons :: Artifact Promotion :: Parent</name>

--- a/addons/repo-proxy/common/pom.xml
+++ b/addons/repo-proxy/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-repo-proxy-common</artifactId>
   <name>Indy :: Add-Ons :: Repository-Proxy :: Common</name>

--- a/addons/repo-proxy/common/pom.xml
+++ b/addons/repo-proxy/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-repo-proxy-common</artifactId>
   <name>Indy :: Add-Ons :: Repository-Proxy :: Common</name>

--- a/addons/repo-proxy/ftests/pom.xml
+++ b/addons/repo-proxy/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-repo-proxy</artifactId>

--- a/addons/repo-proxy/ftests/pom.xml
+++ b/addons/repo-proxy/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-repo-proxy</artifactId>

--- a/addons/repo-proxy/jaxrs/pom.xml
+++ b/addons/repo-proxy/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-repo-proxy-jaxrs</artifactId>

--- a/addons/repo-proxy/jaxrs/pom.xml
+++ b/addons/repo-proxy/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-repo-proxy</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-repo-proxy-jaxrs</artifactId>

--- a/addons/repo-proxy/pom.xml
+++ b/addons/repo-proxy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-repo-proxy</artifactId>
   <name>Indy :: Add-Ons :: Repository-Proxy :: Parent</name>

--- a/addons/repo-proxy/pom.xml
+++ b/addons/repo-proxy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-repo-proxy</artifactId>
   <name>Indy :: Add-Ons :: Repository-Proxy :: Parent</name>

--- a/addons/revisions/common/pom.xml
+++ b/addons/revisions/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-revisions</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-revisions-common</artifactId>
   <name>Indy :: Add-Ons :: Revisions :: Common</name>

--- a/addons/revisions/common/pom.xml
+++ b/addons/revisions/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-revisions</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-revisions-common</artifactId>
   <name>Indy :: Add-Ons :: Revisions :: Common</name>

--- a/addons/revisions/jaxrs/pom.xml
+++ b/addons/revisions/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-revisions</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-revisions-jaxrs</artifactId>

--- a/addons/revisions/jaxrs/pom.xml
+++ b/addons/revisions/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-revisions</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-revisions-jaxrs</artifactId>

--- a/addons/revisions/pom.xml
+++ b/addons/revisions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-revisions</artifactId>
   <name>Indy :: Add-Ons :: Revisions :: Parent</name>

--- a/addons/revisions/pom.xml
+++ b/addons/revisions/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-revisions</artifactId>
   <name>Indy :: Add-Ons :: Revisions :: Parent</name>

--- a/addons/schedule/common/pom.xml
+++ b/addons/schedule/common/pom.xml
@@ -9,11 +9,15 @@
         <version>2.5.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>indy-schedule-model-java</artifactId>
-    <name>Indy :: Add-Ons :: Schedule :: Java Domain Model</name>
+    <artifactId>indy-schedule-common</artifactId>
+    <name>Indy :: Add-Ons :: Schedule :: Common</name>
 
     <dependencies>
-        <!--Datastax Java Driver-->
+        <dependency>
+            <groupId>org.commonjava.indy</groupId>
+            <artifactId>indy-schedule-model-java</artifactId>
+            <version>2.5.0-SNAPSHOT</version>
+        </dependency>
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
@@ -24,6 +28,17 @@
             <artifactId>cassandra-driver-mapping</artifactId>
             <version>${datastaxVersion}</version>
         </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <version>${cassandraUnitVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.commonjava.indy</groupId>
+            <artifactId>indy-subsys-cassandra</artifactId>
+        </dependency>
     </dependencies>
+
 
 </project>

--- a/addons/schedule/common/src/main/conf/conf.d/schedule.conf
+++ b/addons/schedule/common/src/main/conf/conf.d/schedule.conf
@@ -1,0 +1,3 @@
+[schedule]
+schedule.keyspace=schedule
+schedule.keyspace.replica=3

--- a/addons/schedule/common/src/main/java/org/commonjava/indy/schedule/ScheduleDB.java
+++ b/addons/schedule/common/src/main/java/org/commonjava/indy/schedule/ScheduleDB.java
@@ -1,4 +1,4 @@
-package org.commonjava.indy.schedule.datastax;
+package org.commonjava.indy.schedule;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.PreparedStatement;
@@ -6,6 +6,7 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
+import org.commonjava.indy.schedule.conf.ScheduleDBConfig;
 import org.commonjava.indy.schedule.datastax.model.DtxSchedule;
 import org.commonjava.indy.subsys.cassandra.CassandraClient;
 import org.slf4j.Logger;
@@ -18,10 +19,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-
-import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
-import static com.datastax.driver.core.querybuilder.QueryBuilder.ttl;
 
 @ApplicationScoped
 public class ScheduleDB

--- a/addons/schedule/common/src/main/java/org/commonjava/indy/schedule/ScheduleDBUtil.java
+++ b/addons/schedule/common/src/main/java/org/commonjava/indy/schedule/ScheduleDBUtil.java
@@ -1,4 +1,6 @@
-package org.commonjava.indy.schedule.datastax;
+package org.commonjava.indy.schedule;
+
+import org.commonjava.indy.schedule.conf.ScheduleDBConfig;
 
 public class ScheduleDBUtil
 {

--- a/addons/schedule/common/src/main/java/org/commonjava/indy/schedule/conf/ScheduleDBConfig.java
+++ b/addons/schedule/common/src/main/java/org/commonjava/indy/schedule/conf/ScheduleDBConfig.java
@@ -1,4 +1,4 @@
-package org.commonjava.indy.schedule.datastax;
+package org.commonjava.indy.schedule.conf;
 
 import org.commonjava.indy.conf.IndyConfigInfo;
 import org.commonjava.indy.conf.SystemPropertyProvider;

--- a/addons/schedule/common/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
+++ b/addons/schedule/common/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
@@ -1,19 +1,18 @@
 package org.commonjava.indy.schedule;
 
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.commonjava.indy.schedule.conf.ScheduleDBConfig;
 import org.commonjava.indy.schedule.datastax.JobType;
-import org.commonjava.indy.schedule.datastax.ScheduleDB;
-import org.commonjava.indy.schedule.datastax.ScheduleDBConfig;
 import org.commonjava.indy.schedule.datastax.model.DtxSchedule;
 import org.commonjava.indy.subsys.cassandra.CassandraClient;
 import org.commonjava.indy.subsys.cassandra.config.CassandraConfig;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collection;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 public class ScheduleTest
@@ -57,10 +56,10 @@ public class ScheduleTest
 
         Collection<DtxSchedule> schedules = scheduleDB.queryExpiredSchedule();
 
-        assertThat( schedules.size(), equalTo( 1 ) );
+        assertThat( schedules.size(), Matchers.equalTo( 1 ) );
 
         schedules.forEach( schedule -> {
-            assertThat(schedule.getExpired(), equalTo(true));
+            assertThat( schedule.getExpired(), Matchers.equalTo( true));
         } );
     }
 

--- a/addons/schedule/model-java/pom.xml
+++ b/addons/schedule/model-java/pom.xml
@@ -29,6 +29,10 @@
             <version>${cassandraUnitVersion}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.commonjava.indy</groupId>
+            <artifactId>indy-subsys-cassandra</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/addons/schedule/model-java/pom.xml
+++ b/addons/schedule/model-java/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>schedule</artifactId>
+        <groupId>org.commonjava.indy</groupId>
+        <version>2.4.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>model-java</artifactId>
+
+    <dependencies>
+        <!--Datastax Java Driver-->
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${datastaxVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-mapping</artifactId>
+            <version>${datastaxVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <version>${cassandraUnitVersion}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/JobType.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/JobType.java
@@ -1,0 +1,21 @@
+package org.commonjava.indy.schedule.datastax;
+
+public enum JobType
+{
+
+    CONTENT ("CONTENT"),
+    DisabledTIMEOUT ("Diabled-timeout");
+
+    private final String jobType;
+
+    private JobType( String jobType )
+    {
+        this.jobType = jobType;
+    }
+
+    public String getJobType()
+    {
+        return this.jobType;
+    }
+
+}

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDB.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDB.java
@@ -47,9 +47,9 @@ public class ScheduleDB
 
     private PreparedStatement preparedExpiredUpdate;
 
-    public ScheduleDB( CassandraClient client, String keyspace )
+    public ScheduleDB( ScheduleDBConfig config, CassandraClient client )
     {
-        this.config = new ScheduleDBConfig( keyspace );
+        this.config = config;
         this.client = client;
         init();
     }
@@ -62,7 +62,7 @@ public class ScheduleDB
 
         session = client.getSession( keyspace );
 
-        session.execute( ScheduleDBUtil.getSchemaCreateKeyspace( keyspace ) );
+        session.execute( ScheduleDBUtil.getSchemaCreateKeyspace( config, keyspace ) );
         session.execute( ScheduleDBUtil.getSchemaCreateTableSchedule( keyspace ) );
         session.execute( ScheduleDBUtil.getSchemaCreateTypeIndex4Schedule( keyspace ) );
 
@@ -70,9 +70,9 @@ public class ScheduleDB
 
         expirationMapper = manager.mapper( DtxSchedule.class, keyspace );
 
-        preparedTTLExpiredQuery = session.prepare( "SELECT storekey, jobtype, jobname, scheduletime, lifespan, expired, ttl(ttl) as ttl FROM " + keyspace + ".schedule WHERE expired = false ALLOW FILTERING" );
+        preparedTTLExpiredQuery = session.prepare( "SELECT storekey, jobtype, jobname, scheduletime, lifespan, expired, ttl(ttl) as ttl FROM " + keyspace + "." + ScheduleDBUtil.TABLE_SCHEDULE + " WHERE expired = false ALLOW FILTERING" );
 
-        preparedExpiredQuery = session.prepare( "SELECT storekey, jobtype, jobname, scheduletime, lifespan, expired FROM " + keyspace + ".schedule WHERE expired = true ALLOW FILTERING" );
+        preparedExpiredQuery = session.prepare( "SELECT storekey, jobtype, jobname, scheduletime, lifespan, expired FROM " + keyspace + "." + ScheduleDBUtil.TABLE_SCHEDULE + " WHERE expired = true ALLOW FILTERING" );
 
         preparedTTLSetting = session.prepare( "UPDATE " + keyspace +  "." + ScheduleDBUtil.TABLE_SCHEDULE + " USING TTL ? SET ttl=? WHERE storekey = ? and  jobname = ?" );
 

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDB.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDB.java
@@ -1,0 +1,134 @@
+package org.commonjava.indy.schedule.datastax;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.mapping.Mapper;
+import com.datastax.driver.mapping.MappingManager;
+import org.commonjava.indy.schedule.datastax.model.DtxSchedule;
+import org.commonjava.indy.subsys.cassandra.CassandraClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import static com.datastax.driver.core.querybuilder.QueryBuilder.eq;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.set;
+import static com.datastax.driver.core.querybuilder.QueryBuilder.ttl;
+
+@ApplicationScoped
+public class ScheduleDB
+{
+
+    @Inject
+    CassandraClient client;
+
+    @Inject
+    ScheduleDBConfig config;
+
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
+    private Session session;
+
+    private Mapper<DtxSchedule> expirationMapper;
+
+    private PreparedStatement preparedTTLExpiredQuery;
+
+    private PreparedStatement preparedExpiredQuery;
+
+    private PreparedStatement preparedTTLSetting;
+
+    private PreparedStatement preparedExpiredUpdate;
+
+    public ScheduleDB( CassandraClient client, String keyspace )
+    {
+        this.config = new ScheduleDBConfig( keyspace );
+        this.client = client;
+        init();
+    }
+
+    @PostConstruct
+    public void init()
+    {
+
+        String keyspace = config.getScheduleKeyspace();
+
+        session = client.getSession( keyspace );
+
+        session.execute( ScheduleDBUtil.getSchemaCreateKeyspace( keyspace ) );
+        session.execute( ScheduleDBUtil.getSchemaCreateTableSchedule( keyspace ) );
+        session.execute( ScheduleDBUtil.getSchemaCreateTypeIndex4Schedule( keyspace ) );
+
+        MappingManager manager = new MappingManager( session );
+
+        expirationMapper = manager.mapper( DtxSchedule.class, keyspace );
+
+        preparedTTLExpiredQuery = session.prepare( "SELECT storekey, jobtype, jobname, scheduletime, lifespan, expired, ttl(ttl) as ttl FROM " + keyspace + ".schedule WHERE expired = false ALLOW FILTERING" );
+
+        preparedExpiredQuery = session.prepare( "SELECT storekey, jobtype, jobname, scheduletime, lifespan, expired FROM " + keyspace + ".schedule WHERE expired = true ALLOW FILTERING" );
+
+        preparedTTLSetting = session.prepare( "UPDATE " + keyspace +  "." + ScheduleDBUtil.TABLE_SCHEDULE + " USING TTL ? SET ttl=? WHERE storekey = ? and  jobname = ?" );
+
+        preparedExpiredUpdate = session.prepare( "UPDATE " + keyspace + "." + ScheduleDBUtil.TABLE_SCHEDULE + " SET expired = true WHERE  storekey = ? and  jobname = ?"  );
+    }
+
+
+
+    public void createSchedule( String storeKey, String jobType, String jobName, Long timeout )
+    {
+
+        DtxSchedule schedule = new DtxSchedule( storeKey, jobType, jobName, new Date(), timeout );
+        schedule.setExpired( Boolean.FALSE );
+
+        expirationMapper.save( schedule );
+
+        BoundStatement bound = preparedTTLSetting.bind( schedule.getLifespan().intValue(), schedule.getLifespan(), schedule.getStoreKey(), schedule.getJobName() );
+        session.execute( bound );
+    }
+
+    public Collection<DtxSchedule> queryExpiredSchedule()
+    {
+        BoundStatement bound = preparedExpiredQuery.bind();
+        ResultSet resultSet = session.execute( bound );
+
+        List<DtxSchedule> schedules = new ArrayList<>(  );
+
+        resultSet.forEach( row -> {
+            if ( row != null && row.getBool( "expired" ) )
+            {
+                DtxSchedule schedule = new DtxSchedule(  );
+                schedule.setJobType( row.getString( "jobType" ) );
+                schedule.setJobName( row.getString( "jobName" ) );
+                schedule.setExpired( row.getBool( "expired" ) );
+
+                schedules.add( schedule );
+            }
+        } );
+
+        return schedules;
+    }
+
+    public void queryTTLAndSetExpiredSchedule()
+    {
+        BoundStatement bound = preparedTTLExpiredQuery.bind();
+        ResultSet resultSet = session.execute( bound );
+        resultSet.forEach( row -> {
+            if ( row != null && row.getInt( "ttl" ) == 0 )
+            {
+                BoundStatement boundU =
+                                preparedExpiredUpdate.bind( row.getString( "storekey" ), row.getString( "jobname" ) );
+                session.execute( boundU );
+
+                logger.info( "Expired entry: {}", row );
+            }
+        } );
+    }
+
+}

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBConfig.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBConfig.java
@@ -16,9 +16,12 @@ public class ScheduleDBConfig implements IndyConfigInfo, SystemPropertyProvider
 
     private String scheduleKeyspace;
 
-    public ScheduleDBConfig( String keyspace )
+    private Integer replicationFactor;
+
+    public ScheduleDBConfig( String keyspace, Integer replicationFactor )
     {
         this.scheduleKeyspace = keyspace;
+        this.replicationFactor = replicationFactor;
     }
 
     public String getScheduleKeyspace()
@@ -30,6 +33,17 @@ public class ScheduleDBConfig implements IndyConfigInfo, SystemPropertyProvider
     public void setScheduleKeyspace( String scheduleKeyspace )
     {
         this.scheduleKeyspace = scheduleKeyspace;
+    }
+
+    public Integer getReplicationFactor()
+    {
+        return replicationFactor;
+    }
+
+    @ConfigName( "schedule.keyspace.replica" )
+    public void setReplicationFactor( Integer replicationFactor )
+    {
+        this.replicationFactor = replicationFactor;
     }
 
     @Override

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBConfig.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBConfig.java
@@ -1,0 +1,52 @@
+package org.commonjava.indy.schedule.datastax;
+
+import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.indy.conf.SystemPropertyProvider;
+import org.commonjava.propulsor.config.annotation.ConfigName;
+import org.commonjava.propulsor.config.annotation.SectionName;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.InputStream;
+import java.util.Properties;
+
+@SectionName( "schedule" )
+@ApplicationScoped
+public class ScheduleDBConfig implements IndyConfigInfo, SystemPropertyProvider
+{
+
+    private String scheduleKeyspace;
+
+    public ScheduleDBConfig( String keyspace )
+    {
+        this.scheduleKeyspace = keyspace;
+    }
+
+    public String getScheduleKeyspace()
+    {
+        return scheduleKeyspace;
+    }
+
+    @ConfigName( "schedule.keyspace" )
+    public void setScheduleKeyspace( String scheduleKeyspace )
+    {
+        this.scheduleKeyspace = scheduleKeyspace;
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return null;
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return null;
+    }
+
+    @Override
+    public Properties getSystemPropertyAdditions()
+    {
+        return null;
+    }
+}

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
@@ -5,6 +5,12 @@ public class ScheduleDBUtil
 
     public static final String TABLE_SCHEDULE = "schedule";
 
+    public static String getSchemaCreateKeyspace( String keyspace )
+    {
+        return "CREATE KEYSPACE IF NOT EXISTS " + keyspace
+                        + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1};";
+    }
+
     public static String getSchemaCreateTableSchedule( String keyspace )
     {
         return "CREATE TABLE IF NOT EXISTS " + keyspace + "." + TABLE_SCHEDULE + " ("
@@ -13,7 +19,8 @@ public class ScheduleDBUtil
                         + "storekey varchar,"
                         + "scheduletime timestamp,"
                         + "lifespan bigint,"
-                        + "expiration varchar,"
+                        + "expired boolean,"
+                        + "ttl bigint,"
                         + "PRIMARY KEY (storekey, jobname)"
                         + ");";
     }

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
@@ -3,9 +3,11 @@ package org.commonjava.indy.schedule.datastax;
 public class ScheduleDBUtil
 {
 
+    public static final String TABLE_SCHEDULE = "schedule";
+
     public static String getSchemaCreateTableSchedule( String keyspace )
     {
-        return "CREATE TABLE IF NOT EXISTS " + keyspace + ".schedule ("
+        return "CREATE TABLE IF NOT EXISTS " + keyspace + "." + TABLE_SCHEDULE + " ("
                         + "jobtype varchar,"
                         + "jobname varchar,"
                         + "storekey varchar,"
@@ -14,6 +16,11 @@ public class ScheduleDBUtil
                         + "expiration varchar,"
                         + "PRIMARY KEY (storekey, jobname)"
                         + ");";
+    }
+
+    public static String getSchemaCreateTypeIndex4Schedule( String keyspace )
+    {
+        return "CREATE INDEX IF NOT EXISTS type_idx on " + keyspace + "." + TABLE_SCHEDULE + " (jobtype)";
     }
 
 }

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
@@ -1,0 +1,19 @@
+package org.commonjava.indy.schedule.datastax;
+
+public class ScheduleDBUtil
+{
+
+    public static String getSchemaCreateTableSchedule( String keyspace )
+    {
+        return "CREATE TABLE IF NOT EXISTS " + keyspace + ".schedule ("
+                        + "jobtype varchar,"
+                        + "jobname varchar,"
+                        + "storekey varchar,"
+                        + "scheduletime timestamp,"
+                        + "lifescan bigint,"
+                        + "expiration varchar,"
+                        + "PRIMARY KEY (storekey, jobname)"
+                        + ");";
+    }
+
+}

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
@@ -5,10 +5,11 @@ public class ScheduleDBUtil
 
     public static final String TABLE_SCHEDULE = "schedule";
 
-    public static String getSchemaCreateKeyspace( String keyspace )
+    public static String getSchemaCreateKeyspace( ScheduleDBConfig config, String keyspace )
     {
         return "CREATE KEYSPACE IF NOT EXISTS " + keyspace
-                        + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':1};";
+                        + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':"
+                        + config.getReplicationFactor() + "};";
     }
 
     public static String getSchemaCreateTableSchedule( String keyspace )

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/ScheduleDBUtil.java
@@ -12,7 +12,7 @@ public class ScheduleDBUtil
                         + "jobname varchar,"
                         + "storekey varchar,"
                         + "scheduletime timestamp,"
-                        + "lifescan bigint,"
+                        + "lifespan bigint,"
                         + "expiration varchar,"
                         + "PRIMARY KEY (storekey, jobname)"
                         + ");";

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/model/DtxSchedule.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/model/DtxSchedule.java
@@ -1,0 +1,124 @@
+package org.commonjava.indy.schedule.datastax.model;
+
+import com.datastax.driver.mapping.annotations.ClusteringColumn;
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+
+import java.util.Date;
+import java.util.Objects;
+
+@Table( name = "schedule", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+public class DtxSchedule
+{
+
+    @PartitionKey
+    private String storeKey;
+
+    @ClusteringColumn
+    private String jobName;
+
+    @Column
+    private String jobType;
+
+    @Column
+    private Date scheduleTime;
+
+    @Column
+    private Long lifescan;
+
+    @Column
+    private String expiration;
+
+    public DtxSchedule() {}
+
+    public DtxSchedule( String jobType, String jobName, String storeKey, Date scheduleTime,
+                        Long lifescan, String expiration )
+    {
+        this.jobType = jobType;
+        this.jobName = jobName;
+        this.storeKey = storeKey;
+        this.scheduleTime = scheduleTime;
+        this.lifescan = lifescan;
+        this.expiration = expiration;
+    }
+
+    public String getJobType()
+    {
+        return jobType;
+    }
+
+    public void setJobType( String jobType )
+    {
+        this.jobType = jobType;
+    }
+
+    public String getJobName()
+    {
+        return jobName;
+    }
+
+    public void setJobName( String jobName )
+    {
+        this.jobName = jobName;
+    }
+
+    public String getStoreKey()
+    {
+        return storeKey;
+    }
+
+    public void setStoreKey( String storeKey )
+    {
+        this.storeKey = storeKey;
+    }
+
+    public Date getScheduleTime()
+    {
+        return scheduleTime;
+    }
+
+    public void setScheduleTime( Date scheduleTime )
+    {
+        this.scheduleTime = scheduleTime;
+    }
+
+    public Long getLifescan()
+    {
+        return lifescan;
+    }
+
+    public void setLifescan( Long lifescan )
+    {
+        this.lifescan = lifescan;
+    }
+
+    public String getExpiration()
+    {
+        return expiration;
+    }
+
+    public void setExpiration( String expiration )
+    {
+        this.expiration = expiration;
+    }
+
+    @Override
+    public boolean equals( Object o )
+    {
+        if ( this == o )
+            return true;
+        if ( o == null || getClass() != o.getClass() )
+            return false;
+        DtxSchedule that = (DtxSchedule) o;
+        return storeKey.equals( that.storeKey ) && jobName.equals( that.jobName ) && jobType.equals( that.jobType )
+                        && scheduleTime.equals( that.scheduleTime ) && lifescan.equals( that.lifescan )
+                        && expiration.equals( that.expiration );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( storeKey, jobName, jobType, scheduleTime, lifescan, expiration );
+    }
+}

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/model/DtxSchedule.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/model/DtxSchedule.java
@@ -28,19 +28,21 @@ public class DtxSchedule
     private Long lifespan;
 
     @Column
-    private String expiration;
+    private Boolean expired;
+
+    @Column
+    private Long ttl;
 
     public DtxSchedule() {}
 
-    public DtxSchedule( String jobType, String jobName, String storeKey, Date scheduleTime,
-                        Long lifespan, String expiration )
+    public DtxSchedule( String storeKey, String jobType, String jobName, Date scheduleTime,
+                        Long lifespan )
     {
         this.jobType = jobType;
         this.jobName = jobName;
         this.storeKey = storeKey;
         this.scheduleTime = scheduleTime;
         this.lifespan = lifespan;
-        this.expiration = expiration;
     }
 
     public String getJobType()
@@ -93,14 +95,24 @@ public class DtxSchedule
         this.lifespan = lifespan;
     }
 
-    public String getExpiration()
+    public Boolean getExpired()
     {
-        return expiration;
+        return expired;
     }
 
-    public void setExpiration( String expiration )
+    public void setExpired( Boolean expired )
     {
-        this.expiration = expiration;
+        this.expired = expired;
+    }
+
+    public Long getTtl()
+    {
+        return ttl;
+    }
+
+    public void setTtl( Long ttl )
+    {
+        this.ttl = ttl;
     }
 
     @Override
@@ -113,12 +125,12 @@ public class DtxSchedule
         DtxSchedule that = (DtxSchedule) o;
         return storeKey.equals( that.storeKey ) && jobName.equals( that.jobName ) && jobType.equals( that.jobType )
                         && scheduleTime.equals( that.scheduleTime ) && lifespan.equals( that.lifespan )
-                        && expiration.equals( that.expiration );
+                        && expired.equals( that.expired );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( storeKey, jobName, jobType, scheduleTime, lifespan, expiration );
+        return Objects.hash( storeKey, jobName, jobType, scheduleTime, lifespan, expired );
     }
 }

--- a/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/model/DtxSchedule.java
+++ b/addons/schedule/model-java/src/main/java/org/commonjava/indy/schedule/datastax/model/DtxSchedule.java
@@ -25,7 +25,7 @@ public class DtxSchedule
     private Date scheduleTime;
 
     @Column
-    private Long lifescan;
+    private Long lifespan;
 
     @Column
     private String expiration;
@@ -33,13 +33,13 @@ public class DtxSchedule
     public DtxSchedule() {}
 
     public DtxSchedule( String jobType, String jobName, String storeKey, Date scheduleTime,
-                        Long lifescan, String expiration )
+                        Long lifespan, String expiration )
     {
         this.jobType = jobType;
         this.jobName = jobName;
         this.storeKey = storeKey;
         this.scheduleTime = scheduleTime;
-        this.lifescan = lifescan;
+        this.lifespan = lifespan;
         this.expiration = expiration;
     }
 
@@ -83,14 +83,14 @@ public class DtxSchedule
         this.scheduleTime = scheduleTime;
     }
 
-    public Long getLifescan()
+    public Long getLifespan()
     {
-        return lifescan;
+        return lifespan;
     }
 
-    public void setLifescan( Long lifescan )
+    public void setLifespan( Long lifespan )
     {
-        this.lifescan = lifescan;
+        this.lifespan = lifespan;
     }
 
     public String getExpiration()
@@ -112,13 +112,13 @@ public class DtxSchedule
             return false;
         DtxSchedule that = (DtxSchedule) o;
         return storeKey.equals( that.storeKey ) && jobName.equals( that.jobName ) && jobType.equals( that.jobType )
-                        && scheduleTime.equals( that.scheduleTime ) && lifescan.equals( that.lifescan )
+                        && scheduleTime.equals( that.scheduleTime ) && lifespan.equals( that.lifespan )
                         && expiration.equals( that.expiration );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( storeKey, jobName, jobType, scheduleTime, lifescan, expiration );
+        return Objects.hash( storeKey, jobName, jobType, scheduleTime, lifespan, expiration );
     }
 }

--- a/addons/schedule/model-java/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
+++ b/addons/schedule/model-java/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
@@ -33,7 +33,7 @@ public class ScheduleTest
         config.setCassandraPort( 9142 );
 
         CassandraClient client = new CassandraClient( config );
-        ScheduleDB scheduleDB = new ScheduleDB( client, SCHEDULE_KEYSPACE );
+        scheduleDB = new ScheduleDB( client, SCHEDULE_KEYSPACE );
     }
 
     @After

--- a/addons/schedule/model-java/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
+++ b/addons/schedule/model-java/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
@@ -1,0 +1,66 @@
+package org.commonjava.indy.schedule;
+
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.commonjava.indy.schedule.datastax.JobType;
+import org.commonjava.indy.schedule.datastax.ScheduleDB;
+import org.commonjava.indy.schedule.datastax.model.DtxSchedule;
+import org.commonjava.indy.subsys.cassandra.CassandraClient;
+import org.commonjava.indy.subsys.cassandra.config.CassandraConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class ScheduleTest
+{
+
+    private static final String SCHEDULE_KEYSPACE = "schedule";
+
+    ScheduleDB scheduleDB;
+
+    @Before
+    public void start() throws Exception
+    {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+
+        CassandraConfig config = new CassandraConfig();
+        config.setEnabled( true );
+        config.setCassandraHost( "localhost" );
+        config.setCassandraPort( 9142 );
+
+        CassandraClient client = new CassandraClient( config );
+        ScheduleDB scheduleDB = new ScheduleDB( client, SCHEDULE_KEYSPACE );
+    }
+
+    @After
+    public void stop() throws Exception
+    {
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+    }
+
+    @Test
+    public void test() throws Exception
+    {
+        Long timeout = Long.valueOf( 10 );
+
+        scheduleDB.createSchedule( "maven:hosted:test", JobType.CONTENT.getJobType(), "org/jboss", timeout );
+
+        Thread.sleep( timeout * 1000 );
+
+        scheduleDB.queryTTLAndSetExpiredSchedule();
+
+        Collection<DtxSchedule> schedules = scheduleDB.queryExpiredSchedule();
+
+        assertThat( schedules.size(), equalTo( 1 ) );
+
+        schedules.forEach( schedule -> {
+            assertThat(schedule.getExpired(), equalTo(true));
+        } );
+    }
+
+
+}

--- a/addons/schedule/model-java/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
+++ b/addons/schedule/model-java/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
@@ -3,6 +3,7 @@ package org.commonjava.indy.schedule;
 import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
 import org.commonjava.indy.schedule.datastax.JobType;
 import org.commonjava.indy.schedule.datastax.ScheduleDB;
+import org.commonjava.indy.schedule.datastax.ScheduleDBConfig;
 import org.commonjava.indy.schedule.datastax.model.DtxSchedule;
 import org.commonjava.indy.subsys.cassandra.CassandraClient;
 import org.commonjava.indy.subsys.cassandra.config.CassandraConfig;
@@ -33,7 +34,8 @@ public class ScheduleTest
         config.setCassandraPort( 9142 );
 
         CassandraClient client = new CassandraClient( config );
-        scheduleDB = new ScheduleDB( client, SCHEDULE_KEYSPACE );
+        ScheduleDBConfig scheduleDBConfig = new ScheduleDBConfig( SCHEDULE_KEYSPACE, 1 );
+        scheduleDB = new ScheduleDB( scheduleDBConfig, client );
     }
 
     @After

--- a/addons/schedule/pom.xml
+++ b/addons/schedule/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>indy-addons</artifactId>
+        <groupId>org.commonjava.indy</groupId>
+        <version>2.4.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>schedule</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>model-java</module>
+    </modules>
+
+    <properties>
+        <projectOwner>Red Hat, Inc.</projectOwner>
+        <projectEmail>nos-devel@redhat.com</projectEmail>
+        <javaVersion>1.8</javaVersion>
+        <datastaxVersion>3.7.2</datastaxVersion>
+        <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
+    </properties>
+</project>

--- a/addons/schedule/pom.xml
+++ b/addons/schedule/pom.xml
@@ -2,24 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <artifactId>indy-addons</artifactId>
         <groupId>org.commonjava.indy</groupId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>schedule</artifactId>
+    <artifactId>indy-schedule</artifactId>
+    <name>Indy :: Add-Ons :: Schedule :: Parent</name>
+
     <packaging>pom</packaging>
+
     <modules>
+        <module>common</module>
         <module>model-java</module>
     </modules>
 
-    <properties>
-        <projectOwner>Red Hat, Inc.</projectOwner>
-        <projectEmail>nos-devel@redhat.com</projectEmail>
-        <javaVersion>1.8</javaVersion>
-        <datastaxVersion>3.7.2</datastaxVersion>
-        <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
-    </properties>
 </project>

--- a/addons/sli/pom.xml
+++ b/addons/sli/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-sli</artifactId>
   <name>Indy :: Add-Ons :: Service Level Indicators Reporting :: JAX-RS</name>

--- a/addons/sli/pom.xml
+++ b/addons/sli/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-addons</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-sli</artifactId>
   <name>Indy :: Add-Ons :: Service Level Indicators Reporting :: JAX-RS</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -60,6 +60,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>javax.activation-api</artifactId>
+    </dependency>
   </dependencies>
   
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-api</artifactId>

--- a/api/src/main/java/org/commonjava/indy/metrics/RequestContextHelper.java
+++ b/api/src/main/java/org/commonjava/indy/metrics/RequestContextHelper.java
@@ -185,6 +185,8 @@ public class RequestContextHelper
     @MDC
     public static final String CUMULATIVE_COUNTS = "cumulative-counts";
 
+    @Thread
+    public static final String IS_RAW_VIEW = "is-raw-view";
 
     // these are well-known values we'll be using in our log aggregation filters
     public static final String REQUEST_PHASE_START = "start";

--- a/api/src/main/java/org/commonjava/indy/util/ContentUtils.java
+++ b/api/src/main/java/org/commonjava/indy/util/ContentUtils.java
@@ -35,8 +35,8 @@ public final class ContentUtils
      */
     public static List<StoreResource> dedupeListing( final List<StoreResource> listing )
     {
-        final List<StoreResource> result = new ArrayList<StoreResource>();
-        final Map<String, StoreResource> mapping = new LinkedHashMap<String, StoreResource>();
+        final List<StoreResource> result = new ArrayList<>();
+        final Map<String, StoreResource> mapping = new LinkedHashMap<>();
         for ( final StoreResource res : listing )
         {
             final String path = res.getPath();

--- a/bindings/jaxrs/pom.xml
+++ b/bindings/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-bindings</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-bindings-jaxrs</artifactId>

--- a/bindings/jaxrs/pom.xml
+++ b/bindings/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-bindings</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-bindings-jaxrs</artifactId>

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-bindings</artifactId>

--- a/bindings/pom.xml
+++ b/bindings/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-bindings</artifactId>

--- a/boot/jaxrs/pom.xml
+++ b/boot/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.boot</groupId>
     <artifactId>indy-booters</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <groupId>org.commonjava.indy.boot</groupId>

--- a/boot/jaxrs/pom.xml
+++ b/boot/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.boot</groupId>
     <artifactId>indy-booters</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.boot</groupId>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <groupId>org.commonjava.indy.boot</groupId>

--- a/boot/pom.xml
+++ b/boot/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.boot</groupId>

--- a/clients/core-java/pom.xml
+++ b/clients/core-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-clients-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-client-core-java</artifactId>

--- a/clients/core-java/pom.xml
+++ b/clients/core-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-clients-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-client-core-java</artifactId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-clients-parent</artifactId>

--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-clients-parent</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-core</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-core</artifactId>

--- a/db/common/pom.xml
+++ b/db/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>indy-db-common</artifactId>

--- a/db/common/pom.xml
+++ b/db/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>indy-db-common</artifactId>

--- a/db/flat/pom.xml
+++ b/db/flat/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-db</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-db-flat</artifactId>

--- a/db/flat/pom.xml
+++ b/db/flat/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-db</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-db-flat</artifactId>

--- a/db/infinispan/pom.xml
+++ b/db/infinispan/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>indy-db-infinispan</artifactId>

--- a/db/infinispan/pom.xml
+++ b/db/infinispan/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>indy-db-infinispan</artifactId>

--- a/db/memory/pom.xml
+++ b/db/memory/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-db</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-db-memory</artifactId>

--- a/db/memory/pom.xml
+++ b/db/memory/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-db</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-db-memory</artifactId>

--- a/db/metrics/pom.xml
+++ b/db/metrics/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-db</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-db-metrics</artifactId>

--- a/db/metrics/pom.xml
+++ b/db/metrics/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-db</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-db-metrics</artifactId>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-db</artifactId>

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-db</artifactId>

--- a/deployments/launcher/pom.xml
+++ b/deployments/launcher/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-deployments</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.launch</groupId>

--- a/deployments/launcher/pom.xml
+++ b/deployments/launcher/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-deployments</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <groupId>org.commonjava.indy.launch</groupId>

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-deployments</artifactId>

--- a/deployments/pom.xml
+++ b/deployments/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-deployments</artifactId>

--- a/deployments/standalone/launcher/pom.xml
+++ b/deployments/standalone/launcher/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-standalone</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>indy-standalone-launcher</artifactId>

--- a/deployments/standalone/launcher/pom.xml
+++ b/deployments/standalone/launcher/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-standalone</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>indy-standalone-launcher</artifactId>

--- a/deployments/standalone/pom.xml
+++ b/deployments/standalone/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-deployments</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>2.4.1-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-standalone</artifactId>

--- a/deployments/standalone/pom.xml
+++ b/deployments/standalone/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-deployments</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-standalone</artifactId>

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.embed</groupId>

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <groupId>org.commonjava.indy.embed</groupId>

--- a/filers/default/pom.xml
+++ b/filers/default/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-file-managers</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-filer-default</artifactId>

--- a/filers/default/pom.xml
+++ b/filers/default/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-file-managers</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-filer-default</artifactId>

--- a/filers/pom.xml
+++ b/filers/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-file-managers</artifactId>

--- a/filers/pom.xml
+++ b/filers/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-file-managers</artifactId>

--- a/ftests/common/pom.xml
+++ b/ftests/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-ftests-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-common</artifactId>

--- a/ftests/common/pom.xml
+++ b/ftests/common/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-ftests-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-common</artifactId>

--- a/ftests/core/pom.xml
+++ b/ftests/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-ftests-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-core</artifactId>

--- a/ftests/core/pom.xml
+++ b/ftests/core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-ftests-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-core</artifactId>

--- a/ftests/metrics/pom.xml
+++ b/ftests/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>indy-ftests-parent</artifactId>
         <groupId>org.commonjava.indy</groupId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ftests/metrics/pom.xml
+++ b/ftests/metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>indy-ftests-parent</artifactId>
         <groupId>org.commonjava.indy</groupId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/ftests/pom.xml
+++ b/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ftests-parent</artifactId>

--- a/ftests/pom.xml
+++ b/ftests/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ftests-parent</artifactId>

--- a/models/core-java/pom.xml
+++ b/models/core-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-models-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-model-core-java</artifactId>

--- a/models/core-java/pom.xml
+++ b/models/core-java/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-models-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-model-core-java</artifactId>

--- a/models/pom.xml
+++ b/models/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-models-parent</artifactId>

--- a/models/pom.xml
+++ b/models/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-models-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <pathmappedStorageVersion>1.7</pathmappedStorageVersion>
 
     <!-- commonjava/redhat projects -->
-    <atlasVersion>1.1.0</atlasVersion>
+    <atlasVersion>1.1.1-SNAPSHOT</atlasVersion>
     <galleyVersion>1.4</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   
   <groupId>org.commonjava.indy</groupId>
   <artifactId>indy-parent</artifactId>
-  <version>2.4.1-SNAPSHOT</version>
+  <version>2.4.1</version>
   
   <packaging>pom</packaging>
   
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/CommonJava/indy</connection>
     <developerConnection>scm:git:https://github.com/CommonJava/indy</developerConnection>
     <url>http://github.com/Commonjava/indy</url>
-    <tag>HEAD</tag>
+    <tag>indy-parent-2.4.1</tag>
   </scm>
 
   <repositories>
@@ -187,7 +187,7 @@
       <dependency>
         <groupId>org.commonjava.indy.ui</groupId>
         <artifactId>indy-ui-layover</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <!-- <type>war</type> -->
         <scope>runtime</scope>
       </dependency>
@@ -195,22 +195,22 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-model-core-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-api</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-core</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-core</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -218,32 +218,32 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-flat</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-metrics</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-infinispan</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-bindings-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy.launch</groupId>
         <artifactId>indy-launcher</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>skinny</classifier>
         <scope>provided</scope>
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.commonjava.indy.launch</groupId>
         <artifactId>indy-launcher</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>complete</classifier>
         <scope>provided</scope>
@@ -259,7 +259,7 @@
       <dependency>
         <groupId>org.commonjava.indy.launch</groupId>
         <artifactId>indy-launcher</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>data</classifier>
         <scope>provided</scope>
@@ -267,7 +267,7 @@
       <dependency>
         <groupId>org.commonjava.indy.launch</groupId>
         <artifactId>indy-launcher</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>etc</classifier>
         <scope>provided</scope>
@@ -276,17 +276,17 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -294,7 +294,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>uiset</classifier>
         <scope>provided</scope>
@@ -302,12 +302,12 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-dot-maven-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-dot-maven-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -315,22 +315,22 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-dot-maven-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-dot-maven</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-httprox-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-httprox-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -338,17 +338,17 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-httprox</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-index</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-index</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -356,51 +356,51 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-memory</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-test-db</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-test-fixtures-core</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-test-providers-core</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-test-utils</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-filer-default</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-honeycomb</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-honeycomb</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -408,17 +408,17 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-flatfile</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-cassandra</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-cassandra</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -426,79 +426,79 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-infinispan</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-http</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-git</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-groovy</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-prefetch</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-cpool</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-client-core-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-core</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-folo</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-client-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-model-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -506,7 +506,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -514,33 +514,33 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-promote</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-client-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-model-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -548,7 +548,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -556,19 +556,19 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>dataset</classifier>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-implied-repos-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-implied-repos-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -576,37 +576,37 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-implied-repos-model-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-implied-repos-client-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-implied-repos</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy.embed</groupId>
         <artifactId>indy-embedder</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy.boot</groupId>
         <artifactId>indy-booter-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-keycloak</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-keycloak</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -614,7 +614,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-infinispan</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -622,7 +622,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-prefetch</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -631,7 +631,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -639,103 +639,103 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-model-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-client-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-path-mapped-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-path-mapped-model-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-path-mapped-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-maven-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-maven-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-npm-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-pkg-maven</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-pkg-npm</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-npm-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-npm-model-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-client-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-diagnostics</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -743,28 +743,28 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-hosted-by-archive-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-hosted-by-archive-client-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-hosted-by-archive</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-hosted-by-archive-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-hosted-by-archive-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
       </dependency>
@@ -772,22 +772,22 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-core</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-reporter</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-prometheus</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-reporter</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -796,28 +796,28 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-metrics</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-sli</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy.rest</groupId>
         <artifactId>indy-rest-api</artifactId>
         <type>yaml</type>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy.rest</groupId>
         <artifactId>indy-rest-api</artifactId>
         <type>json</type>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>provided</scope>
       </dependency>
 
@@ -856,33 +856,33 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-content-browse</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-model-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-client-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -890,35 +890,35 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-ui</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>reactui</classifier>
         <type>tar.gz</type>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-changelog-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-changelog-client-java</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-changelog</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-changelog-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-changelog-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
       </dependency>
@@ -936,12 +936,12 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-event-audit-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-event-audit-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -956,23 +956,23 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-repo-proxy-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-repo-proxy-jaxrs</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-repo-proxy</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-repo-proxy-common</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <kojijiVersion>2.12</kojijiVersion>
     <rwxVersion>2.3</rwxVersion>
     <jhttpcVersion>1.11</jhttpcVersion>
-    <weftVersion>1.17-SNAPSHOT</weftVersion>
+    <weftVersion>1.17</weftVersion>
     <httpTestserverVersion>1.4</httpTestserverVersion>
     <propulsorVersion>1.4</propulsorVersion>
     <auditQueryVersion>0.13.1</auditQueryVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   
   <groupId>org.commonjava.indy</groupId>
   <artifactId>indy-parent</artifactId>
-  <version>2.4.1</version>
+  <version>2.5.0-SNAPSHOT</version>
   
   <packaging>pom</packaging>
   
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/CommonJava/indy</connection>
     <developerConnection>scm:git:https://github.com/CommonJava/indy</developerConnection>
     <url>http://github.com/Commonjava/indy</url>
-    <tag>indy-parent-2.4.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>
@@ -187,7 +187,7 @@
       <dependency>
         <groupId>org.commonjava.indy.ui</groupId>
         <artifactId>indy-ui-layover</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <!-- <type>war</type> -->
         <scope>runtime</scope>
       </dependency>
@@ -195,22 +195,22 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-model-core-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-api</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-core</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-core</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -218,32 +218,32 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-flat</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-metrics</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-infinispan</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-bindings-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy.launch</groupId>
         <artifactId>indy-launcher</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>skinny</classifier>
         <scope>provided</scope>
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.commonjava.indy.launch</groupId>
         <artifactId>indy-launcher</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>complete</classifier>
         <scope>provided</scope>
@@ -259,7 +259,7 @@
       <dependency>
         <groupId>org.commonjava.indy.launch</groupId>
         <artifactId>indy-launcher</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>data</classifier>
         <scope>provided</scope>
@@ -267,7 +267,7 @@
       <dependency>
         <groupId>org.commonjava.indy.launch</groupId>
         <artifactId>indy-launcher</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>etc</classifier>
         <scope>provided</scope>
@@ -276,17 +276,17 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -294,7 +294,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>uiset</classifier>
         <scope>provided</scope>
@@ -302,12 +302,12 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-dot-maven-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-dot-maven-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -315,22 +315,22 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-dot-maven-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-dot-maven</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-httprox-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-httprox-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -338,17 +338,17 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-httprox</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-index</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-index</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -356,51 +356,51 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-db-memory</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-test-db</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-test-fixtures-core</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-test-providers-core</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-test-utils</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-filer-default</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-honeycomb</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-honeycomb</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -408,17 +408,17 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-flatfile</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-cassandra</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-cassandra</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -426,79 +426,79 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-infinispan</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-http</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-git</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-groovy</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-prefetch</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-cpool</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-client-core-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-core</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-folo</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-client-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-model-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -506,7 +506,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -514,33 +514,33 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-promote</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-client-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-model-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -548,7 +548,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>dataset</classifier>
         <scope>provided</scope>
@@ -556,19 +556,19 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-promote-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>dataset</classifier>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-implied-repos-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-implied-repos-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -576,37 +576,37 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-implied-repos-model-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-implied-repos-client-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-implied-repos</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy.embed</groupId>
         <artifactId>indy-embedder</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy.boot</groupId>
         <artifactId>indy-booter-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-keycloak</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-keycloak</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -614,7 +614,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-infinispan</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -622,7 +622,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-prefetch</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -631,7 +631,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <type>tar.gz</type>
         <classifier>confset</classifier>
         <scope>provided</scope>
@@ -639,103 +639,103 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-model-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-client-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-koji-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-path-mapped-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-path-mapped-model-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-path-mapped-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-maven-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-maven-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-npm-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-pkg-maven</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-pkg-npm</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-npm-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-pkg-npm-model-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-client-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-diagnostics</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -743,28 +743,28 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-hosted-by-archive-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-hosted-by-archive-client-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-hosted-by-archive</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-hosted-by-archive-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-hosted-by-archive-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
       </dependency>
@@ -772,22 +772,22 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-core</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-reporter</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-prometheus</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-metrics-reporter</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -796,28 +796,28 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-metrics</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-sli</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
 
       <dependency>
         <groupId>org.commonjava.indy.rest</groupId>
         <artifactId>indy-rest-api</artifactId>
         <type>yaml</type>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy.rest</groupId>
         <artifactId>indy-rest-api</artifactId>
         <type>json</type>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>provided</scope>
       </dependency>
 
@@ -856,33 +856,33 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-content-browse</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-model-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-client-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -890,35 +890,35 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-content-browse-ui</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>reactui</classifier>
         <type>tar.gz</type>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-changelog-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-changelog-client-java</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-changelog</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-changelog-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-changelog-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
       </dependency>
@@ -936,12 +936,12 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-event-audit-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-event-audit-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
         <scope>provided</scope>
@@ -956,23 +956,23 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-repo-proxy-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-repo-proxy-jaxrs</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-ftests-repo-proxy</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-repo-proxy-common</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
         <classifier>confset</classifier>
         <type>tar.gz</type>
       </dependency>

--- a/rest/api/pom.xml
+++ b/rest/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.commonjava.indy.rest</groupId>
       <artifactId>indy-rest-parent</artifactId>
-      <version>2.4.1</version>
+      <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>indy-rest-api</artifactId>

--- a/rest/api/pom.xml
+++ b/rest/api/pom.xml
@@ -21,7 +21,7 @@
     <parent>
       <groupId>org.commonjava.indy.rest</groupId>
       <artifactId>indy-rest-parent</artifactId>
-      <version>2.4.1-SNAPSHOT</version>
+      <version>2.4.1</version>
     </parent>
 
     <artifactId>indy-rest-api</artifactId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
 
   <groupId>org.commonjava.indy.rest</groupId>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.commonjava.indy.rest</groupId>

--- a/subsys/cassandra/pom.xml
+++ b/subsys/cassandra/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsystems</artifactId>
-        <version>2.4.1</version>
+        <version>2.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>indy-subsys-cassandra</artifactId>

--- a/subsys/cassandra/pom.xml
+++ b/subsys/cassandra/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsystems</artifactId>
-        <version>2.4.1-SNAPSHOT</version>
+        <version>2.4.1</version>
     </parent>
 
     <artifactId>indy-subsys-cassandra</artifactId>

--- a/subsys/cpool/pom.xml
+++ b/subsys/cpool/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-subsys-cpool</artifactId>

--- a/subsys/cpool/pom.xml
+++ b/subsys/cpool/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-subsys-cpool</artifactId>

--- a/subsys/flatfile/pom.xml
+++ b/subsys/flatfile/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-subsys-flatfile</artifactId>

--- a/subsys/flatfile/pom.xml
+++ b/subsys/flatfile/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-subsys-flatfile</artifactId>

--- a/subsys/git/pom.xml
+++ b/subsys/git/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-subsys-git</artifactId>

--- a/subsys/git/pom.xml
+++ b/subsys/git/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-subsys-git</artifactId>

--- a/subsys/groovy/pom.xml
+++ b/subsys/groovy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-subsys-groovy</artifactId>

--- a/subsys/groovy/pom.xml
+++ b/subsys/groovy/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-subsys-groovy</artifactId>

--- a/subsys/honeycomb/pom.xml
+++ b/subsys/honeycomb/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsystems</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/honeycomb/pom.xml
+++ b/subsys/honeycomb/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsystems</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/http/pom.xml
+++ b/subsys/http/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-subsys-http</artifactId>

--- a/subsys/http/pom.xml
+++ b/subsys/http/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-subsys-http</artifactId>

--- a/subsys/infinispan/pom.xml
+++ b/subsys/infinispan/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-subsys-infinispan</artifactId>

--- a/subsys/infinispan/pom.xml
+++ b/subsys/infinispan/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-subsys-infinispan</artifactId>

--- a/subsys/jaxrs/pom.xml
+++ b/subsys/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-subsys-jaxrs</artifactId>

--- a/subsys/jaxrs/pom.xml
+++ b/subsys/jaxrs/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-subsys-jaxrs</artifactId>

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
@@ -69,6 +69,9 @@ public class IndyDeployment
     private UIConfiguration uiConfiguration;
 
     @Inject
+    private SlashTolerationFilter slashTolerationFilter;
+
+    @Inject
     private ThreadContextFilter threadContextFilter;
 
     @Inject
@@ -163,6 +166,11 @@ public class IndyDeployment
                                                     .addMapping( "/api-docs*" )
                                                     .addMapping( "/api-docs/*" );
 
+        final FilterInfo slashTolerationFilter =
+                        Servlets.filter("SlashToleration", SlashTolerationFilter.class,
+                                 new ImmediateInstanceFactory<>(
+                                         this.slashTolerationFilter ) );
+
         final FilterInfo honeycombFilter =
                         Servlets.filter( "Honeycomb", HoneycombFilter.class,
                                  new ImmediateInstanceFactory<>(
@@ -191,6 +199,11 @@ public class IndyDeployment
                                                       .setContextPath( contextRoot )
                                                       .addServletContextAttribute( ResteasyDeployment.class.getName(),
                                                                                    deployment )
+
+                                                      .addFilter( slashTolerationFilter )
+                                                      .addFilterUrlMapping( slashTolerationFilter.getName(),
+                                                                            "//*", DispatcherType.REQUEST )
+
                                                       .addServlet( resteasyServlet )
 
                                                       .addFilter( threadContextFilter )

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SlashTolerationFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SlashTolerationFilter.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */package org.commonjava.indy.bind.jaxrs;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@ApplicationScoped
+public class SlashTolerationFilter
+        implements Filter
+{
+    @Override
+    public void doFilter( ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain )
+            throws IOException, ServletException
+    {
+        final HttpServletRequest hsr = (HttpServletRequest) servletRequest;
+        String newURI = hsr.getRequestURI().replaceAll( "/+", "/" );
+        servletRequest.getRequestDispatcher(newURI).forward(servletRequest, servletResponse);
+    }
+}

--- a/subsys/kafka/pom.xml
+++ b/subsys/kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsystems</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/kafka/pom.xml
+++ b/subsys/kafka/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsystems</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/keycloak/pom.xml
+++ b/subsys/keycloak/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <artifactId>indy-subsys-keycloak</artifactId>
   <name>Indy :: Subsystems :: Keycloak</name>

--- a/subsys/keycloak/pom.xml
+++ b/subsys/keycloak/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-subsystems</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <artifactId>indy-subsys-keycloak</artifactId>
   <name>Indy :: Subsystems :: Keycloak</name>

--- a/subsys/metrics/core/pom.xml
+++ b/subsys/metrics/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsys-metrics</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/metrics/core/pom.xml
+++ b/subsys/metrics/core/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsys-metrics</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/metrics/pom.xml
+++ b/subsys/metrics/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsystems</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/metrics/pom.xml
+++ b/subsys/metrics/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsystems</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/metrics/prometheus/pom.xml
+++ b/subsys/metrics/prometheus/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsys-metrics</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/metrics/prometheus/pom.xml
+++ b/subsys/metrics/prometheus/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsys-metrics</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/metrics/reporter/pom.xml
+++ b/subsys/metrics/reporter/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsys-metrics</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/metrics/reporter/pom.xml
+++ b/subsys/metrics/reporter/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsys-metrics</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/pom.xml
+++ b/subsys/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-subsystems</artifactId>

--- a/subsys/pom.xml
+++ b/subsys/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-subsystems</artifactId>

--- a/subsys/prefetch/pom.xml
+++ b/subsys/prefetch/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsystems</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/subsys/prefetch/pom.xml
+++ b/subsys/prefetch/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>indy-subsystems</artifactId>
     <groupId>org.commonjava.indy</groupId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/test/db/pom.xml
+++ b/test/db/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-test-db</artifactId>

--- a/test/db/pom.xml
+++ b/test/db/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-test-db</artifactId>

--- a/test/fixtures-core/pom.xml
+++ b/test/fixtures-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-test-fixtures-core</artifactId>

--- a/test/fixtures-core/pom.xml
+++ b/test/fixtures-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-test-fixtures-core</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-test</artifactId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-test</artifactId>

--- a/test/providers-core/pom.xml
+++ b/test/providers-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-test-providers-core</artifactId>

--- a/test/providers-core/pom.xml
+++ b/test/providers-core/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-test-providers-core</artifactId>

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-test-utils</artifactId>

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-test</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-test-utils</artifactId>

--- a/tools/assemblies/pom.xml
+++ b/tools/assemblies/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.tools</groupId>
     <artifactId>indy-tools</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-assemblies</artifactId>

--- a/tools/assemblies/pom.xml
+++ b/tools/assemblies/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.tools</groupId>
     <artifactId>indy-tools</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-assemblies</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.tools</groupId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <groupId>org.commonjava.indy.tools</groupId>

--- a/uis/layover/package-lock.json
+++ b/uis/layover/package-lock.json
@@ -268,9 +268,9 @@
       "dev": true
     },
     "angular": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/angular/-/angular-1.8.0.tgz",
-      "integrity": "sha512-VdaMx+Qk0Skla7B5gw77a8hzlcOakwF8mjlW13DpIWIDlfqwAbSSLfd8N/qZnzEmQF4jC4iofInd3gE7vL8ZZg=="
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/angular/-/angular-1.5.8.tgz",
+      "integrity": "sha1-klpTkrjCEtCVctxEbbfgEmTglMs="
     },
     "angular-loader": {
       "version": "1.5.8",

--- a/uis/layover/package.json
+++ b/uis/layover/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/Commonjava/indy",
   "license": "ASLv2",
   "dependencies": {
-    "angular": "1.8.0",
+    "angular": "1.5.8",
     "angular-ui-bootstrap": "0.13.4",
     "angular-route": "1.5.8",
     "angular-loader": "1.5.8",

--- a/uis/layover/pom.xml
+++ b/uis/layover/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.ui</groupId>
     <artifactId>indy-uis</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <artifactId>indy-ui-layover</artifactId>

--- a/uis/layover/pom.xml
+++ b/uis/layover/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy.ui</groupId>
     <artifactId>indy-uis</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-ui-layover</artifactId>

--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <groupId>org.commonjava.indy.ui</groupId>

--- a/uis/pom.xml
+++ b/uis/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-parent</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.4.1</version>
   </parent>
   
   <groupId>org.commonjava.indy.ui</groupId>


### PR DESCRIPTION
This is the very beginning of the implementation, that we can discuss the partition key or how many tables we can define for schedules and expiration for specific purpose.

Currently the major query against the schedule is the following two:
`select * from schedule where jobtype='Disable-timeout'`
`select * from schedule where storekey='' and jobtype='CONTENT'`

After moving into cassandra, since there is no trigger happening if the TTL expired,  we may need to regularly query the schedule to check the expired ones. 