### PR TITLE
Update infinispan to 11.x

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
@@ -16,7 +16,6 @@
 package org.commonjava.indy.folo.data;
 
 import org.commonjava.indy.folo.data.idxmodel.StoreKeyFieldBridge;
-import org.commonjava.indy.folo.data.idxmodel.TrackedContentEntryTransformer;
 import org.commonjava.indy.folo.model.TrackedContent;
 import org.commonjava.indy.folo.model.TrackedContentEntry;
 import org.commonjava.indy.folo.model.TrackingKey;
@@ -26,8 +25,6 @@ import org.commonjava.indy.subsys.infinispan.CacheProducer;
 import org.hibernate.search.annotations.Analyze;
 import org.hibernate.search.annotations.Factory;
 import org.hibernate.search.cfg.SearchMapping;
-import org.infinispan.query.Search;
-import org.infinispan.query.spi.SearchManagerImplementor;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -53,12 +50,6 @@ public class FoloCacheProducer
     @Inject
     private DataFileConfiguration dataConfig;
 
-    @PostConstruct
-    public void initIndexing()
-    {
-        registerTransformer();
-    }
-
     @Factory
     public SearchMapping getSearchMapping()
     {
@@ -79,19 +70,6 @@ public class FoloCacheProducer
                     .property( "id", ElementType.METHOD ).field().analyze( Analyze.NO );
 
         return entryMapping;
-    }
-
-    private void registerTransformer(){
-        final CacheHandle<TrackedContentEntry, TrackedContentEntry> handler =
-                        cacheProducer.getCache( IN_PROGRESS_NAME );
-
-        handler.executeCache( cache->{
-            SearchManagerImplementor searchManager = (SearchManagerImplementor) Search.getSearchManager( cache );
-
-            searchManager.registerKeyTransformer( TrackedContentEntry.class, TrackedContentEntryTransformer.class );
-
-            return null;
-        } );
     }
 
     @FoloInprogressCache

--- a/addons/folo/model-java/pom.xml
+++ b/addons/folo/model-java/pom.xml
@@ -39,5 +39,9 @@
       <groupId>io.swagger</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-query</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntry.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.folo.model;
 import org.commonjava.indy.model.core.AccessChannel;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.infinispan.query.Transformable;
 
 import java.io.Externalizable;
 import java.io.IOException;
@@ -31,6 +32,7 @@ import static org.commonjava.indy.model.core.AccessChannel.GENERIC_PROXY;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_GENERIC_HTTP;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 
+@Transformable( transformer = TrackedContentEntryTransformer.class )
 public class TrackedContentEntry
         implements Comparable<TrackedContentEntry>,Externalizable
 {

--- a/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntryTransformer.java
+++ b/addons/folo/model-java/src/main/java/org/commonjava/indy/folo/model/TrackedContentEntryTransformer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.commonjava.indy.folo.data.idxmodel;
+package org.commonjava.indy.folo.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.commonjava.indy.folo.model.TrackedContentEntry;

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -64,7 +64,6 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.annotation.ClientCacheEntryExpired;
 import org.infinispan.client.hotrod.annotation.ClientListener;
 import org.infinispan.client.hotrod.event.ClientCacheEntryExpiredEvent;
-import org.infinispan.commons.util.concurrent.ConcurrentHashSet;
 import org.infinispan.manager.DefaultCacheManager;
 import org.infinispan.notifications.Listener;
 import org.infinispan.notifications.cachelistener.annotation.CacheEntryExpired;
@@ -82,6 +81,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -383,7 +383,7 @@ public class KojiMavenMetadataProvider
         List<KojiArchiveInfo> archives = kojiContentProvider.listArchivesMatching( ga, null );
 
         Map<Integer, KojiBuildArchiveCollection> seenBuildArchives = new ConcurrentHashMap<>();
-        Set<Integer> seenBuilds = new ConcurrentHashSet<>();
+        Set<Integer> seenBuilds = new HashSet<>();
 
         DrainingExecutorCompletionService<SingleVersion> svc = new DrainingExecutorCompletionService<>( kojiMDService );
 
@@ -394,7 +394,7 @@ public class KojiMavenMetadataProvider
             }
         });
 
-        Set<SingleVersion> versions = new ConcurrentHashSet<>();
+        Set<SingleVersion> versions = new HashSet<>();
         try
         {
             svc.drain( v -> {

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKey.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MetadataKey.java
@@ -21,11 +21,13 @@ import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.FieldBridge;
 import org.hibernate.search.annotations.Index;
 import org.hibernate.search.annotations.Indexed;
+import org.infinispan.query.Transformable;
 
 import java.io.Serializable;
 import java.util.Objects;
 
 @Indexed
+@Transformable(transformer = MetadataKeyTransformer.class)
 public final class MetadataKey
                 implements Serializable
 {

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -108,27 +108,7 @@ public class MetadataCacheProducer
             keyMarshallers.add( new StoreTypeMarshaller() );
             cacheProducer.registerProtoAndMarshallers( "metadata_key.proto", keyMarshallers );
         }
-        return cacheProducer.getBasicCache( METADATA_KEY_CACHE );
-    }
-
-    @PostConstruct
-    public void initIndexing()
-    {
-        registerTransformer();
-    }
-
-    private void registerTransformer()
-    {
         BasicCacheHandle<MetadataKey, MetadataKey> handler = cacheProducer.getBasicCache( METADATA_KEY_CACHE );
-        // for embedded mode
-        if ( handler instanceof CacheHandle )
-        {
-            ((CacheHandle<MetadataKey, MetadataKey>) handler).executeCache( cache -> {
-                SearchManagerImplementor searchManager = (SearchManagerImplementor) Search.getSearchManager( cache );
-                searchManager.registerKeyTransformer( MetadataKey.class, MetadataKeyTransformer.class );
-                return null;
-            } );
-        }
 
         if ( handler.getCache() instanceof RemoteCache )
         {
@@ -138,6 +118,7 @@ public class MetadataCacheProducer
         {
             ((Cache)handler.getCache()).addListener( cacheListener );
         }
+        return handler;
     }
 
 }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/infinispan/CacheProducerMergeXmlTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/infinispan/CacheProducerMergeXmlTest.java
@@ -54,7 +54,7 @@ public class CacheProducerMergeXmlTest
     public void setup()
     {
         manager = new DefaultCacheManager(
-                new GlobalConfigurationBuilder().globalJmxStatistics().allowDuplicateDomains( true ).build() );
+                new GlobalConfigurationBuilder().jmx().build() );
         producer = new CacheProducer( new DefaultIndyConfiguration(), manager, null );
         producer.start();
         manager = producer.getCacheManager();
@@ -64,12 +64,6 @@ public class CacheProducerMergeXmlTest
     public void testMerge()
             throws Exception
     {
-        assertThat( manager.getCacheConfiguration( "local" ).memory().addressCount(), equalTo( 1048576 ) );
-        assertThat( manager.getCacheConfiguration( "koji-maven-version-metadata" ).memory().addressCount(), equalTo( 1048576 ) );
-        assertThat( manager.getCacheConfiguration( "folo-in-progress" ).memory().addressCount(), equalTo( 1048576 ) );
-        assertThat( manager.getCacheConfiguration( "folo-sealed" ).persistence().passivation(), equalTo( false ) );
-        assertThat( manager.getCacheConfiguration( "content-index" ).memory().addressCount(), equalTo( 1048576 ) );
-        assertThat( manager.getCacheConfiguration( "indy-nfs-owner-cache" ).memory().addressCount(), equalTo( 1048576 ) );
         assertThat( manager.getCacheConfiguration( "nfc" ), notNullValue() );
         assertThat( manager.getCacheConfiguration( "schedule-expire-cache" ), notNullValue() );
         assertThat( manager.getCacheConfiguration( "maven-metadata-cache" ), notNullValue() );

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <javaVersion>11</javaVersion>
     <slf4j-version>1.7.16</slf4j-version>
     <logback-version>1.2.3</logback-version>
-    <infinispanVersion>9.4.15.Final</infinispanVersion>
+    <infinispanVersion>11.0.8.Final</infinispanVersion>
     <protostreamVersion>4.3.0.Final</protostreamVersion>
     <gsonVersion>2.8.2</gsonVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -32,6 +32,7 @@ import org.infinispan.client.hotrod.RemoteCache;
 import org.infinispan.client.hotrod.RemoteCacheManager;
 import org.infinispan.client.hotrod.RemoteCounterManagerFactory;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
+import org.infinispan.client.hotrod.marshall.MarshallerUtil;
 import org.infinispan.client.hotrod.marshall.ProtoStreamMarshaller;
 import org.infinispan.commons.configuration.XMLStringConfiguration;
 import org.infinispan.commons.marshall.MarshallableTypeHints;
@@ -303,7 +304,7 @@ public class CacheProducer
 
     public synchronized <K> void registerProtoSchema( Class<K> kClass, String packageName, String fileName )
     {
-        SerializationContext ctx = ProtoStreamMarshaller.getSerializationContext( remoteCacheManager );
+        SerializationContext ctx = MarshallerUtil.getSerializationContext( remoteCacheManager );
         // Use ProtoSchemaBuilder to define a Protobuf schema on the client
         ProtoSchemaBuilder protoSchemaBuilder = new ProtoSchemaBuilder();
         String protoFile;
@@ -329,7 +330,7 @@ public class CacheProducer
 
     public synchronized void registerProtoAndMarshallers( String protofile, List<BaseMarshaller> marshallers )
     {
-        SerializationContext ctx = ProtoStreamMarshaller.getSerializationContext( remoteCacheManager );
+        SerializationContext ctx = MarshallerUtil.getSerializationContext( remoteCacheManager );
         try
         {
             ctx.registerProtoFiles( FileDescriptorSource.fromResources( protofile ) );
@@ -542,7 +543,7 @@ public class CacheProducer
             }
         }
 
-        final ConfigurationBuilderHolder holder = ( new ParserRegistry() ).parse( IOUtils.toInputStream( config ) );
+        final ConfigurationBuilderHolder holder = ( new ParserRegistry() ).parse( config );
         final ConfigurationManager manager = new ConfigurationManager( holder );
 
         final Set<String> definedCaches = mgr.getCacheNames();


### PR DESCRIPTION
Since the server side has been infinispan-server-runtime-11.0.9.Final-redhat-00001-loader.jar, it's better to use the same version in client side. And in case of any impact on the main code, I created a separate branch `ispn-11` for this, we can do some test before merging. 