### PR TITLE
Update propulsor to 1.5-SNAPSHOT for http/2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <jhttpcVersion>1.11</jhttpcVersion>
     <weftVersion>1.18-SNAPSHOT</weftVersion>
     <httpTestserverVersion>1.4</httpTestserverVersion>
-    <propulsorVersion>1.4</propulsorVersion>
+    <propulsorVersion>1.5-SNAPSHOT</propulsorVersion>
     <auditQueryVersion>0.13.1</auditQueryVersion>
     <annotationVersion>1.3.2</annotationVersion>
     <activationVersion>1.2.0</activationVersion>


### PR DESCRIPTION
As subject.
With this, we can declare Indy supports HTTP/2. However, client side needs to change (e.g., mvn settings.xml). What I learned is to add "Upgrade: h2c" header. Maybe we need to run sth like 'curl --verbose' to verify HTTP/2 is in action.