### PR TITLE
Init the NFC cache at startup

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/inject/CoreProvider.java
+++ b/core/src/main/java/org/commonjava/indy/core/inject/CoreProvider.java
@@ -69,6 +69,19 @@ public class CoreProvider
     public void init()
     {
         this.objectMapper = new IndyObjectMapper( objectMapperModules, objectMapperModuleSets );
+
+        String nfcProvider = indyConfiguration.getNfcProvider();
+        logger.info( "Apply nfc provider: {}", nfcProvider );
+        if ( CASSANDRA_NFC_PROVIDER.equals( nfcProvider ) )
+        {
+            notFoundCache = new CassandraNotFoundCache( indyConfiguration, cacheProducer,
+                                                        cassandraClient );
+        }
+        else
+        {
+            notFoundCache = new IspnNotFoundCache( indyConfiguration, nfcCache ); // default
+        }
+
     }
 
     @Produces
@@ -83,23 +96,6 @@ public class CoreProvider
 
     @Produces
     @Default
-    public NotFoundCache getNotFoundCache()
-    {
-        if ( notFoundCache == null )
-        {
-            String nfcProvider = indyConfiguration.getNfcProvider();
-            logger.info( "Apply nfc provider: {}", nfcProvider );
-            if ( CASSANDRA_NFC_PROVIDER.equals( nfcProvider ) )
-            {
-                notFoundCache = new CassandraNotFoundCache( indyConfiguration, cacheProducer,
-                                                            cassandraClient );
-            }
-            else
-            {
-                notFoundCache = new IspnNotFoundCache( indyConfiguration, nfcCache ); // default
-            }
-        }
-        return notFoundCache;
-    }
+    public NotFoundCache getNotFoundCache() { return notFoundCache; }
 
 }


### PR DESCRIPTION
When I debug the remote cache issue, and found that the log "Apply nfc provider .... " showed several times(7 times). I think this should be initialized at startup and the log should be expected only once.  Please correct me if I am wrong. 