### PR TITLE
Workaround NPE when downloading a checksum via httprox

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/util/HttpConduitWrapper.java
@@ -203,7 +203,7 @@ public class HttpConduitWrapper
                 writeHeader( ApplicationHeader.last_modified, lastMod );
             }
 
-            String contentType = metadata.getContentType();
+            String contentType = metadata != null ? metadata.getContentType() : null;
             writeHeader( ApplicationHeader.content_type,
                          contentType != null ? contentType : contentController.getContentType( path ) );
 


### PR DESCRIPTION
**cherry-picked from #1847**

When downloading an md5 or a sha1, the metadata object is null for some
reason, but the code does not expect it in a single specific place,
while it does in others. Also setting the contentType to null seems safe,
because it is checked for null further down in the code.

Not sure if it is correct state that metadata is null, but this should
help unblock other features development in PNC.