### PR TITLE
Fix api/admin/pathmap/content NPE when target repo is gone

### DIFF
--- a/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/common/PathMappedController.java
+++ b/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/common/PathMappedController.java
@@ -15,15 +15,15 @@
  */
 package org.commonjava.indy.pathmapped.common;
 
-import org.commonjava.indy.data.StoreDataManager;
-import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.model.galley.KeyedLocation;
 import org.commonjava.indy.pathmapped.model.PathMappedDeleteResult;
 import org.commonjava.indy.pathmapped.model.PathMappedListResult;
-import org.commonjava.indy.util.LocationUtils;
 import org.commonjava.maven.galley.cache.pathmapped.PathMappedCacheProvider;
 import org.commonjava.maven.galley.model.ConcreteResource;
+import org.commonjava.maven.galley.model.Location;
+import org.commonjava.maven.galley.model.SimpleLocation;
 import org.commonjava.maven.galley.spi.cache.CacheProvider;
 import org.commonjava.storage.pathmapped.core.PathMappedFileManager;
 import org.commonjava.storage.pathmapped.spi.PathDB;
@@ -40,9 +40,6 @@ public class PathMappedController
 {
     @Inject
     private CacheProvider cacheProvider;
-
-    @Inject
-    private StoreDataManager storeDataManager;
 
     private PathMappedCacheProvider pathMappedCacheProvider;
 
@@ -107,8 +104,27 @@ public class PathMappedController
                     throws Exception
     {
         StoreKey storeKey = new StoreKey( packageType, StoreType.get( type ), name );
-        ArtifactStore store = storeDataManager.getArtifactStore( storeKey );
-        return new ConcreteResource( LocationUtils.toLocation( store ), path );
+        // we just need a simple keyed location which provides the name to underlying pathMappedCacheProvider
+        Location location = new SimpleKeyedLocation( storeKey );
+        return new ConcreteResource( location, path );
     }
 
+    private static class SimpleKeyedLocation
+                    extends SimpleLocation
+                    implements KeyedLocation
+    {
+        private final StoreKey storeKey;
+
+        public SimpleKeyedLocation( StoreKey storeKey )
+        {
+            super( storeKey.toString() );
+            this.storeKey = storeKey;
+        }
+
+        @Override
+        public StoreKey getKey()
+        {
+            return storeKey;
+        }
+    }
 }

--- a/addons/path-mapped/jaxrs/src/main/java/org/commonjava/indy/pathmapped/jaxrs/PathMappedResource.java
+++ b/addons/path-mapped/jaxrs/src/main/java/org/commonjava/indy/pathmapped/jaxrs/PathMappedResource.java
@@ -136,8 +136,8 @@ public class PathMappedResource
         }
         catch ( Exception e )
         {
-            logger.warn( e.getMessage(), e );
-            if ( e.getMessage().contains( "not exist" ) )
+            logger.warn( "Get pathmap content failed, message: " + e.getMessage(), e );
+            if ( e.getMessage() != null && e.getMessage().contains( "not exist" ) )
             {
                 return Response.status( Response.Status.NOT_FOUND ).build();
             }


### PR DESCRIPTION
If user delete a repo or group, the pathmap/admin api will fail. like:
```
curl http://indy-indy-stage.apps.ocp-c1.prod.psi.redhat.com/api/admin/pathmapped/content/npm/group/build-17670/load-json-file/package.json
java.lang.NullPointerException
	at org.commonjava.indy.pathmapped.jaxrs.PathMappedResource.get(PathMappedResource.java:140)
```
We need to avoid such because this api is meant to query/debug pathdb problems.