### PR TITLE
LegacyReadonlyPhysicalStore use separated legacyBaseDir

### DIFF
--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -237,7 +237,8 @@ public class DefaultGalleyStorageProvider
             }
         }
 
-        PhysicalStore physicalStore = new LegacyReadonlyPhysicalStore( storeRoot );
+        File legacyBaseDir = config.getLegacyStorageBasedir();
+        PhysicalStore physicalStore = new LegacyReadonlyPhysicalStore( storeRoot, legacyBaseDir );
 
         logger.info( "Create cacheProviderFactory, pathDB: {}, physicalStore: {}", pathDB, physicalStore );
         cacheProviderFactory =

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
@@ -42,6 +42,8 @@ public class DefaultStorageProviderConfiguration
 
     private File storageBasedir;
 
+    private File legacyStorageBasedir;
+
     private File nfsStoreBasedir;
 
     public DefaultStorageProviderConfiguration()
@@ -71,7 +73,6 @@ public class DefaultStorageProviderConfiguration
     }
 
     @ConfigName( "storage.dir" )
-    @Deprecated
     public void setStorageRootDirectory( final File storageBasedir )
     {
         this.storageBasedir = storageBasedir;
@@ -199,5 +200,19 @@ public class DefaultStorageProviderConfiguration
     public String getDeduplicatePattern()
     {
         return deduplicatePattern;
+    }
+
+    /**
+     * After switching to pathmap storage, we take the old storage dir as legacy. Files in the legacy dir are read-only.
+     */
+    public File getLegacyStorageBasedir()
+    {
+        return legacyStorageBasedir;
+    }
+
+    @ConfigName( "storage.legacy.dir" )
+    public void setLegacyStorageBasedir( File legacyStorageBasedir )
+    {
+        this.legacyStorageBasedir = legacyStorageBasedir;
     }
 }


### PR DESCRIPTION
This allows Indy to config legacy storage using different base dir. We can mount it elsewhere like "/mnt/legacy/storage". This is useful as in:
1. legacy and new storage dirs not mixed;
2. easy back up (legacy volume is readonly, not need to backup);
3. separate from other dirs on the same volume (indy/data, indy/ui) to make the migration easier. 

I plan to test it when migrating old stage content to baremetal.