### PR TITLE
Fix the path mask checker

### DIFF
--- a/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/inject/PathMappedMavenGACacheGroupRepositoryFilter.java
+++ b/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/inject/PathMappedMavenGACacheGroupRepositoryFilter.java
@@ -57,7 +57,7 @@ public class PathMappedMavenGACacheGroupRepositoryFilter
     @Override
     public int getPriority()
     {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
@@ -37,10 +37,13 @@ public class PathMaskChecker
             return true;
         }
 
+        logger.info("Original path:{}", path);
         String pathForCheck = path.startsWith( "/" ) ? path.substring( 1 ) : path;
+        logger.info( "Path for check:{}", pathForCheck );
 
         for ( String pattern : maskPatterns )
         {
+            logger.info( "Pattern: {}", pattern );
             // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
             if ( isRegexPattern( pattern ) )
             {

--- a/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
@@ -37,26 +37,28 @@ public class PathMaskChecker
             return true;
         }
 
+        String pathForCheck = path.startsWith( "/" ) ? path.substring( 1 ) : path;
+
         for ( String pattern : maskPatterns )
         {
             // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
             if ( isRegexPattern( pattern ) )
             {
                 final String realRegex = pattern.substring( 2, pattern.length() - 1 );
-                if ( path.matches( realRegex ) )
+                if ( pathForCheck.matches( realRegex ) )
                 {
                     logger.trace( "Checking mask in: {}, pattern with regex: {} - MATCH", repo.getName(), realRegex );
                     return true;
                 }
             }
-            else if ( path.startsWith( pattern ) )
+            else if ( pathForCheck.startsWith( pattern ) )
             {
                 logger.trace( "Checking mask in: {}, pattern: {} - MATCH", repo.getName(), pattern );
                 return true;
             }
         }
 
-        logger.debug( "Path {} not available in path mask {} of repo {}", path, maskPatterns, repo );
+        logger.info( "Path {} not available in path mask {} of repo {}", path, maskPatterns, repo );
 
         return false;
     }

--- a/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
@@ -37,13 +37,10 @@ public class PathMaskChecker
             return true;
         }
 
-        logger.info("Original path:{}", path);
         String pathForCheck = path.startsWith( "/" ) ? path.substring( 1 ) : path;
-        logger.info( "Path for check:{}", pathForCheck );
 
         for ( String pattern : maskPatterns )
         {
-            logger.info( "Pattern: {}", pattern );
             // adding allPlaintext to the condition to reduce the number of isRegexPattern() calls
             if ( isRegexPattern( pattern ) )
             {

--- a/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/PathMaskChecker.java
@@ -58,7 +58,7 @@ public class PathMaskChecker
             }
         }
 
-        logger.info( "Path {} not available in path mask {} of repo {}", path, maskPatterns, repo );
+        logger.debug( "Path {} not available in path mask {} of repo {}", path, maskPatterns, repo );
 
         return false;
     }

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/fixture/ResultBufferingGroupRepoFilter.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/fixture/ResultBufferingGroupRepoFilter.java
@@ -6,6 +6,7 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
 import org.slf4j.Logger;
 
+import javax.annotation.Priority;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Named;
 import java.util.HashMap;
@@ -27,7 +28,7 @@ public class ResultBufferingGroupRepoFilter
     @Override
     public int getPriority()
     {
-        return 0;
+        return 1;
     }
 
     @Override


### PR DESCRIPTION
Fix for https://projects.engineering.redhat.com/browse/MMENG-1490.

The paths for promotion looks as follows ( including "/" at the very begining ):
```
/org/jboss/mod_cluster/mod_cluster-load-spi/1.4.3.Final-redhat-00001/mod_cluster-load-spi-1.4.3.Final-redhat-00001.jar
```

But the path mask pattern is:
```
r|org\/jboss\/mod_cluster\/.+\/1.4.3.Final-redhat-00001\/.+|
```

That regex does not match the path with the prefix "/", which prevents the downloading from brew.