### PR TITLE
[NCL-5937] Fix storage path for uploaded scoped NPM packages

### DIFF
--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -427,6 +427,12 @@ public class NPMContentAccessHandler
                 {
                     return null;
                 }
+                // remove scope if present
+                if ( tarball.startsWith( '@' ) && tarball.contains( '/' ) )
+                {
+                    tarball = tarball.split( '/', 2 )[1];
+                }
+
                 tarballPath = Paths.get( idnode.asText(), "-", tarball ).toString();
                 tarballContent = anode.findPath( "data" ).asText();
             }

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -428,9 +428,9 @@ public class NPMContentAccessHandler
                     return null;
                 }
                 // remove scope if present
-                if ( tarball.startsWith( '@' ) && tarball.contains( '/' ) )
+                if ( tarball.startsWith( "@" ) && tarball.contains( "/" ) )
                 {
-                    tarball = tarball.split( '/', 2 )[1];
+                    tarball = tarball.split( "/", 2 )[1];
                 }
 
                 tarballPath = Paths.get( idnode.asText(), "-", tarball ).toString();


### PR DESCRIPTION
Currently if a scoped package is uploaded it ends up on path `@scope/package/-/@scope/package-1.0.0.tgz`, but the correct path would be `@scope/package/-/package-1.0.0.tgz`. This should fix it.