### PR TITLE
Use NonReadonlyLocation when need to bypass the hosted readonly permission

### DIFF
--- a/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/HostedMetadataRemergedOnPathPromoteToReadonlyHostedTest.java
+++ b/addons/promote/ftests/src/main/java/org/commonjava/indy/promote/ftest/HostedMetadataRemergedOnPathPromoteToReadonlyHostedTest.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.promote.ftest;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.client.core.IndyClientModule;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
@@ -152,6 +153,10 @@ public class HostedMetadataRemergedOnPathPromoteToReadonlyHostedTest
         client.content()
               .store( a.getKey(), PATH, new ByteArrayInputStream(
                               aPreContent.getBytes() ) );
+
+        // Add this to test the metadata and its siblings clean-up during the promotion
+        String md5 = DigestUtils.md5Hex( aPreContent );
+        client.content().store( a.getKey(), PATH + ".md5", new ByteArrayInputStream( md5.getBytes() ) );
 
         //
         bPomPath = POM_PATH_TEMPLATE.replaceAll( "%version%", B_VERSION );

--- a/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
@@ -19,8 +19,6 @@ import org.commonjava.indy.content.IndyLocationExpander;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.model.Location;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -53,6 +51,14 @@ public class CacheOnlyLocation
         this.isReadOnly = isReadOnly;
     }
 
+    public static CacheOnlyLocation copyOf( final CacheOnlyLocation location )
+    {
+        CacheOnlyLocation ret = new CacheOnlyLocation( location.getKey(), location.isHosted, location.isAllowReleases,
+                                                       location.isAllowSnapshots, location.isReadOnly );
+        ret.attributes.putAll( location.attributes );
+        return ret;
+    }
+
     public CacheOnlyLocation( final HostedRepository repo )
     {
         this.isHosted = true;
@@ -68,13 +74,22 @@ public class CacheOnlyLocation
         this.key = repo.getKey();
     }
 
+    public CacheOnlyLocation( final StoreKey key, final boolean isHosted, final boolean isAllowReleases,
+                              final boolean isAllowSnapshots, final boolean isReadOnly )
+    {
+        this.isHosted = isHosted;
+        this.isAllowReleases = isAllowReleases;
+        this.isAllowSnapshots = isAllowSnapshots;
+        this.isReadOnly = isReadOnly;
+        this.key = key;
+    }
+
     public CacheOnlyLocation( final StoreKey key )
     {
         this.isHosted = false;
         this.isAllowReleases = true;
         this.isAllowSnapshots = false;
         this.isReadOnly = true;
-
         this.key = key;
     }
 

--- a/api/src/main/java/org/commonjava/indy/util/LocationUtils.java
+++ b/api/src/main/java/org/commonjava/indy/util/LocationUtils.java
@@ -45,6 +45,17 @@ public final class LocationUtils
     {
     }
 
+    public static Location getNonReadonlyLocation( final Location location )
+    {
+        if ( location instanceof CacheOnlyLocation )
+        {
+            CacheOnlyLocation ret = CacheOnlyLocation.copyOf( (CacheOnlyLocation) location );
+            ret.setReadonly( false );
+            return ret;
+        }
+        return location;
+    }
+
     public static KeyedLocation toLocation( final ArtifactStore store )
     {
         if ( store == null )

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -624,24 +624,13 @@ public class DefaultDownloadManager
 
         try
         {
-            KeyedLocation loc = LocationUtils.toLocation( store );
+            Location loc = LocationUtils.toLocation( store );
             boolean resetReadonly = ( !loc.allowsStoring() && isIgnoreReadonly( eventMetadata ) );
-            ConcreteResource resource;
             if ( resetReadonly )
             {
-                resource = new ConcreteResource( loc, path )
-                {
-                    @Override
-                    public boolean allowsStoring()
-                    {
-                        return true;
-                    }
-                };
+                loc = LocationUtils.getNonReadonlyLocation( loc );
             }
-            else
-            {
-                resource = new ConcreteResource( loc, path );
-            }
+            ConcreteResource resource = new ConcreteResource( loc, path );
 
             Transfer txfr = transfers.store( resource, stream, eventMetadata );
             nfc.clearMissing( resource );
@@ -1032,23 +1021,12 @@ public class DefaultDownloadManager
         try
         {
             Location loc = item.getLocation();
-            ConcreteResource resource;
-            boolean resetReadonly = ( !loc.allowsStoring() && isIgnoreReadonly( eventMetadata ) );
+            boolean resetReadonly = ( !loc.allowsDeletion() && isIgnoreReadonly( eventMetadata ) );
             if ( resetReadonly )
             {
-                resource = new ConcreteResource( loc, item.getPath() )
-                {
-                    @Override
-                    public boolean allowsDeletion()
-                    {
-                        return true;
-                    }
-                };
+                loc = LocationUtils.getNonReadonlyLocation( loc );
             }
-            else
-            {
-                resource = new ConcreteResource( loc, item.getPath() );
-            }
+            ConcreteResource resource = new ConcreteResource( loc, item.getPath() );
             transfers.delete( resource, eventMetadata );
         }
         catch ( final TransferException e )


### PR DESCRIPTION
In order to bypass the readonly during promotion, we have to create a non-readonly Location object. 
This is an amendment for a prev fix. What is the problem of prev fix? The answer is: we can not only override the Resource's method because the Location object can be use in very deep places, where indy try to delete the checksum transfer. At that moment, the resource object is different, so it can not bypass the readonly. 