### PR TITLE
Fix missing deps for new o11yphant:1.3-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1588,7 +1588,12 @@
       <!-- o11yphant dependencies -->
       <dependency>
         <groupId>org.commonjava.util</groupId>
-        <artifactId>o11yphant-honeycomb</artifactId>
+        <artifactId>o11yphant-honeycomb-api</artifactId>
+        <version>${o11yphantVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.util</groupId>
+        <artifactId>o11yphant-honeycomb-core</artifactId>
         <version>${o11yphantVersion}</version>
       </dependency>
       <dependency>

--- a/subsys/groovy/pom.xml
+++ b/subsys/groovy/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-honeycomb</artifactId>
+      <artifactId>o11yphant-honeycomb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/subsys/honeycomb/pom.xml
+++ b/subsys/honeycomb/pom.xml
@@ -30,7 +30,7 @@
   <dependencies>
     <dependency>
       <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-honeycomb</artifactId>
+      <artifactId>o11yphant-honeycomb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyCustomTraceIdProvider.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyCustomTraceIdProvider.java
@@ -22,7 +22,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.commonjava.o11yphant.honeycomb.util.TraceIdUtils.getUUIDTraceId;
-import static org.commonjava.o11yphant.metrics.RequestContextHelper.TRACE_ID;
+import static org.commonjava.o11yphant.metrics.RequestContextConstants.TRACE_ID;
 
 @ApplicationScoped
 public class IndyCustomTraceIdProvider implements CustomTraceIdProvider


### PR DESCRIPTION
Seems the missing o11yphant-honeycomb:1.3-SNAPSHOT dep is blocking other prs build like https://github.com/Commonjava/indy/pull/1832. This is fixing the problem.