### PR TITLE
Fix the remote metadata cache

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/cache/MetadataCacheProducer.java
@@ -108,18 +108,16 @@ public class MetadataCacheProducer
             keyMarshallers.add( new StoreTypeMarshaller() );
             cacheProducer.registerProtoAndMarshallers( "metadata_key.proto", keyMarshallers );
         }
-        return cacheProducer.getBasicCache( METADATA_KEY_CACHE );
-    }
 
-    @PostConstruct
-    public void initIndexing()
-    {
-        registerTransformer();
-    }
-
-    private void registerTransformer()
-    {
         BasicCacheHandle<MetadataKey, MetadataKey> handler = cacheProducer.getBasicCache( METADATA_KEY_CACHE );
+
+        registerTransformer( handler );
+
+        return handler;
+    }
+
+    private void registerTransformer( BasicCacheHandle handler )
+    {
         // for embedded mode
         if ( handler instanceof CacheHandle )
         {


### PR DESCRIPTION
fix the stage issue: 
```
org.infinispan.client.hotrod.exceptions.HotRodClientException: org.infinispan.commons.CacheConfigurationException: The declared indexed type 'metadata_key.MetadataKey' is not known. Please register its proto schema file first.
```

Need to make sure the proto schema file is registered first before getting the remote cache.