### PR TITLE
Promote: Expand NPMPackagePath support to be used in promotion

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackagePath.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackagePath.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.indy.pkg.npm.content;
 
+import java.util.Optional;
+
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 
 public class PackagePath
@@ -109,6 +111,21 @@ public class PackagePath
     public String getVersionPath()
     {
         return isScoped() ? normalize( scopedName, packageName, version ) : normalize( packageName, version );
+    }
+
+    public static Optional<PackagePath> parse( final String tarPath )
+    {
+        String[] parts = tarPath.split( "/" );
+        if ( parts.length < 3 )
+        {
+            return Optional.empty();
+        }
+        else if ( tarPath.startsWith( "@" ) && parts.length < 4 )
+        {
+            return Optional.empty();
+        }
+        PackagePath packagePath = new PackagePath( tarPath );
+        return Optional.of( packagePath );
     }
 
     @Override

--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/PackagePathTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/PackagePathTest.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class PackagePathTest
+{
+    @Test
+    public void testNormal()
+    {
+        Optional<PackagePath> packagePath = PackagePath.parse( "jquery/-/jquery-1.2.3-redhat-1.tgz" );
+        assertTrue( packagePath.isPresent() );
+        PackagePath path = packagePath.get();
+        assertFalse( path.isScoped() );
+        assertThat( path.getPackageName(), equalTo( "jquery" ) );
+        assertThat( path.getVersionPath(), equalTo( "jquery/1.2.3-redhat-1" ) );
+        assertThat( path.getVersion(), equalTo( "1.2.3-redhat-1" ) );
+        packagePath = PackagePath.parse( "jquery/jquery-1.2.3-redhat-1.tgz" );
+        assertFalse( packagePath.isPresent() );
+    }
+
+    @Test
+    public void testScoped()
+    {
+        Optional<PackagePath> packagePath = PackagePath.parse( "@angular/core/-/core-1.2.3-redhat-1.tgz" );
+        assertTrue( packagePath.isPresent() );
+        PackagePath path = packagePath.get();
+        assertTrue( path.isScoped() );
+        assertThat( path.getPackageName(), equalTo( "core" ) );
+        assertThat( path.getScopedName(), equalTo( "@angular" ) );
+        assertThat( path.getVersionPath(), equalTo( "@angular/core/1.2.3-redhat-1" ) );
+        assertThat( path.getVersion(), equalTo( "1.2.3-redhat-1" ) );
+        packagePath = PackagePath.parse( "@angular/core/jquery-1.2.3-redhat-1.tgz" );
+        assertFalse( packagePath.isPresent() );
+    }
+}

--- a/addons/promote/common/pom.xml
+++ b/addons/promote/common/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>indy-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-pkg-npm-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidationTools.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.promote.validate;
 
 import groovy.lang.Closure;
+import org.bouncycastle.util.Pack;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.PoolWeftExecutorService;
 import org.commonjava.cdi.util.weft.WeftExecutorService;
@@ -30,6 +31,8 @@ import org.commonjava.indy.data.ArtifactStoreQuery;
 import org.commonjava.indy.measure.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.PackageTypeConstants;
+import org.commonjava.indy.pkg.npm.content.PackagePath;
 import org.commonjava.indy.promote.conf.PromoteConfig;
 import org.commonjava.indy.promote.validate.model.ValidationRequest;
 import org.commonjava.indy.util.LocationUtils;
@@ -66,9 +69,11 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -336,6 +341,11 @@ public class PromotionValidationTools
     {
         ArtifactPathInfo pathInfo = ArtifactPathInfo.parse( path );
         return pathInfo == null ? null : pathInfo.getArtifact();
+    }
+
+    public Optional<PackagePath> getNPMPackagePath( final String tarPath )
+    {
+        return PackagePath.parse( tarPath );
     }
 
     public MavenMetadataView getMetadata( final ProjectRef ref, final List<? extends Location> locations )


### PR DESCRIPTION
   This will be used in promotion validation as sort of
   ArtifactInfo.parse in npm type