### PR TITLE
Npm schedule: add test for remote pkg metadata timeout

### DIFF
--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataRevisitTimeoutTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataRevisitTimeoutTest.java
@@ -18,12 +18,14 @@ package org.commonjava.indy.pkg.npm.content;
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.pkg.npm.model.DistTag;
 import org.commonjava.indy.pkg.npm.model.PackageMetadata;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,6 +63,7 @@ public class NPMMetadataRevisitTimeoutTest
     private static final String PATH = "jquery";
 
     @Test
+    @Category( TimingDependent.class )
     public void test()
             throws Exception
     {
@@ -76,15 +79,6 @@ public class NPMMetadataRevisitTimeoutTest
             mapper.writeValue( resp.getWriter(), src );
             resp.getWriter().flush();
         } );
-
-        //FIXME: After using galley-0.16.8, I'm not sure the second retrieval of npm metadata will get path of
-        //       "A/jquery/package.json" while the first retrieval is "A/jquery". So I add a new expectation here
-        //       to let the second retrieval can work. Need further checking.
-        //        server.expect( "GET", server.formatUrl( REPO, PATH+"/package.json" ), (req, resp)->{
-        //            resp.setStatus( 200 );
-        //            mapper.writeValue( resp.getWriter(), src );
-        //            resp.getWriter().flush();
-        //        } );
 
         final int METADATA_TIMEOUT_SECOND = 3;
         final int TIMEOUT_WAIT_MILLI_S = 1000;

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataWithContentTimeoutTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataWithContentTimeoutTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.commonjava.indy.client.core.helper.PathInfo;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.ftest.core.category.TimingDependent;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.pkg.PackageTypeConstants;
+import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.io.InputStream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * This case tests if remote package.json will timeout correctly
+ * when: <br />
+ * <ul>
+ *      <li>remote repo A contains package.json with real content for a given package</li>
+ *      <li>package.json is retrieved via remote repo A by client</li>
+ *      <li>package.json metadata timeout is scheduled</li>
+ * </ul>
+ * then: <br />
+ * <ul>
+ *     <li>package.json expires with metadata timeout and is removed from local storage in remote repository A</li>
+ * </ul>
+ */
+public class NPMMetadataWithContentTimeoutTest
+        extends AbstractContentManagementTest
+{
+    @Rule
+    public ExpectationServer server = new ExpectationServer( "repos" );
+
+    @Test
+    @Category( TimingDependent.class )
+    public void timeout()
+            throws Exception
+    {
+        final int METADATA_TIMEOUT_SECONDS = 4;
+        final int METADATA_TIMEOUT_WAITING_MILLISECONDS = 2500;
+
+        final String repoId = "test-repo";
+        final String pkgPath = "@babel/parser";
+        final String pkgMetaPath = pkgPath + "/package.json";
+
+        final String metadataUrl = server.formatUrl( repoId, pkgPath );
+
+        // mocking up a http server that expects access to metadata
+        try (InputStream is = getClass().getResourceAsStream( "babel-parser-7.0.0-beta.48.json" ))
+        {
+            server.expect( metadataUrl, 200, is );
+        }
+
+        // set up remote repository pointing to the test http server, and timeout little later
+        final String changelog = "Timeout Testing: " + name.getMethodName();
+        final RemoteRepository repository =
+                new RemoteRepository( PackageTypeConstants.PKG_TYPE_NPM, repoId, server.formatUrl( repoId ) );
+        repository.setMetadataTimeoutSeconds( METADATA_TIMEOUT_SECONDS );
+        client.stores().create( repository, changelog, RemoteRepository.class );
+
+        // first time trigger normal content storage with timeout, should be 4s
+        PathInfo pkgPathFile = client.content().getInfo( repository.getKey(), pkgPath );
+        client.content().get( repository.getKey(), pkgPath ).close(); // force storage
+        assertThat( "no metadata result", pkgPathFile, notNullValue() );
+        assertThat( "metadata doesn't exist", pkgPathFile.exists(), equalTo( true ) );
+
+        pkgPathFile = client.content().getInfo( repository.getKey(), pkgMetaPath );
+        client.content().get( repository.getKey(), pkgPath ).close();
+        assertThat( "no metadata result", pkgPathFile, notNullValue() );
+        assertThat( "metadata doesn't exist", pkgPathFile.exists(), equalTo( true ) );
+
+        Location location = LocationUtils.toLocation( repository );
+        File pkgFile = getPhysicalStorageFile( location, pkgPath );
+        File pkgMetaFile = getPhysicalStorageFile( location, pkgMetaPath );
+
+        assertThat( "pkg dir doesn't exist", pkgFile.exists(), equalTo( true ) );
+        assertThat( "metadata doesn't exist", pkgMetaFile.exists(), equalTo( true ) );
+
+        // wait for first 2.5s
+        sleepAndRunFileGC( METADATA_TIMEOUT_WAITING_MILLISECONDS );
+
+        // as the metadata content re-request, the metadata timeout interval should NOT be re-scheduled
+        client.content().get( repository.getKey(), pkgPath ).close();
+        client.content().get( repository.getKey(), pkgMetaPath ).close();
+
+        // will wait another 4s
+        sleepAndRunFileGC( METADATA_TIMEOUT_WAITING_MILLISECONDS + 1500 );
+        // as rescheduled, the artifact should not be deleted
+        assertThat( "artifact should be removed as the rescheduled of metadata should not succeed",
+                    pkgFile.exists(), equalTo( false ) );
+        assertThat( "artifact should be removed as the rescheduled of metadata should not succeed",
+                    pkgMetaFile.exists(), equalTo( false ) );
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}

--- a/addons/pkg-npm/ftests/src/main/resources/babel-parser-7.0.0-beta.48.json
+++ b/addons/pkg-npm/ftests/src/main/resources/babel-parser-7.0.0-beta.48.json
@@ -1,0 +1,51 @@
+{
+  "_id": "@babel/parser",
+  "_rev": "87-0bf11730f53724368fe4fc3bef482fed",
+  "name": "@babel/parser",
+  "dist-tags": {
+    "latest": "7.0.0-beta.48"
+  },
+  "versions": {
+    "7.0.0-beta.48": {
+      "name": "@babel/parser",
+      "version": "7.0.0-beta.48",
+      "description": "A JavaScript parser",
+      "author": {
+        "name": "Sebastian McKenzie",
+        "email": "sebmck@gmail.com"
+      },
+      "homepage": "https://babeljs.io/",
+      "license": "MIT",
+      "keywords": [
+        "babel",
+        "javascript",
+        "parser",
+        "tc39",
+        "ecmascript",
+        "@babel/parser"
+      ],
+      "main": "lib/index.js",
+      "files": [
+        "bin",
+        "lib"
+      ],
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "bin": {
+        "parser": "./bin/babel-parser.js"
+      },
+      "_id": "@babel/parser@7.0.0-beta.48",
+      "_npmVersion": "5.6.0",
+      "_nodeVersion": "8.10.0",
+      "dist": {
+        "integrity": "sha512-X3pKxvy7vL79zc/6XS6cCObyuRMnsRGRu7d3zVSPZGCdxkK0/wTeFRwseRjcvhReV/6LW2D8H8qHVFFL0c+5+w==",
+        "shasum": "f93895cbacee703c0ec98e5af3901c77edd9f1d7",
+        "tarball": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.48.tgz",
+        "fileCount": 6,
+        "unpackedSize": 380503,
+        "npm-signature": "-----BEGIN PGP SIGNATURE-----\r\nVersion: OpenPGP.js v3.0.4\r\nComment: https://openpgpjs.org\r\n\r\nwsFcBAEBCAAQBQJbBxCGCRA9TVsSAnZWagAALkIQAI8MHP43v0t5yW+5eb8a\nFvCKyfUV5pYIAgLwyT6QlxWhW37Yy2x1jqzQPVFDz3TEvXHSetOroranW1v6\nH3RrGgFfV6ouyrKnYgk8JpTXHWlHKXWB0m0BqkOrMQwDdQVVVeIxdpQr1yrb\noyt5AjRZ272dKN0Q4iQTeLqC6uxUXYlarbBRUgWXx5BuLh//rVjIJGQ5Fj2m\nZcFFGRjbyw9Hdb0/wo7x0lV6VEi4Oh2wRNZuskIFBRNAiHdrCLf1IZEDsQRE\nGRXuKXc6Xj8LeHvoS2V5Vvs7dbuUq5lq5oiRiTEkPt032MSftU8tsl4UysVn\n1krvHCQYqNCg5WgKJlqXZCae+AxUWj9UacC98aq4vAeZl3DVzoJ5n5ENcHcI\na9Wrs0qumfODoxaDOSs+DNXAYnSc91zoguH187OOCLfas2Gw1MyRIXnJwvnH\nVnwnQyFBuRDDigxBGrRVVFkY6cf+vzoSaVIs5VL8wI85FDtKK/JmTtGwWLtk\nE1xG2tQVl622gWNZqPvoKbS5U1glbq9oPq7ECkPwWA9DSzdBidXfdezyMxJe\n1weMKBjz4+cOvzDS5ybdDPjQE1HlfQ3ffWz8nMm1agoLMXBz5e9pqYo098sL\n+FbijDCbi2Db3fD3UT1DBFMp3+GHuhe4/Aiow2TgL6l9rPlijvXVtAZdnRPV\ng+id\r\n=kdOk\r\n-----END PGP SIGNATURE-----\r\n"
+      }
+    }
+  }
+}


### PR DESCRIPTION
These two enhanced ftests want to ensure the package metadata for npm in remote repo can be expired correctly with scheduled timeout.