### PR TITLE
Fix NPE from IndyCassandraConnectionRootSpanFields constructor

### DIFF
--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyCassandraConnectionRootSpanFields.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyCassandraConnectionRootSpanFields.java
@@ -13,17 +13,18 @@ import java.util.Map;
 public class IndyCassandraConnectionRootSpanFields
                 extends CassandraConnectionRootSpanFields
 {
-    private CassandraClient cassandraClient;
+
+    private final Map<String, Session> sessions;
 
     @Inject
     public IndyCassandraConnectionRootSpanFields( CassandraClient cassandraClient )
     {
-        this.cassandraClient = cassandraClient;
+        this.sessions = Collections.unmodifiableMap( cassandraClient.getSessions() );
     }
 
     @Override
     protected Map<String, Session> getSessions()
     {
-        return Collections.unmodifiableMap( cassandraClient.getSessions() );
+        return sessions;
     }
 }


### PR DESCRIPTION
Fix NPE from constructor. This error is due to erroneous inherit instanciation follow. 