### PR TITLE
Re-apply "Switched compliation to generate JDK11 bytecode. (#1778)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,9 @@ pipeline {
             }
         }
         stage('Build') {
+            environment{
+                JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+            }
             steps {
                 sh 'mvn -B -V clean verify -DskipNpmConfig=false'
             }

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation> -->
 
     <!-- thirdparty projects -->
-    <javaVersion>1.8</javaVersion>
+    <javaVersion>11</javaVersion>
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
     <infinispanVersion>9.4.15.Final</infinispanVersion>


### PR DESCRIPTION
This was originally reverted in #1785, but I got the CI builder image fixed, so it should work now. We have to merge it before Jenkins will pickup the changes to the Jenkinsfile, though, which explains this big revert-reapply mess.

This reverts commit 559158e1052edc370f48cf504caa481464602547.