### PR TITLE
Call FoloISPN2CassandraMigrationAction from REST

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
@@ -27,6 +27,7 @@ import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.core.bind.jaxrs.ContentAccessHandler;
 import org.commonjava.indy.core.ctl.ContentController;
+import org.commonjava.indy.folo.action.FoloISPN2CassandraMigrationAction;
 import org.commonjava.indy.folo.ctl.FoloAdminController;
 import org.commonjava.indy.folo.ctl.FoloConstants;
 import org.commonjava.indy.folo.data.FoloContentException;
@@ -404,5 +405,17 @@ public class FoloAdminResource
         return handler.doDelete( request, new EventMetadata(  ) );
     }
 
+    @Inject
+    private FoloISPN2CassandraMigrationAction foloISPN2CassandraMigrationAction;
+
+    @ApiOperation( "Import folo from ISPN cache to Cassandra." )
+    @ApiResponses( { @ApiResponse( code = 201, message = "Import folo from ISPN cache to Cassandra." ) } )
+    @Path( "/importToCassandra" )
+    @PUT
+    public Response importFoloToCassandra( final @Context UriInfo uriInfo, final @Context HttpServletRequest request )
+    {
+        new Thread( () -> foloISPN2CassandraMigrationAction.migrate() ).start(); // run it on backend
+        return Response.created( uriInfo.getRequestUri() ).build();
+    }
 
 }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/admin/MaintenanceHandler.java
@@ -336,5 +336,4 @@ public class MaintenanceHandler
 
         return Response.created( uriInfo.getRequestUri() ).build();
     }
-
 }


### PR DESCRIPTION
The folo migration breaks when the dat is big (23G on prod) and cluster will reboot indy if it takes too long. I change it to call from MaintenanceHandler directly via REST.