### PR TITLE
Upgrade honeycomb API version and add POD_NAME as potential nodeId envar source

### DIFF
--- a/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/DefaultIndyConfiguration.java
@@ -124,7 +124,12 @@ public class DefaultIndyConfiguration
     {
         Logger logger = LoggerFactory.getLogger( getClass() );
 
-        String nodeId = System.getenv( "HOSTNAME" );
+        String nodeId = System.getenv( "POD_NAME" );
+        if ( isBlank( nodeId ) )
+        {
+            nodeId = System.getenv( "HOSTNAME" );
+        }
+
         if ( isBlank( nodeId ) )
         {
             nodeId = System.getenv( "HOST" );

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <jgroupsVersion>4.0.4.Final</jgroupsVersion>
     <httpcoreVersion>4.4.9</httpcoreVersion>
     <httpclientVersion>4.5.9</httpclientVersion>
-    <honeycombVersion>1.1.0</honeycombVersion>
+    <honeycombVersion>1.5.1</honeycombVersion>
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.7.2</datastaxVersion>
     <pathmappedStorageVersion>1.9-SNAPSHOT</pathmappedStorageVersion>

--- a/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyCustomTraceIdProvider.java
+++ b/subsys/honeycomb/src/main/java/org/commonjava/indy/subsys/honeycomb/IndyCustomTraceIdProvider.java
@@ -15,13 +15,13 @@
  */
 package org.commonjava.indy.subsys.honeycomb;
 
+import io.honeycomb.beeline.tracing.ids.W3CTraceIdProvider;
 import org.commonjava.o11yphant.honeycomb.CustomTraceIdProvider;
 import org.commonjava.o11yphant.metrics.RequestContextHelper;
 
 import javax.enterprise.context.ApplicationScoped;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.commonjava.o11yphant.honeycomb.util.TraceIdUtils.getUUIDTraceId;
 import static org.commonjava.o11yphant.metrics.RequestContextConstants.TRACE_ID;
 
 @ApplicationScoped
@@ -30,11 +30,24 @@ public class IndyCustomTraceIdProvider implements CustomTraceIdProvider
     @Override
     public String generateId()
     {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String generateTraceId()
+    {
         String traceId = RequestContextHelper.getContext( TRACE_ID );
         if ( isNotBlank(traceId ))
         {
             return traceId;
         }
-        return getUUIDTraceId();
+
+        return W3CTraceIdProvider.getInstance().generateTraceId();
+    }
+
+    @Override
+    public String generateSpanId()
+    {
+        return W3CTraceIdProvider.getInstance().generateSpanId();
     }
 }


### PR DESCRIPTION
The new Honeycomb API has some small changes for W3C trace propagation compliance (https://www.w3.org/TR/trace-context/)