### PR TITLE
Promotion: Add promote admin REST resource

### DIFF
--- a/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteAdminClientModule.java
+++ b/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteAdminClientModule.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.client;
+
+import org.apache.http.HttpStatus;
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.client.core.util.UrlUtils;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.promote.model.GroupPromoteRequest;
+import org.commonjava.indy.promote.model.GroupPromoteResult;
+import org.commonjava.indy.promote.model.PathsPromoteRequest;
+import org.commonjava.indy.promote.model.PathsPromoteResult;
+import org.commonjava.indy.promote.model.ValidationRuleDTO;
+import org.commonjava.indy.promote.model.ValidationRuleSet;
+
+import javax.xml.ws.Response;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.commonjava.indy.client.core.util.UrlUtils.buildUrl;
+
+public class IndyPromoteAdminClientModule
+        extends IndyClientModule
+{
+
+    public static final String PROMOTE_ADMIN_BASEPATH = "admin/promotion";
+
+    public static final String VALIDATION_BASEPATH = PROMOTE_ADMIN_BASEPATH + "/validation";
+
+    public static final String VALIDATION_RELOAD_PATH = VALIDATION_BASEPATH + "/reload";
+
+    public static final String VALIDATION_RELOAD_RULES_PATH = VALIDATION_RELOAD_PATH + "/rules";
+
+    public static final String VALIDATION_RELOAD_RULESETS_PATH = VALIDATION_RELOAD_PATH + "/rulesets";
+
+    public static final String VALIDATION_RELOAD_ALL_PATH = VALIDATION_RELOAD_PATH + "/all";
+
+    public static final String VALIDATION_RULES_BASEPATH = VALIDATION_BASEPATH + "/rules";
+
+    public static final String VALIDATION_RULES_GET_ALL_PATH = VALIDATION_RULES_BASEPATH + "/all";
+
+    public static final String VALIDATION_RULES_GET_BY_NAME_PATH = VALIDATION_RULES_BASEPATH + "/named";
+
+    public static final String VALIDATION_RULESET_BASEPATH = VALIDATION_BASEPATH + "/rulesets";
+
+    public static final String VALIDATION_RULESET_GET_ALL_PATH = VALIDATION_RULESET_BASEPATH + "/all";
+
+    public static final String VALIDATION_RULESET_GET_BY_STOREKEY_PATH = VALIDATION_RULESET_BASEPATH + "/storekey";
+
+    public static final String VALIDATION_RULESET_GET_BY_NAME_PATH = VALIDATION_RULESET_BASEPATH + "/named";
+
+    public boolean reloadRules()
+            throws IndyClientException
+    {
+        return http.put( VALIDATION_RELOAD_RULES_PATH, null, HttpStatus.SC_OK );
+
+    }
+
+    public boolean reloadRuleSets()
+            throws IndyClientException
+    {
+        return http.put( VALIDATION_RELOAD_RULESETS_PATH, null, HttpStatus.SC_OK );
+
+    }
+
+    public boolean reloadRuleBundles()
+            throws IndyClientException
+    {
+        return http.put( VALIDATION_RELOAD_ALL_PATH, null, HttpStatus.SC_OK );
+
+    }
+
+    public List<?> getAllRules()
+            throws IndyClientException
+    {
+        return http.get( VALIDATION_RULES_GET_ALL_PATH, List.class );
+    }
+
+    public ValidationRuleDTO getRuleByName( final String name )
+            throws IndyClientException
+    {
+        return http.get( buildUrl( VALIDATION_RULES_GET_BY_NAME_PATH, name ), ValidationRuleDTO.class );
+    }
+
+    public List<?> getAllRuleSets()
+            throws IndyClientException
+    {
+        return http.get( VALIDATION_RULESET_GET_ALL_PATH, List.class );
+    }
+
+    public ValidationRuleSet getRuleSetByName( final String name )
+            throws IndyClientException
+    {
+        return http.get( buildUrl( VALIDATION_RULESET_GET_BY_NAME_PATH, name ), ValidationRuleSet.class );
+    }
+
+    public ValidationRuleSet getRuleSetByStoreKey( final StoreKey key )
+            throws IndyClientException
+    {
+        return http.get( buildUrl( VALIDATION_RULESET_GET_BY_STOREKEY_PATH, key.toString() ), ValidationRuleSet.class );
+    }
+}

--- a/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteAdminClientModule.java
+++ b/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteAdminClientModule.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.commonjava.indy.client.core.util.UrlUtils.buildUrl;
 
@@ -68,28 +69,29 @@ public class IndyPromoteAdminClientModule
     public boolean reloadRules()
             throws IndyClientException
     {
-        return http.put( VALIDATION_RELOAD_RULES_PATH, null, HttpStatus.SC_OK );
+        return http.put( VALIDATION_RELOAD_RULES_PATH, "", HttpStatus.SC_OK );
 
     }
 
     public boolean reloadRuleSets()
             throws IndyClientException
     {
-        return http.put( VALIDATION_RELOAD_RULESETS_PATH, null, HttpStatus.SC_OK );
+        return http.put( VALIDATION_RELOAD_RULESETS_PATH, "", HttpStatus.SC_OK );
 
     }
 
     public boolean reloadRuleBundles()
             throws IndyClientException
     {
-        return http.put( VALIDATION_RELOAD_ALL_PATH, null, HttpStatus.SC_OK );
+        return http.put( VALIDATION_RELOAD_ALL_PATH, "", HttpStatus.SC_OK );
 
     }
 
-    public List<?> getAllRules()
+    public List<String> getAllRules()
             throws IndyClientException
     {
-        return http.get( VALIDATION_RULES_GET_ALL_PATH, List.class );
+        List<?> rules = http.get( VALIDATION_RULES_GET_ALL_PATH, List.class );
+        return rules.stream().map( Object::toString ).collect( Collectors.toList() );
     }
 
     public ValidationRuleDTO getRuleByName( final String name )
@@ -98,10 +100,11 @@ public class IndyPromoteAdminClientModule
         return http.get( buildUrl( VALIDATION_RULES_GET_BY_NAME_PATH, name ), ValidationRuleDTO.class );
     }
 
-    public List<?> getAllRuleSets()
+    public List<String> getAllRuleSets()
             throws IndyClientException
     {
-        return http.get( VALIDATION_RULESET_GET_ALL_PATH, List.class );
+        List<?> rules = http.get( VALIDATION_RULESET_GET_ALL_PATH, List.class );
+        return rules.stream().map( Object::toString ).collect( Collectors.toList() );
     }
 
     public ValidationRuleSet getRuleSetByName( final String name )

--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromoteValidationsManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromoteValidationsManager.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 @ApplicationScoped
@@ -251,9 +252,26 @@ public class PromoteValidationsManager
         return mapping == null ? null : mapping.getRule();
     }
 
-    public ValidationRuleDTO getNamedRuleAsDTO( final String name )
+    public Optional<ValidationRuleDTO> getNamedRuleAsDTO( final String name )
     {
-        return toDTO().getRules().get( name );
+        final Map<String, ValidationRuleDTO> rules = toDTO().getRules();
+        ValidationRuleDTO dto = rules.get( name );
+        if ( dto == null )
+        {
+            dto = rules.get( name + ".groovy" );
+        }
+        return dto == null ? Optional.empty() : Optional.of( dto );
+    }
+
+    public Optional<ValidationRuleSet> getNamedRuleSet( final String name )
+    {
+        final Map<String, ValidationRuleSet> ruleSets = toDTO().getRuleSets();
+        ValidationRuleSet ruleSet = ruleSets.get( name );
+        if ( ruleSet == null )
+        {
+            ruleSet = ruleSets.get( name + ".json" );
+        }
+        return ruleSet == null ? Optional.empty() : Optional.of( ruleSet );
     }
 
     public synchronized ValidationRuleMapping removeRuleNamed( final String name, final ChangeSummary changelog )

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/admin/AbstractAdminValidationTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/admin/AbstractAdminValidationTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest.admin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
+import org.commonjava.indy.promote.client.IndyPromoteAdminClientModule;
+import org.commonjava.indy.promote.model.ValidationRuleSet;
+import org.commonjava.indy.test.fixture.core.CoreServerFixture;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+public abstract class AbstractAdminValidationTest
+        extends AbstractIndyFunctionalTest
+{
+    protected IndyPromoteAdminClientModule module;
+
+    @Override
+    public void start()
+            throws Throwable
+    {
+        super.start();
+        module = client.module( IndyPromoteAdminClientModule.class );
+    }
+
+    @Override
+    protected void initTestData( CoreServerFixture fixture )
+            throws IOException
+    {
+        getRuleScriptFiles().forEach( ( k, v ) -> {
+            try
+            {
+                deployRule( k, v );
+            }
+            catch ( IOException e )
+            {
+                logger.error( e.getMessage(), e );
+            }
+        } );
+
+        Map<String, ValidationRuleSet> sets = getRuleSets();
+        if ( sets != null && !sets.isEmpty() )
+        {
+            sets.forEach( ( name, set ) -> {
+                try
+                {
+                    deployRuleSet( name, set );
+                }
+                catch ( IOException e )
+                {
+                    logger.error( e.getMessage(), e );
+                }
+            } );
+
+        }
+
+        super.initTestData( fixture );
+    }
+
+    protected void deployRule( String ruleName, String ruleContent )
+            throws IOException
+    {
+        String fileName = ruleName.endsWith( ".groovy" ) ? ruleName : ruleName + ".groovy";
+        String rulePath = "promote/rules/" + fileName;
+        deleteRule( fileName );
+        writeDataFile( rulePath, ruleContent );
+    }
+
+    protected void deployRuleSet( String fileName,  ValidationRuleSet ruleSet )
+            throws IOException
+    {
+        String json = new ObjectMapper().writeValueAsString( ruleSet );
+        String ruleSetFileName = fileName.endsWith( ".json" ) ? fileName : fileName + ".json";
+        String rulesetPath = "promote/rule-sets/" + ruleSetFileName;
+        deleteRuleSet( ruleSetFileName );
+        writeDataFile( rulesetPath, json );
+    }
+
+    protected boolean deleteRule( String ruleName )
+    {
+        String fileName = ruleName.endsWith( ".groovy" ) ? ruleName : ruleName + ".groovy";
+        return new File( dataDir, "promote/rules/" + fileName ).delete();
+    }
+
+    protected boolean deleteRuleSet( String ruleSetFileName )
+    {
+        String fileName = ruleSetFileName.endsWith( ".json" ) ? ruleSetFileName : ruleSetFileName + ".json";
+        return new File( dataDir, "promote/rule-sets/" + fileName ).delete();
+    }
+
+    protected abstract Map<String, String> getRuleScriptFiles()
+            throws IOException;
+
+    protected abstract Map<String, ValidationRuleSet> getRuleSets()
+            throws IOException;
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Collections.singletonList( new IndyPromoteAdminClientModule() );
+    }
+
+    @Override
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
+    {
+        super.initTestConfig( fixture );
+        writeConfigFile( "conf.d/threadpools.conf", "[threadpools]\nenabled=true" );
+    }
+
+}

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/admin/RuleAndRuleSetGetTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/admin/RuleAndRuleSetGetTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest.admin;
+
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.promote.model.ValidationRuleDTO;
+import org.commonjava.indy.promote.model.ValidationRuleSet;
+import org.hamcrest.CoreMatchers;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Validate rules & ruleset get functions through REST endpoints
+ * When <br />
+ *
+ *  <ol>
+ *      <li>Deployed rules files and rule-sets files</li>
+ *  </ol>
+ *
+ *  Then <br />
+ *
+ *  <ol>
+ *      <li>Can get all rule & rule-set file names through REST endpoints</li>
+ *      <li>Can get rule file content through REST endpoints</li>
+ *      <li>Can get rule-set file content through REST endpoints</li>
+ *  </ol>
+ *
+ */
+public class RuleAndRuleSetGetTest
+        extends AbstractAdminValidationTest
+{
+    protected Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final String RULE1 = "maven-artifact-refs-via.groovy";
+
+    private static final String RULE2 = "maven-no-pre-existing-paths.groovy";
+
+    private static final String PREFIX = "artifact-refs-via/";
+
+    private static final String RULESET_TEST_NAME = "test";
+
+    private static final String RULESET_TEST_STOREKEY = "maven:group:test";
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        getRuleScriptFiles().forEach( ( name, content ) -> {
+            ValidationRuleDTO rule = null;
+            try
+            {
+                rule = module.getRuleByName( name );
+            }
+            catch ( IndyClientException e )
+            {
+                logger.error( "Exception happened!", e );
+            }
+            assertNotNull( rule );
+            assertThat( rule.getName(), equalTo( name ) );
+            assertNotNull( rule.getSpec() );
+            assertThat( rule.getSpec().length() > 0, equalTo( true ) );
+        } );
+
+        getRuleSets().forEach( ( name, set ) -> {
+            ValidationRuleSet ruleSet = null;
+            try
+            {
+                ruleSet = module.getRuleSetByName( name );
+            }
+            catch ( IndyClientException e )
+            {
+                logger.error( "Exception happened!", e );
+            }
+            assertNotNull( ruleSet );
+            assertThat( ruleSet.getName(), containsString( name ) );
+            assertThat( ruleSet.getStoreKeyPattern(), equalTo( RULESET_TEST_STOREKEY ) );
+        } );
+
+        ValidationRuleSet ruleSet = null;
+        try
+        {
+            ruleSet = module.getRuleSetByStoreKey( StoreKey.fromString( RULESET_TEST_STOREKEY ) );
+        }
+        catch ( IndyClientException e )
+        {
+            logger.error( "Exception happened!", e );
+        }
+        assertNotNull( ruleSet );
+        assertThat( ruleSet.getName(), containsString( RULESET_TEST_NAME ) );
+        assertThat( ruleSet.getStoreKeyPattern(), equalTo( RULESET_TEST_STOREKEY ) );
+
+        List<String> ruleNames = module.getAllRules();
+        assertThat( ruleNames.size(), equalTo( 2 ) );
+        assertThat( ruleNames, CoreMatchers.hasItems( RULE1, RULE2 ) );
+
+        List<String> ruleSetNames = module.getAllRuleSets();
+        assertThat( ruleSetNames.size(), equalTo( 1 ) );
+        assertThat( ruleSetNames.get( 0 ), containsString( "test" ) );
+    }
+
+    @Override
+    protected Map<String, String> getRuleScriptFiles()
+            throws IOException
+    {
+        String basePath = "promote/rules/";
+        Map<String, String> scripts = new HashMap<>();
+        scripts.put( RULE1, readTestResource( basePath + RULE1 ) );
+        scripts.put( RULE2, readTestResource( basePath + RULE2 ) );
+        return scripts;
+    }
+
+    @Override
+    protected Map<String, ValidationRuleSet> getRuleSets()
+            throws IOException
+    {
+        ValidationRuleSet ruleSet = new ValidationRuleSet();
+        ruleSet.setName( RULESET_TEST_NAME );
+        ruleSet.setStoreKeyPattern( RULESET_TEST_STOREKEY );
+        ruleSet.setRuleNames( new ArrayList<>( getRuleScriptFiles().keySet() ) );
+
+        ruleSet.setValidationParameters( Collections.singletonMap( "availableInStores", "group:other" ) );
+
+        return Collections.singletonMap( ruleSet.getName(), ruleSet );
+    }
+
+}

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/admin/RuleReloadTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/admin/RuleReloadTest.java
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest.admin;
+
+import org.commonjava.indy.promote.model.ValidationRuleDTO;
+import org.commonjava.indy.promote.model.ValidationRuleSet;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Validate rules reload functions through REST endpoints
+ * When <br />
+ *
+ *  <ol>
+ *      <li>Added a new rule in fs</li>
+ *      <li>Changed an existed rule in fs</li>
+ *      <li>Deleted an existed rule in fs</li>
+ *  </ol>
+ *
+ *  Then <br />
+ *
+ *  <ol>
+ *      <li>Reloaded rules through rest can get new added rule</li>
+ *      <li>Reloaded rules through rest can get changed rule's content</li>
+ *      <li>Reloaded rules through rest can detect deleted rule</li>
+ *  </ol>
+ *
+ */
+public class RuleReloadTest
+        extends AbstractAdminValidationTest
+{
+    protected Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final String RULE_NEW = "new-rule.groovy";
+
+    private static final String RULE_CHNAGE = "change-rule.groovy";
+
+    private static final String RULE_CHANGE_INIT_CONTENT_STR = "This is a changing test rule";
+    private static final String RULE_CHANGE_CHANGED_CONTENT_STR = "This is a changed test rule";
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        List<String> allRules = module.getAllRules();
+        assertNotNull( allRules );
+        assertThat( allRules.size(), equalTo( 1 ) );
+        assertThat( allRules, hasItem( RULE_CHNAGE ) );
+        assertThat( allRules.contains( RULE_NEW ), equalTo( false ) );
+
+        ValidationRuleDTO rule = module.getRuleByName( RULE_CHNAGE );
+        assertThat( rule.getName(), equalTo( RULE_CHNAGE ) );
+        assertThat( rule.getSpec(), containsString( RULE_CHANGE_INIT_CONTENT_STR ) );
+        assertThat( rule.getSpec().contains( RULE_CHANGE_CHANGED_CONTENT_STR ), equalTo( false ) );
+
+        rule = module.getRuleByName( RULE_NEW );
+        assertThat( rule, nullValue() );
+
+        deployRule( RULE_NEW, getNewRuleContent() );
+        deployRule( RULE_CHNAGE, getChangedRuleContent() );
+        module.reloadRules();
+
+        allRules = module.getAllRules();
+        assertThat( allRules.size(), equalTo( 2 ) );
+        assertThat( allRules, hasItems( RULE_NEW, RULE_CHNAGE ) );
+
+        rule = module.getRuleByName( RULE_NEW );
+        assertThat( rule.getName(), equalTo( RULE_NEW ) );
+        assertThat( rule.getSpec(), containsString( "This is a new test rule" ) );
+
+        rule = module.getRuleByName( RULE_CHNAGE );
+        assertThat( rule.getName(), equalTo( RULE_CHNAGE ) );
+        assertThat( rule.getSpec(), containsString( RULE_CHANGE_CHANGED_CONTENT_STR ) );
+        assertThat( rule.getSpec().contains( RULE_CHANGE_INIT_CONTENT_STR ), equalTo( false ) );
+
+        deleteRule( RULE_NEW );
+        module.reloadRules();
+
+        allRules = module.getAllRules();
+        assertNotNull( allRules );
+        assertThat( allRules.size(), equalTo( 1 ) );
+        assertThat( allRules, hasItem( RULE_CHNAGE ) );
+        assertThat( allRules.contains( RULE_NEW ), equalTo( false ) );
+
+        rule = module.getRuleByName( RULE_NEW );
+        assertThat( rule, nullValue() );
+
+        rule = module.getRuleByName( RULE_CHNAGE );
+        assertThat( rule.getName(), equalTo( RULE_CHNAGE ) );
+        assertThat( rule.getSpec(), containsString( RULE_CHANGE_CHANGED_CONTENT_STR ) );
+        assertThat( rule.getSpec().contains( RULE_CHANGE_INIT_CONTENT_STR ), equalTo( false ) );
+
+    }
+
+    private String getNewRuleContent()
+    {
+        /* @formatter:off */
+        return "package org.commonjava.indy.promote.rules;"
+            + "import org.commonjava.indy.promote.validate.model.ValidationRequest;"
+            + "import org.commonjava.indy.promote.validate.model.ValidationRule;"
+            + "class NewRule implements ValidationRule {"
+            + " String validate(ValidationRequest request) {"
+            + "     return \"This is a new test rule\";"
+            + " }"
+            + "}";
+        /* @formatter:on */
+    }
+
+    private String getInitChangeRuleContent()
+    {
+        /* @formatter:off */
+        return "package org.commonjava.indy.promote.rules;"
+                + "import org.commonjava.indy.promote.validate.model.ValidationRequest;"
+                + "import org.commonjava.indy.promote.validate.model.ValidationRule;"
+                + "class ChangeRule implements ValidationRule {"
+                + " String validate(ValidationRequest request) {"
+                + "     return \"" + RULE_CHANGE_INIT_CONTENT_STR + "\";"
+                + " }"
+                + "}";
+        /* @formatter:on */
+    }
+
+    private String getChangedRuleContent()
+    {
+        /* @formatter:off */
+        return "package org.commonjava.indy.promote.rules;"
+                + "import org.commonjava.indy.promote.validate.model.ValidationRequest;"
+                + "import org.commonjava.indy.promote.validate.model.ValidationRule;"
+                + "class ChangeRule implements ValidationRule {"
+                + " String validate(ValidationRequest request) {"
+                + "     return \"" + RULE_CHANGE_CHANGED_CONTENT_STR + "\";"
+                + " }"
+                + "}";
+        /* @formatter:on */
+    }
+
+    @Override
+    protected Map<String, String> getRuleScriptFiles()
+    {
+        Map<String, String> scripts = new HashMap<>();
+        scripts.put( RULE_CHNAGE, getInitChangeRuleContent() );
+        return scripts;
+    }
+
+    @Override
+    protected Map<String, ValidationRuleSet> getRuleSets()
+    {
+        return Collections.emptyMap();
+    }
+
+}

--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/admin/RuleSetReloadTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/admin/RuleSetReloadTest.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.ftest.admin;
+
+import org.commonjava.indy.promote.model.ValidationRuleSet;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Validate rules reload functions through REST endpoints
+ * When <br />
+ *
+ *  <ol>
+ *      <li>Added a new rule-set in fs</li>
+ *      <li>Changed an existed rule-set in fs</li>
+ *      <li>Deleted an existed rule-set in fs</li>
+ *  </ol>
+ *
+ *  Then <br />
+ *
+ *  <ol>
+ *      <li>Reloaded rule-sets through rest can get new added rule-set</li>
+ *      <li>Reloaded rule-sets through rest can get changed rule-set's content</li>
+ *      <li>Reloaded rule-sets through rest can detect deleted rule-set</li>
+ *  </ol>
+ *
+ */
+public class RuleSetReloadTest
+        extends AbstractAdminValidationTest
+{
+    protected Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final String RULE_SET_NEW = "new-rule-set.json";
+
+    private static final String RULE_SET_CHANGE = "change-rule-set.json";
+
+    private static final String RULE_SET_CHANGE_INIT_CONTENT_STR = "This is a changing test rule";
+
+    private static final String RULE_SET_CHANGE_CHANGED_CONTENT_STR = "This is a changed test rule";
+
+    @Test
+    public void run()
+            throws Exception
+    {
+        List<String> allRuleSets = module.getAllRuleSets();
+        assertNotNull( allRuleSets );
+        assertThat( allRuleSets.size(), equalTo( 1 ) );
+        assertThat( allRuleSets, hasItem( RULE_SET_CHANGE ) );
+        assertThat( allRuleSets.contains( RULE_SET_NEW ), equalTo( false ) );
+
+        ValidationRuleSet ruleSet = module.getRuleSetByName( RULE_SET_CHANGE );
+        assertThat( ruleSet.getName(), equalTo( RULE_SET_CHANGE ) );
+        assertThat( ruleSet.getStoreKeyPattern(), equalTo( "group:test" ) );
+        assertThat( ruleSet.getRuleNames(), hasItem( "change-rule.groovy" ) );
+        assertThat( ruleSet.getRuleNames().contains( "changed-rule.groovy" ), equalTo( false ) );
+
+        ruleSet = module.getRuleSetByName( RULE_SET_NEW );
+        assertThat( ruleSet, nullValue() );
+
+        deployRuleSet( RULE_SET_NEW, getNewRuleSet() );
+        deployRuleSet( RULE_SET_CHANGE, getChangedRuleSet() );
+        module.reloadRuleSets();
+
+        allRuleSets = module.getAllRuleSets();
+        assertThat( allRuleSets.size(), equalTo( 2 ) );
+        assertThat( allRuleSets, hasItems( RULE_SET_NEW, RULE_SET_CHANGE ) );
+
+        ruleSet = module.getRuleSetByName( RULE_SET_NEW );
+        assertThat( ruleSet.getName(), equalTo( RULE_SET_NEW ) );
+        assertThat( ruleSet.getStoreKeyPattern(), equalTo( "hosted:test" ) );
+        assertThat( ruleSet.getRuleNames(), hasItem( "new-rule.groovy" ) );
+
+        ruleSet = module.getRuleSetByName( RULE_SET_CHANGE );
+        assertThat( ruleSet.getName(), equalTo( RULE_SET_CHANGE ) );
+        assertThat( ruleSet.getStoreKeyPattern(), equalTo( "remote:test" ) );
+        assertThat( ruleSet.getRuleNames(), hasItem( "changed-rule.groovy" ) );
+        assertThat( ruleSet.getRuleNames().contains( "change-rule.groovy" ), equalTo( false ) );
+
+        deleteRuleSet( RULE_SET_NEW );
+        module.reloadRuleSets();
+
+        allRuleSets = module.getAllRuleSets();
+        assertNotNull( allRuleSets );
+        assertThat( allRuleSets.size(), equalTo( 1 ) );
+        assertThat( allRuleSets, hasItem( RULE_SET_CHANGE ) );
+        assertThat( allRuleSets.contains( RULE_SET_NEW ), equalTo( false ) );
+
+        ruleSet = module.getRuleSetByName( RULE_SET_NEW );
+        assertThat( ruleSet, nullValue() );
+
+        ruleSet = module.getRuleSetByName( RULE_SET_CHANGE );
+        assertThat( ruleSet.getName(), equalTo( RULE_SET_CHANGE ) );
+        assertThat( ruleSet.getStoreKeyPattern(), equalTo( "remote:test" ) );
+        assertThat( ruleSet.getRuleNames(), hasItem( "changed-rule.groovy" ) );
+        assertThat( ruleSet.getRuleNames().contains( "change-rule.groovy" ), equalTo( false ) );
+
+    }
+
+    private ValidationRuleSet getNewRuleSet()
+    {
+        ValidationRuleSet ruleSet = new ValidationRuleSet();
+        ruleSet.setName( "Rule for " + RULE_SET_NEW );
+        ruleSet.setStoreKeyPattern( "hosted:test" );
+        ruleSet.setRuleNames( Collections.singletonList( "new-rule.groovy" ) );
+        return ruleSet;
+
+    }
+
+    private ValidationRuleSet getInitChangeRuleSet()
+    {
+        ValidationRuleSet ruleSet = new ValidationRuleSet();
+        ruleSet.setName( "Rule for " + RULE_SET_CHANGE );
+        ruleSet.setStoreKeyPattern( "group:test" );
+        ruleSet.setRuleNames( Collections.singletonList( "change-rule.groovy" ) );
+        return ruleSet;
+    }
+
+    private ValidationRuleSet getChangedRuleSet()
+    {
+        ValidationRuleSet ruleSet = new ValidationRuleSet();
+        ruleSet.setName( "Rule for " + RULE_SET_CHANGE + " with changing" );
+        ruleSet.setStoreKeyPattern( "remote:test" );
+        ruleSet.setRuleNames( Collections.singletonList( "changed-rule.groovy" ) );
+        return ruleSet;
+    }
+
+    @Override
+    protected Map<String, String> getRuleScriptFiles()
+    {
+        return Collections.emptyMap();
+
+    }
+
+    @Override
+    protected Map<String, ValidationRuleSet> getRuleSets()
+    {
+        Map<String, ValidationRuleSet> ruleSets = new HashMap<>();
+        ruleSets.put( RULE_SET_CHANGE, getInitChangeRuleSet() );
+        return ruleSets;
+    }
+
+}

--- a/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteAdminResource.java
+++ b/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteAdminResource.java
@@ -46,6 +46,9 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -86,7 +89,7 @@ public class PromoteAdminResource
             try
             {
                 validationsManager.parseRules();
-                return Response.ok().build();
+                return Response.ok( new ArrayList<>( validationsManager.toDTO().getRules().keySet() ) ).build();
             }
             catch ( PromotionException e )
             {
@@ -108,7 +111,7 @@ public class PromoteAdminResource
             try
             {
                 validationsManager.parseRuleSets();
-                return Response.ok().build();
+                return Response.ok( new ArrayList<>( validationsManager.toDTO().getRuleSets().keySet() ) ).build();
             }
             catch ( PromotionException e )
             {
@@ -130,7 +133,10 @@ public class PromoteAdminResource
             try
             {
                 validationsManager.parseRuleBundles();
-                return Response.ok().build();
+                Map<String, List<String>> bundles = new HashMap<>( 2 );
+                bundles.put( "rules", new ArrayList<>( validationsManager.toDTO().getRules().keySet() ) );
+                bundles.put( "rule-sets", new ArrayList<>( validationsManager.toDTO().getRuleSets().keySet() ) );
+                return Response.ok(bundles).build();
             }
             catch ( PromotionException e )
             {
@@ -147,19 +153,18 @@ public class PromoteAdminResource
     @Path( "/validation/rules/all" )
     @GET
     @Consumes( ApplicationContent.application_json )
-    public Response getAllRules( final @PathParam( "name" ) String ruleName,
-                                 final @Context HttpServletRequest servletRequest,
+    public Response getAllRules( final @Context HttpServletRequest servletRequest,
                                  final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
     {
         return checkEnabledAnd( () -> {
             Map<String, ValidationRuleDTO> rules = validationsManager.toDTO().getRules();
-            if ( rules.isEmpty() )
+            if ( !rules.isEmpty() )
             {
                 return Response.ok( new ArrayList<>( rules.keySet() ) ).build();
             }
             else
             {
-                return Response.status( Response.Status.NOT_FOUND ).build();
+                return Response.status( Response.Status.NOT_FOUND ).entity( Collections.emptyList() ).build();
             }
         } );
     }
@@ -195,19 +200,18 @@ public class PromoteAdminResource
     @Path( "/validation/rulesets/all" )
     @GET
     @Consumes( ApplicationContent.application_json )
-    public Response getAllRuleSets( final @PathParam( "storeKey" ) String storeKey,
-                                    final @Context HttpServletRequest servletRequest,
+    public Response getAllRuleSets( final @Context HttpServletRequest servletRequest,
                                     final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
     {
         return checkEnabledAnd( () -> {
             Map<String, ValidationRuleSet> ruleSets = validationsManager.toDTO().getRuleSets();
-            if ( ruleSets.isEmpty() )
+            if ( !ruleSets.isEmpty() )
             {
                 return Response.ok( new ArrayList<>( ruleSets.keySet() ) ).build();
             }
             else
             {
-                return Response.status( Response.Status.NOT_FOUND ).build();
+                return Response.status( Response.Status.NOT_FOUND ).entity( Collections.emptyList() ).build();
             }
         } );
     }

--- a/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteAdminResource.java
+++ b/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteAdminResource.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.promote.bind.jaxrs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.SecurityManager;
+import org.commonjava.indy.bind.jaxrs.util.REST;
+import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.promote.data.PromotionException;
+import org.commonjava.indy.promote.model.GroupPromoteResult;
+import org.commonjava.indy.promote.model.ValidationRuleDTO;
+import org.commonjava.indy.promote.model.ValidationRuleSet;
+import org.commonjava.indy.promote.validate.PromoteValidationsManager;
+import org.commonjava.indy.util.ApplicationContent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.SecurityContext;
+import javax.ws.rs.core.UriInfo;
+
+import static org.commonjava.indy.util.ApplicationContent.application_json;
+
+@Api( value = "Promote administration resource to manage configurations for content promotion." )
+@Path( "/api/admin/promotion" )
+@Produces( { application_json } )
+@REST
+public class PromoteAdminResource
+        implements IndyResources
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private PromoteValidationsManager validationsManager;
+
+    @Inject
+    private ObjectMapper mapper;
+
+    @Inject
+    private SecurityManager securityManager;
+
+    @Inject
+    private ResponseHelper responseHelper;
+
+    @ApiOperation( "Promote a source repository into the membership of a target group (subject to validation)." )
+    @ApiResponse( code = 200, message = "Promotion operation finished (consult response content for success/failure).",
+                  response = Response.class )
+    @ApiImplicitParam( name = "body", paramType = "body",
+                       value = "JSON request specifying source and target, with other configuration options",
+                       required = true, dataType = "org.commonjava.indy.promote.model.GroupPromoteRequest" )
+    @Path( "/validation/reload/rules" )
+    @PUT
+    @Consumes( ApplicationContent.application_json )
+    public Response reloadRules( final @Context HttpServletRequest servletRequest,
+                                 final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
+    {
+        Response response;
+        if ( !validationsManager.isEnabled() )
+        {
+            response = responseHelper.formatBadRequestResponse(
+                    "Content promotion is disabled. Please check your indy configuration for more info." );
+        }
+        else
+        {
+            try
+            {
+                validationsManager.parseRules();
+                response = Response.ok().build();
+            }
+            catch ( PromotionException e )
+            {
+                logger.error( e.getMessage(), e );
+                response = responseHelper.formatResponse( e );
+            }
+        }
+        return response;
+    }
+
+    @ApiOperation( "" )
+    @ApiResponse( code = 200, message = "Promotion operation finished (consult response content for success/failure).",
+                  response = Response.class )
+    @ApiImplicitParam( name = "body", paramType = "body",
+                       value = "JSON request specifying source and target, with other configuration options",
+                       allowMultiple = false, required = true,
+                       dataType = "org.commonjava.indy.promote.model.GroupPromoteRequest" )
+    @Path( "/validation/reload/rulesets" )
+    @PUT
+    @Consumes( ApplicationContent.application_json )
+    public Response reloadRuleSets( final @Context HttpServletRequest servletRequest,
+                                    final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
+    {
+        Response response;
+        if ( !validationsManager.isEnabled() )
+        {
+            response = responseHelper.formatBadRequestResponse(
+                    "Content promotion is disabled. Please check your indy configuration for more info." );
+        }
+        else
+        {
+            try
+            {
+                validationsManager.parseRuleSets();
+                response = Response.ok().build();
+            }
+            catch ( PromotionException e )
+            {
+                logger.error( e.getMessage(), e );
+                response = responseHelper.formatResponse( e );
+            }
+        }
+        return response;
+    }
+
+    @ApiOperation( "" )
+    @ApiResponse( code = 200, message = "Promotion operation finished (consult response content for success/failure).",
+                  response = GroupPromoteResult.class )
+    @ApiImplicitParam( name = "body", paramType = "body", value = "", required = true,
+                       dataType = "org.commonjava.indy.promote.model.GroupPromoteRequest" )
+    @Path( "/validation/rules/{name}" )
+    @GET
+    @Consumes( ApplicationContent.application_json )
+    public Response getRule( final @PathParam( "name" ) String ruleName,
+                             final @Context HttpServletRequest servletRequest,
+                             final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
+    {
+        if ( validationsManager.isEnabled() )
+        {
+            return Response.ok( validationsManager.getNamedRuleAsDTO( ruleName ) ).build();
+        }
+        else
+        {
+            return responseHelper.formatBadRequestResponse(
+                    "Content promotion is disabled. Please check your indy configuration for more info." );
+        }
+    }
+
+    @ApiOperation( "" )
+    @ApiResponse( code = 200, message = "Promotion operation finished (consult response content for success/failure).",
+                  response = Response.class )
+    @ApiImplicitParam( name = "body", paramType = "body", value = "", required = true,
+                       dataType = "org.commonjava.indy.promote.model.GroupPromoteRequest" )
+    @Path( "/validation/rulesets/{storeKey}" )
+    @GET
+    @Consumes( ApplicationContent.application_json )
+    public Response getRuleSet( final @PathParam( "storeKey" ) StoreKey storeKey,
+                                final @Context HttpServletRequest servletRequest,
+                                final @Context SecurityContext securityContext, final @Context UriInfo uriInfo )
+    {
+        if ( validationsManager.isEnabled() )
+        {
+            return Response.ok( validationsManager.getRuleSetMatching( storeKey ) ).build();
+        }
+        else
+        {
+            return responseHelper.formatBadRequestResponse(
+                    "Content promotion is disabled. Please check your indy configuration for more info." );
+        }
+    }
+
+}

--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationCatalogDTO.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/ValidationCatalogDTO.java
@@ -43,7 +43,7 @@ public class ValidationCatalogDTO
 
     public Map<String, ValidationRuleDTO> getRules()
     {
-        return rules == null ? Collections.<String, ValidationRuleDTO>emptyMap() : rules;
+        return rules == null ? Collections.emptyMap() : rules;
     }
 
     public void setRules( final Map<String, ValidationRuleDTO> rules )

--- a/deployments/launcher/src/main/etc/indy/main.conf
+++ b/deployments/launcher/src/main/etc/indy/main.conf
@@ -1,3 +1,4 @@
+standalone=true
 # passthrough.timeout=300
 # nfc.timeout=300
 # nfc.sweep.minutes=30

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseHelper.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseHelper.java
@@ -92,7 +92,7 @@ public class ResponseHelper
     public Response formatCreatedResponseWithJsonEntity( final URI location, final Object dto,
                                                          final Consumer<ResponseBuilder> builderModifier )
     {
-        ResponseBuilder builder = null;
+        ResponseBuilder builder;
         if ( dto == null )
         {
             builder = Response.noContent();
@@ -285,11 +285,10 @@ public class ResponseHelper
         // 500-level error; use 502 response.
         Logger logger = LoggerFactory.getLogger( ResponseHelper.class );
         logger.info( "Formatting response with code: {}", code );
-        ResponseBuilder builder = null;
+        ResponseBuilder builder;
         if ( code / 100 == 5 )
         {
             setContext( HTTP_STATUS, String.valueOf( 502 ) );
-            builder = Response.status( 502 );
         }
 
         setContext( HTTP_STATUS, String.valueOf( code ) );
@@ -461,7 +460,7 @@ public class ResponseHelper
             LOGGER.debug( "Sending response: {} {}\n{}", code.getStatusCode(), code.getReasonPhrase(), msg );
         }
 
-        setContext( HTTP_STATUS, code == null ? "000" : String.valueOf( code.getStatusCode() ) );
+        setContext( HTTP_STATUS, String.valueOf( code.getStatusCode() ) );
 
         ResponseBuilder builder = Response.status( code ).type( MediaType.TEXT_PLAIN ).entity( msg );
 


### PR DESCRIPTION
  Add these rest endpoints for promotion admin functions:
  * PUT /api/admin/promotion/validation/reload/rules: reload promotion validation rules
  * PUT /api/admin/promotion/validation/reload/rulesets: reload promotion validation rule-sets
  * PUT /api/admin/promotion/validation/reload/all: reload rules and rulesets bundle together
  * GET /api/admin/promotion/validation/rules/all: get all rules' names
  * GET /api/admin/promotion/validation/rules/named/$name: get rule content by rule name
  * GET /api/admin/promotion/validatoin/rulesets/all: get all rulesets' names
  * GET /api/admin/promotion/validatoin/rulesets/named/$name: get ruleset content by ruleset name
  * GET /api/admin/promotion/validatoin/rulesets/storekey/$storekey: get rule-set content by storeKey
