### PR TITLE
Revert "re-apply JDK 11 changes, but adapted to use withEnv instead"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,9 +17,11 @@ pipeline {
         }
         stage('Build') {
             steps {
-                withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
-                    sh 'mvn -B -V clean verify -DskipNpmConfig=false'
+                sh 'mvn -B -V clean verify -DskipNpmConfig=false'
+                withEnv(['FOOBAR_HOME=/tmp']){
+                    sh "echo: using FOOBAR_HOME $FOOBAR_HOME"
                 }
+                sh "echo: again using FOOBAR_HOME $FOOBAR_HOME"
             }
         }
         stage('Function Test') {
@@ -27,9 +29,7 @@ pipeline {
                 expression { env.CHANGE_ID != null } // Pull request
             }
             steps {
-                withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
-                    sh 'mvn -B -V verify -Prun-its -Pci -DskipNpmConfig=false'
-                }
+                sh 'mvn -B -V verify -Prun-its -Pci -DskipNpmConfig=false'
             }
         }
         stage('Load OCP Mappings') {
@@ -83,9 +83,7 @@ pipeline {
             }
             steps {
                 echo "Deploy"
-                withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
-                    sh 'mvn help:effective-settings -B -V -DskipTests=true -DskipNpmConfig=false deploy -e'
-                }
+                sh 'mvn help:effective-settings -B -V -DskipTests=true -DskipNpmConfig=false deploy -e'
             }
         }
         stage('Archive') {

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation> -->
 
     <!-- thirdparty projects -->
-    <javaVersion>11</javaVersion>
+    <javaVersion>1.8</javaVersion>
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
     <infinispanVersion>9.4.15.Final</infinispanVersion>


### PR DESCRIPTION
Reverts Commonjava/indy#1789

It looks like we're still using the cassandra plugin, which won't work with JDK11. I think we could disable these Cassandra tests by default, and only trigger them if an envar is set which specifies an external Cassandra instance...but we'll need to configure it to create/destroy a generate keyspace name too...I'm looking into that now.