### PR TITLE
Fix storekey deserialization to support object way

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/StoreKeyDeserializer.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/StoreKeyDeserializer.java
@@ -15,17 +15,17 @@
  */
 package org.commonjava.indy.model.core.io;
 
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.StoreType;
+
 import java.io.IOException;
 
-import org.commonjava.indy.model.core.StoreKey;
-
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-
 public final class StoreKeyDeserializer
-    extends StdDeserializer<StoreKey>
+        extends StdDeserializer<StoreKey>
 {
     private static final long serialVersionUID = 1L;
 
@@ -36,9 +36,17 @@ public final class StoreKeyDeserializer
 
     @Override
     public StoreKey deserialize( final JsonParser parser, final DeserializationContext context )
-        throws IOException, JsonProcessingException
+            throws IOException
     {
         final String keyStr = parser.getText();
+        if ( keyStr != null && keyStr.trim().equals( "{" ) )
+        {
+            JsonNode node = parser.getCodec().readTree( parser );
+            String pkgType = node.get( "packageType" ).textValue();
+            String type = node.get( "type" ).textValue();
+            String name = node.get( "name" ).textValue();
+            return new StoreKey( pkgType, StoreType.get( type ), name );
+        }
         return StoreKey.fromString( keyStr );
     }
 

--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/io/StoreKeySerializer.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/io/StoreKeySerializer.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import org.commonjava.indy.model.core.StoreKey;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
@@ -34,7 +33,7 @@ public final class StoreKeySerializer
 
     @Override
     public void serialize( final StoreKey key, final JsonGenerator generator, final SerializerProvider provider )
-        throws IOException, JsonProcessingException
+        throws IOException
     {
         generator.writeString( key.toString() );
     }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/core/io/ModelJSONTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/core/io/ModelJSONTest.java
@@ -15,12 +15,19 @@
  */
 package org.commonjava.indy.model.core.io;
 
+import static org.commonjava.indy.model.core.StoreType.hosted;
+import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.PackageTypeConstants;
+import org.hamcrest.CoreMatchers;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,13 +52,27 @@ public class ModelJSONTest
     }
 
     @Test
-    public void deserializeHostedRepo()
+    public void deserializeHostedRepoWithObjKey()
         throws Exception
     {
-        final String json = loadJson( "hosted-with-storage.json" );
+        final String json = loadJson( "hosted-with-storage-objkey.json" );
         System.out.println( json );
         final HostedRepository repo = mapper.readValue( json, HostedRepository.class );
         System.out.println( repo );
+        assertThat( repo.getPackageType(), is( PKG_TYPE_MAVEN ) );
+        assertThat( repo.getType(), is( hosted ) );
+    }
+
+    @Test
+    public void deserializeHostedRepoWithStringKey()
+            throws Exception
+    {
+        final String json = loadJson( "hosted-with-storage-stringkey.json" );
+        System.out.println( json );
+        final HostedRepository repo = mapper.readValue( json, HostedRepository.class );
+        System.out.println( repo );
+        assertThat( repo.getPackageType(), is( PKG_TYPE_MAVEN ) );
+        assertThat( repo.getType(), is( hosted ) );
     }
 
 }

--- a/models/core-java/src/test/resources/model-io/hosted-with-storage-objkey.json
+++ b/models/core-java/src/test/resources/model-io/hosted-with-storage-objkey.json
@@ -1,0 +1,12 @@
+{
+  "allow_snapshots":true,
+  "allow_releases":true,
+  "snapshotTimeoutSeconds":86400,
+  "type": "hosted",
+  "key": {
+    "packageType": "maven",
+    "type": "hosted",
+    "name": "local-deployments"
+  },
+  "storage":"/tmp/local-deployments"
+}

--- a/models/core-java/src/test/resources/model-io/hosted-with-storage-stringkey.json
+++ b/models/core-java/src/test/resources/model-io/hosted-with-storage-stringkey.json
@@ -3,6 +3,6 @@
   "allow_releases":true,
   "snapshotTimeoutSeconds":86400,
   "type": "hosted",
-  "key":"maven:hosted:local-deployments",
+  "key": "maven:hosted:local-deployments",
   "storage":"/tmp/local-deployments"
 }


### PR DESCRIPTION
   We found that Indy StoreKeyDeserializer will only recongnize the
   StoreKey with the pkgType:type:name format in json, and will ignore
   any other format even if it is a valid json object of StoreKey. This
   fix will also include the correct json object of StoreKey as correct
   input.