### PR TITLE
Added Byteman to thirdparty libraries.

### DIFF
--- a/deployments/launcher/pom.xml
+++ b/deployments/launcher/pom.xml
@@ -196,6 +196,11 @@
       <artifactId>swagger-annotations</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.byteman</groupId>
+      <artifactId>byteman</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.commonjava.indy</groupId>


### PR DESCRIPTION
 This adds Byteman. Necessary for the runtime to load the javaagent with Byteman.
 This is necessary for setting j.s.Statement.setQueryTimeout method as a workround.