### PR TITLE
MMENG-1419 Fix incorrect group checksum files of maven-metadata.xml

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -367,6 +367,18 @@ public class MavenMetadataGenerator
                                               final EventMetadata eventMetadata )
             throws IndyWorkflowException
     {
+        final Transfer rawTarget = fileManager.getTransfer( group, path );
+        // First we check the metadata and all of its siblings metadata files
+        if ( canProcess( path ) && exists( rawTarget ) )
+        {
+            // Means there is no metadata change if this transfer exists, so directly return it.
+            logger.trace( "Raw metadata file exists for group {} of path {}, no need to regenerate.", group.getKey(),
+                          path );
+            eventMetadata.set( GROUP_METADATA_EXISTS, true );
+            return rawTarget;
+        }
+
+        // Then changed back to the metadata itself whatever the path is
         String toMergePath = path;
         if ( !path.endsWith( MavenMetadataMerger.METADATA_NAME ) )
         {
@@ -377,7 +389,8 @@ public class MavenMetadataGenerator
         if ( exists( target ) )
         {
             // Means there is no metadata change if this transfer exists, so directly return it.
-            logger.trace( "Metadata file exists for group {} of path {}, no need to regenerate.", group.getKey(), path );
+            logger.trace( "Merged metadata file exists for group {} of path {}, no need to regenerate.", group.getKey(),
+                          toMergePath );
             eventMetadata.set( GROUP_METADATA_EXISTS, true );
             return target;
         }


### PR DESCRIPTION
Currently the checksum of maven-metadata for group always returns the metadata content but not checksum value. Seems we bypassed it in MavenMetadataGenerator.