### PR TITLE
Add config for fileEvent topic

### DIFF
--- a/addons/event-publisher/common/pom.xml
+++ b/addons/event-publisher/common/pom.xml
@@ -25,6 +25,10 @@
             <groupId>org.commonjava.indy</groupId>
             <artifactId>indy-folo-model-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.commonjava.indy</groupId>
+            <artifactId>indy-subsys-kafka</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/addons/event-publisher/common/src/main/java/org/commonjava/indy/event/publisher/KafkaEventPublisher.java
+++ b/addons/event-publisher/common/src/main/java/org/commonjava/indy/event/publisher/KafkaEventPublisher.java
@@ -146,7 +146,8 @@ public class KafkaEventPublisher
     {
         try
         {
-            kafkaProducer.send( kafkaConfig.getFileEventTopic(), objectMapper.writeValueAsString( fileEvent ), 60000 );
+            kafkaProducer.send( kafkaConfig.getFileEventTopic(), objectMapper.writeValueAsString( fileEvent ),
+                                kafkaConfig.getTimeoutMillis() );
         }
         catch ( Throwable e )
         {

--- a/pom.xml
+++ b/pom.xml
@@ -1726,7 +1726,7 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-kafka</artifactId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.7.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1722,6 +1722,12 @@
         <artifactId>indy-event-model</artifactId>
         <version>1.0-SNAPSHOT</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-subsys-kafka</artifactId>
+        <version>2.6.0-SNAPSHOT</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   

--- a/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/conf/KafkaConfig.java
+++ b/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/conf/KafkaConfig.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.subsys.kafka.conf;
 
 import org.commonjava.indy.conf.IndyConfigInfo;
 import org.commonjava.propulsor.config.ConfigurationException;
+import org.commonjava.propulsor.config.annotation.ConfigName;
 import org.commonjava.propulsor.config.annotation.SectionName;
 import org.commonjava.propulsor.config.section.MapSectionListener;
 
@@ -34,6 +35,8 @@ public class KafkaConfig extends MapSectionListener
 
     private Boolean enabled;
 
+    private String fileEventTopic;
+
     public KafkaConfig()
     {
     }
@@ -41,6 +44,17 @@ public class KafkaConfig extends MapSectionListener
     public boolean isEnabled()
     {
         return enabled == null ? DEFAULT_ENABLED : enabled;
+    }
+
+    public String getFileEventTopic()
+    {
+        return fileEventTopic;
+    }
+
+    @ConfigName( "topic.file_event" )
+    public void setFileEventTopic( String fileEventTopic )
+    {
+        this.fileEventTopic = fileEventTopic;
     }
 
     @Override

--- a/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/conf/KafkaConfig.java
+++ b/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/conf/KafkaConfig.java
@@ -33,9 +33,13 @@ public class KafkaConfig extends MapSectionListener
 
     private static final boolean DEFAULT_ENABLED = false;
 
+    private static final long DEFALUT_TIMEOUTMILLIS = 60000;
+
     private Boolean enabled;
 
     private String fileEventTopic;
+
+    private Long timeoutMillis;
 
     public KafkaConfig()
     {
@@ -65,6 +69,17 @@ public class KafkaConfig extends MapSectionListener
         {
             this.enabled = Boolean.parseBoolean( s );
         }
+    }
+
+    public Long getTimeoutMillis()
+    {
+        return timeoutMillis == null ? DEFALUT_TIMEOUTMILLIS : timeoutMillis ;
+    }
+
+    @ConfigName( "timeout_in_mills" )
+    public void setTimeoutMillis( Long timeoutMillis )
+    {
+        this.timeoutMillis = timeoutMillis;
     }
 
     @Override


### PR DESCRIPTION
Looks log appender has its config in the XML configuration(e.g.: [logback.xml](https://gitlab.cee.redhat.com/nos/nos-ansible-playbooks/-/blob/master/playbooks/nos-automation/files/indy-perf/etc/logging/logback.xml) ) we can use this producer for the connection to our internal kafka instance. 