### PR TITLE
Refactor schedule expiration to use ispn query api

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
@@ -20,17 +20,22 @@ import org.commonjava.indy.core.change.StoreEnablementManager;
 import org.commonjava.indy.core.expire.Expiration;
 import org.commonjava.indy.core.expire.ExpirationSet;
 import org.commonjava.indy.core.expire.ScheduleManager;
+import org.commonjava.indy.core.expire.ScheduleValue;
 import org.commonjava.indy.core.expire.StoreKeyMatcher;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.infinispan.commons.api.BasicCache;
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -85,11 +90,16 @@ public class SchedulerController
 
             // This key matcher will compare with the cache key group to see if the group ends with the "Disable-Timeout"(jobtype)
             ExpirationSet expirations = scheduleManager.findMatchingExpirations(
-                    cacheHandle -> cacheHandle.execute( BasicCache::keySet )
-                                              .stream()
-                                              .filter( key -> key.getType()
-                                                                 .equals( StoreEnablementManager.DISABLE_TIMEOUT ) )
-                                              .collect( Collectors.toSet() ) );
+                    cacheHandle -> {
+                        QueryFactory queryFactory = Search.getQueryFactory( cacheHandle.getCache() );
+                        Query q = queryFactory.from( ScheduleValue.class ).having( "key.type" ).eq( StoreEnablementManager.DISABLE_TIMEOUT ).build();
+                        List<ScheduleValue> list = q.list();
+                        return list.stream().map( ScheduleValue::getKey ).collect( Collectors.toSet());
+//                        cacheHandle.execute( BasicCache::keySet )
+//                                   .stream()
+//                                   .filter( key -> key.getType().equals( StoreEnablementManager.DISABLE_TIMEOUT ) )
+//                                   .collect( Collectors.toSet() );
+                    } );
 
 
             // TODO: This seems REALLY inefficient...

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleKey.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleKey.java
@@ -17,6 +17,10 @@ package org.commonjava.indy.core.expire;
 
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -25,13 +29,20 @@ import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.util.Objects;
 
+@Indexed
 public class ScheduleKey implements Externalizable, Serializable
 {
+    @Field( index = Index.YES, analyze = Analyze.NO )
     private StoreKey storeKey;
 
+    @Field( index = Index.YES, analyze = Analyze.NO )
     private String type;
 
+    @Field( index = Index.YES, analyze = Analyze.NO )
     private String name;
+
+    @Field( index = Index.YES, analyze = Analyze.NO )
+    private String groupName;
 
     public ScheduleKey()
     {
@@ -42,6 +53,7 @@ public class ScheduleKey implements Externalizable, Serializable
         this.storeKey = storeKey;
         this.type = type;
         this.name = name;
+        this.groupName = ScheduleManager.groupName( this.storeKey, this.type );
     }
 
     public StoreKey getStoreKey()
@@ -59,9 +71,9 @@ public class ScheduleKey implements Externalizable, Serializable
         return name;
     }
 
-    public String groupName()
+    public String getGroupName()
     {
-        return ScheduleManager.groupName( this.storeKey, this.type );
+        return groupName;
     }
 
     public static ScheduleKey fromGroupWithName( final String group, final String name )
@@ -134,5 +146,7 @@ public class ScheduleKey implements Externalizable, Serializable
 
         final String nameStr = (String) in.readObject();
         name = "".equals( nameStr ) ? null : nameStr;
+
+        groupName = ScheduleManager.groupName( storeKey, type );
     }
 }

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleValue.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleValue.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.expire;
+
+import org.commonjava.indy.model.core.StoreType;
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.util.Map;
+
+@Indexed
+public class ScheduleValue
+        implements Externalizable
+{
+    @Field( index = Index.YES, analyze = Analyze.NO )
+    private ScheduleKey key;
+
+    @Field( index = Index.NO, analyze = Analyze.NO )
+    private Map<String, Object> dataPayload;
+
+    public ScheduleValue( ScheduleKey key, Map<String, Object> dataPayload )
+    {
+        this.key = key;
+        this.dataPayload = dataPayload;
+    }
+
+    public ScheduleKey getKey()
+    {
+        return key;
+    }
+
+    public Map<String, Object> getDataPayload()
+    {
+        return dataPayload;
+    }
+
+    @Override
+    public void writeExternal( ObjectOutput out )
+            throws IOException
+    {
+        out.writeObject( key );
+        out.writeObject( dataPayload );
+    }
+
+    @Override
+    public void readExternal( ObjectInput in )
+            throws IOException, ClassNotFoundException
+    {
+        this.key = (ScheduleKey)in.readObject();
+        this.dataPayload = (Map)in.readObject();
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/expire/StoreKeyMatcher.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/StoreKeyMatcher.java
@@ -18,8 +18,12 @@ package org.commonjava.indy.core.expire;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheKeyMatcher;
-import org.infinispan.commons.api.BasicCache;
+import org.infinispan.query.Search;
+import org.infinispan.query.dsl.Query;
+import org.infinispan.query.dsl.QueryFactory;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -43,9 +47,13 @@ public class StoreKeyMatcher
     @Override
     public Set<ScheduleKey> matches( CacheHandle<ScheduleKey, ?> cacheHandle )
     {
-        return cacheHandle.execute( BasicCache::keySet )
-                          .stream()
-                          .filter( key -> key != null && key.exists() && key.groupName().equals( groupName ) )
-                          .collect( Collectors.toSet() );
+        QueryFactory queryFactory = Search.getQueryFactory( cacheHandle.getCache() );
+        Query q = queryFactory.from( ScheduleValue.class ).having( "key.groupName" ).eq( groupName ).build();
+        List<ScheduleValue> list = q.list();
+        return list.stream().map( ScheduleValue::getKey ).collect( Collectors.toSet());
+//        return cacheHandle.execute( BasicCache::keySet )
+//                          .stream()
+//                          .filter( key -> key != null && key.exists() && key.groupName().equals( groupName ) )
+//                          .collect( Collectors.toSet() );
     }
 }

--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.core.expire.cache;
 
 import org.commonjava.indy.cluster.IndyNode;
 import org.commonjava.indy.core.expire.ScheduleKey;
+import org.commonjava.indy.core.expire.ScheduleValue;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import org.slf4j.Logger;
@@ -48,7 +49,7 @@ public class ScheduleCacheProducer
     @ScheduleCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<ScheduleKey, Map> scheduleExpireCache()
+    public CacheHandle<ScheduleKey, ScheduleValue> scheduleExpireCache()
     {
         return cacheProducer.getCache( SCHEDULE_EXPIRE );
     }

--- a/core/src/test/java/org/commonjava/indy/core/expire/ScheduleManagerTest.java
+++ b/core/src/test/java/org/commonjava/indy/core/expire/ScheduleManagerTest.java
@@ -52,7 +52,7 @@ public class ScheduleManagerTest
     {
         StoreKey k = new StoreKey( "maven", StoreType.remote, "repo1" );
         ScheduleKey key = new ScheduleKey(k, ScheduleManager.CONTENT_JOB_TYPE, "/abc");
-        final StoreKey sk = ScheduleManager.storeKeyFrom( key.groupName() );
+        final StoreKey sk = ScheduleManager.storeKeyFrom( key.getGroupName() );
         System.out.println(">>> " + sk);
         assertNotNull( sk );
         assertEquals( sk, k );


### PR DESCRIPTION
  We found that the ScheduleManager.cancel method will trigger the full table scan of the ScheduleCache because of the looping in its stream usage. This caused really bad performance impact on indy-static server. This commit is addressing this problem. It refactor the cache value object from a Map to a pojo which contains that map, and do indexing from ispn level. And then replace the stream looping with ispn query api.