### PR TITLE
use latest o11yphant and express prom-specific node label config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.7.2</datastaxVersion>
     <pathmappedStorageVersion>1.8</pathmappedStorageVersion>
-    <o11yphantVersion>1.2</o11yphantVersion>
+    <o11yphantVersion>1.3-SNAPSHOT</o11yphantVersion>
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.1</atlasVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1588,7 +1588,12 @@
       <!-- o11yphant dependencies -->
       <dependency>
         <groupId>org.commonjava.util</groupId>
-        <artifactId>o11yphant-honeycomb</artifactId>
+        <artifactId>o11yphant-honeycomb-api</artifactId>
+        <version>${o11yphantVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.util</groupId>
+        <artifactId>o11yphant-honeycomb-core</artifactId>
         <version>${o11yphantVersion}</version>
       </dependency>
       <dependency>

--- a/subsys/groovy/pom.xml
+++ b/subsys/groovy/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-honeycomb</artifactId>
+      <artifactId>o11yphant-honeycomb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>

--- a/subsys/honeycomb/pom.xml
+++ b/subsys/honeycomb/pom.xml
@@ -30,7 +30,7 @@
   <dependencies>
     <dependency>
       <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-honeycomb</artifactId>
+      <artifactId>o11yphant-honeycomb-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyCustomTraceIdProvider.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyCustomTraceIdProvider.java
@@ -22,7 +22,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.commonjava.o11yphant.honeycomb.util.TraceIdUtils.getUUIDTraceId;
-import static org.commonjava.o11yphant.metrics.RequestContextHelper.TRACE_ID;
+import static org.commonjava.o11yphant.metrics.RequestContextConstants.TRACE_ID;
 
 @ApplicationScoped
 public class IndyCustomTraceIdProvider implements CustomTraceIdProvider

--- a/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/conf/IndyMetricsConfig.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/conf/IndyMetricsConfig.java
@@ -87,6 +87,8 @@ public class IndyMetricsConfig
 
     private final static String PROMETHEUS_EXPRESSED_METRICS = "prometheus.expressed.metrics";
 
+    private static final String PROMETHEUS_NODE_LABEL = "prometheus.node.label";
+
     private static final int DEFAULT_METER_RATIO = 1;
 
     private boolean ispnMetricsEnabled;
@@ -138,6 +140,8 @@ public class IndyMetricsConfig
     private Integer meterRatio;
 
     private String prometheusExpressedMetrics;
+
+    private String prometheusNodeLabel;
 
     public boolean isMeasureTransport()
     {
@@ -377,6 +381,7 @@ public class IndyMetricsConfig
     public PrometheusConfig getPrometheusConfig()
     {
         PrometheusConfig ret = new PrometheusConfig();
+        ret.setNodeLabel( prometheusNodeLabel );
         if ( prometheusExpressedMetrics != null )
         {
             ret.setExpressedMetrics( Arrays.asList( prometheusExpressedMetrics.split( "\\s*,\\s*" ) ) );
@@ -404,5 +409,16 @@ public class IndyMetricsConfig
     public void setPrometheusExpressedMetrics( String prometheusExpressedMetrics )
     {
         this.prometheusExpressedMetrics = prometheusExpressedMetrics;
+    }
+
+    public String getPrometheusNodeLabel()
+    {
+        return prometheusNodeLabel;
+    }
+
+    @ConfigName( PROMETHEUS_NODE_LABEL )
+    public void setPrometheusNodeLabel( String prometheusNodeLabel )
+    {
+        this.prometheusNodeLabel = prometheusNodeLabel;
     }
 }


### PR DESCRIPTION
We need a prometheus node-label that won't also be part of the metric name, so the node prefix is not suitable. This provides a separate configuration point called `prometheus.node.label` to accomplish that task, and upgrades to o11yphant 1.3-SNAPSHOT to get configuration classes + usage that's compatible.