### PR TITLE
Fix the AbstractMethod error from SlashTolerationFilter

### DIFF
--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SlashTolerationFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SlashTolerationFilter.java
@@ -24,6 +24,12 @@ public class SlashTolerationFilter
         implements Filter
 {
     @Override
+    public void init( final FilterConfig filterConfig )
+                    throws ServletException
+    {
+    }
+
+    @Override
     public void doFilter( ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain )
             throws IOException, ServletException
     {
@@ -31,4 +37,10 @@ public class SlashTolerationFilter
         String newURI = hsr.getRequestURI().replaceAll( "/+", "/" );
         servletRequest.getRequestDispatcher(newURI).forward(servletRequest, servletResponse);
     }
+
+    @Override
+    public void destroy()
+    {
+    }
+
 }


### PR DESCRIPTION
[ERROR] [XNIO-2 task-1] io.undertow.request no no - UT005023: Exception handling request to /
java.lang.AbstractMethodError: org.commonjava.indy.bind.jaxrs.SlashTolerationFilter.init(Ljavax/servlet/FilterConfig;)V 

It seems the jboss-servlet-api and javax.servlet.api both contains javax.servlet.Filter interface and the runtime chosen one does not impl the init/destroy methods. I did not dig why this happens but this pr should be able to fix it.