### PR TITLE
Fix to obtain the cache from remote as default

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/IndyKojiContentProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/IndyKojiContentProvider.java
@@ -262,7 +262,7 @@ public class IndyKojiContentProvider
             return supplier.getKojiContent();
         }
 
-        CacheHandle<K, V> cache = cacheProducer.getCache( name );
+        BasicCacheHandle<K, V> cache = cacheProducer.getBasicCache( name );
         V ret = cache.get( key );
         if ( ret == null )
         {


### PR DESCRIPTION
Use the method getBasicCache to make sure to obtain the cache
from remote as default(e.g.: koji-tags), and return the embedded
one if there is no remote definition.