### PR TITLE
Add allowAttachSelf to failsafe plugin for jdk11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,6 @@ def my_bc = null
 
 pipeline {
     agent { label 'maven-jdk11' }
-    environment {
-        JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
-    }
     stages {
         stage('Prepare') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def bc_section = 'build-configs'
 def my_bc = null
 
 pipeline {
-    agent { label 'maven-jdk11' }
+    agent { label 'maven' }
     stages {
         stage('Prepare') {
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def bc_section = 'build-configs'
 def my_bc = null
 
 pipeline {
-    agent { label 'maven' }
+    agent { label 'maven-jdk11' }
     environment {
         JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,11 +9,13 @@ def my_bc = null
 
 pipeline {
     agent { label 'maven' }
+    environment {
+        JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
+    }
     stages {
         stage('Prepare') {
             steps {
                 sh 'printenv'
-                sh 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk'
             }
         }
         stage('Build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         stage('Prepare') {
             steps {
                 sh 'printenv'
+                sh 'export JAVA_HOME=/usr/lib/jvm/java-11-openjdk'
             }
         }
         stage('Build') {

--- a/pom.xml
+++ b/pom.xml
@@ -1848,6 +1848,7 @@
             <redirectTestOutputToFile>${test-redirectOutput}</redirectTestOutputToFile>
             <forkCount>${it-forkCount}</forkCount>
             <reportsDirectory>${failsafe.report.dir}</reportsDirectory>
+            <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
 <!--             <rerunFailingTestsCount>1</rerunFailingTestsCount> -->
             <includes>
               <include>**/*Test.java</include>


### PR DESCRIPTION
As we use mvn in three places, it is better to set a global envar.