### PR TITLE
Fix wrong snapshot version in metadata.xml

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -1050,7 +1050,7 @@ public class MavenMetadataGenerator
             final Map<String, String> coordMap = new HashMap<>();
             coordMap.put( ARTIFACT_ID, info.getArtifactId() );
             coordMap.put( GROUP_ID, info.getGroupId() );
-            coordMap.put( VERSION, info.getMajorVersion() + LOCAL_SNAPSHOT_VERSION_PART );
+            coordMap.put( VERSION, info.getReleaseVersion() + LOCAL_SNAPSHOT_VERSION_PART );
 
             final String lastUpdated = SnapshotUtils.generateUpdateTimestamp( SnapshotUtils.getCurrentTimestamp() );
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -1050,7 +1050,7 @@ public class MavenMetadataGenerator
             final Map<String, String> coordMap = new HashMap<>();
             coordMap.put( ARTIFACT_ID, info.getArtifactId() );
             coordMap.put( GROUP_ID, info.getGroupId() );
-            coordMap.put( VERSION, info.getVersion() );
+            coordMap.put( VERSION, info.getMajorVersion() + LOCAL_SNAPSHOT_VERSION_PART );
 
             final String lastUpdated = SnapshotUtils.generateUpdateTimestamp( SnapshotUtils.getCurrentTimestamp() );
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <pathmappedStorageVersion>1.7</pathmappedStorageVersion>
 
     <!-- commonjava/redhat projects -->
-    <atlasVersion>1.1.0</atlasVersion>
+    <atlasVersion>1.1.1-SNAPSHOT</atlasVersion>
     <galleyVersion>1.4</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>


### PR DESCRIPTION
The snapshot version should not be the raw remote version, but "xxx-snapshot". For example,
https://oss.sonatype.org/content/repositories/snapshots/org/commonjava/maven/galley/galley-transport-httpclient/0.10.4-SNAPSHOT/maven-metadata.xml
This depends on https://github.com/Commonjava/atlas/pull/87