### PR TITLE
Add table for affected stores

### DIFF
--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/AffectedStoreMigrationAction.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/AffectedStoreMigrationAction.java
@@ -1,0 +1,51 @@
+package org.commonjava.indy.cassandra.data;
+
+import org.commonjava.indy.action.IndyLifecycleException;
+import org.commonjava.indy.action.MigrationAction;
+import org.commonjava.indy.data.StoreDataManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named( "cassandra-affected-store-data-migration" )
+public class AffectedStoreMigrationAction implements MigrationAction
+{
+
+    @Inject
+    StoreDataManager dataManager;
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Override
+    public boolean migrate() throws IndyLifecycleException
+    {
+        if ( dataManager instanceof CassandraStoreDataManager )
+        {
+            if ( !((CassandraStoreDataManager)dataManager).isAffectedEmpty() )
+            {
+                logger.info( "Affected store is not empty. Migration already done." );
+                return true;
+            }
+
+            logger.info( "Init affected stores based on the store data" );
+
+            ( (CassandraStoreDataManager) dataManager ).initAffectedBy();
+        }
+
+        return true;
+    }
+
+    @Override
+    public int getMigrationPriority()
+    {
+        return 99;
+    }
+
+    @Override
+    public String getId()
+    {
+        return "Init affected store table based on the original store data.";
+    }
+}

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
@@ -205,6 +205,11 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
             if ( processed.add( key ) )
             {
                 DtxAffectedStore affectedStore = storeQuery.getAffectedStore( key );
+                if ( affectedStore == null )
+                {
+                    processed.add( key );
+                    continue;
+                }
                 Set<StoreKey> affected = affectedStore.getAffectedStoreKeys();
                 if ( affected != null )
                 {

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreQuery.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreQuery.java
@@ -9,6 +9,7 @@ import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
 import org.commonjava.indy.conf.IndyConfiguration;
 import org.commonjava.indy.core.conf.IndyStoreManagerConfig;
+import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.subsys.cassandra.CassandraClient;
 import org.commonjava.indy.subsys.cassandra.util.SchemaUtils;
@@ -21,6 +22,7 @@ import javax.inject.Inject;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.commonjava.indy.cassandra.data.CassandraStoreUtil.TABLE_AFFECTED_STORE;
 import static org.commonjava.indy.cassandra.data.CassandraStoreUtil.TABLE_STORE;
 
 @ApplicationScoped
@@ -52,6 +54,14 @@ public class CassandraStoreQuery
 
     private PreparedStatement preparedArtifactStoresQueryByKeys;
 
+    private PreparedStatement preparedAffectedStoresQuery;
+
+    private PreparedStatement preparedAffectedStoresIncrement;
+
+    private PreparedStatement preparedAffectedStoresReduction;
+
+    private PreparedStatement preparedAffectedStoreExistedQuery;
+
     public CassandraStoreQuery() {}
 
     public CassandraStoreQuery( CassandraClient client, IndyStoreManagerConfig config, IndyConfiguration indyConfig )
@@ -73,6 +83,7 @@ public class CassandraStoreQuery
         session.execute( SchemaUtils.getSchemaCreateKeyspace( keySpace, indyConfig.getKeyspaceReplicas() ));
         session.execute( CassandraStoreUtil.getSchemaCreateTableStore( keySpace ) );
         session.execute( CassandraStoreUtil.getSchemaCreateIndex4Store( keySpace ) );
+        session.execute( CassandraStoreUtil.getSchemaCreateTableAffectedStore( keySpace ) );
 
         MappingManager manager = new MappingManager( session );
 
@@ -93,6 +104,16 @@ public class CassandraStoreQuery
         preparedArtifactStoreExistedQuery = session.prepare( "SELECT name FROM " + keySpace + "." + TABLE_STORE + " LIMIT 1");
 
         preparedArtifactStoreDel = session.prepare( "DELETE FROM " + keySpace + "." + TABLE_STORE + " WHERE typekey=? AND namehashprefix=? AND name=? IF EXISTS" );
+
+        preparedAffectedStoresQuery = session.prepare( "SELECT key, affectedStores FROM " + keySpace + "." + TABLE_AFFECTED_STORE + " WHERE key=? ");
+
+        preparedAffectedStoresIncrement =
+                        session.prepare( "UPDATE " + keySpace + "." + TABLE_AFFECTED_STORE + " SET affectedStores = affectedStores + ? WHERE key=?" );
+
+        preparedAffectedStoresReduction =
+                        session.prepare( "UPDATE " + keySpace + "." + TABLE_AFFECTED_STORE + " SET affectedStores = affectedStores - ? WHERE key=?" );
+
+        preparedAffectedStoreExistedQuery = session.prepare( "SELECT key FROM " + keySpace + "." + TABLE_AFFECTED_STORE + " LIMIT 1");
     }
 
     public DtxArtifactStore getArtifactStore( String packageType, StoreType type, String name )
@@ -137,7 +158,7 @@ public class CassandraStoreQuery
     {
         BoundStatement bound = preparedArtifactStoresQuery.bind();
         ResultSet result = session.execute( bound );
-        return result.one() != null;
+        return result.one() == null;
     }
 
     public DtxArtifactStore removeArtifactStore( String packageType, StoreType type, String name )
@@ -179,5 +200,55 @@ public class CassandraStoreQuery
     public void createDtxArtifactStore( DtxArtifactStore dtxArtifactStore )
     {
         storeMapper.save( dtxArtifactStore );
+    }
+
+    public DtxAffectedStore getAffectedStore( StoreKey key )
+    {
+        BoundStatement bound = preparedAffectedStoresQuery.bind(key.toString());
+        ResultSet result = session.execute( bound );
+        return toDtxAffectedStore( result.one() );
+    }
+
+    private DtxAffectedStore toDtxAffectedStore( Row row )
+    {
+        if ( row == null )
+        {
+            return null;
+        }
+
+        DtxAffectedStore store = new DtxAffectedStore();
+        store.setKey( row.getString( CassandraStoreUtil.KEY ) );
+        store.setAffectedStores( row.getSet( CassandraStoreUtil.AFFECTED_STORES, String.class ) );
+
+        return store;
+    }
+
+    public void addAffectedStore( StoreKey storeKey, StoreKey affected )
+    {
+        BoundStatement bound = preparedAffectedStoresIncrement.bind();
+
+        Set<String> increment = new HashSet();
+        increment.add( affected.toString() );
+        bound.setSet( 0, increment );
+        bound.setString( 1, storeKey.toString() );
+        session.execute( bound );
+    }
+
+    public void removeAffectedStore( StoreKey storeKey, StoreKey affected )
+    {
+        BoundStatement bound = preparedAffectedStoresReduction.bind();
+
+        Set<String> reduction = new HashSet();
+        reduction.add( affected.toString() );
+        bound.setSet( 0, reduction );
+        bound.setString( 1, storeKey.toString() );
+        session.execute( bound );
+    }
+
+    public Boolean isAffectedEmpty()
+    {
+        BoundStatement bound = preparedAffectedStoreExistedQuery.bind();
+        ResultSet result = session.execute( bound );
+        return result.one() == null;
     }
 }

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreUtil.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreUtil.java
@@ -6,6 +6,7 @@ public class CassandraStoreUtil
 {
 
     public static final String TABLE_STORE = "artifactstore";
+    public static final String TABLE_AFFECTED_STORE = "affected_store";
 
     public static final String PACKAGE_TYPE = "packageType";
     public static final String STORE_TYPE = "storeType";
@@ -59,6 +60,9 @@ public class CassandraStoreUtil
     public static final String CONSTITUENTS = "constituents";
     public static final String PREPEND_CONSTITUENT = "prependConstituent";
 
+    public static final String KEY = "key";
+    public static final String AFFECTED_STORES = "affectedStores";
+
     public static final int MODULO_VALUE = 10;
 
     public static String getSchemaCreateTableStore( String keySpace )
@@ -81,6 +85,15 @@ public class CassandraStoreUtil
                         + "rescaninprogress boolean,"
                         + "extras map<text, text>,"
                         + "PRIMARY KEY (( typekey, namehashprefix ), name )"
+                        + ");";
+    }
+
+    public static String getSchemaCreateTableAffectedStore( String keyspace )
+    {
+        return "CREATE TABLE IF NOT EXISTS " + keyspace + "." + TABLE_AFFECTED_STORE + " ("
+                        + "key varchar,"
+                        + "affectedStores set<text>,"
+                        + "PRIMARY KEY ( key )"
                         + ");";
     }
 

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/DtxAffectedStore.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/DtxAffectedStore.java
@@ -1,0 +1,53 @@
+package org.commonjava.indy.cassandra.data;
+
+import com.datastax.driver.mapping.annotations.Column;
+import com.datastax.driver.mapping.annotations.PartitionKey;
+import com.datastax.driver.mapping.annotations.Table;
+import org.commonjava.indy.model.core.StoreKey;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.commonjava.indy.cassandra.data.CassandraStoreUtil.TABLE_AFFECTED_STORE;
+
+@Table( name = TABLE_AFFECTED_STORE, readConsistency = "QUORUM", writeConsistency = "QUORUM" )
+public class DtxAffectedStore
+{
+
+    @PartitionKey
+    private String key;
+
+    @Column
+    private Set<String> affectedStores;
+
+    public String getKey()
+    {
+        return key;
+    }
+
+    public void setKey( String key )
+    {
+        this.key = key;
+    }
+
+    public Set<String> getAffectedStores()
+    {
+        return affectedStores;
+    }
+
+    public void setAffectedStores( Set<String> affectedStores )
+    {
+        this.affectedStores = affectedStores;
+    }
+
+    public Set<StoreKey> getAffectedStoreKeys()
+    {
+        Set<StoreKey> storeKeys = new HashSet<>();
+        for ( String key : affectedStores )
+        {
+            storeKeys.add( StoreKey.fromString( key ) );
+        }
+        return storeKeys;
+    }
+
+}

--- a/db/cassandra/src/test/java/org/commonjava/indy/cassandra/data/CassandraStoreTest.java
+++ b/db/cassandra/src/test/java/org/commonjava/indy/cassandra/data/CassandraStoreTest.java
@@ -73,11 +73,11 @@ public class CassandraStoreTest
     public void testIsEmpty()
     {
 
-        assertThat( storeQuery.isEmpty(), equalTo( Boolean.FALSE ));
+        assertThat( storeQuery.isEmpty(), equalTo( Boolean.TRUE ));
 
         createTestStore( PackageTypeConstants.PKG_TYPE_MAVEN, StoreType.hosted.name() );
 
-        assertThat( storeQuery.isEmpty(), equalTo( Boolean.TRUE ));
+        assertThat( storeQuery.isEmpty(), equalTo( Boolean.FALSE ));
     }
 
     @Test

--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -666,6 +666,10 @@ public abstract class AbstractStoreDataManager
 
     public boolean isExcludedGroup( Group group )
     {
+        if ( indyConfiguration == null )
+        {
+            return false;
+        }
         String filter = indyConfiguration.getAffectedGroupsExcludeFilter();
         return isNotBlank( filter ) && group.getName().matches( filter );
     }

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -84,6 +84,24 @@ public class MemoryStoreDataManager
     }
 
     @Override
+    protected void removeAffectedBy( StoreKey key, StoreKey affected )
+    {
+
+    }
+
+    @Override
+    protected void addAffectedBy( StoreKey key, StoreKey affected )
+    {
+
+    }
+
+    @Override
+    protected void removeAffectedStore( StoreKey key )
+    {
+
+    }
+
+    @Override
     protected ArtifactStore removeArtifactStoreInternal( StoreKey key )
     {
         return stores.remove( key );


### PR DESCRIPTION
To avoid to scan all the group store on querying the affectedBy each time, adding the table for the affected stores, that stores the info of the storeKey and its affected stores, and implement the method `affectedBy` and `refreshAffectedBy` as well in CassandraStoreDataManager.