### PR TITLE
Allow jvm attach for ftests that use BytemanRunner.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1848,6 +1848,7 @@
             <redirectTestOutputToFile>${test-redirectOutput}</redirectTestOutputToFile>
             <forkCount>${it-forkCount}</forkCount>
             <reportsDirectory>${failsafe.report.dir}</reportsDirectory>
+            <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
 <!--             <rerunFailingTestsCount>1</rerunFailingTestsCount> -->
             <includes>
               <include>**/*Test.java</include>


### PR DESCRIPTION
This PR solves the problem where BytemanRunner tests needing to connect to another JVM.
Solves #1794 