### PR TITLE
Promote: Fix listing problem for promotion of npm pkg

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang.StringUtils;
 import org.commonjava.cdi.util.weft.DrainingExecutorCompletionService;
 import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.Locker;
+import org.commonjava.cdi.util.weft.ThreadContext;
 import org.commonjava.cdi.util.weft.WeftExecutorService;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.IndyWorkflowException;
@@ -659,7 +660,12 @@ public class PromotionManager
         List<Transfer> contents;
         if ( paths == null || paths.isEmpty() )
         {
+            // This is used to let galley ignore the NPMPathStorageCalculator handling,
+            // which will append package.json to a directory transfer and make listing not applicable.
+            ThreadContext context = ThreadContext.getContext( true );
+            context.put( RequestContextHelper.IS_RAW_VIEW, Boolean.TRUE );
             contents = downloadManager.listRecursively( source, DownloadManager.ROOT_PATH );
+            context.put( RequestContextHelper.IS_RAW_VIEW, Boolean.FALSE );
         }
         else
         {

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/PromoteRequest.java
@@ -20,17 +20,17 @@ import org.commonjava.indy.model.core.StoreKey;
 /**
  * Created by jdcasey on 9/11/15.
  */
-public interface PromoteRequest<T extends PromoteRequest<T>>
+public interface PromoteRequest
 {
     StoreKey getSource();
 
-    T setSource( StoreKey source );
+    PromoteRequest setSource( StoreKey source );
 
     StoreKey getTargetKey();
 
     boolean isDryRun();
 
-    T setDryRun( boolean dryRun );
+    PromoteRequest setDryRun( boolean dryRun );
 
     boolean isFireEvents();
 

--- a/api/src/main/java/org/commonjava/indy/metrics/RequestContextHelper.java
+++ b/api/src/main/java/org/commonjava/indy/metrics/RequestContextHelper.java
@@ -185,6 +185,8 @@ public class RequestContextHelper
     @MDC
     public static final String CUMULATIVE_COUNTS = "cumulative-counts";
 
+    @Thread
+    public static final String IS_RAW_VIEW = "is-raw-view";
 
     // these are well-known values we'll be using in our log aggregation filters
     public static final String REQUEST_PHASE_START = "start";

--- a/api/src/main/java/org/commonjava/indy/util/ContentUtils.java
+++ b/api/src/main/java/org/commonjava/indy/util/ContentUtils.java
@@ -35,8 +35,8 @@ public final class ContentUtils
      */
     public static List<StoreResource> dedupeListing( final List<StoreResource> listing )
     {
-        final List<StoreResource> result = new ArrayList<StoreResource>();
-        final Map<String, StoreResource> mapping = new LinkedHashMap<String, StoreResource>();
+        final List<StoreResource> result = new ArrayList<>();
+        final Map<String, StoreResource> mapping = new LinkedHashMap<>();
         for ( final StoreResource res : listing )
         {
             final String path = res.getPath();


### PR DESCRIPTION
This fix is used to let galley ignore the NPMPathStorageCalculator handling, which will append package.json to a directory transfer and make listing not applicable.