### PR TITLE
Add schedule expiration cache migrator

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/expire/InfinispanScheduleExpirationMigrationAction.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/InfinispanScheduleExpirationMigrationAction.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.core.expire;
+
+import org.commonjava.indy.action.MigrationAction;
+import org.commonjava.indy.audit.ChangeSummary;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.subsys.datafile.DataFileManager;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.CacheProducer;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Named( "infinispan-schedule-expiration-migration" )
+public class InfinispanScheduleExpirationMigrationAction
+        implements MigrationAction
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private static final String SCHEDULE_CACHE_V1 = "schedule-expire-cache";
+
+    @Inject
+    private DataFileManager dataFileManager;
+
+    @Inject
+    private CacheProducer cacheProducer;
+
+    @Inject
+    private CacheHandle<ScheduleKey, ScheduleValue> scheduleCacheV2;
+
+    @Inject
+    private IndyObjectMapper objectMapper;
+
+    protected InfinispanScheduleExpirationMigrationAction()
+    {
+    }
+
+    @Override
+    public boolean migrate()
+    {
+        final Set<ScheduleKey> result = Collections.synchronizedSet( new HashSet<>() );
+        if ( cacheProducer != null )
+        {
+            EmbeddedCacheManager cacheManager = cacheProducer.getCacheManager();
+            if ( cacheManager.cacheExists( SCHEDULE_CACHE_V1 ) )
+            {
+                logger.info( "Migrating from legacy schedule expiration cache: {}", SCHEDULE_CACHE_V1 );
+                cacheProducer.getCache( SCHEDULE_CACHE_V1 ).executeCache( c -> {
+                    c.forEach( ( key, value ) -> {
+                        if ( key instanceof ScheduleKey && value instanceof Map )
+                        {
+                            logger.info( "Migrating from legacy cache: {}", key );
+                            scheduleCacheV2.put( (ScheduleKey) key,
+                                                 new ScheduleValue( (ScheduleKey) key, (Map) value ) );
+                            result.add( (ScheduleKey) key );
+                        }
+                    } );
+                    c.clearAsync();
+                    return null;
+                } );
+            }
+        }
+        return !result.isEmpty();
+    }
+
+    @Override
+    public int getMigrationPriority()
+    {
+        return 99;
+    }
+
+    @Override
+    public String getId()
+    {
+        return "Legacy ISPN schedule-expiration cache data migrator";
+    }
+}

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -724,7 +724,13 @@ public class ScheduleManager
         if ( !e.isPre() )
         {
             final ScheduleKey expiredKey = e.getKey();
-            final Map<String, Object> expiredContent = e.getValue().getDataPayload();
+            final ScheduleValue value = e.getValue();
+            if ( value == null )
+            {
+                logger.warn( "The cache value for ISPN creation event of schedule expiration is null, key is {} .", expiredKey );
+                return;
+            }
+            final Map<String, Object> expiredContent = value.getDataPayload();
             if ( expiredKey != null && expiredContent != null )
             {
                 logger.debug( "Expiration Created: {}", expiredKey );
@@ -747,15 +753,13 @@ public class ScheduleManager
         if ( !e.isPre() )
         {
             final ScheduleKey expiredKey = e.getKey();
-/*
-            if ( scheduleEventLockCache.containsKey( expiredKey ) )
+            final ScheduleValue value = e.getValue();
+            if ( value == null )
             {
-                logger.info( "Another instance {} is still handling expiration event for {}", expiredKey,
-                             scheduleEventLockCache.containsKey( expiredKey ) );
+                logger.warn( "The cache value for ISPN expired event of schedule expiration is null, key is {} .", expiredKey );
                 return;
             }
-*/
-            final Map<String, Object> expiredContent = e.getValue().getDataPayload();
+            final Map<String, Object> expiredContent = value.getDataPayload();
             if ( expiredKey != null && expiredContent != null )
             {
                 logger.debug( "EXPIRED: {}", expiredKey );

--- a/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/cache/ScheduleCacheProducer.java
@@ -42,7 +42,7 @@ public class ScheduleCacheProducer
     @Inject
     private CacheProducer cacheProducer;
 
-    private static final String SCHEDULE_EXPIRE = "schedule-expire-cache";
+    private static final String SCHEDULE_EXPIRE = "schedule-expire-cache-v2";
 
     private static final String SCHEDULE_EVENT_LOCK = "schedule-event-lock-cache";
 

--- a/subsys/infinispan/src/main/resources/infinispan-jdbc.xml
+++ b/subsys/infinispan/src/main/resources/infinispan-jdbc.xml
@@ -140,6 +140,20 @@
       </persistence>
     </local-cache>
 
+    <local-cache name="schedule-expire-cache-v2" configuration="local-template">
+      <expiration interval="300" />
+      <persistence>
+        <jdbc:string-keyed-jdbc-store fetch-state="false" read-only="false" purge="false" preload="true" key-to-string-mapper="org.commonjava.indy.core.expire.ScheduleCacheKey2StringMapper">
+          <jdbc:data-source jndi-url="java:/comp/env/jdbc/infinispan" />
+          <jdbc:string-keyed-table drop-on-exit="false" create-on-start="true" prefix="indy_cache">
+            <jdbc:id-column name="id_column" type="TEXT" />
+            <jdbc:data-column name="data_column" type="BYTEA" />
+            <jdbc:timestamp-column name="timestamp_column" type="BIGINT" />
+          </jdbc:string-keyed-table>
+        </jdbc:string-keyed-jdbc-store>
+      </persistence>
+    </local-cache>
+
     <local-cache name="nfc" configuration="local-template">
       <!--
         Expires in 72 hours and run expiration every 15 minutes.

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -69,6 +69,13 @@
       </persistence>
     </local-cache>
 
+    <local-cache name="schedule-expire-cache-v2" configuration="local-template">
+      <expiration interval="300" />
+      <persistence passivation="true">
+        <file-store shared="false" preload="false" fetch-state="false" path="${indy.data}/scheduler"/>
+      </persistence>
+    </local-cache>
+
     <local-cache name="nfc" configuration="local-template">
       <!--
         Expires in 72 hours and run expiration every 15 minutes.


### PR DESCRIPTION
As we will release new version in maint and I've found that the new ScheduleValue has been included, which causes the ScheduleCache data changing, I think we need the migration of this cache.

   * Add new data migrator to address expiration value type change.
   * Fix some NPE problem in ScheduleManager for new expiration value
     type change.