### PR TITLE
Udpate remote cache manager

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheManager.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataCacheManager.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.pkg.maven.content;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataCache;
 import org.commonjava.indy.pkg.maven.content.cache.MavenMetadataKeyCache;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.infinispan.query.Search;
 import org.infinispan.query.dsl.Query;
@@ -39,11 +40,11 @@ public class MetadataCacheManager
 
     @Inject
     @MavenMetadataCache
-    private CacheHandle<MetadataKey, MetadataInfo> metadataCache;
+    private BasicCacheHandle<MetadataKey, MetadataInfo> metadataCache;
 
     @Inject
     @MavenMetadataKeyCache
-    private CacheHandle<MetadataKey, MetadataKey> metadataKeyCache;
+    private BasicCacheHandle<MetadataKey, MetadataKey> metadataKeyCache;
 
     private QueryFactory queryFactory;
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -87,7 +87,7 @@ public class MetadataCacheProducer
             keyMarshallers.add( new StoreKeyMarshaller() );
             cacheProducer.registerProtoAndMarshallers( "metadata_key.proto", keyMarshallers );
         }
-        return cacheProducer.getCache( METADATA_CACHE );
+        return cacheProducer.getBasicCache( METADATA_CACHE );
     }
 
     @MavenMetadataKeyCache
@@ -102,7 +102,7 @@ public class MetadataCacheProducer
             keyMarshallers.add( new StoreKeyMarshaller() );
             cacheProducer.registerProtoAndMarshallers( "metadata_key.proto", keyMarshallers );
         }
-        return cacheProducer.getCache( METADATA_KEY_CACHE );
+        return cacheProducer.getBasicCache( METADATA_KEY_CACHE );
     }
 
     @PostConstruct
@@ -113,14 +113,18 @@ public class MetadataCacheProducer
 
     private void registerTransformer()
     {
-        final CacheHandle<MetadataKey, MetadataKey> handler = cacheProducer.getCache( METADATA_KEY_CACHE );
-        handler.executeCache( cache -> {
-            SearchManagerImplementor searchManager = (SearchManagerImplementor) Search.getSearchManager( cache );
-            searchManager.registerKeyTransformer( MetadataKey.class, MetadataKeyTransformer.class );
+        BasicCacheHandle<MetadataKey, MetadataKey> handler = cacheProducer.getBasicCache( METADATA_KEY_CACHE );
+        // for embedded mode
+        if ( handler instanceof CacheHandle )
+        {
+            ((CacheHandle<MetadataKey, MetadataKey>) handler).executeCache( cache -> {
+                SearchManagerImplementor searchManager = (SearchManagerImplementor) Search.getSearchManager( cache );
+                searchManager.registerKeyTransformer( MetadataKey.class, MetadataKeyTransformer.class );
+                return null;
+            } );
+        }
 
-            cache.addListener( cacheListener );
-            return null;
-        } );
+        handler.getCache().addListener( cacheListener );
     }
 
 }

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -21,8 +21,10 @@ import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.pkg.maven.content.MetadataKey;
 import org.commonjava.indy.pkg.maven.content.MetadataInfo;
 import org.commonjava.indy.pkg.maven.content.MetadataKeyTransformer;
+import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
+import org.commonjava.indy.subsys.infinispan.config.ISPNRemoteConfiguration;
 import org.commonjava.maven.galley.model.Transfer;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
@@ -51,12 +53,20 @@ public class MetadataCacheProducer
     @Inject
     private CacheProducer cacheProducer;
 
+    @Inject
+    private ISPNRemoteConfiguration remoteConfiguration;
+
     @MavenMetadataCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<MetadataKey, MetadataInfo> mavenMetadataCacheCfg()
+    public BasicCacheHandle<MetadataKey, MetadataInfo> mavenMetadataCacheCfg()
     {
-        return cacheProducer.getCache( METADATA_CACHE );
+        /* TODO need to add @ProtoField annotation later for the key and value of the cache
+        if ( remoteConfiguration.isEnabled() )
+        {
+            cacheProducer.registerProtoSchema( MetadataKey.class, "maven.metadata", "metadata.proto" );
+        }*/
+        return cacheProducer.getBasicCache( METADATA_CACHE );
     }
 
     @MavenMetadataKeyCache

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -21,6 +21,13 @@ import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.pkg.maven.content.MetadataKey;
 import org.commonjava.indy.pkg.maven.content.MetadataInfo;
 import org.commonjava.indy.pkg.maven.content.MetadataKeyTransformer;
+import org.commonjava.indy.pkg.maven.content.marshaller.MetadataInfoMarshaller;
+import org.commonjava.indy.pkg.maven.content.marshaller.MetadataKeyMarshaller;
+import org.commonjava.indy.pkg.maven.content.marshaller.MetadataMarshaller;
+import org.commonjava.indy.pkg.maven.content.marshaller.SnapshotMarshaller;
+import org.commonjava.indy.pkg.maven.content.marshaller.SnapshotVersionMarshaller;
+import org.commonjava.indy.pkg.maven.content.marshaller.StoreKeyMarshaller;
+import org.commonjava.indy.pkg.maven.content.marshaller.VersioningMarshaller;
 import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
@@ -29,6 +36,7 @@ import org.commonjava.maven.galley.model.Transfer;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
 import org.infinispan.notifications.cachelistener.event.CacheEntryExpiredEvent;
+import org.infinispan.protostream.MessageMarshaller;
 import org.infinispan.query.Search;
 import org.infinispan.query.spi.SearchManagerImplementor;
 import org.slf4j.Logger;
@@ -39,6 +47,8 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 @ApplicationScoped
 public class MetadataCacheProducer
@@ -61,19 +71,37 @@ public class MetadataCacheProducer
     @ApplicationScoped
     public BasicCacheHandle<MetadataKey, MetadataInfo> mavenMetadataCacheCfg()
     {
-        /* TODO need to add @ProtoField annotation later for the key and value of the cache
         if ( remoteConfiguration.isEnabled() )
         {
-            cacheProducer.registerProtoSchema( MetadataKey.class, "maven.metadata", "metadata.proto" );
-        }*/
-        return cacheProducer.getBasicCache( METADATA_CACHE );
+            List<MessageMarshaller> infoMarshallers = new ArrayList<>();
+            infoMarshallers.add( new MetadataInfoMarshaller() );
+            infoMarshallers.add( new MetadataMarshaller() );
+            infoMarshallers.add( new VersioningMarshaller() );
+            infoMarshallers.add( new SnapshotMarshaller() );
+            infoMarshallers.add( new SnapshotVersionMarshaller() );
+            infoMarshallers.add( new VersioningMarshaller() );
+            cacheProducer.registerProtoAndMarshallers( "metadata_info.proto", infoMarshallers );
+
+            List<MessageMarshaller> keyMarshallers = new ArrayList<>();
+            keyMarshallers.add( new MetadataKeyMarshaller() );
+            keyMarshallers.add( new StoreKeyMarshaller() );
+            cacheProducer.registerProtoAndMarshallers( "metadata_key.proto", keyMarshallers );
+        }
+        return cacheProducer.getCache( METADATA_CACHE );
     }
 
     @MavenMetadataKeyCache
     @Produces
     @ApplicationScoped
-    public CacheHandle<MetadataKey, MetadataKey> mavenMetadataKeyCacheCfg()
+    public BasicCacheHandle<MetadataKey, MetadataKey> mavenMetadataKeyCacheCfg()
     {
+        if ( remoteConfiguration.isEnabled() )
+        {
+            List<MessageMarshaller> keyMarshallers = new ArrayList<>();
+            keyMarshallers.add( new MetadataKeyMarshaller() );
+            keyMarshallers.add( new StoreKeyMarshaller() );
+            cacheProducer.registerProtoAndMarshallers( "metadata_key.proto", keyMarshallers );
+        }
         return cacheProducer.getCache( METADATA_KEY_CACHE );
     }
 

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/MetadataInfoMarshaller.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/MetadataInfoMarshaller.java
@@ -1,0 +1,37 @@
+package org.commonjava.indy.pkg.maven.content.marshaller;
+
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.commonjava.indy.pkg.maven.content.MetadataInfo;
+import org.infinispan.protostream.MessageMarshaller;
+
+import java.io.IOException;
+
+public class MetadataInfoMarshaller implements MessageMarshaller<MetadataInfo>
+{
+    @Override
+    public MetadataInfo readFrom( ProtoStreamReader reader ) throws IOException
+    {
+        MetadataInfo info = new MetadataInfo( reader.readObject( "metadata", Metadata.class) );
+        info.setMetadataMergeInfo( reader.readString( "metadataMergeInfo" ) );
+        return info;
+    }
+
+    @Override
+    public void writeTo( ProtoStreamWriter writer, MetadataInfo metadataInfo ) throws IOException
+    {
+        writer.writeString( "metadataMergeInfo", metadataInfo.getMetadataMergeInfo() );
+        writer.writeObject( "metadata", metadataInfo.getMetadata(), Metadata.class );
+    }
+
+    @Override
+    public Class<? extends MetadataInfo> getJavaClass()
+    {
+        return MetadataInfo.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "maven.MetadataInfo";
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/MetadataKeyMarshaller.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/MetadataKeyMarshaller.java
@@ -1,0 +1,37 @@
+package org.commonjava.indy.pkg.maven.content.marshaller;
+
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.maven.content.MetadataKey;
+import org.infinispan.protostream.MessageMarshaller;
+
+import java.io.IOException;
+
+public class MetadataKeyMarshaller implements MessageMarshaller<MetadataKey>
+{
+    @Override
+    public MetadataKey readFrom( ProtoStreamReader reader ) throws IOException
+    {
+        StoreKey storeKey = reader.readObject( "storeKey", StoreKey.class );
+        String path = reader.readString( "path" );
+        return new MetadataKey( storeKey, path );
+    }
+
+    @Override
+    public void writeTo( ProtoStreamWriter writer, MetadataKey metadataKey ) throws IOException
+    {
+        writer.writeString( "path", metadataKey.getPath() );
+        writer.writeObject( "storeKey", metadataKey.getStoreKey(), StoreKey.class);
+    }
+
+    @Override
+    public Class<? extends MetadataKey> getJavaClass()
+    {
+        return MetadataKey.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "maven.MetadataKey";
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/MetadataMarshaller.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/MetadataMarshaller.java
@@ -1,0 +1,50 @@
+package org.commonjava.indy.pkg.maven.content.marshaller;
+
+import org.apache.maven.artifact.repository.metadata.Plugin;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.infinispan.protostream.MessageMarshaller;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class MetadataMarshaller implements MessageMarshaller<Metadata>
+{
+    @Override
+    public Metadata readFrom( ProtoStreamReader reader ) throws IOException
+    {
+        Metadata md = new Metadata();
+        md.setModelVersion( reader.readString( "modelVersion" ) );
+        md.setGroupId( reader.readString( "groupId" ) );
+        md.setArtifactId( reader.readString( "artifactId" ) );
+        md.setVersion( reader.readString( "version" ) );
+        md.setPlugins( reader.readCollection( "plugins", new ArrayList<Plugin>(), Plugin.class ) );
+        md.setVersioning( reader.readObject( "versioning", Versioning.class ) );
+        md.setModelEncoding( reader.readString( "modelEncoding" ) );
+        return md;
+    }
+
+    @Override
+    public void writeTo( ProtoStreamWriter writer, Metadata metadata ) throws IOException
+    {
+        writer.writeString( "modelVersion", metadata.getModelVersion() );
+        writer.writeString( "groupId", metadata.getGroupId() );
+        writer.writeString( "artifactId", metadata.getArtifactId() );
+        writer.writeString( "version", metadata.getVersion() );
+        writer.writeObject( "versioning", metadata.getVersioning(), Versioning.class );
+        writer.writeCollection( "plugins", metadata.getPlugins(), Plugin.class );
+        writer.writeString( "modelEncoding", metadata.getModelEncoding() );
+    }
+
+    @Override
+    public Class<? extends Metadata> getJavaClass()
+    {
+        return Metadata.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "maven.Metadata";
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/PluginMarshaller.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/PluginMarshaller.java
@@ -1,0 +1,39 @@
+package org.commonjava.indy.pkg.maven.content.marshaller;
+
+import org.apache.maven.artifact.repository.metadata.Plugin;
+import org.infinispan.protostream.MessageMarshaller;
+
+import java.io.IOException;
+
+public class PluginMarshaller implements MessageMarshaller<Plugin>
+{
+    @Override
+    public Plugin readFrom( ProtoStreamReader reader ) throws IOException
+    {
+        Plugin plugin = new Plugin();
+        plugin.setArtifactId( reader.readString( "artifactId" ) );
+        plugin.setName( reader.readString( "name" ) );
+        plugin.setPrefix( reader.readString( "prefix" ) );
+        return plugin;
+    }
+
+    @Override
+    public void writeTo( ProtoStreamWriter writer, Plugin plugin ) throws IOException
+    {
+        writer.writeString( "artifactId", plugin.getArtifactId());
+        writer.writeString( "name", plugin.getName() );
+        writer.writeString( "prefix", plugin.getPrefix());
+    }
+
+    @Override
+    public Class<? extends Plugin> getJavaClass()
+    {
+        return Plugin.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "maven.Plugin";
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/SnapshotMarshaller.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/SnapshotMarshaller.java
@@ -1,0 +1,39 @@
+package org.commonjava.indy.pkg.maven.content.marshaller;
+
+import org.apache.maven.artifact.repository.metadata.Snapshot;
+import org.infinispan.protostream.MessageMarshaller;
+
+import java.io.IOException;
+
+public class SnapshotMarshaller implements MessageMarshaller<Snapshot>
+{
+    @Override
+    public Snapshot readFrom( ProtoStreamReader reader ) throws IOException
+    {
+        Snapshot snapshot = new Snapshot();
+        snapshot.setBuildNumber( reader.readInt( "buildNumber" ) );
+        snapshot.setTimestamp( reader.readString( "timestamp" ) );
+        snapshot.setLocalCopy( reader.readBoolean( "localCopy" ) );
+        return snapshot;
+    }
+
+    @Override
+    public void writeTo( ProtoStreamWriter writer, Snapshot snapshot ) throws IOException
+    {
+        writer.writeInt( "buildNumber", snapshot.getBuildNumber());
+        writer.writeString( "timestamp", snapshot.getTimestamp() );
+        writer.writeBoolean( "localCopy", snapshot.isLocalCopy());
+    }
+
+    @Override
+    public Class<? extends Snapshot> getJavaClass()
+    {
+        return Snapshot.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "maven.Snapshot";
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/SnapshotVersionMarshaller.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/SnapshotVersionMarshaller.java
@@ -1,0 +1,41 @@
+package org.commonjava.indy.pkg.maven.content.marshaller;
+
+import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
+import org.infinispan.protostream.MessageMarshaller;
+
+import java.io.IOException;
+
+public class SnapshotVersionMarshaller implements MessageMarshaller<SnapshotVersion>
+{
+    @Override
+    public SnapshotVersion readFrom( ProtoStreamReader reader ) throws IOException
+    {
+        SnapshotVersion version = new SnapshotVersion();
+        version.setClassifier( reader.readString( "classifier" ) );
+        version.setExtension( reader.readString( "extension" ) );
+        version.setUpdated( reader.readString( "updated" ) );
+        version.setVersion( reader.readString( "version" ) );
+        return version;
+    }
+
+    @Override
+    public void writeTo( ProtoStreamWriter writer, SnapshotVersion snapshotVersion ) throws IOException
+    {
+        writer.writeString( "classifier", snapshotVersion.getClassifier() );
+        writer.writeString( "extension", snapshotVersion.getExtension() );
+        writer.writeString( "updated", snapshotVersion.getUpdated() );
+        writer.writeString( "version", snapshotVersion.getVersion() );
+    }
+
+    @Override
+    public Class<? extends SnapshotVersion> getJavaClass()
+    {
+        return SnapshotVersion.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "maven.SnapshotVersion";
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/StoreKeyMarshaller.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/StoreKeyMarshaller.java
@@ -1,0 +1,39 @@
+package org.commonjava.indy.pkg.maven.content.marshaller;
+
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+import org.infinispan.protostream.MessageMarshaller;
+
+import java.io.IOException;
+
+public class StoreKeyMarshaller implements MessageMarshaller<StoreKey>
+{
+    @Override
+    public StoreKey readFrom( ProtoStreamReader reader ) throws IOException
+    {
+        String packageType = reader.readString( "packageType" );
+        StoreType storeType = reader.readEnum( "storeType", StoreType.class );
+        String name = reader.readString( "name" );
+        return new StoreKey( packageType, storeType, name );
+    }
+
+    @Override
+    public void writeTo( ProtoStreamWriter writer, StoreKey storeKey ) throws IOException
+    {
+        writer.writeString( "name", storeKey.getName() );
+        writer.writeString( "packageType", storeKey.getPackageType() );
+        writer.writeEnum( "storeType", storeKey.getType());
+    }
+
+    @Override
+    public Class<? extends StoreKey> getJavaClass()
+    {
+        return StoreKey.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "maven.StoreKey";
+    }
+}

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/VersioningMarshaller.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/marshaller/VersioningMarshaller.java
@@ -1,0 +1,47 @@
+package org.commonjava.indy.pkg.maven.content.marshaller;
+
+import org.apache.maven.artifact.repository.metadata.Snapshot;
+import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
+import org.apache.maven.artifact.repository.metadata.Versioning;
+import org.infinispan.protostream.MessageMarshaller;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class VersioningMarshaller implements MessageMarshaller<Versioning>
+{
+    @Override
+    public Versioning readFrom( ProtoStreamReader reader ) throws IOException
+    {
+        Versioning versioning = new Versioning();
+        versioning.setRelease( reader.readString( "release" ) );
+        versioning.setLatest( reader.readString( "latest" ) );
+        versioning.setLastUpdated( reader.readString( "lastUpdated" ) );
+        versioning.setSnapshotVersions( reader.readCollection( "snapshotVersions", new ArrayList<SnapshotVersion>(), SnapshotVersion.class ) );
+        versioning.setVersions( reader.readCollection( "versions", new ArrayList<String>(), String.class ) );
+        return versioning;
+    }
+
+    @Override
+    public void writeTo( ProtoStreamWriter writer, Versioning versioning ) throws IOException
+    {
+        writer.writeString( "latest", versioning.getLatest() );
+        writer.writeString( "release", versioning.getRelease() );
+        writer.writeString( "lastUpdated", versioning.getLastUpdated() );
+        writer.writeObject( "snapshot", versioning.getSnapshot(), Snapshot.class);
+        writer.writeCollection( "snapshotVersions", versioning.getSnapshotVersions(), SnapshotVersion.class );
+        writer.writeCollection( "versions", versioning.getVersions(), String.class );
+    }
+
+    @Override
+    public Class<? extends Versioning> getJavaClass()
+    {
+        return Versioning.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "maven.Versioning";
+    }
+}

--- a/addons/pkg-maven/common/src/main/resources/metadata_info.proto
+++ b/addons/pkg-maven/common/src/main/resources/metadata_info.proto
@@ -1,0 +1,51 @@
+package metadata_info;
+
+message MetadataInfo
+{
+    optional metadata metadata = 1;
+    optional string metadataMergeInfo = 2;
+}
+
+message Metadata
+{
+    optional string modelVersion = 1;
+    required string groupId = 2;
+    required string artifactId = 3;
+    required string version = 4;
+    optional Versioning versioning = 5;
+    repeated Plugin plugins = 6;
+    optional string modelEncoding = 7;
+}
+
+message Versioning
+{
+    optional string latest = 1;
+    optional string release = 2;
+    optional Snapshot snapshot = 3;
+    repeated string versions = 4;
+    optional string lastUpdated = 5;
+    repeated SnapshotVersion snapshotVersions = 6;
+}
+
+message Plugin
+{
+    optional string artifactId = 1;
+    optional string name = 2;
+    optional string prefix = 3;
+}
+
+message Snapshot
+{
+    optional string timestamp = 1;
+    optional int32 buildNumber = 2;
+    optional bool localCopy = 3;
+}
+
+message SnapshotVersion
+{
+    optional string classifier = 1;
+    optional string extension = 2;
+    optional string version = 3;
+    optional string updated = 4;
+}
+

--- a/addons/pkg-maven/common/src/main/resources/metadata_key.proto
+++ b/addons/pkg-maven/common/src/main/resources/metadata_key.proto
@@ -1,0 +1,20 @@
+package metadata_key;
+
+message MetadataKey
+{
+    StoreKey storeKey = 1;
+    string path = 2;
+}
+
+message StoreKey
+{
+    string packageType = 1;
+
+    enum StoreType {
+        group = 1;
+        remote = 2;
+        hosted = 3;
+    }
+
+    string name = 3;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <javaVersion>11</javaVersion>
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
-    <infinispanVersion>9.4.15.Final</infinispanVersion>
+    <infinispanVersion>11.0.3.Final</infinispanVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <hibernateVersion>5.8.1.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
     <infinispanVersion>9.4.15.Final</infinispanVersion>
+    <protostreamVersion>4.3.0.Final</protostreamVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <hibernateVersion>5.8.1.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>
@@ -1036,6 +1037,16 @@
         <groupId>org.infinispan</groupId>
         <artifactId>infinispan-clustered-lock</artifactId>
         <version>${infinispanVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan</groupId>
+        <artifactId>infinispan-remote-query-client</artifactId>
+        <version>${infinispanVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan.protostream</groupId>
+        <artifactId>protostream-processor</artifactId>
+        <version>${protostreamVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1045,6 +1045,12 @@
       </dependency>
       <dependency>
         <groupId>org.infinispan.protostream</groupId>
+        <artifactId>protostream</artifactId>
+        <version>${protostreamVersion}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.infinispan.protostream</groupId>
         <artifactId>protostream-processor</artifactId>
         <version>${protostreamVersion}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <javaVersion>11</javaVersion>
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
-    <infinispanVersion>11.0.3.Final</infinispanVersion>
+    <infinispanVersion>9.4.15.Final</infinispanVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <hibernateVersion>5.8.1.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>

--- a/subsys/infinispan/pom.xml
+++ b/subsys/infinispan/pom.xml
@@ -66,6 +66,14 @@
       <artifactId>infinispan-client-hotrod</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-remote-query-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan.protostream</groupId>
+      <artifactId>protostream-processor</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/subsys/infinispan/src/main/conf/conf.d/cache-example.xml
+++ b/subsys/infinispan/src/main/conf/conf.d/cache-example.xml
@@ -1,0 +1,6 @@
+<infinispan>
+    <cache-container>
+        <distributed-cache name="example">
+        </distributed-cache>
+    </cache-container>
+</infinispan>

--- a/subsys/infinispan/src/main/conf/conf.d/hotrod-client.properties
+++ b/subsys/infinispan/src/main/conf/conf.d/hotrod-client.properties
@@ -1,0 +1,24 @@
+# Connection
+infinispan.client.hotrod.server_list=rmt-infinispan.spmm-automation.svc.cluster.local:11222
+
+# Client intelligence
+# External clients can use `BASIC` intelligence only.
+infinispan.client.hotrod.client_intelligence=BASIC
+
+# Authentication
+infinispan.client.hotrod.use_auth=true
+# Application user credentials.
+infinispan.client.hotrod.auth_username=testuser
+infinispan.client.hotrod.auth_password=testpassword
+infinispan.client.hotrod.auth_server_name=infinispan
+infinispan.client.hotrod.auth_realm=default
+infinispan.client.hotrod.sasl_properties.javax.security.sasl.qop=auth
+infinispan.client.hotrod.sasl_mechanism=DIGEST-MD5
+
+# Encryption
+infinispan.client.hotrod.sni_host_name=rmt-infinispan.spmm-automation.svc.cluster.local
+# Path to the TLS certificate.
+infinispan.client.hotrod.trust_store_path=/etc/indy/conf/ispn/tls.crt
+
+# Cache definition ( works on 11.x.Final but not 9.x.Final )
+#infinispan.client.hotrod.cache.example.configuration_uri=file:/var/lib/ispn/cache-example.xml

--- a/subsys/infinispan/src/main/conf/conf.d/hotrod-client.properties
+++ b/subsys/infinispan/src/main/conf/conf.d/hotrod-client.properties
@@ -1,4 +1,5 @@
 # Connection
+#infinispan.client.hotrod.server_list=rmt-infinispan.spmm-automation.svc.cluster.local:11222
 infinispan.client.hotrod.server_list=rmt-infinispan.spmm-automation.svc.cluster.local:11222
 
 # Client intelligence

--- a/subsys/infinispan/src/main/conf/conf.d/hotrod-client.properties
+++ b/subsys/infinispan/src/main/conf/conf.d/hotrod-client.properties
@@ -5,6 +5,9 @@ infinispan.client.hotrod.server_list=rmt-infinispan.spmm-automation.svc.cluster.
 # External clients can use `BASIC` intelligence only.
 infinispan.client.hotrod.client_intelligence=BASIC
 
+# The marshaller that serializes keys and values
+infinispan.client.hotrod.marshaller=org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller
+
 # Authentication
 infinispan.client.hotrod.use_auth=true
 # Application user credentials.

--- a/subsys/infinispan/src/main/conf/conf.d/hotrod-client.properties
+++ b/subsys/infinispan/src/main/conf/conf.d/hotrod-client.properties
@@ -1,5 +1,4 @@
 # Connection
-#infinispan.client.hotrod.server_list=rmt-infinispan.spmm-automation.svc.cluster.local:11222
 infinispan.client.hotrod.server_list=rmt-infinispan.spmm-automation.svc.cluster.local:11222
 
 # Client intelligence

--- a/subsys/infinispan/src/main/conf/conf.d/infinispan-remote.conf
+++ b/subsys/infinispan/src/main/conf/conf.d/infinispan-remote.conf
@@ -4,15 +4,4 @@
 #
 #enabled=true
 
-# Remote Infinispan server. Default localhost.
-#remote.server=localhost
-
-# By default, hotrod endpoint on port 11222.
-#
-#hotrod.port=11222
-
-# Caches matching below patterns are remote caches. Patterns split by comma.
-#
-#remote.patterns=remote.+
-
 #hotrod.client.config=/etc/indy/conf/hotrod-client.properties

--- a/subsys/infinispan/src/main/conf/conf.d/infinispan-remote.conf
+++ b/subsys/infinispan/src/main/conf/conf.d/infinispan-remote.conf
@@ -14,3 +14,5 @@
 # Caches matching below patterns are remote caches. Patterns split by comma.
 #
 #remote.patterns=remote.+
+
+#hotrod.client.config=/etc/indy/conf/hotrod-client.properties

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/BasicCacheHandle.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/BasicCacheHandle.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.subsys.infinispan;
 
 import org.commonjava.o11yphant.metrics.DefaultMetricsManager;
+import org.infinispan.Cache;
 import org.infinispan.commons.api.BasicCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,6 +70,8 @@ public class BasicCacheHandle<K,V>
     {
         return name;
     }
+
+    public Cache<K,V> getCache() { return (Cache<K, V>) this.cache; }
 
     public <R> R execute( Function<BasicCache<K, V>, R> operation )
     {

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -234,7 +234,7 @@ public class CacheProducer
     public synchronized <K, V> BasicCacheHandle<K, V> getBasicCache( String named )
     {
         BasicCacheHandle handle = caches.computeIfAbsent( named, ( k ) -> {
-            if ( remoteConfiguration.isEnabled() && remoteConfiguration.isRemoteCache( k ) )
+            if ( remoteConfiguration.isEnabled() )
             {
                 RemoteCache<K, V> cache = null;
                 try
@@ -242,7 +242,7 @@ public class CacheProducer
                     // For infinispan 9.x, it needs to load the specific cache configuration to create it
                     // For infinispan 11.x, there is no need to load this configuration here, instead, declaring it
                     // in hotrod-client.properties and get the cache by remoteCacheManager.getCache( "cacheName" )
-                    File confDir = indyConfiguration.getIndyConfDir();
+                    /*File confDir = indyConfiguration.getIndyConfDir();
                     File cacheConf = new File( confDir, "cache-" + named + ".xml" );
                     if ( cacheConf.exists() )
                     {
@@ -258,7 +258,8 @@ public class CacheProducer
                     {
                         throw new RuntimeException( "Cannot read cache configuration from file: " + cacheConf, e );
                     }
-                    cache = remoteCacheManager.administration().getOrCreateCache( named, new XMLStringConfiguration( confStr ) );
+                    cache = remoteCacheManager.administration().getOrCreateCache( named, new XMLStringConfiguration( confStr ) );*/
+                    cache = remoteCacheManager.getCache( named );
                     if ( cache == null )
                     {
                         logger.warn( "Can not get remote cache, name: {}", k );

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -253,7 +253,7 @@ public class CacheProducer
                     // in hotrod-client.properties and get the cache by remoteCacheManager.getCache( "cacheName" )
                     File confDir = indyConfiguration.getIndyConfDir();
                     File cacheConf = new File( confDir, "cache-" + named + ".xml" );
-                    if ( cacheConf.exists() )
+                    if ( !cacheConf.exists() )
                     {
                         logger.warn( "Invalid conf path, name: {}, path: {}", named, cacheConf );
                         return null;

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -234,7 +234,7 @@ public class CacheProducer
     public synchronized <K, V> BasicCacheHandle<K, V> getBasicCache( String named )
     {
         BasicCacheHandle handle = caches.computeIfAbsent( named, ( k ) -> {
-            if ( remoteConfiguration.isEnabled() )
+            if ( remoteConfiguration.isEnabled() && remoteConfiguration.isRemoteCache( k ) )
             {
                 RemoteCache<K, V> cache = null;
                 try
@@ -242,7 +242,7 @@ public class CacheProducer
                     // For infinispan 9.x, it needs to load the specific cache configuration to create it
                     // For infinispan 11.x, there is no need to load this configuration here, instead, declaring it
                     // in hotrod-client.properties and get the cache by remoteCacheManager.getCache( "cacheName" )
-                    /*File confDir = indyConfiguration.getIndyConfDir();
+                    File confDir = indyConfiguration.getIndyConfDir();
                     File cacheConf = new File( confDir, "cache-" + named + ".xml" );
                     if ( cacheConf.exists() )
                     {
@@ -258,8 +258,7 @@ public class CacheProducer
                     {
                         throw new RuntimeException( "Cannot read cache configuration from file: " + cacheConf, e );
                     }
-                    cache = remoteCacheManager.administration().getOrCreateCache( named, new XMLStringConfiguration( confStr ) );*/
-                    cache = remoteCacheManager.getCache( named );
+                    cache = remoteCacheManager.administration().getOrCreateCache( named, new XMLStringConfiguration( confStr ) );
                     if ( cache == null )
                     {
                         logger.warn( "Can not get remote cache, name: {}", k );

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/config/ISPNRemoteConfiguration.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/config/ISPNRemoteConfiguration.java
@@ -18,13 +18,10 @@ package org.commonjava.indy.subsys.infinispan.config;
 import org.commonjava.indy.conf.IndyConfigInfo;
 import org.commonjava.propulsor.config.annotation.ConfigName;
 import org.commonjava.propulsor.config.annotation.SectionName;
-import org.infinispan.client.hotrod.impl.ConfigurationProperties;
 
 import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
 import java.io.InputStream;
-
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 @SectionName( "infinispan-remote" )
 @ApplicationScoped
@@ -36,12 +33,6 @@ public class ISPNRemoteConfiguration
     private static final Boolean DEFAULT_ENABLED = Boolean.FALSE;
 
     private Boolean enabled;
-
-    private String remoteServer;
-
-    private Integer hotrodPort;
-
-    private String remotePatterns;
 
     private String hotrodClientConfigPath;
 
@@ -60,39 +51,6 @@ public class ISPNRemoteConfiguration
         this.enabled = enabled;
     }
 
-    public String getRemoteServer()
-    {
-        return remoteServer == null ? DEFAULT_REMOTE_SERVER : remoteServer;
-    }
-
-    @ConfigName( "remote.server" )
-    public void setRemoteServer( String remoteServer )
-    {
-        this.remoteServer = remoteServer;
-    }
-
-    public Integer getHotrodPort()
-    {
-        return hotrodPort == null ? ConfigurationProperties.DEFAULT_HOTROD_PORT : hotrodPort;
-    }
-
-    @ConfigName( "hotrod.port" )
-    public void setHotrodPort( Integer hotrodPort )
-    {
-        this.hotrodPort = hotrodPort;
-    }
-
-    public String getRemotePatterns()
-    {
-        return remotePatterns;
-    }
-
-    @ConfigName( "remote.patterns" )
-    public void setRemotePatterns( String remotePatterns )
-    {
-        this.remotePatterns = remotePatterns;
-    }
-
     public String getHotrodClientConfigPath()
     {
         return hotrodClientConfigPath;
@@ -102,30 +60,6 @@ public class ISPNRemoteConfiguration
     public void setHotrodClientConfigPath( String hotrodClientConfigPath )
     {
         this.hotrodClientConfigPath = hotrodClientConfigPath;
-    }
-
-    // utils
-
-    public boolean isRemoteCache( String cacheName )
-    {
-        if ( remotePatterns == null )
-        {
-            return false;
-        }
-
-        String[] patterns = remotePatterns.split( "," );
-        for ( String pattern : patterns )
-        {
-            if ( isNotBlank( pattern ) )
-            {
-                if ( cacheName.matches( pattern ) || cacheName.equals( pattern ) )
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
     }
 
     @Override

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/config/ISPNRemoteConfiguration.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/config/ISPNRemoteConfiguration.java
@@ -43,6 +43,8 @@ public class ISPNRemoteConfiguration
 
     private String remotePatterns;
 
+    private String hotrodClientConfigPath;
+
     public ISPNRemoteConfiguration()
     {
     }
@@ -89,6 +91,17 @@ public class ISPNRemoteConfiguration
     public void setRemotePatterns( String remotePatterns )
     {
         this.remotePatterns = remotePatterns;
+    }
+
+    public String getHotrodClientConfigPath()
+    {
+        return hotrodClientConfigPath;
+    }
+
+    @ConfigName( "hotrod.client.config" )
+    public void setHotrodClientConfigPath( String hotrodClientConfigPath )
+    {
+        this.hotrodClientConfigPath = hotrodClientConfigPath;
     }
 
     // utils

--- a/subsys/infinispan/src/main/resources/default-infinispan-remote.conf
+++ b/subsys/infinispan/src/main/resources/default-infinispan-remote.conf
@@ -4,13 +4,4 @@
 #
 #enabled=true
 
-# Remote Infinispan server. Default localhost.
-#remote.server=localhost
-
-# By default, hotrod endpoint on port 11222.
-#
-#hotrod.port=11222
-
-# Caches matching below patterns are remote caches. Patterns split by comma.
-#
-#remote.patterns=remote.+
+#hotrod.client.config=/etc/indy/conf/hotrod-client.properties


### PR DESCRIPTION
This patch includes:

- Init remote cache manager based on the hotrod-client.properties
- Add protobuf message and the related marshallers to support remote search 
