### PR TITLE
Fix scheduler causing blocked threads

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -286,8 +286,7 @@ public class ScheduleManager
         {
             //            logger.info( "[PROXY TIMEOUT SET] {}/{}; {}", repo.getKey(), path, new Date( System.currentTimeMillis()
             //                + timeout ) );
-            cancel( new StoreKeyMatcher( key, CONTENT_JOB_TYPE ), path );
-
+            removeCache( new ScheduleKey( key, CONTENT_JOB_TYPE, path ) );
             scheduleContentExpiration( key, path, timeout );
         }
     }
@@ -708,10 +707,7 @@ public class ScheduleManager
 
     private void removeCache( final ScheduleKey cacheKey )
     {
-        if ( scheduleCache.containsKey( cacheKey ) )
-        {
-            scheduleCache.remove( cacheKey );
-        }
+        scheduleCache.remove( cacheKey );
     }
 
     @CacheEntryCreated


### PR DESCRIPTION
We received lots of JVM Blocked Threads alert today. I found those threads on indy-static were blocked by StoreKeyMatcher.matches(StoreKeyMatcher.java:52).
See full thread dump at [threaddump-20201102.log](https://github.com/Commonjava/indy/files/5474593/threaddump-20201102.log)
Each file event triggers a cancel() and the latter calls matches() which unfortunately do a **full table scan** to iterate through all cache keys. I believe this is a mistake. To find the target entry, we just use the schedulekey.