### PR TITLE
Refactor storeQuery to avoid to scan full table

### DIFF
--- a/addons/content-index/src/main/java/org/commonjava/indy/content/index/warmer/ContentIndexWarmer.java
+++ b/addons/content-index/src/main/java/org/commonjava/indy/content/index/warmer/ContentIndexWarmer.java
@@ -117,7 +117,7 @@ public class ContentIndexWarmer
 
                             try
                             {
-                                List<ArtifactStore> stores = storeDataManager.query().getOrderedConcreteStoresInGroup( g.getName() );
+                                List<ArtifactStore> stores = storeDataManager.query().getOrderedConcreteStoresInGroup( g.getPackageType(), g.getName() );
 
                                 stores.forEach( s -> {
                                     List<Transfer> txfrs = transferMap.get( s.getKey() );

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/data/StorageAdvisor.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/data/StorageAdvisor.java
@@ -57,9 +57,8 @@ public class StorageAdvisor
                 try
                 {
                     constituents = dataManager.query()
-                                              .packageType( MAVEN_PKG_KEY )
                                               .enabledState( true )
-                                              .getOrderedConcreteStoresInGroup( store.getName() );
+                                              .getOrderedConcreteStoresInGroup( MAVEN_PKG_KEY, store.getName() );
                 }
                 catch ( final IndyDataException e )
                 {

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/ArtifactStoreSubStore.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/ArtifactStoreSubStore.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.dotmaven.store.sub;
 
+import io.undertow.util.HeaderValues;
 import net.sf.webdav.StoredObject;
 import net.sf.webdav.exceptions.WebdavException;
 import net.sf.webdav.spi.ITransaction;
@@ -43,6 +44,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -347,13 +349,21 @@ public class ArtifactStoreSubStore
             final StoreType type = matcher.getStoreType();
             try
             {
-                List<String> noms = indy.query()
-                           .packageType( packageType )
-                           .storeTypes( type )
-                           .stream()
-                           .map( ArtifactStore::getName )
-                           .collect( Collectors.toList() );
+                List<? extends ArtifactStore> stores = new ArrayList<>();
+                if ( StoreType.group.equals( type ) )
+                {
+                    stores = indy.query().getAllGroups( packageType );
+                }
+                else if ( StoreType.hosted.equals( type ) )
+                {
+                    stores = indy.query().getAllHostedRepositories( packageType );
+                }
+                else if ( StoreType.remote.equals( type ) )
+                {
+                    stores = indy.query().getAllRemoteRepositories( packageType );
+                }
 
+                List<String> noms = stores.stream().map( ArtifactStore::getName ).collect( Collectors.toList());
                 names = noms.toArray( new String[noms.size()] );
             }
             catch ( final IndyDataException e )

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/ArtifactStoreSubStore.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/ArtifactStoreSubStore.java
@@ -181,7 +181,7 @@ public class ArtifactStoreSubStore
         {
             if ( key != null && StoreType.group == key.getType() )
             {
-                final List<ArtifactStore> stores = indy.query().packageType( key.getPackageType() ).enabledState( true ).getOrderedStoresInGroup( key.getName() );
+                final List<ArtifactStore> stores = indy.query().enabledState( true ).getOrderedStoresInGroup( key.getPackageType(), key.getName() );
                 for ( final ArtifactStore store : stores )
                 {
                     //                    logger.info( "Getting Transfer for: {} from: {}", path, store );
@@ -284,7 +284,7 @@ public class ArtifactStoreSubStore
                 if ( key != null && StoreType.group == key.getType() )
                 {
                     final List<ArtifactStore> stores =
-                            indy.query().packageType( key.getPackageType() ).getOrderedStoresInGroup( key.getName() );
+                            indy.query().getOrderedStoresInGroup( key.getPackageType(), key.getName() );
 
                     final Set<String> noms = new TreeSet<>();
                     for ( final ArtifactStore store : stores )

--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/SettingsSubStore.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/store/sub/SettingsSubStore.java
@@ -20,6 +20,7 @@ import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAV
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -130,10 +131,21 @@ public class SettingsSubStore
         {
             final StoreType type = matcher.getStoreType();
 
-            List<? extends ArtifactStore> all;
+            List<? extends ArtifactStore> all = new ArrayList<>();
             try
             {
-                all = indy.query().packageType( MAVEN_PKG_KEY ).storeTypes( type ).getAll();
+                if ( StoreType.group.equals( type ) )
+                {
+                    all = indy.query().getAllGroups( MAVEN_PKG_KEY );
+                }
+                else if ( StoreType.hosted.equals( type ) )
+                {
+                    all = indy.query().getAllHostedRepositories( MAVEN_PKG_KEY );
+                }
+                else if ( StoreType.remote.equals( type ) )
+                {
+                    all = indy.query().getAllRemoteRepositories( MAVEN_PKG_KEY );
+                }
             }
             catch ( final IndyDataException e )
             {

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/data/HttProxOriginMigrationAction.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/data/HttProxOriginMigrationAction.java
@@ -24,6 +24,7 @@ import org.commonjava.indy.httprox.handler.ProxyAcceptHandler;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.GenericPackageTypeDescriptor;
 import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
@@ -32,8 +33,10 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.commonjava.indy.model.core.GenericPackageTypeDescriptor.GENERIC_PKG_KEY;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 
 /**
  * Created by jdcasey on 9/19/16.
@@ -56,10 +59,14 @@ public class HttProxOriginMigrationAction
     private boolean doMigrate()
             throws IndyLifecycleException
     {
-        List<RemoteRepository> repos;
+        List<RemoteRepository> repos = new ArrayList<>();
         try
         {
-            repos = storeDataManager.query().noPackageType().getAllRemoteRepositories();
+            Set<String> defaults = PackageTypes.getPackageTypes();
+            for ( String packageType : defaults )
+            {
+                repos.addAll( storeDataManager.query().getAllRemoteRepositories( packageType ));
+            }
         }
         catch ( IndyDataException e )
         {

--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyResponseHelper.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/ProxyResponseHelper.java
@@ -144,9 +144,9 @@ public class ProxyResponseHelper
             String groupName = repoCreator.formatId( url.getHost(), port, 0, trackingId, StoreType.group );
 
             ArtifactStoreQuery<Group> query =
-                            storeManager.query().packageType( GENERIC_PKG_KEY ).storeType( Group.class );
+                            storeManager.query().storeType( Group.class );
 
-            Group group = query.getGroup( groupName );
+            Group group = query.getGroup( GENERIC_PKG_KEY, groupName );
             logger.debug( "Get httproxy group, group: {}", group );
 
             if ( group == null )
@@ -164,9 +164,10 @@ public class ProxyResponseHelper
             final String baseUrl = getBaseUrl( url, false );
 
             ArtifactStoreQuery<RemoteRepository> query =
-                            storeManager.query().packageType( GENERIC_PKG_KEY ).storeType( RemoteRepository.class );
+                            storeManager.query().storeType( RemoteRepository.class );
 
-            remote = query.stream()
+            remote = query.getAllRemoteRepositories( GENERIC_PKG_KEY )
+                          .stream()
                           .filter( store -> store.getUrl().equals( baseUrl )
                                           && store.getMetadata( TRACKING_ID ) == null )
                           .findFirst()
@@ -248,10 +249,9 @@ public class ProxyResponseHelper
         }
 
         Predicate<ArtifactStore> filter = abstractProxyRepositoryCreator.getNameFilter( name );
-        List<String> l = storeManager.query()
-                                     .packageType( GENERIC_PKG_KEY )
-                                     .storeType( RemoteRepository.class )
-                                     .stream( filter )
+        List<String> l = storeManager.query().getAllRemoteRepositories( GENERIC_PKG_KEY )
+                                     .stream()
+                                     .filter( filter )
                                      .map( repository -> repository.getName() )
                                      .collect( Collectors.toList() );
 

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
@@ -392,7 +392,7 @@ public class ImpliedRepositoryDetector
                 List<RemoteRepository> rrs = null;
                 try
                 {
-                    rrs = storeManager.query().packageType( MAVEN_PKG_KEY ).getRemoteRepositoryByUrl( repo.getUrl() );
+                    rrs = storeManager.query().getRemoteRepositoryByUrl( MAVEN_PKG_KEY, repo.getUrl() );
                 }
                 catch ( IndyDataException e )
                 {

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetector.java
@@ -270,7 +270,7 @@ public class ImpliedRepositoryDetector
         boolean anyChanged = false;
         try
         {
-            final Set<Group> groups = storeManager.query().packageType( MAVEN_PKG_KEY ).getGroupsContaining( key );
+            final Set<Group> groups = storeManager.query().getGroupsContaining( key );
             if ( groups != null )
             {
                 logger.debug( "{} groups contain: {}\n  {}", groups.size(), key, new JoinString( "\n  ", groups ) );

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposOriginMigrationAction.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposOriginMigrationAction.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import static org.commonjava.indy.implrepo.data.ImpliedReposStoreDataManagerDecorator.IMPLIED_REPO_ORIGIN;
 import static org.commonjava.indy.model.core.ArtifactStore.METADATA_ORIGIN;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 
 /**
  * Created by jdcasey on 9/19/16.
@@ -58,7 +59,7 @@ public class ImpliedReposOriginMigrationAction
         List<RemoteRepository> remoteRepositories;
         try
         {
-            remoteRepositories = storeDataManager.query().getAllRemoteRepositories();
+            remoteRepositories = storeDataManager.query().getAllRemoteRepositories( PKG_TYPE_MAVEN );
         }
         catch ( IndyDataException e )
         {

--- a/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposQueryDelegate.java
+++ b/addons/implied-repos/common/src/main/java/org/commonjava/indy/implrepo/data/ImpliedReposQueryDelegate.java
@@ -56,13 +56,13 @@ public class ImpliedReposQueryDelegate
     }
 
     @Override
-    public List<ArtifactStore> getOrderedConcreteStoresInGroup( String groupName )
+    public List<ArtifactStore> getOrderedConcreteStoresInGroup( String packageType, String groupName )
             throws IndyDataException
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
         logger.trace( "Retrieving ordered concrete (recursive) members for group: {}", groupName );
 
-        List<ArtifactStore> result = delegate().getOrderedConcreteStoresInGroup( groupName );
+        List<ArtifactStore> result = delegate().getOrderedConcreteStoresInGroup( packageType, groupName );
         if ( logger.isTraceEnabled() )
         {
             logger.trace( "Raw ordered concrete membership for group: {} is:\n  {}", groupName,
@@ -80,10 +80,10 @@ public class ImpliedReposQueryDelegate
     }
 
     @Override
-    public List<ArtifactStore> getOrderedStoresInGroup( String groupName )
+    public List<ArtifactStore> getOrderedStoresInGroup( String packageType, String groupName )
             throws IndyDataException
     {
-        List<ArtifactStore> delegateResult = delegate().getOrderedStoresInGroup( groupName );
+        List<ArtifactStore> delegateResult = delegate().getOrderedStoresInGroup( packageType, groupName );
 
         return maybeFilter( groupName, delegateResult );
     }

--- a/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetectorTest.java
+++ b/addons/implied-repos/common/src/test/java/org/commonjava/indy/implrepo/change/ImpliedRepositoryDetectorTest.java
@@ -145,13 +145,13 @@ public class ImpliedRepositoryDetectorTest
     private RemoteRepository getRemote()
             throws IndyDataException
     {
-        return storeManager.query().packageType( MAVEN_PKG_KEY ).getRemoteRepository( REMOTE_NAME );
+        return storeManager.query().getRemoteRepository( MAVEN_PKG_KEY, REMOTE_NAME );
     }
 
     private Group getGroup()
             throws IndyDataException
     {
-        return storeManager.query().packageType( MAVEN_PKG_KEY ).getGroup( GROUP_NAME );
+        return storeManager.query().getGroup( MAVEN_PKG_KEY, GROUP_NAME );
     }
 
     //    @Test
@@ -183,7 +183,7 @@ public class ImpliedRepositoryDetectorTest
             detector.wait();
         }
 
-        assertThat( storeManager.query().packageType( MAVEN_PKG_KEY ).getRemoteRepository( "i-repo-one" ), notNullValue() );
+        assertThat( storeManager.query().getRemoteRepository( MAVEN_PKG_KEY, "i-repo-one" ), notNullValue() );
 
         assertThat( getGroup().getConstituents().contains( new StoreKey( MAVEN_PKG_KEY, StoreType.remote, "i-repo-one" ) ),
                     equalTo( true ) );
@@ -204,7 +204,7 @@ public class ImpliedRepositoryDetectorTest
             detector.wait();
         }
 
-        assertThat( storeManager.query().packageType( MAVEN_PKG_KEY ).getRemoteRepository( "i-repo-one" ), notNullValue() );
+        assertThat( storeManager.query().getRemoteRepository( MAVEN_PKG_KEY, "i-repo-one" ), notNullValue() );
 
         assertThat( getGroup().getConstituents().contains( new StoreKey( StoreType.remote, "i-repo-one" ) ),
                     equalTo( true ) );

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiOriginMigrationAction.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiOriginMigrationAction.java
@@ -20,6 +20,7 @@ import org.commonjava.indy.action.MigrationAction;
 import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
@@ -28,9 +29,11 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.commonjava.indy.koji.model.IndyKojiConstants.KOJI_ORIGIN;
 import static org.commonjava.indy.model.core.ArtifactStore.METADATA_ORIGIN;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 
 /**
  * Created by jdcasey on 9/19/16.
@@ -53,10 +56,14 @@ public class KojiOriginMigrationAction
     private boolean doMigrate()
             throws IndyLifecycleException
     {
-        List<RemoteRepository> repos;
+        List<RemoteRepository> repos = new ArrayList<>();
         try
         {
-            repos = storeDataManager.query().noPackageType().getAllRemoteRepositories();
+            Set<String> defaults = PackageTypes.getPackageTypes();
+            for ( String packageType : defaults )
+            {
+                repos.addAll( storeDataManager.query().getAllRemoteRepositories( packageType ));
+            }
         }
         catch ( IndyDataException e )
         {

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRemovePemMigrationAction.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRemovePemMigrationAction.java
@@ -21,6 +21,7 @@ import org.commonjava.indy.audit.ChangeSummary;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.koji.conf.IndyKojiConfig;
+import org.commonjava.indy.model.core.PackageTypes;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.pkg.PackageTypeConstants;
 import org.commonjava.maven.galley.event.EventMetadata;
@@ -30,6 +31,9 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 
 public class KojiRemovePemMigrationAction
                 implements MigrationAction
@@ -73,10 +77,14 @@ public class KojiRemovePemMigrationAction
     private boolean doMigrate() throws IndyLifecycleException
     {
 
-        List<RemoteRepository> repos;
+        List<RemoteRepository> repos = new ArrayList<>();
         try
         {
-            repos = storeDataManager.query().noPackageType().getAllRemoteRepositories();
+            Set<String> defaults = PackageTypes.getPackageTypes();
+            for ( String packageType : defaults )
+            {
+                repos.addAll( storeDataManager.query().getAllRemoteRepositories( packageType ));
+            }
         }
         catch ( IndyDataException e )
         {

--- a/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/cache/PathMappedMavenGACache.java
+++ b/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/cache/PathMappedMavenGACache.java
@@ -267,9 +267,7 @@ public class PathMappedMavenGACache
 
     private Set<String> getMatchedStores() throws IndyDataException
     {
-        Set<String> matched = storeDataManager.query()
-                                              .packageType( PKG_TYPE_MAVEN )
-                                              .getAllHostedRepositories()
+        Set<String> matched = storeDataManager.query().getAllHostedRepositories( PKG_TYPE_MAVEN )
                                               .stream()
                                               .filter( hosted -> hosted.getName().matches( gaStorePattern ) )
                                               .map( hostedRepository -> hostedRepository.getKey().getName() )

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/change/PackageStoreListener.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/change/PackageStoreListener.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.util.Set;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
 import static org.commonjava.indy.util.LocationUtils.getKey;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
@@ -88,7 +89,7 @@ public class PackageStoreListener
         {
             if ( hosted == storeKey.getType() )
             {
-                HostedRepository hosted = dataManager.query().packageType( PackageTypeConstants.PKG_TYPE_NPM ).getHostedRepository( storeKey.getName() );
+                HostedRepository hosted = dataManager.query().getHostedRepository( PKG_TYPE_NPM, storeKey.getName() );
                 try
                 {
                     doClear( hosted, pkgMetadataPath );
@@ -100,7 +101,7 @@ public class PackageStoreListener
                                     hosted, e.getMessage() ), e );
                 }
 
-                final Set<Group> groups = dataManager.query().packageType( PackageTypeConstants.PKG_TYPE_NPM ).getGroupsAffectedBy( storeKey );
+                final Set<Group> groups = dataManager.query().getGroupsAffectedBy( storeKey );
                 if ( groups != null )
                 {
                     for ( final Group group : groups )

--- a/api/src/main/java/org/commonjava/indy/content/IndyLocationExpander.java
+++ b/api/src/main/java/org/commonjava/indy/content/IndyLocationExpander.java
@@ -93,7 +93,7 @@ public class IndyLocationExpander
                 {
                     logger.debug( "Expanding group: {}", gl.getKey() );
                     final List<ArtifactStore> members =
-                            data.query().packageType( gl.getKey().getPackageType() ).getOrderedConcreteStoresInGroup( gl.getKey().getName() );
+                            data.query().getOrderedConcreteStoresInGroup( gl.getKey().getPackageType(), gl.getKey().getName() );
 
                     if ( members != null )
                     {

--- a/api/src/main/java/org/commonjava/indy/data/ArtifactStoreQuery.java
+++ b/api/src/main/java/org/commonjava/indy/data/ArtifactStoreQuery.java
@@ -122,4 +122,22 @@ public interface ArtifactStoreQuery<T extends ArtifactStore>
             throws IndyDataException;
 
     ArtifactStoreQuery<T> noPackageType();
+
+    List<RemoteRepository> getAllRemoteRepositories( String packageType )
+                    throws IndyDataException;
+
+    List<RemoteRepository> getAllRemoteRepositories( String packageType, Boolean enabled )
+                    throws IndyDataException;
+
+    List<HostedRepository> getAllHostedRepositories( String packageType )
+                    throws IndyDataException;
+
+    List<HostedRepository> getAllHostedRepositories( String packageType, Boolean enabled )
+                    throws IndyDataException;
+
+    List<Group> getAllGroups( String packageType )
+                    throws IndyDataException;
+
+    List<Group> getAllGroups( String packageType, Boolean enabled )
+                    throws IndyDataException;
 }

--- a/api/src/main/java/org/commonjava/indy/data/ArtifactStoreQuery.java
+++ b/api/src/main/java/org/commonjava/indy/data/ArtifactStoreQuery.java
@@ -45,9 +45,6 @@ public interface ArtifactStoreQuery<T extends ArtifactStore>
 {
     ArtifactStoreQuery<T> rewrap( StoreDataManager manager );
 
-    ArtifactStoreQuery<T> packageType( String packageType )
-            throws IndyDataException;
-
     <C extends ArtifactStore> ArtifactStoreQuery<C> storeType( Class<C> storeCls );
 
     ArtifactStoreQuery<T> storeTypes( StoreType... types );
@@ -88,17 +85,26 @@ public interface ArtifactStoreQuery<T extends ArtifactStore>
     Set<Group> getGroupsContaining( StoreKey storeKey )
             throws IndyDataException;
 
+    Set<Group> getGroupsContaining( StoreKey storeKey, Boolean enabled )
+                    throws IndyDataException;
+
     List<RemoteRepository> getRemoteRepositoryByUrl( String packageType, String url )
             throws IndyDataException;
 
     List<RemoteRepository> getRemoteRepositoryByUrl( String packageType, String url, Boolean enabled )
                     throws IndyDataException;
 
-    List<ArtifactStore> getOrderedConcreteStoresInGroup( String groupName )
+    List<ArtifactStore> getOrderedConcreteStoresInGroup( String packageType, String groupName )
             throws IndyDataException;
 
-    List<ArtifactStore> getOrderedStoresInGroup( String groupName )
+    List<ArtifactStore> getOrderedConcreteStoresInGroup( String packageType, String groupName, Boolean enabled )
+                    throws IndyDataException;
+
+    List<ArtifactStore> getOrderedStoresInGroup( String packageType, String groupName )
             throws IndyDataException;
+
+    List<ArtifactStore> getOrderedStoresInGroup( String packageType, String groupName, Boolean enabled )
+                    throws IndyDataException;
 
     Set<Group> getGroupsAffectedBy( StoreKey... keys )
             throws IndyDataException;
@@ -106,22 +112,13 @@ public interface ArtifactStoreQuery<T extends ArtifactStore>
     Set<Group> getGroupsAffectedBy( Collection<StoreKey> keys )
             throws IndyDataException;
 
-    List<RemoteRepository> getAllRemoteRepositories()
+    RemoteRepository getRemoteRepository( String packageType, String name )
             throws IndyDataException;
 
-    List<HostedRepository> getAllHostedRepositories()
+    HostedRepository getHostedRepository( String packageType, String name )
             throws IndyDataException;
 
-    List<Group> getAllGroups()
-            throws IndyDataException;
-
-    RemoteRepository getRemoteRepository( String name )
-            throws IndyDataException;
-
-    HostedRepository getHostedRepository( String name )
-            throws IndyDataException;
-
-    Group getGroup( String name )
+    Group getGroup( String packageType, String name )
             throws IndyDataException;
 
     ArtifactStoreQuery<T> noPackageType();

--- a/api/src/main/java/org/commonjava/indy/data/ArtifactStoreQuery.java
+++ b/api/src/main/java/org/commonjava/indy/data/ArtifactStoreQuery.java
@@ -88,8 +88,11 @@ public interface ArtifactStoreQuery<T extends ArtifactStore>
     Set<Group> getGroupsContaining( StoreKey storeKey )
             throws IndyDataException;
 
-    List<RemoteRepository> getRemoteRepositoryByUrl( String url )
+    List<RemoteRepository> getRemoteRepositoryByUrl( String packageType, String url )
             throws IndyDataException;
+
+    List<RemoteRepository> getRemoteRepositoryByUrl( String packageType, String url, Boolean enabled )
+                    throws IndyDataException;
 
     List<ArtifactStore> getOrderedConcreteStoresInGroup( String groupName )
             throws IndyDataException;

--- a/api/src/main/java/org/commonjava/indy/data/DelegatingArtifactStoreQuery.java
+++ b/api/src/main/java/org/commonjava/indy/data/DelegatingArtifactStoreQuery.java
@@ -252,4 +252,40 @@ public class DelegatingArtifactStoreQuery<T extends ArtifactStore>
         delegate.noPackageType();
         return this;
     }
+
+    @Override
+    public List<RemoteRepository> getAllRemoteRepositories( String packageType ) throws IndyDataException
+    {
+        return delegate.getAllRemoteRepositories( packageType );
+    }
+
+    @Override
+    public List<RemoteRepository> getAllRemoteRepositories( String packageType, Boolean enabled ) throws IndyDataException
+    {
+        return delegate.getAllRemoteRepositories( packageType, enabled );
+    }
+
+    @Override
+    public List<HostedRepository> getAllHostedRepositories( String packageType ) throws IndyDataException
+    {
+        return delegate.getAllHostedRepositories( packageType );
+    }
+
+    @Override
+    public List<HostedRepository> getAllHostedRepositories( String packageType, Boolean enabled ) throws IndyDataException
+    {
+        return delegate.getAllHostedRepositories( packageType, enabled );
+    }
+
+    @Override
+    public List<Group> getAllGroups( String packageType ) throws IndyDataException
+    {
+        return delegate.getAllGroups( packageType );
+    }
+
+    @Override
+    public List<Group> getAllGroups( String packageType, Boolean enabled ) throws IndyDataException
+    {
+        return delegate.getAllGroups( packageType, enabled );
+    }
 }

--- a/api/src/main/java/org/commonjava/indy/data/DelegatingArtifactStoreQuery.java
+++ b/api/src/main/java/org/commonjava/indy/data/DelegatingArtifactStoreQuery.java
@@ -58,14 +58,6 @@ public class DelegatingArtifactStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public ArtifactStoreQuery<T> packageType( final String packageType )
-            throws IndyDataException
-    {
-        delegate.packageType( packageType );
-        return this;
-    }
-
-    @Override
     public <C extends ArtifactStore> ArtifactStoreQuery<C> storeType( final Class<C> storeCls )
     {
         delegate.storeType( storeCls );
@@ -170,6 +162,13 @@ public class DelegatingArtifactStoreQuery<T extends ArtifactStore>
     }
 
     @Override
+    public Set<Group> getGroupsContaining( final StoreKey storeKey, final Boolean enabled )
+                    throws IndyDataException
+    {
+        return delegate.getGroupsContaining( storeKey, enabled );
+    }
+
+    @Override
     public List<RemoteRepository> getRemoteRepositoryByUrl( final String packageType, final String url )
             throws IndyDataException
     {
@@ -184,17 +183,31 @@ public class DelegatingArtifactStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String groupName )
+    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String packageType, final String groupName )
             throws IndyDataException
     {
-        return delegate.getOrderedConcreteStoresInGroup( groupName );
+        return delegate.getOrderedConcreteStoresInGroup( packageType, groupName );
     }
 
     @Override
-    public List<ArtifactStore> getOrderedStoresInGroup( final String groupName )
+    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String packageType, final String groupName, final Boolean enabled )
+                    throws IndyDataException
+    {
+        return delegate.getOrderedConcreteStoresInGroup( packageType, groupName, enabled );
+    }
+
+    @Override
+    public List<ArtifactStore> getOrderedStoresInGroup( final String packageType, final String groupName )
             throws IndyDataException
     {
-        return delegate.getOrderedStoresInGroup( groupName );
+        return delegate.getOrderedStoresInGroup( packageType, groupName );
+    }
+
+    @Override
+    public List<ArtifactStore> getOrderedStoresInGroup( final String packageType, final String groupName, final Boolean enabled )
+                    throws IndyDataException
+    {
+        return delegate.getOrderedStoresInGroup( packageType, groupName, enabled );
     }
 
     @Override
@@ -212,45 +225,24 @@ public class DelegatingArtifactStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public List<RemoteRepository> getAllRemoteRepositories()
+    public RemoteRepository getRemoteRepository( final String packageType, final String name )
             throws IndyDataException
     {
-        return delegate.getAllRemoteRepositories();
+        return delegate.getRemoteRepository( packageType, name );
     }
 
     @Override
-    public List<HostedRepository> getAllHostedRepositories()
+    public HostedRepository getHostedRepository( final String packageType, final String name )
             throws IndyDataException
     {
-        return delegate.getAllHostedRepositories();
+        return delegate.getHostedRepository( packageType, name );
     }
 
     @Override
-    public List<Group> getAllGroups()
+    public Group getGroup( final String packageType, final String name )
             throws IndyDataException
     {
-        return delegate.getAllGroups();
-    }
-
-    @Override
-    public RemoteRepository getRemoteRepository( final String name )
-            throws IndyDataException
-    {
-        return delegate.getRemoteRepository( name );
-    }
-
-    @Override
-    public HostedRepository getHostedRepository( final String name )
-            throws IndyDataException
-    {
-        return delegate.getHostedRepository( name );
-    }
-
-    @Override
-    public Group getGroup( final String name )
-            throws IndyDataException
-    {
-        return delegate.getGroup( name );
+        return delegate.getGroup( packageType, name );
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/data/DelegatingArtifactStoreQuery.java
+++ b/api/src/main/java/org/commonjava/indy/data/DelegatingArtifactStoreQuery.java
@@ -170,10 +170,17 @@ public class DelegatingArtifactStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public List<RemoteRepository> getRemoteRepositoryByUrl( final String url )
+    public List<RemoteRepository> getRemoteRepositoryByUrl( final String packageType, final String url )
             throws IndyDataException
     {
-        return delegate.getRemoteRepositoryByUrl( url );
+        return delegate.getRemoteRepositoryByUrl( packageType, url );
+    }
+
+    @Override
+    public List<RemoteRepository> getRemoteRepositoryByUrl( final String packageType,final String url, final Boolean enabled )
+                    throws IndyDataException
+    {
+        return delegate.getRemoteRepositoryByUrl( packageType, url, enabled );
     }
 
     @Override

--- a/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
+++ b/api/src/main/java/org/commonjava/indy/data/StoreDataManager.java
@@ -169,6 +169,8 @@ public interface StoreDataManager
      */
     void asyncGroupAffectedBy( ContextualTask contextualTask );
 
+    Set<ArtifactStore> getArtifactStoresByPkgAndType( String packageType, StoreType storeType );
+
     class ContextualTask
     {
         private String threadName;

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/MaintenanceController.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/MaintenanceController.java
@@ -60,7 +60,7 @@ public class MaintenanceController
 
     public Set<StoreKey> getTombstoneStores( String packageType ) throws IndyDataException
     {
-        List<HostedRepository> stores = storeDataManager.query().packageType( packageType ).getAllHostedRepositories();
+        List<HostedRepository> stores = storeDataManager.query().getAllHostedRepositories( packageType );
         Set<StoreKey> tombstoneStores = new HashSet<>();
         for ( HostedRepository hosted : stores )
         {

--- a/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
+++ b/core/src/main/java/org/commonjava/indy/core/change/StoreContentListener.java
@@ -144,7 +144,6 @@ public class StoreContentListener
         try
         {
             groups.addAll( storeDataManager.query()
-                                           .packageType( group.getPackageType() )
                                            .getGroupsAffectedBy( group.getKey() ) );
         }
         catch ( IndyDataException e )
@@ -258,7 +257,7 @@ public class StoreContentListener
             {
                 try
                 {
-                    affected = ( storeDataManager.query().packageType( key.getPackageType() ).getGroupsAffectedBy( key ) );
+                    affected = ( storeDataManager.query().getGroupsAffectedBy( key ) );
                 }
                 catch ( IndyDataException e )
                 {

--- a/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
@@ -125,7 +125,7 @@ public abstract class AbstractMergedContentGenerator
         try
         {
             groups.addAll(
-                    storeManager.query().packageType( store.getPackageType() ).getGroupsAffectedBy( store.getKey() ) );
+                    storeManager.query().getGroupsAffectedBy( store.getKey() ) );
         }
         catch ( IndyDataException e )
         {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -267,9 +267,8 @@ public class DefaultContentManager
         try
         {
             members = storeManager.query()
-                                  .packageType( group.getPackageType() )
                                   .enabledState( true )
-                                  .getOrderedConcreteStoresInGroup( group.getName() );
+                                  .getOrderedConcreteStoresInGroup( group.getPackageType(), group.getName() );
         }
         catch ( final IndyDataException e )
         {
@@ -343,9 +342,8 @@ public class DefaultContentManager
             try
             {
                 final List<ArtifactStore> allMembers = storeManager.query()
-                                      .packageType( store.getPackageType() )
                                       .enabledState( true )
-                                      .getOrderedConcreteStoresInGroup( store.getName() );
+                                      .getOrderedConcreteStoresInGroup( store.getPackageType(), store.getName() );
 
                 final Transfer txfr = store( allMembers, store.getKey(), path, stream, op, eventMetadata );
                 logger.debug( "Stored: {} for group: {} in: {}", path, store.getKey(), txfr );

--- a/core/src/main/java/org/commonjava/indy/core/ctl/AdminController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/AdminController.java
@@ -161,7 +161,7 @@ public class AdminController
     {
         try
         {
-            return storeManager.query().packageType( packageType ).getRemoteRepositoryByUrl( url );
+            return storeManager.query().getRemoteRepositoryByUrl( packageType, url );
         }
         catch ( IndyDataException e )
         {

--- a/core/src/main/java/org/commonjava/indy/core/ctl/AdminController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/AdminController.java
@@ -123,13 +123,15 @@ public class AdminController
     {
         try
         {
-            ArtifactStoreQuery<ArtifactStore> query = storeManager.query().storeTypes( type );
             if ( !ALL_PACKAGE_TYPES.equals( packageType ) )
             {
-                return query.packageType( packageType ).getAll();
+                return storeManager.getArtifactStoresByPkgAndType( packageType, type )
+                                   .stream()
+                                   .collect( Collectors.toList() );
             }
             else
             {
+                ArtifactStoreQuery<ArtifactStore> query = storeManager.query().storeTypes( type );
                 return query.getAllByDefaultPackageTypes();
             }
         }

--- a/core/src/main/java/org/commonjava/indy/core/ctl/NfcController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/NfcController.java
@@ -240,11 +240,12 @@ public class NfcController
                 }
                 default:
                 {
-                    storeManager.query()
-                                .packageType( key.getPackageType() )
-                                .concreteStores()
-                                .stream( s -> s.getName().equals( key.getName() ) )
-                                .forEach( store -> clear( store, path ) );
+                    List<ArtifactStore> stores = new ArrayList<>();
+                    stores.addAll( storeManager.query().getAllRemoteRepositories( key.getPackageType() ) );
+                    stores.addAll( storeManager.query().getAllHostedRepositories( key.getPackageType() ) );
+                    stores.stream()
+                          .filter( s -> s.getName().equals( key.getName() ) )
+                          .forEach( store -> clear( store, path ) );
                     break;
                 }
             }

--- a/core/src/main/java/org/commonjava/indy/core/ctl/NfcController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/NfcController.java
@@ -141,7 +141,7 @@ public class NfcController
             List<ArtifactStore> stores;
             try
             {
-                stores = storeManager.query().packageType( key.getPackageType() ).getOrderedConcreteStoresInGroup( key.getName() );
+                stores = storeManager.query().getOrderedConcreteStoresInGroup( key.getPackageType(), key.getName() );
             }
             catch ( final IndyDataException e )
             {
@@ -231,7 +231,7 @@ public class NfcController
             {
                 case group:
                 {
-                    final List<ArtifactStore> stores = storeManager.query().packageType( key.getPackageType() ).getOrderedConcreteStoresInGroup( key.getName() );
+                    final List<ArtifactStore> stores = storeManager.query().getOrderedConcreteStoresInGroup( key.getPackageType(), key.getName() );
                     for ( final ArtifactStore store : stores )
                     {
                         clear( store, path );
@@ -293,8 +293,7 @@ public class NfcController
                 {
                     //Warn: This is very expensive if group holds thousands of repositories
                     final List<StoreKey> stores = storeManager.query()
-                                                              .packageType( key.getPackageType() )
-                                                              .getOrderedConcreteStoresInGroup( key.getName() )
+                                                              .getOrderedConcreteStoresInGroup( key.getPackageType(), key.getName() )
                                                               .stream()
                                                               .map( artifactStore -> artifactStore.getKey() )
                                                               .collect( Collectors.toList() );

--- a/core/src/main/java/org/commonjava/indy/core/data/StoreDataSetupAction.java
+++ b/core/src/main/java/org/commonjava/indy/core/data/StoreDataSetupAction.java
@@ -61,10 +61,7 @@ public class StoreDataSetupAction
             logger.info( "Verfiying that Indy basic stores are installed..." );
             storeManager.install();
 
-            if ( !storeManager.query()
-                              .packageType( MAVEN_PKG_KEY )
-                              .storeType( RemoteRepository.class )
-                              .containsByName( "central" ) )
+            if ( storeManager.query().getRemoteRepository( MAVEN_PKG_KEY, "central" ) == null )
             {
                 final RemoteRepository central =
                         new RemoteRepository( MAVEN_PKG_KEY, "central", "https://repo.maven.apache.org/maven2/" );
@@ -76,10 +73,7 @@ public class StoreDataSetupAction
                 
             }
 
-            if ( !storeManager.query()
-                              .packageType( MAVEN_PKG_KEY )
-                              .storeType( HostedRepository.class )
-                              .containsByName( "local-deployments" ) )
+            if ( storeManager.query().getHostedRepository( MAVEN_PKG_KEY, "local-deployments"  ) == null )
             {
                 final HostedRepository local = new HostedRepository( MAVEN_PKG_KEY, "local-deployments" );
                 local.setAllowReleases( true );
@@ -91,10 +85,7 @@ public class StoreDataSetupAction
                                                                           DEFAULT_SETUP ) );
             }
 
-            if ( !storeManager.query()
-                              .packageType( MAVEN_PKG_KEY )
-                              .storeType( Group.class )
-                              .containsByName( "public" ) )
+            if ( storeManager.query().getGroup( MAVEN_PKG_KEY, "public" ) == null )
             {
                 final Group pub = new Group( MAVEN_PKG_KEY, "public" );
                 pub.addConstituent( new StoreKey( MAVEN_PKG_KEY, StoreType.remote, "central" ) );

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
@@ -117,6 +117,17 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
     }
 
     @Override
+    public Set<ArtifactStore> getArtifactStoresByPkgAndType( final String pkg, final StoreType type )
+    {
+        Set<DtxArtifactStore> dtxArtifactStoreSet = storeQuery.getArtifactStoresByPkgAndType( pkg, type );
+        Set<ArtifactStore> storeSet = new HashSet<>(  );
+        dtxArtifactStoreSet.forEach( dtxArtifactStore -> {
+            storeSet.add( toArtifactStore( dtxArtifactStore ) );
+        } );
+        return storeSet;
+    }
+
+    @Override
     public boolean hasArtifactStore( StoreKey key )
     {
         ArtifactStore artifactStore = getArtifactStoreInternal( key );

--- a/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
@@ -519,6 +519,54 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
         return this;
     }
 
+    @Override
+    public List<RemoteRepository> getAllRemoteRepositories( String packageType )
+    {
+        return getAllRemoteRepositories( packageType, Boolean.TRUE );
+    }
+
+    @Override
+    public List<RemoteRepository> getAllRemoteRepositories( String packageType, Boolean enabled )
+    {
+        return dataManager.getArtifactStoresByPkgAndType( packageType, StoreType.remote )
+                          .stream()
+                          .filter( item -> enabled.equals( !item.isDisabled() ) )
+                          .map( item -> (RemoteRepository) item )
+                          .collect( Collectors.toList() );
+    }
+
+    @Override
+    public List<HostedRepository> getAllHostedRepositories( String packageType )
+    {
+        return getAllHostedRepositories( packageType, Boolean.TRUE );
+    }
+
+    @Override
+    public List<HostedRepository> getAllHostedRepositories( String packageType, Boolean enabled )
+    {
+        return dataManager.getArtifactStoresByPkgAndType( packageType, StoreType.hosted )
+                          .stream()
+                          .filter( item -> enabled.equals( !item.isDisabled() ) )
+                          .map( item -> (HostedRepository) item )
+                          .collect( Collectors.toList() );
+    }
+
+    @Override
+    public List<Group> getAllGroups( String packageType )
+    {
+        return getAllGroups( packageType, Boolean.TRUE );
+    }
+
+    @Override
+    public List<Group> getAllGroups( String packageType, Boolean enabled )
+    {
+        return dataManager.getArtifactStoresByPkgAndType( packageType, group )
+                          .stream()
+                          .filter( item -> enabled.equals( !item.isDisabled() ) )
+                          .map( item -> (Group) item )
+                          .collect( Collectors.toList() );
+    }
+
     private List<ArtifactStore> getGroupOrdering( final String groupName,
                                                   final boolean includeGroups, final boolean recurseGroups )
             throws IndyDataException

--- a/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
+++ b/db/infinispan/src/main/java/org/commonjava/indy/infinispan/data/InfinispanStoreDataManager.java
@@ -280,6 +280,16 @@ public class InfinispanStoreDataManager
     }
 
     @Override
+    public Set<ArtifactStore> getArtifactStoresByPkgAndType( String packageType, StoreType storeType )
+    {
+        return stores.executeCache( c -> c.values()
+                                          .stream()
+                                          .filter( item -> packageType.equals( item.getPackageType() )
+                                                          && storeType.equals( item.getType() ) ) )
+                     .collect( Collectors.toSet() );
+    }
+
+    @Override
     protected void refreshAffectedBy( final ArtifactStore store, final ArtifactStore original, StoreUpdateAction action )
     {
         if ( store == null )

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -23,6 +23,7 @@ import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.db.common.AbstractStoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @ApplicationScoped
@@ -141,6 +143,16 @@ public class MemoryStoreDataManager
     public Stream<StoreKey> streamArtifactStoreKeys()
     {
         return stores.keySet().stream();
+    }
+
+    @Override
+    public Set<ArtifactStore> getArtifactStoresByPkgAndType( String packageType, StoreType storeType )
+    {
+        return stores.values()
+                     .stream()
+                     .filter( item -> packageType.equals( item.getPackageType() ) && storeType.equals(
+                                     item.getType() ) )
+                     .collect( Collectors.toSet() );
     }
 
     @Override

--- a/db/memory/src/test/java/org/commonjava/indy/mem/data/ConcurrencyTest.java
+++ b/db/memory/src/test/java/org/commonjava/indy/mem/data/ConcurrencyTest.java
@@ -225,7 +225,7 @@ public class ConcurrencyTest
                 logger.debug( "Grabbing all artifact stores" );
                 try
                 {
-                    dataManager.query().packageType( MAVEN_PKG_KEY ).getAllGroups();
+                    dataManager.query().getAllGroups( MAVEN_PKG_KEY );
                     return null;
                 }
                 catch ( IndyDataException e )

--- a/db/memory/src/test/java/org/commonjava/indy/mem/data/ConcurrencyTest.java
+++ b/db/memory/src/test/java/org/commonjava/indy/mem/data/ConcurrencyTest.java
@@ -180,7 +180,7 @@ public class ConcurrencyTest
                     logger.debug( "Grabbing groups containing: {}", repo.getKey() );
                     try
                     {
-                        if (!dataManager.query().packageType( MAVEN_PKG_KEY ).getGroupsContaining( repo.getKey() ).isEmpty())
+                        if (!dataManager.query().getGroupsContaining( repo.getKey() ).isEmpty())
                         {
                             return null;
                         }

--- a/db/metrics/src/main/java/org/commonjava/indy/db/metered/MeasuringStoreQuery.java
+++ b/db/metrics/src/main/java/org/commonjava/indy/db/metered/MeasuringStoreQuery.java
@@ -369,14 +369,41 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public List<RemoteRepository> getRemoteRepositoryByUrl( final String url )
+    public List<RemoteRepository> getRemoteRepositoryByUrl( final String packageType, final String url )
             throws IndyDataException
     {
         AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
         List<RemoteRepository> result = metricsManager.wrapWithStandardMetrics( ()->{
             try
             {
-                return query.getRemoteRepositoryByUrl( url );
+                return query.getRemoteRepositoryByUrl( packageType, url );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getRemoteRepositoryByUrl" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<RemoteRepository> getRemoteRepositoryByUrl( final String packageType, final String url, final Boolean enabled )
+                    throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        List<RemoteRepository> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getRemoteRepositoryByUrl( packageType, url, enabled );
             }
             catch ( IndyDataException e )
             {

--- a/db/metrics/src/main/java/org/commonjava/indy/db/metered/MeasuringStoreQuery.java
+++ b/db/metrics/src/main/java/org/commonjava/indy/db/metered/MeasuringStoreQuery.java
@@ -679,4 +679,160 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
         query.noPackageType();
         return this;
     }
+
+    @Override
+    public List<RemoteRepository> getAllRemoteRepositories( String packageType ) throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        List<RemoteRepository> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getAllRemoteRepositories( packageType );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getAllRemoteRepositories" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<RemoteRepository> getAllRemoteRepositories( String packageType, Boolean enabled ) throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        List<RemoteRepository> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getAllRemoteRepositories( packageType, enabled );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getAllRemoteRepositories" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<HostedRepository> getAllHostedRepositories( String packageType ) throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        List<HostedRepository> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getAllHostedRepositories( packageType );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getAllHostedRepositories" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<HostedRepository> getAllHostedRepositories( String packageType, Boolean enabled ) throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        List<HostedRepository> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getAllHostedRepositories( packageType, enabled );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getAllHostedRepositories" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<Group> getAllGroups( String packageType ) throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        List<Group> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getAllGroups( packageType );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getAllGroups" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<Group> getAllGroups( String packageType, Boolean enabled ) throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        List<Group> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getAllGroups( packageType, enabled );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getAllGroups" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
 }

--- a/db/metrics/src/main/java/org/commonjava/indy/db/metered/MeasuringStoreQuery.java
+++ b/db/metrics/src/main/java/org/commonjava/indy/db/metered/MeasuringStoreQuery.java
@@ -57,14 +57,6 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public ArtifactStoreQuery<T> packageType( final String packageType )
-            throws IndyDataException
-    {
-        query.packageType( packageType );
-        return this;
-    }
-
-    @Override
     public <C extends ArtifactStore> ArtifactStoreQuery<C> storeType( final Class<C> storeCls )
     {
         query.storeType( storeCls );
@@ -369,6 +361,33 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
     }
 
     @Override
+    public Set<Group> getGroupsContaining( final StoreKey storeKey, final Boolean enabled )
+                    throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        Set<Group> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getGroupsContaining( storeKey );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getGroupsContaining" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    @Override
     public List<RemoteRepository> getRemoteRepositoryByUrl( final String packageType, final String url )
             throws IndyDataException
     {
@@ -423,7 +442,7 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String groupName )
+    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String packageType, final String groupName )
             throws IndyDataException
     {
         logger.trace( "START: metric store-query wrapper ordered-concrete-stores-in-group" );
@@ -433,7 +452,7 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
             List<ArtifactStore> result = metricsManager.wrapWithStandardMetrics( () -> {
                 try
                 {
-                    return query.getOrderedConcreteStoresInGroup( groupName );
+                    return query.getOrderedConcreteStoresInGroup( packageType, groupName );
                 }
                 catch ( IndyDataException e )
                 {
@@ -458,14 +477,76 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public List<ArtifactStore> getOrderedStoresInGroup( final String groupName )
+    public List<ArtifactStore> getOrderedConcreteStoresInGroup( final String packageType, final String groupName, final Boolean enabled )
+                    throws IndyDataException
+    {
+        logger.trace( "START: metric store-query wrapper ordered-concrete-stores-in-group" );
+        try
+        {
+            AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+            List<ArtifactStore> result = metricsManager.wrapWithStandardMetrics( () -> {
+                try
+                {
+                    return query.getOrderedConcreteStoresInGroup( packageType, groupName, enabled );
+                }
+                catch ( IndyDataException e )
+                {
+                    errorRef.set( e );
+                }
+
+                return null;
+            }, () -> "getOrderedConcreteStoresInGroup" );
+
+            IndyDataException error = errorRef.get();
+            if ( error != null )
+            {
+                throw error;
+            }
+
+            return result;
+        }
+        finally
+        {
+            logger.trace( "END: metric store-query wrapper ordered-concrete-stores-in-group" );
+        }
+    }
+
+    @Override
+    public List<ArtifactStore> getOrderedStoresInGroup( final String packageType, final String groupName )
             throws IndyDataException
     {
         AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
         List<ArtifactStore> result = metricsManager.wrapWithStandardMetrics( ()->{
             try
             {
-                return query.getOrderedStoresInGroup( groupName );
+                return query.getOrderedStoresInGroup( packageType, groupName );
+            }
+            catch ( IndyDataException e )
+            {
+                errorRef.set( e );
+            }
+
+            return null;
+        }, ()-> "getOrderedStoresInGroup" );
+
+        IndyDataException error = errorRef.get();
+        if ( error != null )
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<ArtifactStore> getOrderedStoresInGroup( final String packageType, final String groupName, final Boolean enabled )
+                    throws IndyDataException
+    {
+        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
+        List<ArtifactStore> result = metricsManager.wrapWithStandardMetrics( ()->{
+            try
+            {
+                return query.getOrderedStoresInGroup( packageType, groupName, enabled );
             }
             catch ( IndyDataException e )
             {
@@ -539,95 +620,14 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public List<RemoteRepository> getAllRemoteRepositories()
-            throws IndyDataException
-    {
-        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
-        List<RemoteRepository> result = metricsManager.wrapWithStandardMetrics( ()->{
-            try
-            {
-                return query.getAllRemoteRepositories();
-            }
-            catch ( IndyDataException e )
-            {
-                errorRef.set( e );
-            }
-
-            return null;
-        }, ()-> "getAllRemoteRepositories" );
-
-        IndyDataException error = errorRef.get();
-        if ( error != null )
-        {
-            throw error;
-        }
-
-        return result;
-    }
-
-    @Override
-    public List<HostedRepository> getAllHostedRepositories()
-            throws IndyDataException
-    {
-        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
-        List<HostedRepository> result = metricsManager.wrapWithStandardMetrics( ()->{
-            try
-            {
-                return query.getAllHostedRepositories();
-            }
-            catch ( IndyDataException e )
-            {
-                errorRef.set( e );
-            }
-
-            return null;
-        }, ()-> "getAllHostedRepositories" );
-
-        IndyDataException error = errorRef.get();
-        if ( error != null )
-        {
-            throw error;
-        }
-
-        return result;
-    }
-
-    @Override
-    public List<Group> getAllGroups()
-            throws IndyDataException
-    {
-        AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
-        List<Group> result = metricsManager.wrapWithStandardMetrics( ()->{
-            try
-            {
-                return query.getAllGroups();
-            }
-            catch ( IndyDataException e )
-            {
-                errorRef.set( e );
-            }
-
-            return null;
-        }, ()-> "getAllGroups" );
-
-        IndyDataException error = errorRef.get();
-        if ( error != null )
-        {
-            throw error;
-        }
-
-        return result;
-    }
-
-    @Override
-    public RemoteRepository getRemoteRepository( final String name )
+    public RemoteRepository getRemoteRepository( final String packageType, final String name )
             throws IndyDataException
     {
         AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
         RemoteRepository result = metricsManager.wrapWithStandardMetrics( ()->{
             try
             {
-                return query.getRemoteRepository( name );
+                return query.getRemoteRepository( packageType, name );
             }
             catch ( IndyDataException e )
             {
@@ -647,14 +647,14 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public HostedRepository getHostedRepository( final String name )
+    public HostedRepository getHostedRepository( final String packageType, final String name )
             throws IndyDataException
     {
         AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
         HostedRepository result = metricsManager.wrapWithStandardMetrics( ()->{
             try
             {
-                return query.getHostedRepository( name );
+                return query.getHostedRepository( packageType, name );
             }
             catch ( IndyDataException e )
             {
@@ -674,14 +674,14 @@ public class MeasuringStoreQuery<T extends ArtifactStore>
     }
 
     @Override
-    public Group getGroup( final String name )
+    public Group getGroup( final String packageType, final String name )
             throws IndyDataException
     {
         AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
         Group result = metricsManager.wrapWithStandardMetrics( ()->{
             try
             {
-                return query.getGroup( name );
+                return query.getGroup( packageType, name );
             }
             catch ( IndyDataException e )
             {

--- a/test/db/src/main/java/org/commonjava/indy/core/data/GroupDataManagerTCK.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/GroupDataManagerTCK.java
@@ -88,7 +88,7 @@ public abstract class GroupDataManagerTCK
 
         store( grp );
 
-        final Group result = manager.query().packageType( MAVEN_PKG_KEY ).storeType( Group.class ).getByName( grp.getName() );
+        final Group result = manager.query().getGroup( MAVEN_PKG_KEY, grp.getName() );
 
         assertThat( result, notNullValue() );
         assertThat( result.getName(), equalTo( grp.getName() ) );
@@ -136,7 +136,7 @@ public abstract class GroupDataManagerTCK
 
         manager.deleteArtifactStore( grp.getKey(), summary, new EventMetadata() );
 
-        final Group result = manager.query().packageType( MAVEN_PKG_KEY ).storeType( Group.class ).getByName( grp.getName() );
+        final Group result = manager.query().getGroup( MAVEN_PKG_KEY, grp.getName() );
 
         assertThat( result, nullValue() );
     }
@@ -152,7 +152,7 @@ public abstract class GroupDataManagerTCK
 
         store( grp );
 
-        final Group result = manager.query().packageType( MAVEN_PKG_KEY ).storeType( Group.class ).getByName( grp.getName() );
+        final Group result = manager.query().getGroup( MAVEN_PKG_KEY, grp.getName() );
 
         assertThat( result, notNullValue() );
         assertThat( result.getName(), equalTo( grp.getName() ) );
@@ -176,7 +176,7 @@ public abstract class GroupDataManagerTCK
 
         store( grp );
 
-        final List<ArtifactStore> repos = manager.query().packageType( MAVEN_PKG_KEY ).getOrderedConcreteStoresInGroup( grp.getName() );
+        final List<ArtifactStore> repos = manager.query().getOrderedConcreteStoresInGroup( MAVEN_PKG_KEY, grp.getName() );
 
         assertThat( repos, notNullValue() );
         assertThat( repos.size(), equalTo( 2 ) );
@@ -198,7 +198,7 @@ public abstract class GroupDataManagerTCK
 
         store( grp );
 
-        final List<ArtifactStore> result = manager.query().packageType( MAVEN_PKG_KEY ).getOrderedConcreteStoresInGroup( grp.getName() );
+        final List<ArtifactStore> result = manager.query().getOrderedConcreteStoresInGroup( MAVEN_PKG_KEY, grp.getName() );
 
         assertThat( result, notNullValue() );
         assertThat( result.size(), equalTo( 2 ) );
@@ -222,7 +222,7 @@ public abstract class GroupDataManagerTCK
 
         store( grp, grp );
 
-        final List<Group> result = manager.query().packageType( MAVEN_PKG_KEY ).storeType( Group.class ).getAll();
+        final List<Group> result = manager.query().getAllGroups( MAVEN_PKG_KEY );
 
         assertThat( result, notNullValue() );
         assertThat( result.size(), equalTo( 1 ) );
@@ -239,7 +239,7 @@ public abstract class GroupDataManagerTCK
 
         store( grp, grp2 );
 
-        final List<Group> result = manager.query().packageType( MAVEN_PKG_KEY ).storeType( Group.class ).getAll();
+        final List<Group> result = manager.query().getAllGroups( MAVEN_PKG_KEY );
 
         assertThat( result, notNullValue() );
         assertThat( result.size(), equalTo( 2 ) );

--- a/test/db/src/main/java/org/commonjava/indy/core/data/RepositoryDataManagerTCK.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/RepositoryDataManagerTCK.java
@@ -84,14 +84,14 @@ public abstract class RepositoryDataManagerTCK
         storeRemoteRepository( repo, true );
 
         List<RemoteRepository> result =
-                manager.query().packageType( MAVEN_PKG_KEY ).storeType( RemoteRepository.class ).getAll();
+                manager.query().getAllRemoteRepositories( MAVEN_PKG_KEY );
 
         assertThat( result, notNullValue() );
         assertThat( result.size(), equalTo( 1 ) );
 
         storeRemoteRepository( repo, true );
 
-        result = manager.query().packageType( MAVEN_PKG_KEY ).storeType( RemoteRepository.class ).getAll();
+        result = manager.query().getAllRemoteRepositories( MAVEN_PKG_KEY );
 
         assertThat( result, notNullValue() );
         assertThat( result.size(), equalTo( 1 ) );
@@ -109,9 +109,7 @@ public abstract class RepositoryDataManagerTCK
         manager.deleteArtifactStore( repo.getKey(), summary, new EventMetadata() );
 
         final ArtifactStore result = manager.query()
-                                            .packageType( MAVEN_PKG_KEY )
-                                            .storeType( RemoteRepository.class )
-                                            .getByName( repo.getName() );
+                                            .getRemoteRepository( MAVEN_PKG_KEY, repo.getName() );
 
         assertThat( result, nullValue() );
     }
@@ -129,7 +127,7 @@ public abstract class RepositoryDataManagerTCK
         storeRemoteRepository( repo2 );
 
         final List<RemoteRepository> repositories =
-        manager.query().packageType( MAVEN_PKG_KEY ).storeType( RemoteRepository.class ).getAll();
+        manager.query().getAllRemoteRepositories( MAVEN_PKG_KEY );
 
         assertThat( repositories, notNullValue() );
         assertThat( repositories.size(), equalTo( 2 ) );


### PR DESCRIPTION
Refactor the storeQuery to add the targeted interfaces to avoid to scan the full table. 