### PR TITLE
Add toolchains to manage switching between JDK8 and JDK11.

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
@@ -1,6 +1,7 @@
 package org.commonjava.indy.folo.data;
 
 import com.datastax.driver.core.*;
+import com.datastax.driver.core.exceptions.DriverException;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
 import org.commonjava.indy.IndyWorkflowException;
@@ -114,6 +115,10 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
         String foloCassandraKeyspace = config.getFoloCassandraKeyspace();
 
         session = cassandraClient.getSession(foloCassandraKeyspace);
+        if (session == null)
+        {
+            throw new DriverException("Session establishment failed.");
+        }
         session.execute(createFoloKeyspace(foloCassandraKeyspace));
         session.execute(createFoloRecordsTable(foloCassandraKeyspace));
         session.execute(createFoloSealedIdx(foloCassandraKeyspace));

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -431,6 +431,43 @@
         </plugin>
 
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-toolchains-plugin</artifactId>
+          <version>3.0.0</version>
+          <executions>
+            <execution>
+              <id>default-pre-integration-test</id>
+              <phase>pre-integration-test</phase>
+              <goals>
+                <goal>toolchain</goal>
+              </goals>
+              <configuration>
+                <toolchains>
+                  <jdk>
+                    <version>1.8</version>
+                    <vendor>OpenJDK</vendor>
+                  </jdk>
+                </toolchains>
+              </configuration>
+            </execution>
+            <execution>
+              <id>default-integration-test</id>
+              <goals>
+                <goal>toolchain</goal>
+              </goals>
+              <configuration>
+                <toolchains>
+                  <jdk>
+                    <version>11</version>
+                    <vendor>OpenJDK</vendor>
+                  </jdk>
+                </toolchains>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>cassandra-maven-plugin</artifactId>
           <version>3.6</version>
@@ -467,6 +504,7 @@
               <dependency>org.commonjava.indy:indy-ftests-changelog</dependency>
               <dependency>org.commonjava.indy:indy-ftests-repo-proxy</dependency>
             </dependenciesToScan>
+            <jvm>${JAVA_11_HOME}/bin/java</jvm>
           </configuration>
           <executions>
             <execution>
@@ -478,6 +516,7 @@
               <configuration>
                 <skip>${skipMainFTests}</skip>
                 <excludedGroups>org.commonjava.indy.ftest.core.category.TimingDependent, org.commonjava.indy.ftest.core.category.BytemanTest</excludedGroups>
+                <jdkToolchain>default-integration-test</jdkToolchain>
               </configuration>
             </execution>
             <execution>
@@ -490,6 +529,7 @@
                 <skip>${skipTimingFTests}</skip>
                 <forkCount>1</forkCount>
                 <groups>org.commonjava.indy.ftest.core.category.TimingDependent, org.commonjava.indy.ftest.core.category.BytemanTest</groups>
+                <toolchain>default-integration-test</toolchain>
               </configuration>
             </execution>
           </executions>
@@ -502,6 +542,10 @@
       </plugin>
       <plugin>
         <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-toolchains-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -17,7 +17,6 @@ package org.commonjava.indy.ftest.core;
 
 import com.datastax.driver.core.Session;
 import com.fasterxml.jackson.databind.Module;
-import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.action.IndyLifecycleException;
@@ -45,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.inject.spi.CDI;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
@@ -199,6 +197,9 @@ public abstract class AbstractIndyFunctionalTest
         CassandraClient cassandraClient = CDI.current().select( CassandraClient.class ).get();
         dropKeyspace( "cache_" , cassandraClient);
         dropKeyspace( "storage_", cassandraClient );
+        dropKeyspace( "schedule_", cassandraClient );
+        dropKeyspace( "store_", cassandraClient );
+
         cassandraClient.close();
         closeCacheProvider();
         closeQuietly( fixture );
@@ -291,6 +292,14 @@ public abstract class AbstractIndyFunctionalTest
                         + "storage.cassandra.keyspace=" + getKeyspace( "storage_" ) );
 
         writeConfigFile( "conf.d/cassandra.conf", "[cassandra]\nenabled=true" );
+        writeConfigFile( "conf.d/store-manager.conf", "[store-manager]\n"
+                    + "store.manager.keyspace=" + getKeyspace("store_") + "_stores\nstore.manager.replica=1");
+
+        writeConfigFile( "conf.d/scheduledb.conf", "[scheduledb]\nschedule.keyspace=" + getKeyspace("schedule_" )
+                        + "_scheduler\nschedule.keyspace.replica=1\n"
+                        + "schedule.partition.range=3600000\nschedule.rate.period=3" );
+
+
         writeConfigFile( "conf.d/durable-state.conf", "[durable-state]\n"
                         + "folo.storage=infinispan\n"
                         + "store.storage=infinispan\n"

--- a/pom.xml
+++ b/pom.xml
@@ -1818,6 +1818,23 @@
           </dependencies>
         </plugin>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-toolchains-plugin</artifactId>
+          <version>3.0.0</version>
+          <goals>
+            <goal>toolchain</goal>
+          </goals>
+          <configuration>
+            <toolchains>
+              <jdk>
+                <version>11</version>
+                <vendor>OpenJDK</vendor>
+              </jdk>
+            </toolchains>
+          </configuration>
+        </plugin>
+
+        <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
             <source>${javaVersion}</source>
@@ -2016,7 +2033,6 @@
             </execution>
           </executions>
         </plugin>
-
 
         <!-- <plugin>
           <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
 This PR looks to solve the problem of starting Cassandra Server with JDK8. By integrating Maven Toolchains.
 This should fix issue #1621 