### PR TITLE
Fix CI problem

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ def bc_section = 'build-configs'
 def my_bc = null
 
 pipeline {
-    agent { label 'maven' }
+    agent { label 'maven-jdk11' }
     stages {
         stage('Prepare') {
             steps {

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <!-- <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation> -->
 
     <!-- thirdparty projects -->
-    <javaVersion>11</javaVersion>
+    <javaVersion>1.8</javaVersion>
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
     <infinispanVersion>9.4.15.Final</infinispanVersion>


### PR DESCRIPTION
We got two problems that cause CI failure. One is the JAVA_HOME not match the latest image. I switch to maven-jdk11 agent which is verified. The second issue is upgrading to java language level 11 caused some ftests fail. atm, I reverted to 1.8.
CC @sswguo 
@ligangty has one pr including these two fixes. To make it simple ans isolated, I push this one.