### PR TITLE
Init storeDataManager for cassandra

### DIFF
--- a/db/cassandra/pom.xml
+++ b/db/cassandra/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>indy-db</artifactId>
+        <groupId>org.commonjava.indy</groupId>
+        <version>2.5.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>indy-db-cassandra</artifactId>
+    <name>Indy :: DB :: Cassandra</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.commonjava.indy</groupId>
+            <artifactId>indy-db-common</artifactId>
+        </dependency>
+        <!--Datastax Java Driver-->
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+            <version>${datastaxVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-mapping</artifactId>
+            <version>${datastaxVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <version>${cassandraUnitVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.commonjava.indy</groupId>
+            <artifactId>indy-subsys-cassandra</artifactId>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
@@ -1,0 +1,347 @@
+package org.commonjava.indy.cassandra.data;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreEventDispatcher;
+import org.commonjava.indy.db.common.AbstractStoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.RemoteRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@ApplicationScoped
+@Alternative
+public class CassandraStoreDataManager extends AbstractStoreDataManager
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    CassandraStoreQuery storeQuery;
+
+    @Inject
+    IndyObjectMapper objectMapper;
+
+    @Override
+    protected StoreEventDispatcher getStoreEventDispatcher()
+    {
+        return null;
+    }
+
+    @Override
+    protected ArtifactStore getArtifactStoreInternal( StoreKey key )
+    {
+        DtxArtifactStore dtxArtifactStore = storeQuery.getArtifactStore( key.getPackageType(), key.getType(), key.getName() );
+
+        return toArtifactStore( dtxArtifactStore );
+    }
+
+    @Override
+    protected ArtifactStore removeArtifactStoreInternal( StoreKey key )
+    {
+        return null;
+    }
+
+    @Override
+    public void clear( ChangeSummary summary ) throws IndyDataException
+    {
+
+    }
+
+    @Override
+    public Set<ArtifactStore> getAllArtifactStores()
+    {
+        Set<DtxArtifactStore> dtxArtifactStoreSet = storeQuery.getAllArtifactStores();
+        Set<ArtifactStore> artifactStoreSet = new HashSet<>(  );
+        dtxArtifactStoreSet.forEach( dtxArtifactStore -> {
+            artifactStoreSet.add( toArtifactStore( dtxArtifactStore ) );
+        } );
+        return artifactStoreSet;
+    }
+
+    @Override
+    public Map<StoreKey, ArtifactStore> getArtifactStoresByKey()
+    {
+        Map<StoreKey, ArtifactStore> ret = new HashMap<>();
+        Set<ArtifactStore> artifactStoreSet = getAllArtifactStores();
+        artifactStoreSet.forEach( store -> {
+            ret.put( store.getKey(), store );
+        } );
+        return ret;
+    }
+
+    @Override
+    public boolean hasArtifactStore( StoreKey key )
+    {
+        ArtifactStore artifactStore = getArtifactStoreInternal( key );
+        return artifactStore != null;
+    }
+
+    @Override
+    public boolean isStarted()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return false;
+    }
+
+    @Override
+    public Stream<StoreKey> streamArtifactStoreKeys()
+    {
+        return null;
+    }
+
+    @Override
+    protected ArtifactStore putArtifactStoreInternal( StoreKey storeKey, ArtifactStore store )
+    {
+        DtxArtifactStore dtxArtifactStore = toDtxArtifactStore( storeKey, store );
+        storeQuery.createDtxArtifactStore( dtxArtifactStore );
+
+        return toArtifactStore( storeQuery.getArtifactStore( storeKey.getPackageType(), storeKey.getType(), storeKey.getName() ));
+    }
+
+    private DtxArtifactStore toDtxArtifactStore( StoreKey storeKey, ArtifactStore store )
+    {
+
+        DtxArtifactStore dtxArtifactStore = new DtxArtifactStore();
+        dtxArtifactStore.setPackageType( storeKey.getPackageType() );
+        dtxArtifactStore.setStoreType( storeKey.getType().name() );
+        dtxArtifactStore.setName( storeKey.getName() );
+        dtxArtifactStore.setDisableTimeout( store.getDisableTimeout() );
+        dtxArtifactStore.setMetadata( store.getMetadata() );
+        dtxArtifactStore.setDescription( store.getDescription() );
+        dtxArtifactStore.setCreateTime( store.getCreateTime() );
+        dtxArtifactStore.setAuthoritativeIndex( store.isAuthoritativeIndex() );
+        dtxArtifactStore.setPathStyle( store.getPathStyle().name() );
+        dtxArtifactStore.setRescanInProgress( store.isRescanInProgress() );
+        dtxArtifactStore.setPathMaskPatterns( store.getPathMaskPatterns() );
+        dtxArtifactStore.setDisabled( store.isDisabled() );
+        dtxArtifactStore.setExtras( toExtra( store) );
+
+        return dtxArtifactStore;
+    }
+
+    private Map<String, String> toExtra( ArtifactStore store )
+    {
+        Map<String, String> extras = new HashMap<>(  );
+        if ( store instanceof HostedRepository )
+        {
+            HostedRepository hostedRepository = (HostedRepository) store;
+            putValueIntoExtra( CassandraStoreUtil.STORAGE, hostedRepository.getStorage(), extras );
+            putValueIntoExtra( CassandraStoreUtil.READONLY, hostedRepository.isReadonly(), extras );
+            putValueIntoExtra( CassandraStoreUtil.SNAPSHOT_TIMEOUT_SECONDS, hostedRepository.getSnapshotTimeoutSeconds(), extras );
+        }
+        if ( store instanceof RemoteRepository )
+        {
+            RemoteRepository remoteRepository = (RemoteRepository) store;
+            putValueIntoExtra( CassandraStoreUtil.URL, remoteRepository.getUrl(), extras);
+            putValueIntoExtra( CassandraStoreUtil.HOST, remoteRepository.getHost(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PORT, remoteRepository.getPort(), extras );
+            putValueIntoExtra( CassandraStoreUtil.USER, remoteRepository.getUser(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PASSWORD, remoteRepository.getPassword(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PROXY_HOST, remoteRepository.getProxyHost(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PROXY_PORT, remoteRepository.getProxyPort(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PROXY_USER, remoteRepository.getProxyUser(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PROXY_PASSWORD, remoteRepository.getProxyPassword(), extras );
+            putValueIntoExtra( CassandraStoreUtil.KEY_CERT_PEM, remoteRepository.getKeyCertPem(), extras );
+            putValueIntoExtra( CassandraStoreUtil.KEY_PASSWORD, remoteRepository.getKeyPassword(), extras );
+            putValueIntoExtra( CassandraStoreUtil.SERVER_CERT_PEM, remoteRepository.getServerCertPem(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PREFETCH_RESCAN_TIMESTAMP, remoteRepository.getPrefetchRescanTimestamp(), extras );
+            putValueIntoExtra( CassandraStoreUtil.METADATA_TIMEOUT_SECONDS, remoteRepository.getMetadataTimeoutSeconds(), extras );
+            putValueIntoExtra( CassandraStoreUtil.CACHE_TIMEOUT_SECONDS, remoteRepository.getCacheTimeoutSeconds(), extras );
+            putValueIntoExtra( CassandraStoreUtil.TIMEOUT_SECONDS, remoteRepository.getTimeoutSeconds(), extras );
+            putValueIntoExtra( CassandraStoreUtil.MAX_CONNECTIONS, remoteRepository.getMaxConnections(), extras );
+            putValueIntoExtra( CassandraStoreUtil.NFC_TIMEOUT_SECONDS, remoteRepository.getNfcTimeoutSeconds(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PASS_THROUGH, remoteRepository.isPassthrough(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PREFETCH_RESCAN, remoteRepository.isPrefetchRescan(), extras );
+            putValueIntoExtra( CassandraStoreUtil.IGNORE_HOST_NAME_VERIFICATION, remoteRepository.isIgnoreHostnameVerification(), extras );
+
+        }
+        if ( store instanceof Group )
+        {
+            Group group = ( Group ) store;
+            putValueIntoExtra( CassandraStoreUtil.CONSTITUENTS, group.getConstituents(), extras );
+            putValueIntoExtra( CassandraStoreUtil.PREPEND_CONSTITUENT, group.isPrependConstituent(), extras );
+        }
+        return extras;
+    }
+
+    private void putValueIntoExtra( String key, Object value, Map<String, String> extras )
+    {
+        if ( value != null )
+        {
+            try
+            {
+                extras.put( key, objectMapper.writeValueAsString( value ) );
+            }
+            catch ( JsonProcessingException e )
+            {
+                logger.warn( "Write value into extra error, key: {}", key, e );
+            }
+        }
+    }
+
+    private ArtifactStore toArtifactStore( final DtxArtifactStore dtxArtifactStore )
+    {
+        if ( dtxArtifactStore == null )
+        {
+            return null;
+        }
+        ArtifactStore store = generateStore( dtxArtifactStore );
+
+        if ( store != null )
+        {
+            store.setDisabled( dtxArtifactStore.isDisabled() );
+            store.setMetadata( dtxArtifactStore.getMetadata() );
+            store.setRescanInProgress( dtxArtifactStore.getRescanInProgress() );
+            store.setDescription( dtxArtifactStore.getDescription() );
+            store.setPathMaskPatterns( dtxArtifactStore.getPathMaskPatterns() );
+            store.setDisableTimeout( dtxArtifactStore.getDisableTimeout() );
+            store.setAuthoritativeIndex( dtxArtifactStore.getAuthoritativeIndex() );
+        }
+        return store;
+    }
+
+    private ArtifactStore generateStore( DtxArtifactStore dtxArtifactStore )
+    {
+        ArtifactStore store = null;
+        if ( dtxArtifactStore.getExtras() != null && !dtxArtifactStore.getExtras().isEmpty() )
+        {
+            if ( dtxArtifactStore.getStoreType().equals( StoreType.hosted.name() ) )
+            {
+                store = new HostedRepository( dtxArtifactStore.getPackageType(), dtxArtifactStore.getName() );
+                ( (HostedRepository) store ).setReadonly( readValueFromExtra( CassandraStoreUtil.READONLY, Boolean.class, dtxArtifactStore.getExtras() ));
+                Integer snapshotTimeoutseconds = readValueFromExtra( CassandraStoreUtil.SNAPSHOT_TIMEOUT_SECONDS, Integer.class, dtxArtifactStore.getExtras());
+                if ( snapshotTimeoutseconds != null )
+                {
+                    ( (HostedRepository) store ).setSnapshotTimeoutSeconds( snapshotTimeoutseconds.intValue() );
+                }
+                ( (HostedRepository) store ).setStorage( dtxArtifactStore.getExtras().get( CassandraStoreUtil.STORAGE ) );
+            }
+            else if ( dtxArtifactStore.getStoreType().equals( StoreType.remote.name() ) )
+            {
+                store = new RemoteRepository( dtxArtifactStore.getPackageType(), dtxArtifactStore.getName(),
+                                              dtxArtifactStore.getExtras().get( CassandraStoreUtil.URL ) );
+                setIfNotNull( ( (RemoteRepository) store )::setUser, dtxArtifactStore.getExtras().get( CassandraStoreUtil.USER ) );
+                setIfNotNull( ( (RemoteRepository) store )::setPassword, dtxArtifactStore.getExtras().get( CassandraStoreUtil.PASSWORD ) );
+                setIfNotNull( ( (RemoteRepository) store )::setHost, dtxArtifactStore.getExtras().get( CassandraStoreUtil.HOST ) );
+                setIfNotNull( ( (RemoteRepository) store )::setProxyHost, dtxArtifactStore.getExtras().get( CassandraStoreUtil.PROXY_HOST ) );
+                setIfNotNull( ( (RemoteRepository) store )::setServerCertPem, dtxArtifactStore.getExtras().get( CassandraStoreUtil.SERVER_CERT_PEM ) );
+                setIfNotNull( ( (RemoteRepository) store )::setKeyCertPem, dtxArtifactStore.getExtras().get( CassandraStoreUtil.KEY_CERT_PEM ) );
+                setIfNotNull( ( (RemoteRepository) store )::setKeyPassword, dtxArtifactStore.getExtras().get( CassandraStoreUtil.KEY_PASSWORD ) );
+                setIfNotNull( ( (RemoteRepository) store )::setProxyPassword, dtxArtifactStore.getExtras().get( CassandraStoreUtil.PROXY_PASSWORD ) );
+                setIfNotNull( ( (RemoteRepository) store )::setProxyUser, dtxArtifactStore.getExtras().get( CassandraStoreUtil.PROXY_USER ) );
+                setIfNotNull( ( (RemoteRepository) store )::setPrefetchRescanTimestamp, dtxArtifactStore.getExtras().get( CassandraStoreUtil.PREFETCH_RESCAN_TIMESTAMP ) );
+
+                Integer timeoutSeconds = readValueFromExtra( CassandraStoreUtil.TIMEOUT_SECONDS, Integer.class, dtxArtifactStore.getExtras());
+                if ( timeoutSeconds != null )
+                {
+                    ( (RemoteRepository) store ).setTimeoutSeconds( timeoutSeconds.intValue() );
+                }
+                Integer metadataTimeoutSeconds = readValueFromExtra( CassandraStoreUtil.METADATA_TIMEOUT_SECONDS, Integer.class, dtxArtifactStore.getExtras());
+                if ( metadataTimeoutSeconds != null )
+                {
+                    ( (RemoteRepository) store ).setMetadataTimeoutSeconds( metadataTimeoutSeconds.intValue() );
+                }
+                Integer cacheTimeoutSeconds = readValueFromExtra( CassandraStoreUtil.CACHE_TIMEOUT_SECONDS, Integer.class, dtxArtifactStore.getExtras());
+                if ( cacheTimeoutSeconds != null )
+                {
+                    ( (RemoteRepository) store ).setCacheTimeoutSeconds( cacheTimeoutSeconds.intValue() );
+                }
+                Integer nfcTimeoutSeconds = readValueFromExtra( CassandraStoreUtil.NFC_TIMEOUT_SECONDS, Integer.class, dtxArtifactStore.getExtras());
+                if ( nfcTimeoutSeconds != null )
+                {
+                    ( (RemoteRepository) store ).setNfcTimeoutSeconds( nfcTimeoutSeconds.intValue() );
+                }
+                Integer maxConnections = readValueFromExtra( CassandraStoreUtil.MAX_CONNECTIONS, Integer.class, dtxArtifactStore.getExtras());
+                if ( maxConnections != null )
+                {
+                    ( (RemoteRepository) store ).setMaxConnections( maxConnections.intValue() );
+                }
+                Integer port = readValueFromExtra( CassandraStoreUtil.PORT, Integer.class, dtxArtifactStore.getExtras());
+                if ( port != null )
+                {
+                    ( (RemoteRepository) store ).setPort( port.intValue() );
+                }
+                Integer proxyPort = readValueFromExtra( CassandraStoreUtil.PROXY_PORT, Integer.class, dtxArtifactStore.getExtras());
+                if ( proxyPort != null )
+                {
+                    ( (RemoteRepository) store ).setProxyPort( proxyPort.intValue() );
+                }
+                Boolean prefetchRescan = readValueFromExtra( CassandraStoreUtil.PREFETCH_RESCAN, Boolean.class, dtxArtifactStore.getExtras());
+                if ( prefetchRescan != null )
+                {
+                    ( (RemoteRepository) store ).setPrefetchRescan( prefetchRescan );
+                }
+                Boolean passThrough = readValueFromExtra( CassandraStoreUtil.PASS_THROUGH, Boolean.class, dtxArtifactStore.getExtras());
+                if ( passThrough != null )
+                {
+                    ( (RemoteRepository) store ).setPassthrough( passThrough );
+                }
+                Boolean ignoreHostnameVerification = readValueFromExtra( CassandraStoreUtil.IGNORE_HOST_NAME_VERIFICATION, Boolean.class, dtxArtifactStore.getExtras());
+                if ( ignoreHostnameVerification != null )
+                {
+                    ( (RemoteRepository) store ).setIgnoreHostnameVerification( ignoreHostnameVerification );
+                }
+            }
+            else if ( dtxArtifactStore.getStoreType().equals( StoreType.group.name() ) )
+            {
+                List<String> constituentStrList = readValueFromExtra( CassandraStoreUtil.CONSTITUENTS, List.class, dtxArtifactStore.getExtras() );
+                List<StoreKey> constituentList = constituentStrList.stream().map( item -> StoreKey.fromString( item ) ).collect( Collectors.toList() );
+                store = new Group( dtxArtifactStore.getPackageType(), dtxArtifactStore.getName(), constituentList );
+
+                Boolean prependConstituent = readValueFromExtra( CassandraStoreUtil.PREPEND_CONSTITUENT, Boolean.class, dtxArtifactStore.getExtras());
+                if ( prependConstituent != null )
+                {
+                    ( (Group) store ).setPrependConstituent( prependConstituent );
+                }
+            }
+        }
+        return store;
+    }
+
+    private <T> void setIfNotNull( final Consumer<T> setter, final T value) {
+        if (value != null) {
+            setter.accept(value);
+        }
+    }
+
+    public <T> T readValueFromExtra(String key, Class<T> valueType, Map<String, String> extras )
+    {
+        try
+        {
+            if ( extras.get( key ) != null )
+            {
+                return objectMapper.readValue( extras.get( key ), valueType );
+            }
+        }
+        catch ( JsonProcessingException e )
+        {
+            logger.warn( "Read value from extra error, key: {}.", key, e );
+        }
+        return null;
+    }
+
+}

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreQuery.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreQuery.java
@@ -1,0 +1,120 @@
+package org.commonjava.indy.cassandra.data;
+
+import com.datastax.driver.core.BoundStatement;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.mapping.Mapper;
+import com.datastax.driver.mapping.MappingManager;
+import org.commonjava.indy.cassandra.data.config.CassandraStoreConfig;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.subsys.cassandra.CassandraClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.HashSet;
+import java.util.Set;
+
+@ApplicationScoped
+public class CassandraStoreQuery
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    CassandraClient client;
+
+    @Inject
+    CassandraStoreConfig storeConfig;
+
+    private Mapper<DtxArtifactStore> storeMapper;
+
+    private Session session;
+
+    private PreparedStatement preparedSingleArtifactStoreQuery;
+
+    private PreparedStatement preparedArtifactStoresQuery;
+
+    public CassandraStoreQuery() {}
+
+    public CassandraStoreQuery( CassandraClient client, CassandraStoreConfig config )
+    {
+        this.client = client;
+        this.storeConfig = config;
+        init();
+    }
+
+    @PostConstruct
+    public void init()
+    {
+
+        String keySpace = storeConfig.getKeyspace();
+
+        session = client.getSession( keySpace );
+
+        session.execute( CassandraStoreUtil.getSchemaCreateKeyspace( keySpace, storeConfig ) );
+        session.execute( CassandraStoreUtil.getSchemaCreateTableStore( keySpace ) );
+
+        MappingManager manager = new MappingManager( session );
+
+        storeMapper = manager.mapper( DtxArtifactStore.class, keySpace );
+
+        preparedSingleArtifactStoreQuery = session.prepare( "select * from " + keySpace + ".artifactstore where packagetype=? and storetype=? and name=?" );
+
+        preparedArtifactStoresQuery = session.prepare( "select * from " + keySpace + ".artifactstore" );
+    }
+
+    public DtxArtifactStore getArtifactStore( String packageType, StoreType type, String name )
+    {
+        BoundStatement bound = preparedSingleArtifactStoreQuery.bind( packageType, type.name(), name );
+        ResultSet result = session.execute( bound );
+        return toDtxArtifactStore( result.one() );
+    }
+
+    public Set<DtxArtifactStore> getAllArtifactStores()
+    {
+
+        BoundStatement bound = preparedArtifactStoresQuery.bind();
+        ResultSet result = session.execute( bound );
+
+        Set<DtxArtifactStore> dtxArtifactStoreSet = new HashSet<>(  );
+        result.forEach( row -> {
+            dtxArtifactStoreSet.add( toDtxArtifactStore( row ) );
+        } );
+
+        return dtxArtifactStoreSet;
+    }
+
+    private DtxArtifactStore toDtxArtifactStore( Row row )
+    {
+        if ( row == null )
+        {
+            return null;
+        }
+        DtxArtifactStore store = new DtxArtifactStore();
+        store.setPackageType( row.getString( CassandraStoreUtil.PACKAGE_TYPE ) );
+        store.setStoreType( row.getString( CassandraStoreUtil.STORE_TYPE ) );
+        store.setName( row.getString( CassandraStoreUtil.NAME ) );
+        store.setPathMaskPatterns( row.getSet( CassandraStoreUtil.PATH_MASK_PATTERNS, String.class ) );
+        store.setPathStyle( row.getString( CassandraStoreUtil.PATH_STYLE ) );
+        store.setDisabled( row.getBool( CassandraStoreUtil.DISABLED ) );
+        store.setDescription( row.getString( CassandraStoreUtil.DESCRIPTION ) );
+        store.setAuthoritativeIndex( row.getBool( CassandraStoreUtil.AUTHORITATIVE_INDEX ) );
+        store.setCreateTime( row.getString( CassandraStoreUtil.CREATE_TIME ) );
+        store.setDisableTimeout( row.getInt( CassandraStoreUtil.DISABLE_TIMEOUT ) );
+        store.setMetadata( row.getMap( CassandraStoreUtil.METADATA, String.class, String.class ) );
+        store.setRescanInProgress( row.getBool( CassandraStoreUtil.RESCAN_IN_PROGRESS ) );
+        store.setTransientMetadata( row.getMap( CassandraStoreUtil.TRANSIENT_METADATA, String.class, String.class ) );
+        store.setExtras( row.getMap( CassandraStoreUtil.EXTRAS, String.class, String.class ) );
+        return store;
+    }
+
+    public void createDtxArtifactStore( DtxArtifactStore dtxArtifactStore )
+    {
+        storeMapper.save( dtxArtifactStore );
+    }
+}

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreUtil.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreUtil.java
@@ -1,0 +1,81 @@
+package org.commonjava.indy.cassandra.data;
+
+import org.commonjava.indy.cassandra.data.config.CassandraStoreConfig;
+
+public class CassandraStoreUtil
+{
+
+    public static final String PACKAGE_TYPE = "packageType";
+    public static final String STORE_TYPE = "storeType";
+    public static final String NAME = "name";
+    public static final String DESCRIPTION = "description";
+    public static final String DISABLED = "disabled";
+    public static final String PATH_STYLE = "pathStyle";
+    public static final String TRANSIENT_METADATA = "transientMetadata";
+    public static final String METADATA = "metadata";
+    public static final String PATH_MASK_PATTERNS = "pathMaskPatterns";
+    public static final String CREATE_TIME = "createTime";
+    public static final String DISABLE_TIMEOUT = "disableTimeout";
+    public static final String RESCAN_IN_PROGRESS = "rescanInProgress";
+    public static final String AUTHORITATIVE_INDEX = "authoritativeIndex";
+    public static final String EXTRAS = "extras";
+
+    // the attributes of remote repository
+    public static final String URL = "url";
+    public static final String HOST = "host";
+    public static final String PORT = "port";
+    public static final String USER = "user";
+    public static final String PASSWORD = "password";
+    public static final String PROXY_HOST = "proxyHost";
+    public static final String PROXY_PORT = "proxyPort";
+    public static final String PROXY_USER = "proxyUser";
+    public static final String PROXY_PASSWORD = "proxyPassword";
+    public static final String KEY_CERT_PEM = "keyCertPem";
+    public static final String KEY_PASSWORD = "keyPassword";
+    public static final String TIMEOUT_SECONDS = "timeoutSeconds";
+    public static final String CACHE_TIMEOUT_SECONDS = "cacheTimeoutSeconds";
+    public static final String METADATA_TIMEOUT_SECONDS = "metadataTimeoutSeconds";
+    public static final String NFC_TIMEOUT_SECONDS = "nfcTimeoutSeconds";
+    public static final String PREFETCH_RESCAN = "prefetchRescan";
+    public static final String PREFETCH_RESCAN_TIMESTAMP = "prefetchRescanTimestamp";
+    public static final String MAX_CONNECTIONS = "maxConnections";
+    public static final String SERVER_CERT_PEM = "serverCertPem";
+    public static final String PASS_THROUGH = "passThrough";
+    public static final String IGNORE_HOST_NAME_VERIFICATION = "ignoreHostnameVerification";
+
+    // the attributes of hosted repository
+    public static final String STORAGE = "storage";
+    public static final String READONLY = "readonly";
+    public static final String SNAPSHOT_TIMEOUT_SECONDS = "snapshotTimeoutSeconds";
+
+    // the attributes of group repository
+    public static final String CONSTITUENTS = "constituents";
+    public static final String PREPEND_CONSTITUENT = "prependConstituent";
+
+    public static String getSchemaCreateKeyspace( String keySpace, CassandraStoreConfig storeConfig )
+    {
+        return "CREATE KEYSPACE IF NOT EXISTS " + keySpace
+                        + " WITH REPLICATION = {'class':'SimpleStrategy', 'replication_factor':" + storeConfig.getReplicationFactor() + "};";
+    }
+
+    public static String getSchemaCreateTableStore( String keySpace )
+    {
+        return "CREATE TABLE IF NOT EXISTS " + keySpace + ".artifactstore ("
+                        + "packagetype varchar,"
+                        + "storetype varchar,"
+                        + "name varchar,"
+                        + "description varchar,"
+                        + "disabled boolean,"
+                        + "pathstyle varchar,"
+                        + "transientmetadata map<text, text>,"
+                        + "metadata map<text, text>,"
+                        + "pathmaskpatterns set<text>,"
+                        + "createtime varchar,"
+                        + "disabletimeout int,"
+                        + "authoritativeindex boolean,"
+                        + "rescaninprogress boolean,"
+                        + "extras map<text, text>,"
+                        + "PRIMARY KEY (( packagetype, storetype ), name )"
+                        + ");";
+    }
+}

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/DtxArtifactStore.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/DtxArtifactStore.java
@@ -1,0 +1,210 @@
+package org.commonjava.indy.cassandra.data;
+
+import com.datastax.driver.mapping.annotations.ClusteringColumn;
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+
+import java.util.Map;
+import java.util.Set;
+
+@Table( name = "artifactstore", readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+public class DtxArtifactStore
+{
+
+    @PartitionKey(0)
+    private String packageType;
+
+    @PartitionKey(1)
+    private String storeType;
+
+    @ClusteringColumn
+    private String name;
+
+    @Column
+    private String description;
+
+    @Column
+    private transient Map<String, String> transientMetadata;
+
+    @Column
+    private Map<String, String> metadata;
+
+    @Column
+    private boolean disabled;
+
+    @Column
+    private int disableTimeout;
+
+    @Column
+    private String pathStyle;
+
+    @Column
+    private Set<String> pathMaskPatterns;
+
+    @Column
+    private Boolean authoritativeIndex;
+
+    @Column
+    private String createTime;
+
+    @Column
+    private Boolean rescanInProgress = false;
+
+    /**
+     * The map holds the specific attributes for each type of repository
+     */
+    @Column
+    private Map<String, String> extras;
+
+    public String getPackageType()
+    {
+        return packageType;
+    }
+
+    public void setPackageType( String packageType )
+    {
+        this.packageType = packageType;
+    }
+
+    public String getStoreType()
+    {
+        return storeType;
+    }
+
+    public void setStoreType( String storeType )
+    {
+        this.storeType = storeType;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName( String name )
+    {
+        this.name = name;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription( String description )
+    {
+        this.description = description;
+    }
+
+    public Map<String, String> getTransientMetadata()
+    {
+        return transientMetadata;
+    }
+
+    public void setTransientMetadata( Map<String, String> transientMetadata )
+    {
+        this.transientMetadata = transientMetadata;
+    }
+
+    public Map<String, String> getMetadata()
+    {
+        return metadata;
+    }
+
+    public void setMetadata( Map<String, String> metadata )
+    {
+        this.metadata = metadata;
+    }
+
+    public boolean isDisabled()
+    {
+        return disabled;
+    }
+
+    public void setDisabled( boolean disabled )
+    {
+        this.disabled = disabled;
+    }
+
+    public int getDisableTimeout()
+    {
+        return disableTimeout;
+    }
+
+    public void setDisableTimeout( int disableTimeout )
+    {
+        this.disableTimeout = disableTimeout;
+    }
+
+    public String getPathStyle()
+    {
+        return pathStyle;
+    }
+
+    public void setPathStyle( String pathStyle )
+    {
+        this.pathStyle = pathStyle;
+    }
+
+    public Set<String> getPathMaskPatterns()
+    {
+        return pathMaskPatterns;
+    }
+
+    public void setPathMaskPatterns( Set<String> pathMaskPatterns )
+    {
+        this.pathMaskPatterns = pathMaskPatterns;
+    }
+
+    public Boolean getAuthoritativeIndex()
+    {
+        return authoritativeIndex;
+    }
+
+    public void setAuthoritativeIndex( Boolean authoritativeIndex )
+    {
+        this.authoritativeIndex = authoritativeIndex;
+    }
+
+    public String getCreateTime()
+    {
+        return createTime;
+    }
+
+    public void setCreateTime( String createTime )
+    {
+        this.createTime = createTime;
+    }
+
+    public Boolean getRescanInProgress()
+    {
+        return rescanInProgress;
+    }
+
+    public void setRescanInProgress( Boolean rescanInProgress )
+    {
+        this.rescanInProgress = rescanInProgress;
+    }
+
+    public Map<String, String> getExtras()
+    {
+        return extras;
+    }
+
+    public void setExtras( Map<String, String> extras )
+    {
+        this.extras = extras;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "DtxArtifactStore{" + "packageType='" + packageType + '\'' + ", storeType='" + storeType + '\''
+                        + ", name='" + name + '\'' + ", description='" + description + '\'' + ", transientMetadata="
+                        + transientMetadata + ", metadata=" + metadata + ", disabled=" + disabled + ", disableTimeout="
+                        + disableTimeout + ", pathStyle='" + pathStyle + '\'' + ", pathMaskPatterns=" + pathMaskPatterns
+                        + ", authoritativeIndex=" + authoritativeIndex + ", createTime='" + createTime + '\''
+                        + ", rescanInProgress=" + rescanInProgress + ", extras=" + extras + '}';
+    }
+}

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/config/CassandraStoreConfig.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/config/CassandraStoreConfig.java
@@ -1,0 +1,60 @@
+package org.commonjava.indy.cassandra.data.config;
+
+import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.propulsor.config.annotation.ConfigName;
+import org.commonjava.propulsor.config.annotation.SectionName;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.InputStream;
+
+@SectionName( "artifact_store" )
+@ApplicationScoped
+public class CassandraStoreConfig implements IndyConfigInfo
+{
+
+    private String keyspace;
+
+    private int replicationFactor;
+
+    public CassandraStoreConfig() {}
+
+    public CassandraStoreConfig( String keyspace, int replicationFactor )
+    {
+        this.keyspace = keyspace;
+        this.replicationFactor = replicationFactor;
+    }
+
+    public String getKeyspace()
+    {
+        return keyspace;
+    }
+
+    @ConfigName( "store.keyspace" )
+    public void setKeyspace( String keyspace )
+    {
+        this.keyspace = keyspace;
+    }
+
+    public int getReplicationFactor()
+    {
+        return replicationFactor;
+    }
+
+    @ConfigName( "store.keyspace.replica" )
+    public void setReplicationFactor( int replicationFactor )
+    {
+        this.replicationFactor = replicationFactor;
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return "";
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return null;
+    }
+}

--- a/db/cassandra/src/test/java/org/commonjava/indy/cassandra/data/CassandraStoreTest.java
+++ b/db/cassandra/src/test/java/org/commonjava/indy/cassandra/data/CassandraStoreTest.java
@@ -1,0 +1,71 @@
+package org.commonjava.indy.cassandra.data;
+
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper;
+import org.commonjava.indy.cassandra.data.config.CassandraStoreConfig;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.subsys.cassandra.CassandraClient;
+import org.commonjava.indy.subsys.cassandra.config.CassandraConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class CassandraStoreTest
+{
+
+
+    CassandraClient client;
+
+    CassandraStoreQuery storeQuery;
+
+    @Before
+    public void start() throws Exception
+    {
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+
+        CassandraConfig config = new CassandraConfig();
+        config.setEnabled( true );
+        config.setCassandraHost( "localhost" );
+        config.setCassandraPort( 9142 );
+
+        client = new CassandraClient( config );
+        CassandraStoreConfig storeConfig = new CassandraStoreConfig("noncontent", 1);
+
+        storeQuery = new CassandraStoreQuery( client, storeConfig );
+
+    }
+
+    @After
+    public void stop()
+    {
+        client.close();
+        EmbeddedCassandraServerHelper.cleanEmbeddedCassandra();
+    }
+
+    @Test
+    public void testQuery()
+    {
+        DtxArtifactStore store = new DtxArtifactStore();
+        store.setPackageType( "maven" );
+        store.setStoreType( StoreType.hosted.name() );
+        store.setName( "build-01" );
+        store.setDescription( "test cassandra store" );
+        store.setDisabled( true );
+
+        Set<String> maskPatterns = new HashSet<>(  );
+
+        store.setPathMaskPatterns( maskPatterns );
+        storeQuery.createDtxArtifactStore( store );
+
+        Set<DtxArtifactStore> storeSet = storeQuery.getAllArtifactStores();
+
+        assertThat(storeSet.size(), equalTo( 1 ));
+
+    }
+
+}

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -35,6 +35,7 @@
     <module>flat</module>
     <module>infinispan</module>
     <module>metrics</module>
+    <module>cassandra</module>
   </modules>
   
 </project>

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -99,6 +99,10 @@
       <artifactId>indy-db-infinispan</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-db-cassandra</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.commonjava.indy.boot</groupId>
       <artifactId>indy-booter-jaxrs</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,11 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-db-cassandra</artifactId>
+        <version>2.5.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-bindings-jaxrs</artifactId>
         <version>2.5.0-SNAPSHOT</version>
       </dependency>


### PR DESCRIPTION
The patch only considers the basic operation against the artifact store in cassandra, for the affectedByStores, let's see if it would be better to use another table instead of the cache. 