### PR TITLE
Fix leaked version

### DIFF
--- a/deployments/standalone/launcher/pom.xml
+++ b/deployments/standalone/launcher/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-standalone</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>indy-standalone-launcher</artifactId>

--- a/deployments/standalone/pom.xml
+++ b/deployments/standalone/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava.indy</groupId>
     <artifactId>indy-deployments</artifactId>
-    <version>2.4.1-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>indy-standalone</artifactId>


### PR DESCRIPTION
Not sure why they not change. I fix the standalone versions manually to 2.5.0.