### PR TITLE
Add .gitignore checking for folo lifecycle start

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloLifecycleParticipant.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloLifecycleParticipant.java
@@ -29,6 +29,7 @@ import org.commonjava.indy.subsys.datafile.DataFile;
 import org.commonjava.indy.subsys.datafile.DataFileManager;
 
 @Named
+@Deprecated
 public class FoloLifecycleParticipant
     implements StartupAction
 {
@@ -69,7 +70,7 @@ public class FoloLifecycleParticipant
         {
             final DataFile dataFile = dataFileManager.getDataFile( ".gitignore" );
             final List<String> lines = dataFile.exists() ? dataFile.readLines() : new ArrayList<String>();
-            if ( !lines.contains( FOLO_DIRECTORY_IGNORE ) )
+            if ( dataFile.exists() && !lines.contains( FOLO_DIRECTORY_IGNORE ) )
             {
                 lines.add( FOLO_DIRECTORY_IGNORE );
 


### PR DESCRIPTION
  As we have dropped the usage of git to manage data dir, and we have
  switched to use infinispan to manage folo records, I don't think this
  folo lifecycle action is still needed. But for safety, I just added
  deprecated, and a .gitignore file existence checking here.