### PR TITLE
File change tracking

### DIFF
--- a/api/src/main/java/org/commonjava/indy/conf/InternalFeatureConfig.java
+++ b/api/src/main/java/org/commonjava/indy/conf/InternalFeatureConfig.java
@@ -33,9 +33,22 @@ public class InternalFeatureConfig implements IndyConfigInfo {
 
     private Boolean storeValidation;
 
+    private Boolean fileChangeTracking;
+
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     public InternalFeatureConfig() {
+    }
+
+    public Boolean getFileChangeTracking()
+    {
+        return fileChangeTracking == null ? Boolean.FALSE : fileChangeTracking;
+    }
+
+    @ConfigName( "file.change.tracking.enabled" )
+    public void setFileChangeTracking( Boolean fileChangeTracking )
+    {
+        this.fileChangeTracking = fileChangeTracking;
     }
 
     public Boolean getStoreValidation() {

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/DefaultGalleyStorageProvider.java
@@ -20,6 +20,7 @@ import org.commonjava.cdi.util.weft.ExecutorConfig;
 import org.commonjava.cdi.util.weft.NamedThreadFactory;
 import org.commonjava.cdi.util.weft.WeftManaged;
 import org.commonjava.indy.conf.IndyConfiguration;
+import org.commonjava.indy.conf.InternalFeatureConfig;
 import org.commonjava.indy.content.IndyChecksumAdvisor;
 import org.commonjava.indy.content.SpecialPathSetProducer;
 import org.commonjava.indy.filer.def.conf.DefaultStorageProviderConfiguration;
@@ -96,6 +97,9 @@ public class DefaultGalleyStorageProvider
 
     @Inject
     private IndyConfiguration indyConfiguration;
+
+    @Inject
+    private InternalFeatureConfig featureConfig;
 
     @Inject
     private FileEventManager fileEventManager;
@@ -278,6 +282,11 @@ public class DefaultGalleyStorageProvider
             decorators.add( decorator );
         }
         decorators.add( getChecksummingTransferDecorator() );
+
+        if ( featureConfig.getFileChangeTracking() )
+        {
+            decorators.add( new FileChangeTrackingDecorator( config ) );
+        }
         transferDecorator = new TransferDecoratorManager( decorators );
     }
 

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/FileChangeTrackingDecorator.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/FileChangeTrackingDecorator.java
@@ -1,0 +1,130 @@
+package org.commonjava.indy.filer.def;
+
+import org.apache.commons.io.FileUtils;
+import org.commonjava.indy.filer.def.conf.DefaultStorageProviderConfiguration;
+import org.commonjava.maven.galley.event.EventMetadata;
+import org.commonjava.maven.galley.io.AbstractTransferDecorator;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.slf4j.Logger;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+public class FileChangeTrackingDecorator
+                extends AbstractTransferDecorator
+{
+    private final Logger logger = getLogger(getClass().getName());
+
+    private final DefaultStorageProviderConfiguration config;
+
+    private volatile int changeCounter = 0;
+
+    private File currentFile;
+
+    FileChangeTrackingDecorator( DefaultStorageProviderConfiguration config )
+    {
+        this.config = config;
+        this.currentFile = generateCurrentFile();
+    }
+
+    private File generateCurrentFile()
+    {
+        File listFile = Path.of( config.getChangeTrackingDirectory() )
+                     .resolve( new SimpleDateFormat( "yyyy-MM-ddThhmmss.lst" ).format( new Date() ) )
+                     .toFile();
+
+        return listFile;
+    }
+
+    @Override
+    public OutputStream decorateWrite( OutputStream stream, Transfer transfer, TransferOperation op,
+                                       EventMetadata metadata ) throws IOException
+    {
+        return new ChangeTrackingOutputStream( super.decorateWrite( stream, transfer, op, metadata ), transfer );
+    }
+
+    @Override
+    public void decorateCopyFrom( Transfer from, Transfer transfer, EventMetadata metadata ) throws IOException
+    {
+        super.decorateCopyFrom( from, transfer, metadata );
+        writeChangedPath( transfer );
+    }
+
+    @Override
+    public void decorateDelete( Transfer transfer, EventMetadata metadata ) throws IOException
+    {
+        super.decorateDelete( transfer, metadata );
+        writeChangedPath( transfer );
+    }
+
+    @Override
+    public void decorateCreateFile( Transfer transfer, EventMetadata metadata ) throws IOException
+    {
+        super.decorateCreateFile( transfer, metadata );
+        writeChangedPath( transfer );
+    }
+
+    private final synchronized void writeChangedPath( Transfer transfer )
+    {
+        Path storageRoot = config.getStorageRootDirectory().toPath().toAbsolutePath().normalize();
+        Path transferPath = transfer.getDetachedFile().toPath().toAbsolutePath().normalize();
+        if ( transferPath.startsWith( storageRoot ) )
+        {
+            try ( FileWriter fw = new FileWriter( getCurrentListFile() ) )
+            {
+                if ( changeCounter < 1 )
+                {
+                    fw.write( "\n" );
+                }
+                fw.write( "./" + transferPath.relativize( storageRoot ) );
+            }
+            catch ( IOException | IllegalArgumentException e )
+            {
+                logger.error( "Failed to write file change: " + transfer.getPath() + " to log: " + currentFile, e );
+            }
+        }
+    }
+
+    private synchronized File getCurrentListFile()
+    {
+        if ( changeCounter >= config.getChangeTrackingRollSize() )
+        {
+            this.currentFile = generateCurrentFile();
+            this.changeCounter = 0;
+        }
+
+        return currentFile;
+    }
+
+    private class ChangeTrackingOutputStream
+                    extends FilterOutputStream
+    {
+        private Transfer transfer;
+
+        public ChangeTrackingOutputStream( OutputStream outputStream, Transfer transfer )
+        {
+            super( outputStream );
+            this.transfer = transfer;
+        }
+
+        @Override
+        public void close() throws IOException
+        {
+            super.close();
+            writeChangedPath( transfer );
+        }
+    }
+}

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/FileChangeTrackingDecorator.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/FileChangeTrackingDecorator.java
@@ -40,25 +40,6 @@ public class FileChangeTrackingDecorator
         resetTrackingFile();
     }
 
-    private void resetTrackingFile()
-    {
-        Date currentDate = new Date();
-        Calendar c = Calendar.getInstance();
-        c.setTime( currentDate );
-        c.set(Calendar.DATE, c.get( Calendar.DATE ) + 1);
-        c.set( Calendar.HOUR, 0 );
-        c.set( Calendar.MINUTE, 0 );
-        c.set( Calendar.SECOND, 0 );
-        c.set( Calendar.MILLISECOND, 0 );
-        this.nextRollDate = c.getTime().getTime();
-        this.currentFile = Paths.get( config.getChangeTrackingDirectory() )
-                     .resolve( new SimpleDateFormat( "yyyy-MM-dd'/'hh'.'mm'.'ss'.'SSS'.lst'" ).format( currentDate ) )
-                     .toFile();
-
-        this.currentFile.getParentFile().mkdirs();
-        this.changeCounter = 0;
-    }
-
     @Override
     public OutputStream decorateWrite( OutputStream stream, Transfer transfer, TransferOperation op,
                                        EventMetadata metadata ) throws IOException
@@ -70,7 +51,7 @@ public class FileChangeTrackingDecorator
     public void decorateCopyFrom( Transfer from, Transfer transfer, EventMetadata metadata ) throws IOException
     {
         super.decorateCopyFrom( from, transfer, metadata );
-        logger.info( "Logging copy-from to changed-file: {}", transfer.getPath() );
+//        logger.info( "Logging copy-from to changed-file: {}", transfer.getPath() );
         writeChangedPath( transfer );
     }
 
@@ -78,7 +59,7 @@ public class FileChangeTrackingDecorator
     public void decorateDelete( Transfer transfer, EventMetadata metadata ) throws IOException
     {
         super.decorateDelete( transfer, metadata );
-        logger.info( "Logging delete to changed-file: {}", transfer.getPath() );
+//        logger.info( "Logging delete to changed-file: {}", transfer.getPath() );
         writeChangedPath( transfer );
     }
 
@@ -86,7 +67,7 @@ public class FileChangeTrackingDecorator
     public void decorateCreateFile( Transfer transfer, EventMetadata metadata ) throws IOException
     {
         super.decorateCreateFile( transfer, metadata );
-        logger.info( "Logging create-file to changed-file: {}", transfer.getPath() );
+//        logger.info( "Logging create-file to changed-file: {}", transfer.getPath() );
         writeChangedPath( transfer );
     }
 
@@ -98,7 +79,7 @@ public class FileChangeTrackingDecorator
         {
             try ( FileWriter fw = new FileWriter( getCurrentListFile(), true ) )
             {
-                logger.info( "Change counter: {}", changeCounter );
+//                logger.info( "Change counter: {}", changeCounter );
                 if ( changeCounter > 1 )
                 {
                     fw.write( "\n" );
@@ -131,6 +112,25 @@ public class FileChangeTrackingDecorator
         return currentFile;
     }
 
+    private void resetTrackingFile()
+    {
+        Date currentDate = new Date();
+        Calendar c = Calendar.getInstance();
+        c.setTime( currentDate );
+        c.set(Calendar.DATE, c.get( Calendar.DATE ) + 1);
+        c.set( Calendar.HOUR, 0 );
+        c.set( Calendar.MINUTE, 0 );
+        c.set( Calendar.SECOND, 0 );
+        c.set( Calendar.MILLISECOND, 0 );
+        this.nextRollDate = c.getTime().getTime();
+        this.currentFile = Paths.get( config.getChangeTrackingDirectory() )
+                                .resolve( new SimpleDateFormat( "yyyy-MM-dd'/'hh'.'mm'.'ss'.'SSS'.lst'" ).format( currentDate ) )
+                                .toFile();
+
+        this.currentFile.getParentFile().mkdirs();
+        this.changeCounter = 0;
+    }
+
     private class ChangeTrackingOutputStream
                     extends FilterOutputStream
     {
@@ -146,7 +146,7 @@ public class FileChangeTrackingDecorator
         public void close() throws IOException
         {
             super.close();
-            logger.info( "Logging write to changed-file: {}", transfer.getPath() );
+//            logger.info( "Logging write to changed-file: {}", transfer.getPath() );
             writeChangedPath( transfer );
         }
     }

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
@@ -23,6 +23,8 @@ import org.commonjava.propulsor.config.annotation.SectionName;
 import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
 import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Properties;
 
 @SectionName( "storage-default" )
@@ -33,7 +35,10 @@ public class DefaultStorageProviderConfiguration
 
     public static final File DEFAULT_BASEDIR = new File( "/var/lib/indy/storage" );
 
+    public static final Integer DEFAULT_CHANGE_TRACKING_ROLL_SIZE = 2000;
+
     // NOTE: Providing a default value negates the detection of whether the NFS CacheProvider should be used or not, in DefaultGalleyStorageProvider.
+
 //    public static final File DEFAULT_NFS_BASEDIR = new File("/mnt/nfs/var/lib/indy/storage");
 
     public static final String STORAGE_DIR = "indy.storage.dir";
@@ -43,6 +48,10 @@ public class DefaultStorageProviderConfiguration
     private File storageBasedir;
 
     private File nfsStoreBasedir;
+
+    private String changeTrackingDirectory;
+
+    private Integer changeTrackingRollSize;
 
     public DefaultStorageProviderConfiguration()
     {
@@ -186,5 +195,31 @@ public class DefaultStorageProviderConfiguration
     public String getDeduplicatePattern()
     {
         return deduplicatePattern;
+    }
+
+    public String getChangeTrackingDirectory()
+    {
+        return changeTrackingDirectory == null ?
+                        Paths.get( getStorageRootDirectory().getAbsolutePath(), ".changes" )
+                             .toAbsolutePath()
+                             .toString() :
+                        changeTrackingDirectory;
+    }
+
+    @ConfigName( "change.tracking.dir" )
+    public void setChangeTrackingDirectory( String changeTrackingDirectory )
+    {
+        this.changeTrackingDirectory = changeTrackingDirectory;
+    }
+
+    public Integer getChangeTrackingRollSize()
+    {
+        return changeTrackingRollSize == null ? DEFAULT_CHANGE_TRACKING_ROLL_SIZE : changeTrackingRollSize;
+    }
+
+    @ConfigName( "change.tracking.roll.size" )
+    public void setDefaultChangeTrackingRollSize( Integer changeTrackingRollSize )
+    {
+        this.changeTrackingRollSize = changeTrackingRollSize;
     }
 }

--- a/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
+++ b/filers/default/src/main/java/org/commonjava/indy/filer/def/conf/DefaultStorageProviderConfiguration.java
@@ -80,7 +80,6 @@ public class DefaultStorageProviderConfiguration
     }
 
     @ConfigName( "storage.dir" )
-    @Deprecated
     public void setStorageRootDirectory( final File storageBasedir )
     {
         this.storageBasedir = storageBasedir;
@@ -218,7 +217,7 @@ public class DefaultStorageProviderConfiguration
     }
 
     @ConfigName( "change.tracking.roll.size" )
-    public void setDefaultChangeTrackingRollSize( Integer changeTrackingRollSize )
+    public void setChangeTrackingRollSize( Integer changeTrackingRollSize )
     {
         this.changeTrackingRollSize = changeTrackingRollSize;
     }

--- a/filers/default/src/test/java/org/commonjava/indy/filer/def/FileChangeTrackingDecoratorTest.java
+++ b/filers/default/src/test/java/org/commonjava/indy/filer/def/FileChangeTrackingDecoratorTest.java
@@ -1,0 +1,169 @@
+package org.commonjava.indy.filer.def;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
+import org.commonjava.indy.filer.def.conf.DefaultStorageProviderConfiguration;
+import org.commonjava.maven.galley.cache.FileCacheProvider;
+import org.commonjava.maven.galley.event.NoOpFileEventManager;
+import org.commonjava.maven.galley.io.HashedLocationPathGenerator;
+import org.commonjava.maven.galley.io.TransferDecoratorManager;
+import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.SimpleLocation;
+import org.commonjava.maven.galley.model.Transfer;
+import org.commonjava.maven.galley.model.TransferOperation;
+import org.commonjava.maven.galley.spi.cache.CacheProvider;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class FileChangeTrackingDecoratorTest
+{
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
+
+    private DefaultStorageProviderConfiguration config;
+
+    private CacheProvider cp;
+
+    private FileChangeTrackingDecorator decorator;
+
+    private void init( int logSize ) throws IOException
+    {
+        config = new DefaultStorageProviderConfiguration();
+        config.setStorageRootDirectory( temp.newFolder( "storage-root" ) );
+        config.setChangeTrackingRollSize( logSize );
+
+        decorator = new FileChangeTrackingDecorator( config );
+
+        cp = new FileCacheProvider( config.getStorageRootDirectory(), new HashedLocationPathGenerator(),
+                                         new NoOpFileEventManager(), new TransferDecoratorManager( decorator ),
+                                         false );
+    }
+
+    @Test
+    public void decorateWrite() throws IOException
+    {
+        init( 10 );
+        Transfer foo = cp.getTransfer( new ConcreteResource( new SimpleLocation( "foo", "http://foo.bar" ),
+                                                             "path/to/foo.txt" ) );
+
+        byte[] data = "This is a test".getBytes();
+        try(OutputStream os = foo.openOutputStream( TransferOperation.UPLOAD ))
+        {
+            os.write( data );
+        }
+
+        verifyLogFileCount( 1 );
+    }
+
+    @Test
+    public void testLogSizeRolling() throws IOException
+    {
+        init( 1 );
+        for ( String path : Arrays.asList( "foo.txt", "bar.txt" ) )
+        {
+            Transfer foo = cp.getTransfer( new ConcreteResource( new SimpleLocation( "foo", "http://foo.bar" ),
+                                                                 "path/to/" + path ) );
+
+            byte[] data = "This is a test".getBytes();
+            try(OutputStream os = foo.openOutputStream( TransferOperation.UPLOAD ))
+            {
+                os.write( data );
+            }
+        }
+
+        verifyLogFileCount( 2 );
+    }
+
+    private void verifyLogFileCount( int total ) throws IOException
+    {
+        File[] files = Paths.get( config.getChangeTrackingDirectory() ).toFile().listFiles();
+
+        List<String> allLines = new ArrayList<>();
+        for ( File file : files )
+        {
+            if ( file.isDirectory() )
+            {
+                for ( File child : file.listFiles() )
+                {
+                    List<String> lines = FileUtils.readLines( child );
+                    System.out.println( child + ": " + lines );
+                    allLines.addAll( lines );
+                }
+            }
+            else
+            {
+                List<String> lines = FileUtils.readLines( file );
+                System.out.println( file + ": " + lines );
+                allLines.addAll( lines );
+            }
+        }
+
+        System.out.println( allLines );
+        assertThat( StringUtils.join( allLines, "\n" ), allLines.size(), equalTo( total ) );
+    }
+
+    @Test
+    public void decorateCopyFrom() throws IOException
+    {
+        init( 1 );
+        SimpleLocation loc = new SimpleLocation( "foo", "http://foo.bar" );
+        ConcreteResource from = new ConcreteResource( loc, "path/to/foo.txt" );
+        Transfer fromTx = cp.getTransfer( from );
+
+        ConcreteResource to = new ConcreteResource( loc, "path/to/bar.txt" );
+        Transfer toTx = cp.getTransfer( to );
+
+        byte[] data = "This is a test".getBytes();
+        try (OutputStream os = fromTx.openOutputStream( TransferOperation.UPLOAD ))
+        {
+            os.write( data );
+        }
+
+        toTx.copyFrom( fromTx );
+        verifyLogFileCount( 2 );
+    }
+
+    @Test
+    public void decorateDelete() throws IOException
+    {
+        init( 1 );
+        SimpleLocation loc = new SimpleLocation( "foo", "http://foo.bar" );
+        ConcreteResource res = new ConcreteResource( loc, "path/to/foo.txt" );
+        Transfer tx = cp.getTransfer( res );
+
+        byte[] data = "This is a test".getBytes();
+        try(OutputStream os = tx.openOutputStream( TransferOperation.UPLOAD ))
+        {
+            os.write( data );
+        }
+
+        tx.delete();
+        verifyLogFileCount( 2 );
+    }
+
+    @Test
+    public void decorateCreateFile() throws IOException
+    {
+        init( 1 );
+        SimpleLocation loc = new SimpleLocation( "foo", "http://foo.bar" );
+        ConcreteResource res = new ConcreteResource( loc, "path/to/foo.txt" );
+        Transfer tx = cp.getTransfer( res );
+
+        tx.mkdirs();
+        tx.createFile();
+        verifyLogFileCount( 1 );
+    }
+}

--- a/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifier.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifier.java
@@ -117,7 +117,6 @@ public class IndyTrafficClassifier
                 {
                     result = singletonList( CLIENT_PROMOTE );
                 }
-                return result;
             }
 
             if ( "promotion".equals( classifierParts[0] ) && "promote".equals( classifierParts[2] ) )

--- a/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifier.java
+++ b/subsys/metrics/src/main/java/org/commonjava/indy/subsys/metrics/IndyTrafficClassifier.java
@@ -117,6 +117,7 @@ public class IndyTrafficClassifier
                 {
                     result = singletonList( CLIENT_PROMOTE );
                 }
+                return result;
             }
 
             if ( "promotion".equals( classifierParts[0] ) && "promote".equals( classifierParts[2] ) )


### PR DESCRIPTION
This is a way of logging the files that get changed in the system, incrementally. The purpose is to provide a more targeted list of changes for our backup systems to use to speed up the backup process.

Why? A Maven (or NPM) repository manager deals in tons of tiny files. When you build up terabytes of these files, the mere act of scanning the filesystem for changes takes hours, which can easily cause us to miss our recovery targets. This is a simple solution intended to avoid the cost of scanning for changed files.

Longer term, it may be better to build this into the filesystem / content microservice...or even use FileStorageEvents to push this behavior into a pipeline piece separated from everything (this should become possible). If we did that, we wouldn't have to have backup system-specific code in our applications.

However, for now, we should try to get this into a staging server with the new backup system design, so we can see how the two perform together.