### PR TITLE
Fix offending IndexOutOfBoundException of folo report/importToCassandra REST endpoint

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
@@ -410,7 +410,7 @@ public class FoloAdminResource
 
     @ApiOperation( "Import folo from ISPN cache to Cassandra." )
     @ApiResponses( { @ApiResponse( code = 201, message = "Import folo from ISPN cache to Cassandra." ) } )
-    @Path( "/importToCassandra" )
+    @Path( "/report/importToCassandra" )
     @PUT
     public Response importFoloToCassandra( final @Context UriInfo uriInfo, final @Context HttpServletRequest request )
     {


### PR DESCRIPTION
The REST endpoint folo/admin/importToCassandra is too short. It offends the metrics code. Error:
java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3
	at org.commonjava.indy.subsys.metrics.IndyTrafficClassifier.calculateCachedFunctionClassifiers(IndyTrafficClassifier.java:121)

This pr changes it to folo/admin/report/importToCassandra. This is a minor fix. I merge it dirrectly.
