### PR TITLE
Promote: Fix deletion error for readonly target

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionHelper.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionHelper.java
@@ -46,6 +46,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.commonjava.indy.data.StoreDataManager.IGNORE_READONLY;
+
 @ApplicationScoped
 public class PromotionHelper
 {
@@ -194,10 +196,11 @@ public class PromotionHelper
     public List<String> deleteFromStore( final Set<String> completed, final ArtifactStore targetStore )
     {
         List<String> errors = new ArrayList<>();
+        final EventMetadata eventMetadata = new EventMetadata().set( IGNORE_READONLY, true );
         completed.forEach( p -> {
             try
             {
-                contentManager.delete( targetStore, p );
+                contentManager.delete( targetStore, p, eventMetadata );
             }
             catch ( IndyWorkflowException e )
             {

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -936,6 +936,7 @@ public class PromotionManager
         }
 
         Transfer target = contentManager.getTransfer( tgt, path, UPLOAD );
+        EventMetadata eventMetadata = new EventMetadata().set( IGNORE_READONLY, true );
 
         /*
          * if we hit an existing metadata.xml, we remove it from both target repo and affected groups. The metadata
@@ -948,12 +949,13 @@ public class PromotionManager
             {
                 if ( target != null && target.exists() )
                 {
-                    target.delete( true );
+                    contentManager.delete( tgt,path, eventMetadata );
+//                    target.delete( true );
                 }
                 result.skipped = true;
                 logger.info( "Metadata, mark as skipped and remove it if exists, target: {}", target );
             }
-            catch ( IOException e )
+            catch ( IndyWorkflowException e )
             {
                 String msg = String.format( "Failed to promote: %s. Target: %s. Failed to remove metadata.",
                                             transfer, request.getTarget() );
@@ -985,9 +987,7 @@ public class PromotionManager
         }
 
         logger.debug( "Store target transfer: {}", target );
-        EventMetadata eventMetadata = new EventMetadata().set( IGNORE_READONLY, true );
-        eventMetadata.set( AFFECTED_GROUPS, new ValuePipe<>( affectedGroups ) );
-        eventMetadata.set( TARGET_STORE, tgt );
+        eventMetadata.set( AFFECTED_GROUPS, new ValuePipe<>( affectedGroups ) ).set( TARGET_STORE, tgt );
 
         try (InputStream stream = transfer.openInputStream( true ))
         {

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteMetadataShouldSkipWithReadonlyTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/PromoteMetadataShouldSkipWithReadonlyTest.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest;
+
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.category.EventDependent;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.promote.client.IndyPromoteClientModule;
+import org.commonjava.indy.promote.model.PathsPromoteRequest;
+import org.commonjava.indy.promote.model.PathsPromoteResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.ByteArrayInputStream;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Check that metadata should be skipped correctly during promotion with no error if the target repo is set to read-only for path promotion
+ * <br/>
+ * GIVEN:
+ * <ul>
+ *     <li>HostedRepository target contains paths for http metadata and signature metadata for a maven metadata.</li>
+ *     <li>HostedRepository target set to readonly</li>
+ * </ul>
+ * <br/>
+ * WHEN:
+ * <ul>
+ *     <li>Repository source will promote same paths to target</li>
+ * </ul>
+ * <br/>
+ * THEN:
+ * <ul>
+ *     <li>These meta files can be promoted to target of skipping with no error</li>
+ * </ul>
+ */
+public class PromoteMetadataShouldSkipWithReadonlyTest
+        extends AbstractContentManagementTest
+{
+    private static final String HOSTED_TARGET_NAME = "target";
+
+    private static final String HOSTED_SOURCE_NAME = "source";
+
+    private HostedRepository target;
+
+    private HostedRepository source;
+
+    private static final String ARTIFACT_PATH = "/org/foo/bar/maven-metadata.xml";
+
+    private static final String HTTP_META_PATH = "/org/foo/bar/maven-metadata.xml.http-metadata.json";
+
+    private static final String MD5_META_PATH = "/org/foo/bar/maven-metadata.xml.md5";
+
+    private static final String HTTP_META_CONTENT_TARGET = "{\"test\":\"target\"}";
+
+    private static final String HTTP_META_CONTENT_SOURCE = "{\"test\":\"source\"}";
+
+    private static final String MD5_META_CONTENT_TARGET = "testmd5intarget";
+
+    private static final String MD5_META_CONTENT_SOURCE = "testmd5insource";
+
+    private static final String ARTIFACT_CONTENT = "This is a test metadata";
+
+    private final IndyPromoteClientModule promote = new IndyPromoteClientModule();
+
+    @Before
+    public void setupRepos()
+            throws Exception
+    {
+        String message = "test setup";
+
+        target = client.stores()
+                       .create( new HostedRepository( PKG_TYPE_MAVEN, HOSTED_TARGET_NAME ), message,
+                                HostedRepository.class );
+        source = client.stores()
+                       .create( new HostedRepository( PKG_TYPE_MAVEN, HOSTED_SOURCE_NAME ), message,
+                                HostedRepository.class );
+
+        client.content()
+              .store( target.getKey(), HTTP_META_PATH,
+                      new ByteArrayInputStream( HTTP_META_CONTENT_TARGET.getBytes() ) );
+        client.content()
+              .store( target.getKey(), MD5_META_PATH, new ByteArrayInputStream( MD5_META_CONTENT_TARGET.getBytes() ) );
+
+        client.content()
+              .store( source.getKey(), HTTP_META_PATH,
+                      new ByteArrayInputStream( HTTP_META_CONTENT_SOURCE.getBytes() ) );
+        client.content()
+              .store( source.getKey(), MD5_META_PATH, new ByteArrayInputStream( MD5_META_CONTENT_SOURCE.getBytes() ) );
+        client.content()
+              .store( source.getKey(), ARTIFACT_PATH, new ByteArrayInputStream( ARTIFACT_CONTENT.getBytes() ) );
+
+        target.setReadonly( true );
+        client.stores().update( target, message );
+
+    }
+
+    @Test
+    @Category( EventDependent.class )
+    public void run()
+            throws Exception
+    {
+        PathsPromoteRequest request =
+                new PathsPromoteRequest( source.getKey(), target.getKey(), ARTIFACT_PATH, HTTP_META_PATH,
+                                         MD5_META_PATH );
+
+        request.setFailWhenExists( true );
+
+        PathsPromoteResult response = promote.promoteByPath( request );
+
+        assertThat( response.succeeded(), equalTo( true ) );
+        assertThat( response.getSkippedPaths().contains( HTTP_META_PATH ), equalTo( true ) );
+        assertThat( response.getSkippedPaths().contains( MD5_META_PATH ), equalTo( true ) );
+        assertThat( response.getSkippedPaths().contains( ARTIFACT_PATH ), equalTo( true ) );
+
+        waitForEventPropagation();
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Collections.singleton( promote );
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+
+}


### PR DESCRIPTION
  In promote, we should always let the transfer promotion happen
  whether the target is readonly or not. But currently there is a bug
  for metadata deletion in promotion. This pr is to fix the problem.