### PR TITLE
re-apply JDK 11 changes, but adapted to use withEnv instead

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,10 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh 'mvn -B -V clean verify -DskipNpmConfig=false'
+                withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
+                    sh 'mvn -B -V clean verify -DskipNpmConfig=false'
+                }
+                
                 withEnv(['FOOBAR_HOME=/tmp']){
                     sh "echo: using FOOBAR_HOME $FOOBAR_HOME"
                 }
@@ -29,7 +32,9 @@ pipeline {
                 expression { env.CHANGE_ID != null } // Pull request
             }
             steps {
-                sh 'mvn -B -V verify -Prun-its -Pci -DskipNpmConfig=false'
+                withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
+                    sh 'mvn -B -V verify -Prun-its -Pci -DskipNpmConfig=false'
+                }
             }
         }
         stage('Load OCP Mappings') {
@@ -83,7 +88,9 @@ pipeline {
             }
             steps {
                 echo "Deploy"
-                sh 'mvn help:effective-settings -B -V -DskipTests=true -DskipNpmConfig=false deploy -e'
+                withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
+                    sh 'mvn help:effective-settings -B -V -DskipTests=true -DskipNpmConfig=false deploy -e'
+                }
             }
         }
         stage('Archive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,11 +20,6 @@ pipeline {
                 withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
                     sh 'mvn -B -V clean verify -DskipNpmConfig=false'
                 }
-                
-                withEnv(['FOOBAR_HOME=/tmp']){
-                    sh "echo: using FOOBAR_HOME $FOOBAR_HOME"
-                }
-                sh "echo: again using FOOBAR_HOME $FOOBAR_HOME"
             }
         }
         stage('Function Test') {

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation> -->
 
     <!-- thirdparty projects -->
-    <javaVersion>1.8</javaVersion>
+    <javaVersion>11</javaVersion>
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
     <infinispanVersion>9.4.15.Final</infinispanVersion>


### PR DESCRIPTION
@whitingjr FYI

This will simply use the JDK11 by specifying JAVA_HOME in the Jenkinsfile, as a wrapper around all maven calls. I've also updated the javaVersion in the pom.xml.