### PR TITLE
Fix the npm url handling

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloNPMContentAccessResource.java
@@ -65,9 +65,7 @@ public class FoloNPMContentAccessResource
     private static final String BASE_PATH = IndyDeployment.API_PREFIX + "/folo/track";
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
-
-    private static final String PACKAGE_JSON = "/package.json";
-
+    
     @Inject
     @NPMContentHandler
     private NPMContentAccessHandler handler;

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/change/PackageStoreListener.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/change/PackageStoreListener.java
@@ -43,6 +43,7 @@ import java.util.Set;
 
 import static org.commonjava.indy.model.core.StoreType.hosted;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_METADATA_NAME;
 import static org.commonjava.indy.util.LocationUtils.getKey;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
@@ -81,7 +82,7 @@ public class PackageStoreListener
         final StoreKey storeKey = getKey( event );
 
         final String pkgPath = normalize( parentPath( event.getTransfer().getParent().getPath() ) );
-        final String pkgMetadataPath = normalize( pkgPath, PackageMetadataMerger.METADATA_NAME ) ;
+        final String pkgMetadataPath = normalize( pkgPath, NPM_METADATA_NAME ) ;
 
         logger.info( "Package metadata: store:{} and path: {}", storeKey.getName(), pkgMetadataPath );
 
@@ -156,7 +157,7 @@ public class PackageStoreListener
 
                     logger.info( "Deleted: {} (success? {})", item, result );
 
-                    if ( item.getPath().endsWith( PackageMetadataMerger.METADATA_NAME ) )
+                    if ( item.getPath().endsWith( NPM_METADATA_NAME ) )
                     {
                         isCleared = result;
                     }
@@ -166,7 +167,7 @@ public class PackageStoreListener
                         fileEvent.fire( new FileDeletionEvent( item, new EventMetadata() ) );
                     }
                 }
-                else if ( item.getPath().endsWith( PackageMetadataMerger.METADATA_NAME ) )
+                else if ( item.getPath().endsWith( NPM_METADATA_NAME ) )
                 {
                     // we should return true here to trigger cache cleaning, because file not exists in store does not mean
                     // metadata not exists in cache.

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/DecoratorUtils.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/DecoratorUtils.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_METADATA_NAME;
+
 public class DecoratorUtils
 {
     private static final Logger logger = LoggerFactory.getLogger( DecoratorUtils.class );
@@ -107,7 +109,7 @@ public class DecoratorUtils
         }
 
         String lastPart = pathParts[pathParts.length - 1];
-        if ( ( "package.json".equals( lastPart ) || lastPart.endsWith( "tgz" ) ) && pathParts.length > 2 )
+        if ( ( NPM_METADATA_NAME.equals( lastPart ) || lastPart.endsWith( "tgz" ) ) && pathParts.length > 2 )
         {
             final String firstPath;
             //Handle if scopedPath like "@types/jquery/***" or singlePath like "jquery/***"

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
@@ -38,6 +38,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.commonjava.indy.content.ContentManager.ENTRY_POINT_BASE_URI;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
 import static org.commonjava.indy.pkg.npm.content.DecoratorUtils.updatePackageJson;
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_METADATA_NAME;
 import static org.jsoup.helper.StringUtil.isBlank;
 
 @ApplicationScoped
@@ -71,7 +72,7 @@ public class NPMPackageMaskingTransferDecorator
 
         logger.debug( "Masking decorator decorateRead, transfer: {}", transfer );
 
-        if ( !( transfer.getFullPath().endsWith( "package.json" ) ) )
+        if ( !( transfer.getFullPath().endsWith( NPM_METADATA_NAME ) ) )
         {
             return stream;
         }

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMStoragePathCalculator.java
@@ -31,7 +31,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
-import static org.commonjava.indy.pkg.npm.content.group.PackageMetadataMerger.METADATA_NAME;
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_METADATA_NAME;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 
 /**
@@ -91,11 +91,11 @@ public class NPMStoragePathCalculator
             final boolean isScopedPath = pkg.startsWith( "@" ) && pkg.split( "/" ).length < 3;
             if ( isSinglePath || isScopedPath )
             {
-                logger.debug( "Modifying target path: {}, appending '{}', store {}", path, METADATA_NAME,
+                logger.debug( "Modifying target path: {}, appending '{}', store {}", path, NPM_METADATA_NAME,
                               key.toString() );
                 return extension != null ?
-                        normalize( pkg, METADATA_NAME + extension ) :
-                        normalize( pkg, METADATA_NAME );
+                        normalize( pkg, NPM_METADATA_NAME + extension ) :
+                        normalize( pkg, NPM_METADATA_NAME );
             }
         }
 

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGenerator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/PackageMetadataGenerator.java
@@ -58,6 +58,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.indy.data.StoreDataManager.IGNORE_READONLY;
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_METADATA_NAME;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
 
@@ -127,9 +128,9 @@ public class PackageMetadataGenerator
         if ( !exists( target ) )
         {
             String toMergePath = realPath;
-            if ( !realPath.endsWith( PackageMetadataMerger.METADATA_NAME ) )
+            if ( !realPath.endsWith( NPM_METADATA_NAME ) )
             {
-                toMergePath = normalize( normalize( parentPath( toMergePath ) ), PackageMetadataMerger.METADATA_NAME );
+                toMergePath = normalize( normalize( parentPath( toMergePath ) ), NPM_METADATA_NAME );
             }
 
             final List<Transfer> sources = new ArrayList<>(  );
@@ -373,7 +374,7 @@ public class PackageMetadataGenerator
             TarArchiveEntry currentEntry = tarIn.getNextTarEntry();
             while ( currentEntry != null )
             {
-                if ( currentEntry.isFile() && currentEntry.getName().equals( "package/package.json" ) )
+                if ( currentEntry.isFile() && currentEntry.getName().equals( "package/" + NPM_METADATA_NAME ) )
                 {
                     metaFile = downloadManager.store( store, versionPath, tarIn, TransferOperation.UPLOAD, new EventMetadata().set( IGNORE_READONLY, Boolean.TRUE ) );
                     break;
@@ -397,12 +398,12 @@ public class PackageMetadataGenerator
     @Override
     public boolean canProcess( String path )
     {
-        return path.endsWith( PackageMetadataMerger.METADATA_NAME );
+        return path.endsWith( NPM_METADATA_NAME );
     }
 
     @Override
     protected String getMergedMetadataName()
     {
-        return PackageMetadataMerger.METADATA_NAME;
+        return NPM_METADATA_NAME;
     }
 }

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMerger.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/group/PackageMetadataMerger.java
@@ -43,7 +43,6 @@ import static org.commonjava.indy.util.LocationUtils.getKey;
 @ApplicationScoped
 public class PackageMetadataMerger
 {
-    public static final String METADATA_NAME = "package.json";
 
     @Inject
     private Instance<PackageMetadataProvider> metadataProviderInstances;

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Future;
 
 import static org.commonjava.indy.core.ctl.PoolUtils.detectOverloadVoid;
 import static org.commonjava.indy.model.core.StoreType.remote;
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_METADATA_NAME;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
 import static org.commonjava.o11yphant.trace.TraceManager.addFieldToActiveSpan;
 
@@ -132,7 +133,7 @@ public class DefaultDirectContentAccess
             throws IndyWorkflowException
     {
         // npm should handle the path as '/project' not '/project/package.json' when retrieves a remote registry
-        if ( store.getType() == remote && store.getPackageType().equals( NPM_PKG_KEY ) )
+        if ( store.getType() == remote && store.getPackageType().equals( NPM_PKG_KEY ) && path.endsWith( NPM_METADATA_NAME ))
         {
             String project = path.substring( 0, path.length()-13 );
             if ( project != null && project.length() > 0 )

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDirectContentAccess.java
@@ -135,7 +135,7 @@ public class DefaultDirectContentAccess
         // npm should handle the path as '/project' not '/project/package.json' when retrieves a remote registry
         if ( store.getType() == remote && store.getPackageType().equals( NPM_PKG_KEY ) && path.endsWith( NPM_METADATA_NAME ))
         {
-            String project = path.substring( 0, path.length()-13 );
+            String project = path.substring( 0, path.length() - ( NPM_METADATA_NAME.length() + 1 ) );
             if ( project != null && project.length() > 0 )
             {
                 path = project;

--- a/models/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/NPMPackageTypeDescriptor.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/pkg/npm/model/NPMPackageTypeDescriptor.java
@@ -29,6 +29,8 @@ public class NPMPackageTypeDescriptor
 {
     public static final String NPM_PKG_KEY = PKG_TYPE_NPM;
 
+    public static final String NPM_METADATA_NAME = "package.json";
+
     public static final String NPM_CONTENT_REST_BASE_PATH = "/api/content/npm";
 
     public static final String NPM_ADMIN_REST_BASE_PATH = "/api/admin/stores/npm";


### PR DESCRIPTION
Fix for https://projects.engineering.redhat.com/browse/MMENG-1757, only the URLs end with `package.json` should be tailored.

After checking the logs, found that when retrieving the npm raw files such as the following two, the urls were tailored by mistake, 
from
```
@babel/helper-validator-identifier/7.10.4
@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz
```

to:
```
@babel/helper-validator-iden 
@babel/helper-validator-identifier/-/helper-validator-identifi 
```

that's why it complained the error `package not found`.


