### PR TITLE
Add content limiting via expiration and eviction for repo-proxy in Indy

### DIFF
--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/conf/RepoProxyConfig.java
@@ -46,6 +46,8 @@ public class RepoProxyConfig
 
     private static final String ENABLED_PARAM = "enabled";
 
+    private static final String CONTENT_LIMITER_ENABLED = "content.limiter.enabled";
+
     private static final String API_PATTERNS_PARAM = "api.url.patterns";
 
     private static final String API_METHODS_PARAM = "api.methods";
@@ -74,6 +76,8 @@ public class RepoProxyConfig
 
     private static final Boolean DEFAULT_CONTENT_BROWSE_REWRITE_ENABLE = Boolean.TRUE;
 
+    private static final Boolean DEFAULT_CONTENT_LIMITER_ENABLE = Boolean.TRUE;
+
     private static final Integer DEFAULT_REMOTE_INDY_REQUEST_TIMEOUT = 60;
 
     private String repoCreatorRuleBaseDir;
@@ -89,6 +93,8 @@ public class RepoProxyConfig
     private Boolean npmMetaRewriteEnabled;
 
     private Boolean contentBrowseRewriteEnabled;
+
+    private Boolean contentLimiterEnabled;
 
     private String defaultRemoteIndyUrl;
 
@@ -122,6 +128,12 @@ public class RepoProxyConfig
         return this.contentBrowseRewriteEnabled == null ?
                 DEFAULT_CONTENT_BROWSE_REWRITE_ENABLE :
                 this.contentBrowseRewriteEnabled;
+    }
+
+    public Boolean isContentLimiterEnabled()
+    {
+        return this.contentLimiterEnabled == null ? DEFAULT_CONTENT_LIMITER_ENABLE :
+                        this.contentLimiterEnabled;
     }
 
     public Set<String> getApiPatterns()
@@ -219,6 +231,9 @@ public class RepoProxyConfig
                 break;
             case REMOTE_INDY_REQUEST_TIMEOUT:
                 this.remoteIndyRequestTimeout = Integer.parseInt( value.trim() );
+                break;
+            case CONTENT_LIMITER_ENABLED:
+                this.contentLimiterEnabled = Boolean.valueOf( value.trim() );
                 break;
             default:
                 break;

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/content/RepoProxyCacheProducer.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/content/RepoProxyCacheProducer.java
@@ -1,0 +1,30 @@
+package org.commonjava.indy.repo.proxy.content;
+
+import org.commonjava.indy.core.expire.ScheduleKey;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.CacheProducer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+import java.util.Map;
+
+public class RepoProxyCacheProducer
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private CacheProducer cacheProducer;
+
+    private static final String REPO_PROXY_CONTENT_CACHE = "repo-proxy-content";
+
+    @RepoProxyContentCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<ScheduleKey, Map> scheduleExpireCache()
+    {
+        return cacheProducer.getCache( REPO_PROXY_CONTENT_CACHE );
+    }
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/content/RepoProxyCacheProducer.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/content/RepoProxyCacheProducer.java
@@ -1,6 +1,5 @@
 package org.commonjava.indy.repo.proxy.content;
 
-import org.commonjava.indy.core.expire.ScheduleKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import org.slf4j.Logger;
@@ -9,7 +8,6 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
-import java.util.Map;
 
 public class RepoProxyCacheProducer
 {
@@ -23,7 +21,7 @@ public class RepoProxyCacheProducer
     @RepoProxyContentCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<ScheduleKey, Map> scheduleExpireCache()
+    public CacheHandle<String, String> scheduleExpireCache()
     {
         return cacheProducer.getCache( REPO_PROXY_CONTENT_CACHE );
     }

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/content/RepoProxyContentCache.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/content/RepoProxyContentCache.java
@@ -1,0 +1,19 @@
+package org.commonjava.indy.repo.proxy.content;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Qualifier used to supply "repo-proxy-content" cache
+ */
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD } )
+@Retention( RetentionPolicy.RUNTIME )
+@Documented
+public @interface RepoProxyContentCache
+{
+}

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/content/RepoProxyContentLimiter.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/content/RepoProxyContentLimiter.java
@@ -1,0 +1,118 @@
+package org.commonjava.indy.repo.proxy.content;
+
+import org.commonjava.indy.IndyWorkflowException;
+import org.commonjava.indy.content.ContentManager;
+import org.commonjava.indy.data.IndyDataException;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.galley.KeyedLocation;
+import org.commonjava.indy.repo.proxy.conf.RepoProxyConfig;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.util.LocationUtils;
+import org.commonjava.maven.galley.event.FileStorageEvent;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntriesEvicted;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
+import org.infinispan.notifications.cachelistener.event.CacheEntriesEvictedEvent;
+import org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import java.util.Map;
+
+@ApplicationScoped
+@Listener
+public class RepoProxyContentLimiter
+{
+
+    private CacheHandle<String, String> storedPaths;
+
+    private RepoProxyConfig config;
+
+    private StoreDataManager storeDataManager;
+
+    private ContentManager contentManager;
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    public RepoProxyContentLimiter( @RepoProxyContentCache CacheHandle<String, String> storedPaths,
+                                    StoreDataManager storeDataManager, ContentManager contentManager,
+                                    RepoProxyConfig config )
+    {
+        this.storedPaths = storedPaths;
+        this.storeDataManager = storeDataManager;
+        this.contentManager = contentManager;
+        this.config = config;
+    }
+
+    public void onContentStorage( @Observes FileStorageEvent storageEvent )
+    {
+        if ( !isEnabled() )
+        {
+            return;
+        }
+
+        StoreKey storeKey = LocationUtils.getKey( storageEvent );
+        String path = storageEvent.getTransfer().getPath();
+        String skp = storeKey.toString() + "#" + path;
+
+        storedPaths.put( skp, skp );
+    }
+
+    private boolean isEnabled()
+    {
+        return config.isEnabled() && config.isContentLimiterEnabled();
+    }
+
+    @CacheEntryExpired
+    public void onContentExpiration( CacheEntryExpiredEvent<String, String> event )
+    {
+        if ( !isEnabled() )
+        {
+            return;
+        }
+
+        clearContent( event.getKey() );
+    }
+
+    @CacheEntriesEvicted
+    public void onContentEviction( CacheEntriesEvictedEvent<String, String> event )
+    {
+        if ( !isEnabled() )
+        {
+            return;
+        }
+
+        Map<String, String> entries = event.getEntries();
+        for ( String skp : entries.keySet() )
+        {
+            clearContent( skp );
+        }
+    }
+
+    private void clearContent( String skp )
+    {
+        String[] parts = skp.split( "#" );
+        StoreKey storeKey = StoreKey.fromString( parts[0] );
+        ArtifactStore store = null;
+        try
+        {
+            store = storeDataManager.getArtifactStore( storeKey );
+            contentManager.delete( store, parts[1] );
+        }
+        catch ( IndyDataException e )
+        {
+            logger.warn( "Failed to lookup store: {} from event: {}", storeKey, skp );
+        }
+        catch ( IndyWorkflowException e )
+        {
+            logger.warn( "Failed to delete: {} from: {}, from event: {}", parts[1], storeKey, skp );
+        }
+    }
+
+}


### PR DESCRIPTION
This adds a new cache-based content limiter for repo-proxy use cases. The idea is to avoid the table scans and other problems associated with scheduled expiration, and instead allow the eviction AND expiration to cause content to be deleted. Eviction is the main mechanism at work here, and allows us to tune disk usage for proxy use cases by tuning the number of cache entries allowed in memory.

The ScheduleManager approach tries to be a lot more correct in tracking and expiring content, and as a result it spends a lot more effort maintaining the cache for deleted or otherwise obsoleted entries. This results in a lot of table scans, using the current approach.

In contrast, the repo content limiter cache allows the entries to become obsolete, in the event content gets deleted. When this happens, the content will not be referenced, and will eventually be evicted through normal operation of the cache. We can store the cache in a database still, and have expiration serve as a backstop for items that were never loaded into memory on restart.

This still needs a test to ensure it works correctly. It also needs a default cache configuration, though I'm not 100% sure we need it.

This is a proposal only. Let's debate the benefit of doing this over adjusting the ScheduleManager to be more efficient, and if this approach is the most beneficial, then we can finish it.