### PR TITLE
Merge remainder of PR #1846 from master

### DIFF
--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
@@ -67,7 +67,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Supplier;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -75,7 +74,6 @@ import static org.commonjava.indy.IndyContentConstants.CHECK_CACHE_ONLY;
 import static org.commonjava.indy.client.core.helper.HttpResources.cleanupResources;
 import static org.commonjava.indy.client.core.helper.HttpResources.entityToString;
 import static org.commonjava.indy.client.core.metric.ClientMetricConstants.HEADER_CLIENT_API;
-import static org.commonjava.indy.client.core.metric.ClientMetricConstants.HEADER_CLIENT_TRACE_ID;
 import static org.commonjava.indy.client.core.util.UrlUtils.buildUrl;
 import static org.commonjava.indy.stats.IndyVersioning.HEADER_INDY_API_VERSION;
 
@@ -119,6 +117,7 @@ public class IndyClientHttp
         baseUrl = location.getUri();
         this.mdcCopyMappings = mdcCopyMappings;
         checkBaseUrl( baseUrl );
+        addClientTraceHeader();
         addApiVersionHeader( apiVersion );
         initUserAgent( apiVersion );
 
@@ -134,6 +133,7 @@ public class IndyClientHttp
         this.location = location;
         baseUrl = location.getUri();
         checkBaseUrl( baseUrl );
+        addClientTraceHeader();
         addApiVersionHeader( apiVersion );
         initUserAgent( apiVersion );
 
@@ -151,12 +151,9 @@ public class IndyClientHttp
         addDefaultHeader( "User-Agent", String.format("Indy/%s (api: %s) via %s", indyVersion, apiVersion, hcUserAgent ) );
     }
 
-    private String addClientTraceHeader()
+    private void addClientTraceHeader()
     {
-        String traceId = UUID.randomUUID().toString();
-        addDefaultHeader( HEADER_CLIENT_TRACE_ID, traceId );
         addDefaultHeader( HEADER_CLIENT_API, String.valueOf( true ) );
-        return traceId;
     }
 
     private void addApiVersionHeader( String apiVersion )

--- a/models/core-java/src/main/java/org/commonjava/indy/stats/IndyVersioning.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/stats/IndyVersioning.java
@@ -15,19 +15,17 @@
  */
 package org.commonjava.indy.stats;
 
-import javax.enterprise.inject.Alternative;
-import javax.inject.Named;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Properties;
+import javax.enterprise.inject.Alternative;
+import javax.inject.Named;
 
 @Alternative
 @Named
 public class IndyVersioning
 {
+    public final static String HEADER_INDY_CLIENT_API = "Indy-Client-API";
 
     public final static String HEADER_INDY_API_VERSION = "Indy-API-Version"; // the API version for the requester
 

--- a/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifier.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifier.java
@@ -117,6 +117,7 @@ public class IndyTrafficClassifier
                 {
                     result = singletonList( CLIENT_PROMOTE );
                 }
+                return result;
             }
 
             if ( "promotion".equals( classifierParts[0] ) && "promote".equals( classifierParts[2] ) )

--- a/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifier.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifier.java
@@ -30,6 +30,7 @@ import org.commonjava.o11yphant.metrics.AbstractTrafficClassifier;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -38,10 +39,30 @@ import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.join;
+import static org.commonjava.indy.stats.IndyVersioning.HEADER_INDY_CLIENT_API;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
-import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.*;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.CLIENT_CONTENT;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.CLIENT_FOLO_ADMIN;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.CLIENT_FOLO_CONTENT;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.CLIENT_PROMOTE;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.CLIENT_REPO_MGMT;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_CONTENT;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_CONTENT_LISTING;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_CONTENT_MAVEN;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_CONTENT_NPM;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_MAVEN_DOWNLOAD;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_MAVEN_UPLOAD;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_METADATA;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_METADATA_MAVEN;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_METADATA_NPM;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_NPM_DOWNLOAD;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_NPM_UPLOAD;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_PROMOTION;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_REPO_MGMT;
+import static org.commonjava.indy.subsys.metrics.IndyTrafficClassifierConstants.FN_TRACKING_RECORD;
 
 @ApplicationScoped
 public class IndyTrafficClassifier
@@ -60,8 +81,7 @@ public class IndyTrafficClassifier
         this.specialPathManager = specialPathManager;
     }
 
-    protected List<String> calculateCachedFunctionClassifiers( String restPath, String method,
-                                                               Map<String, String> headers )
+    protected List<String> calculateCachedFunctionClassifiers( String restPath, String method, Map<String, String> headers )
     {
         List<String> result = new ArrayList<>();
 
@@ -72,6 +92,32 @@ public class IndyTrafficClassifier
             System.arraycopy( pathParts, 1, classifierParts, 0, classifierParts.length );
 
             String restPrefix = join( classifierParts, '/' );
+
+            boolean isClientAPI = isNotBlank(headers.get( HEADER_INDY_CLIENT_API )) ? true : false;
+            if ( isClientAPI )
+            {
+                if ( restPrefix.startsWith( "folo/admin/" ) && FOLO_RECORD_ENDPOINTS.contains( classifierParts[3] ) )
+                {
+                    result = singletonList( CLIENT_FOLO_ADMIN );
+                }
+                else if ( restPrefix.startsWith( "folo/track/" ) && classifierParts.length > 6 )
+                {
+                    result = singletonList( CLIENT_FOLO_CONTENT );
+                }
+                else if ( "admin".equals( classifierParts[0] ) && "stores".equals( classifierParts[1] )
+                        && classifierParts.length > 2 )
+                {
+                    result = singletonList( CLIENT_REPO_MGMT );
+                }
+                else if ( ( "content".equals( classifierParts[0] ) && classifierParts.length > 5 ) )
+                {
+                    result = singletonList( CLIENT_CONTENT );
+                }
+                else if ( restPrefix.startsWith( "promotion/paths/" ) )
+                {
+                    result = singletonList( CLIENT_PROMOTE );
+                }
+            }
 
             if ( "promotion".equals( classifierParts[0] ) && "promote".equals( classifierParts[2] ) )
             {

--- a/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifierConstants.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifierConstants.java
@@ -47,10 +47,22 @@ public final class IndyTrafficClassifierConstants
 
     public static final String FN_NPM_DOWNLOAD = "npm.download";
 
+    public static final String CLIENT_FOLO_ADMIN = "client.folo.admin";
+
+    public static final String CLIENT_FOLO_CONTENT = "client.folo.content";
+
+    public static final String CLIENT_REPO_MGMT = "client.repo.mgmt";
+
+    public static final String CLIENT_CONTENT = "client.content";
+
+    public static final String CLIENT_PROMOTE = "client.promote";
+
+
     public static final String[] FUNCTIONS =
                     { FN_CONTENT, FN_CONTENT_MAVEN, FN_CONTENT_NPM, FN_CONTENT_GENERIC, FN_METADATA, FN_METADATA_MAVEN,
                                     FN_METADATA_NPM, FN_PROMOTION, FN_TRACKING_RECORD, FN_CONTENT_LISTING, FN_REPO_MGMT,
-                                    FN_MAVEN_UPLOAD, FN_MAVEN_DOWNLOAD, FN_NPM_UPLOAD, FN_NPM_DOWNLOAD };
+                                    FN_MAVEN_UPLOAD, FN_MAVEN_DOWNLOAD, FN_NPM_UPLOAD, FN_NPM_DOWNLOAD,
+                                    CLIENT_FOLO_ADMIN, CLIENT_FOLO_CONTENT, CLIENT_REPO_MGMT, CLIENT_CONTENT, CLIENT_PROMOTE};
 
     private IndyTrafficClassifierConstants()
     {


### PR DESCRIPTION
Adding in parts of the client metrics changes that I missed in previous merge attempt.

One important point here is that I've pushed trace context propagation down into the jhttpc library, so the span creation is handled there, along with trace ID creation and passing. That's why we don't use the UUID traceId in the client layer anymore...it's handled in jhttpc, which the client API uses.