### PR TITLE
Wrap the kojiTagInfo list to a class for cache

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/IndyKojiContentProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/IndyKojiContentProvider.java
@@ -88,7 +88,7 @@ public class IndyKojiContentProvider
 
     @Inject
     @KojiTagInfoCache
-    private BasicCacheHandle<Integer, List<KojiTagInfo>> kojiTagsCache;
+    private BasicCacheHandle<Integer, KojiTagInfoEntry> kojiTagsCache;
 
     public IndyKojiContentProvider()
     {
@@ -133,10 +133,10 @@ public class IndyKojiContentProvider
         List<Integer> missed = new ArrayList<>();
         for ( Integer buildId : buildIds )
         {
-            List ret = kojiTagsCache.get( buildId );
+            KojiTagInfoEntry ret = kojiTagsCache.get( buildId );
             if ( ret != null )
             {
-                map.put( buildId, ret );
+                map.put( buildId, ret.getTagInfos() );
             }
             else
             {
@@ -147,7 +147,7 @@ public class IndyKojiContentProvider
         {
             Map<Integer, List<KojiTagInfo>> retrieved = kojiClient.listTags( missed, session );
             map.putAll( retrieved );
-            retrieved.forEach( ( k, v ) -> kojiTagsCache.put( k, v ) );
+            retrieved.forEach( ( k, v ) -> kojiTagsCache.put( k, new KojiTagInfoEntry(v) ) );
         }
         return map;
     }

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiTagInfoEntry.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiTagInfoEntry.java
@@ -1,0 +1,28 @@
+package org.commonjava.indy.koji.content;
+
+import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
+
+import java.util.List;
+
+public class KojiTagInfoEntry
+{
+
+    List<KojiTagInfo> tagInfos;
+
+    public KojiTagInfoEntry(){}
+
+    public KojiTagInfoEntry(List<KojiTagInfo> tagInfos)
+    {
+        this.tagInfos = tagInfos;
+    }
+
+    public List<KojiTagInfo> getTagInfos()
+    {
+        return tagInfos;
+    }
+
+    public void setTagInfos(List<KojiTagInfo> tagInfos)
+    {
+        this.tagInfos = tagInfos;
+    }
+}

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiCacheProducer.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiCacheProducer.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.koji.inject;
 
 import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
 import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.commonjava.indy.koji.content.KojiTagInfoEntry;
 import org.commonjava.indy.pkg.maven.content.marshaller.MetadataMarshaller;
 import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
@@ -60,12 +61,13 @@ public class KojiCacheProducer
     @KojiTagInfoCache
     @Produces
     @ApplicationScoped
-    public BasicCacheHandle<Integer, List<KojiTagInfo>> kojiTagInfoCache()
+    public BasicCacheHandle<Integer, KojiTagInfoEntry> kojiTagInfoCache()
     {
         if ( remoteConfiguration.isEnabled() )
         {
             List<BaseMarshaller> marshallers = new ArrayList<>();
             marshallers.add( new KojiTagInfoMarshaller() );
+            marshallers.add( new KojiTagInfoEntryMarshaller() );
             cacheProducer.registerProtoAndMarshallers( "koji_taginfo.proto", marshallers );
         }
         return cacheProducer.getBasicCache( "koji-tags" );

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiTagInfoEntryMarshaller.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/inject/KojiTagInfoEntryMarshaller.java
@@ -1,0 +1,37 @@
+package org.commonjava.indy.koji.inject;
+
+import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
+import org.commonjava.indy.koji.content.KojiTagInfoEntry;
+import org.infinispan.protostream.MessageMarshaller;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public class KojiTagInfoEntryMarshaller implements MessageMarshaller<KojiTagInfoEntry>
+{
+    @Override
+    public KojiTagInfoEntry readFrom(ProtoStreamReader reader) throws IOException
+    {
+        KojiTagInfoEntry entry = new KojiTagInfoEntry();
+        entry.setTagInfos( reader.readCollection( "tagInfos", new ArrayList<>(), KojiTagInfo.class ) );
+        return entry;
+    }
+
+    @Override
+    public void writeTo(ProtoStreamWriter writer, KojiTagInfoEntry kojiTagInfoEntry) throws IOException
+    {
+        writer.writeCollection("tagInfos", kojiTagInfoEntry.getTagInfos(), KojiTagInfo.class);
+    }
+
+    @Override
+    public Class<? extends KojiTagInfoEntry> getJavaClass()
+    {
+        return KojiTagInfoEntry.class;
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return "koji.KojiTagInfoEntry";
+    }
+}

--- a/addons/koji/common/src/main/resources/koji_taginfo.proto
+++ b/addons/koji/common/src/main/resources/koji_taginfo.proto
@@ -1,5 +1,10 @@
 package koji;
 
+message KojiTagInfoEntry
+{
+   repeated KojiTagInfo tagInfos = 1;
+}
+
 message KojiTagInfo
 {
     optional int32 id = 1;

--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiTagMarshallerTest.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiTagMarshallerTest.java
@@ -1,0 +1,45 @@
+package org.commonjava.indy.koji.content;
+
+import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
+import org.commonjava.indy.koji.inject.KojiTagInfoEntryMarshaller;
+import org.commonjava.indy.koji.inject.KojiTagInfoMarshaller;
+import org.infinispan.commons.marshall.JavaSerializationMarshaller;
+import org.infinispan.protostream.FileDescriptorSource;
+import org.infinispan.protostream.ProtobufUtil;
+import org.infinispan.protostream.SerializationContext;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class KojiTagMarshallerTest
+
+{
+    @Test
+    public void tagInfoMarshaller() throws Exception
+    {
+        SerializationContext ctx = ProtobufUtil.newSerializationContext();
+
+        ctx.registerProtoFiles( FileDescriptorSource.fromResources( "koji_taginfo.proto" ) );
+        ctx.registerMarshaller( new KojiTagInfoMarshaller() );
+        ctx.registerMarshaller( new KojiTagInfoEntryMarshaller() );
+
+        List<KojiTagInfo> tagInfos = new ArrayList<>();
+        KojiTagInfo tagInfo = new KojiTagInfo();
+        tagInfo.setArches(Arrays.asList("x86_64", "ppc64le"));
+        tagInfos.add(tagInfo);
+
+        KojiTagInfoEntry entry = new KojiTagInfoEntry(tagInfos);
+
+        byte[] bytes = ProtobufUtil.toWrappedByteArray(ctx, entry);
+        Object out = ProtobufUtil.fromWrappedByteArray(ctx, bytes);
+
+        assertTrue( out instanceof KojiTagInfoEntry );
+        assertTrue( ((KojiTagInfoEntry) out).getTagInfos().contains("x86") );
+
+    }
+
+}

--- a/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiTagMarshallerTest.java
+++ b/addons/koji/common/src/test/java/org/commonjava/indy/koji/content/KojiTagMarshallerTest.java
@@ -3,7 +3,6 @@ package org.commonjava.indy.koji.content;
 import com.redhat.red.build.koji.model.xmlrpc.KojiTagInfo;
 import org.commonjava.indy.koji.inject.KojiTagInfoEntryMarshaller;
 import org.commonjava.indy.koji.inject.KojiTagInfoMarshaller;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.protostream.FileDescriptorSource;
 import org.infinispan.protostream.ProtobufUtil;
 import org.infinispan.protostream.SerializationContext;
@@ -38,7 +37,8 @@ public class KojiTagMarshallerTest
         Object out = ProtobufUtil.fromWrappedByteArray(ctx, bytes);
 
         assertTrue( out instanceof KojiTagInfoEntry );
-        assertTrue( ((KojiTagInfoEntry) out).getTagInfos().contains("x86") );
+        assertTrue( !((KojiTagInfoEntry) out).getTagInfos().isEmpty() );
+        assertTrue( ((KojiTagInfoEntry) out).getTagInfos().get(0).getArches().contains("x86_64") );
 
     }
 


### PR DESCRIPTION
The ProtoStream marshaller does not currently support the direct marshalling of ArrayList. Alternatively wrapping the list in a new class.