### PR TITLE
Fix deletion failure on readonly repo during promotion

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/data/PromotionManager.java
@@ -949,17 +949,16 @@ public class PromotionManager
             {
                 if ( target != null && target.exists() )
                 {
-                    contentManager.delete( tgt,path, eventMetadata );
-//                    target.delete( true );
+                    contentManager.delete( tgt, path, eventMetadata );
                 }
                 result.skipped = true;
                 logger.info( "Metadata, mark as skipped and remove it if exists, target: {}", target );
             }
             catch ( IndyWorkflowException e )
             {
-                String msg = String.format( "Failed to promote: %s. Target: %s. Failed to remove metadata.",
-                                            transfer, request.getTarget() );
-                logger.info( msg );
+                String msg = String.format( "Failed to promote metadata: %s. Target: %s. Error: %s", transfer,
+                                            request.getTarget(), e.getMessage() );
+                logger.error( msg, e );
                 result.error = msg;
             }
 

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -1031,23 +1031,24 @@ public class DefaultDownloadManager
         try
         {
             Location loc = item.getLocation();
-            boolean resetReadonly = ( !loc.allowsStoring() && isIgnoreReadonly( eventMetadata ) && loc instanceof CacheOnlyLocation );
-            try
+            ConcreteResource resource;
+            boolean resetReadonly = ( !loc.allowsStoring() && isIgnoreReadonly( eventMetadata ) );
+            if ( resetReadonly )
             {
-                if ( resetReadonly )
+                resource = new ConcreteResource( loc, item.getPath() )
                 {
-                    ( (CacheOnlyLocation) loc ).setReadonly( false );
-                }
-                final ConcreteResource resource = new ConcreteResource( loc, item.getPath() );
-                transfers.delete( resource, eventMetadata );
+                    @Override
+                    public boolean allowsDeletion()
+                    {
+                        return true;
+                    }
+                };
             }
-            finally
+            else
             {
-                if ( resetReadonly )
-                {
-                    ( (CacheOnlyLocation) loc ).setReadonly( true );
-                }
+                resource = new ConcreteResource( loc, item.getPath() );
             }
+            transfers.delete( resource, eventMetadata );
         }
         catch ( final TransferException e )
         {

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -625,26 +625,27 @@ public class DefaultDownloadManager
         try
         {
             KeyedLocation loc = LocationUtils.toLocation( store );
-            boolean resetReadonly = ( !loc.allowsStoring() && isIgnoreReadonly( eventMetadata ) && loc instanceof CacheOnlyLocation );
-            try
+            boolean resetReadonly = ( !loc.allowsStoring() && isIgnoreReadonly( eventMetadata ) );
+            ConcreteResource resource;
+            if ( resetReadonly )
             {
-                if ( resetReadonly )
+                resource = new ConcreteResource( loc, path )
                 {
-                    ( (CacheOnlyLocation) loc ).setReadonly( false );
-                }
-                final ConcreteResource resource = new ConcreteResource( loc, path );
+                    @Override
+                    public boolean allowsStoring()
+                    {
+                        return true;
+                    }
+                };
+            }
+            else
+            {
+                resource = new ConcreteResource( loc, path );
+            }
 
-                Transfer txfr = transfers.store( resource, stream, eventMetadata );
-                nfc.clearMissing( resource );
-                return txfr;
-            }
-            finally
-            {
-                if ( resetReadonly )
-                {
-                    ( (CacheOnlyLocation) loc ).setReadonly( true );
-                }
-            }
+            Transfer txfr = transfers.store( resource, stream, eventMetadata );
+            nfc.clearMissing( resource );
+            return txfr;
         }
         catch ( final BadGatewayException e )
         {


### PR DESCRIPTION
This is to fix MMENG-1724 - Readonly hosted repositories prevent promotion.
The store caches a location object which is shared among threads (Ref to LocationUtils.toLocation). Unfortunately this object is not imutable. The flag 'readonly' is set to true/false back and forth, as in the try-finally block. This causes the problem where one promotion thread set it to false and process the deletion while another thread set it back to true and fail the first thread.