### PR TITLE
Fix a wrong line problem

### DIFF
--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SlashTolerationFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/SlashTolerationFilter.java
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.commonjava.indy.bind.jaxrs;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;


### PR DESCRIPTION
   This problem will cause compilation error when after license header
   formatting, which is caused by the package line removed.