### PR TITLE
APIs for scheduler migration

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/SchedulerController.java
@@ -21,23 +21,18 @@ import org.commonjava.indy.core.expire.Expiration;
 import org.commonjava.indy.core.expire.ExpirationSet;
 import org.commonjava.indy.core.expire.ScheduleManager;
 import org.commonjava.indy.core.expire.ScheduleManagerUtils;
-import org.commonjava.indy.core.expire.ScheduleValue;
-import org.commonjava.indy.core.expire.StoreKeyMatcher;
+import org.commonjava.indy.core.expire.ScheduleValueDTO;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
-import org.infinispan.commons.api.BasicCache;
-import org.infinispan.query.Search;
-import org.infinispan.query.dsl.Query;
-import org.infinispan.query.dsl.QueryFactory;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.List;
-import java.util.stream.Collectors;
+import javax.servlet.ServletInputStream;
 
 @ApplicationScoped
 public class SchedulerController
@@ -47,6 +42,11 @@ public class SchedulerController
 
     @Inject
     private StoreDataManager storeDataManager;
+
+    @Inject
+    private IndyObjectMapper objectMapper;
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     protected SchedulerController()
     {
@@ -113,4 +113,15 @@ public class SchedulerController
         return new Expiration( ScheduleManagerUtils.groupName( store.getKey(), StoreEnablementManager.DISABLE_TIMEOUT ), StoreEnablementManager.DISABLE_TIMEOUT );
     }
 
+    public String exportScheduler() throws Exception
+    {
+        return scheduleManager.exportScheduler();
+    }
+
+    public void importScheduler( ServletInputStream inputStream ) throws Exception
+    {
+        ScheduleValueDTO dto = objectMapper.readValue( inputStream, ScheduleValueDTO.class );
+        logger.info( "Import schedulers, size: {}", dto.getItems().size() );
+        scheduleManager.importScheduler( dto.getItems() );
+    }
 }

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleManager.java
@@ -4,6 +4,8 @@ import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 
+import java.util.Set;
+
 public interface ScheduleManager
 {
 
@@ -28,4 +30,7 @@ public interface ScheduleManager
 
     ExpirationSet findMatchingExpirations( final String jobType );
 
+    String exportScheduler() throws Exception;
+
+    void importScheduler( Set<ScheduleValue> inputStream ) throws Exception;
 }

--- a/core/src/main/java/org/commonjava/indy/core/expire/ScheduleValueDTO.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/ScheduleValueDTO.java
@@ -1,0 +1,26 @@
+package org.commonjava.indy.core.expire;
+
+import java.util.Set;
+
+public class ScheduleValueDTO
+{
+
+    private Set<ScheduleValue> items;
+
+    public ScheduleValueDTO() {}
+
+    public ScheduleValueDTO(Set<ScheduleValue> items)
+    {
+        this.items = items;
+    }
+
+    public Set<ScheduleValue> getItems()
+    {
+        return items;
+    }
+
+    public void setItems( Set<ScheduleValue> items )
+    {
+        this.items = items;
+    }
+}


### PR DESCRIPTION
Since we need to get the lifespan for each cache entry, that info[1] is not in our side and needs to check the metadata of cacheEntry, the following APIs does not work for scheduler. `/api/admin/maint/infinispan/cache/{name}`

The PR adds two APIs to support to import and export schedulers for migration purpose. 

[1]. scheduler value example from prod.
```
{
  "maven:remote:central#CONTENT#io/quarkus/resteasy/reactive/resteasy-reactive-common/1.13.0.Final/resteasy-reactive-common-1.13.0.Final.jar" : {
    "key" : {
      "storeKey" : "maven:remote:central",
      "type" : "CONTENT",
      "name" : "io/quarkus/resteasy/reactive/resteasy-reactive-common/1.13.0.Final/resteasy-reactive-common-1.13.0.Final.jar",
      "groupName" : "maven:remote:central#CONTENT"
    },
    "dataPayload" : {
      "JOB_TYPE" : "CONTENT",
      "payload" : "{\n  \"key\" : \"maven:remote:central\",\n  \"path\" : \"io/quarkus/resteasy/reactive/resteasy-reactive-common/1.13.0.Final/resteasy-reactive-common-1.13.0.Final.jar\"\n}",
      "SCHEDULE_TIME" : 1617336016154
    }
  }
```