### PR TITLE
Fix maven snapshot updated

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -1057,12 +1057,9 @@ public class MavenMetadataGenerator
             coordMap.put( GROUP_ID, info.getGroupId() );
             coordMap.put( VERSION, info.getReleaseVersion() + LOCAL_SNAPSHOT_VERSION_PART );
 
-            final String lastUpdated = generateUpdateTimestamp( SnapshotUtils.getCurrentTimestamp() );
 
             doc.appendChild( doc.createElementNS( doc.getNamespaceURI(), "metadata" ) );
             xml.createElement( doc.getDocumentElement(), null, coordMap );
-
-            xml.createElement( doc, "versioning", Collections.singletonMap( LAST_UPDATED, lastUpdated ) );
 
             // the last one is the most recent
             SnapshotPart snap = snaps.get( snaps.size() - 1 );
@@ -1076,6 +1073,9 @@ public class MavenMetadataGenerator
                 snapMap.put( TIMESTAMP, SnapshotUtils.generateSnapshotTimestamp( snap.getTimestamp() ) );
                 snapMap.put( BUILD_NUMBER, Integer.toString( snap.getBuildNumber() ) );
             }
+
+            final String lastUpdated = generateUpdateTimestamp( snap.getTimestamp() );
+            xml.createElement( doc, "versioning", Collections.singletonMap( LAST_UPDATED, lastUpdated ) );
 
             xml.createElement( doc, "versioning/snapshot", snapMap );
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -74,7 +74,6 @@ import java.io.StringReader;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1057,7 +1056,6 @@ public class MavenMetadataGenerator
             coordMap.put( GROUP_ID, info.getGroupId() );
             coordMap.put( VERSION, info.getReleaseVersion() + LOCAL_SNAPSHOT_VERSION_PART );
 
-
             doc.appendChild( doc.createElementNS( doc.getNamespaceURI(), "metadata" ) );
             xml.createElement( doc.getDocumentElement(), null, coordMap );
 
@@ -1099,7 +1097,7 @@ public class MavenMetadataGenerator
 
                     snapMap.put( EXTENSION, mapping == null ? pathInfo.getType() : mapping.getExtension() );
                     snapMap.put( VALUE, pathInfo.getVersion() );
-                    snapMap.put( UPDATED, getUpdatedString( pathInfo.getSnapshotInfo(), lastUpdated ) );
+                    snapMap.put( UPDATED, generateUpdateTimestamp( pathInfo.getSnapshotInfo().getTimestamp() ) );
 
                     xml.createElement( doc, "versioning/snapshotVersions/snapshotVersion", snapMap );
                 }
@@ -1125,22 +1123,6 @@ public class MavenMetadataGenerator
         }
 
         return true;
-    }
-
-    /*
-     * To generate '<updated>yyyyMMDDHHmmSS</updated>'.
-     * This is how Maven dependency resolver decides what the latest snapshot is. We should get it from the timestamp. If null, fall back to lastUpdated.
-     */
-    private String getUpdatedString( SnapshotPart snapshotPart, String lastUpdated )
-    {
-        if ( snapshotPart != null && snapshotPart.getTimestamp() != null )
-        {
-            return generateUpdateTimestamp( snapshotPart.getTimestamp() );
-        }
-        else
-        {
-            return lastUpdated;
-        }
     }
 
     // Parking this here, transplanted from ScheduleManager, because this is where it belongs. It might be


### PR DESCRIPTION
Many times I found maven download obselete snapshot jar files. This is because we generate wrong <updated> tag in maven-metadata. We use the 'current' time for all snapshots, e.g., http://pastebin.test.redhat.com/899830. Unfortunately, maven use this tag to decide which snapshot to use. 
This fix generate the updated tag by the real updated time. 