### PR TITLE
[Cherry-pick-to-maint] Allow force delte for npm metadata

### DIFF
--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReadonlyHostedDeleteFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReadonlyHostedDeleteFileTest.java
@@ -15,7 +15,6 @@
  */
 package org.commonjava.indy.pkg.npm.content;
 
-import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -31,21 +30,22 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /**
- * This case tests if files can be stored in a readonly hosted repo
+ * This case tests if files can be deleted in a readonly hosted repo
  * when: <br />
  * <ul>
- *      <li>creates a readonly hosted repo</li>
- *      <li>stores file in hosted repo once</li>
+ *      <li>creates a non-readonly hosted repo and stores file in it</li>
  *      <li>updates the hosted repo to non-readonly</li>
- *      <li>stores file again</li>
+ *      <li>deletes the file in hosted repo once</li>
+ *      <li>updates the hosted repo to non-readonly</li>
+ *      <li>deletes file again</li>
  * </ul>
  * then: <br />
  * <ul>
- *     <li>the file can not be stored with 405 error first time</li>
- *     <li>the file can be stored successfully with no error second time</li>
+ *     <li>the file can not be deleted with 405 error first time</li>
+ *     <li>the file can be deleted successfully with no error second time</li>
  * </ul>
  */
-public class NPMReaonlyHostedStoreFileTest
+public class NPMReadonlyHostedDeleteFileTest
                 extends AbstractContentManagementTest
 {
 
@@ -55,41 +55,40 @@ public class NPMReaonlyHostedStoreFileTest
         final String content = "This is a test: " + System.nanoTime();
         InputStream stream = new ByteArrayInputStream( content.getBytes() );
 
-        final String path = "jquery/-/jquery-2.1.0.tgz";
+        final String path = "jquery/2.1.0";
 
-        final String repoName = "test-hosted";
+        final String repoName = "test-npm-hosted";
         HostedRepository repo = new HostedRepository( NPM_PKG_KEY, repoName );
-        repo.setReadonly( true );
         repo = client.stores().create( repo, "adding npm hosted repo", HostedRepository.class );
 
         StoreKey storeKey = repo.getKey();
         assertThat( client.content().exists( storeKey, path ), equalTo( false ) );
 
+        client.content().store( storeKey, path, stream );
+
+        assertThat( client.content().exists( storeKey, path ), equalTo( true ) );
+
+        repo.setReadonly( true );
+        client.stores().update( repo, "change read-only true" );
+
         try
         {
-            client.content().store( storeKey, path, stream );
+            client.content().delete( storeKey, path );
         }
         catch ( IndyClientException e )
         {
             assertThat( e.getStatusCode(), equalTo( ApplicationStatus.METHOD_NOT_ALLOWED.code() ) );
         }
 
-        assertThat( client.content().exists( storeKey, path ), equalTo( false ) );
+        assertThat( client.content().exists( storeKey, path ), equalTo( true ) );
 
         repo.setReadonly( false );
         client.stores().update( repo, "change read-only false" );
 
-        stream = new ByteArrayInputStream( content.getBytes() );
-        client.content().store( storeKey, path, stream );
+        client.content().delete( storeKey, path );
 
-        assertThat( client.content().exists( storeKey, path ), equalTo( true ) );
+        assertThat( client.content().exists( storeKey, path ), equalTo( false ) );
 
-        final InputStream is = client.content().get( storeKey, path );
-        final String result = IOUtils.toString( is );
-
-        assertThat( result, equalTo( content ) );
-
-        is.close();
         stream.close();
     }
 

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReadonlyHostedDeleteMetadataTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReadonlyHostedDeleteMetadataTest.java
@@ -1,0 +1,157 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientHttp;
+import org.commonjava.indy.client.core.IndyClientModule;
+import org.commonjava.indy.client.core.module.IndyRawHttpModule;
+import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.pkg.npm.model.PackageMetadata;
+import org.commonjava.indy.pkg.npm.model.VersionMetadata;
+import org.commonjava.indy.util.ApplicationStatus;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This case tests if metadata files can be deleted in a readonly hosted repo
+ * when: <br />
+ * <ul>
+ *      <li>create a readonly hosted repo A and stores a tgz file and a stale metadata</li>
+ *      <li>create a group G to include A</li>
+ *      <li>get metadata from both A and G</li>
+ *      <li>delete the metadata file from hosted repo A</li>
+ *      <li>get the metadata file from A and G again</li>
+ * </ul>
+ * then: <br />
+ * <ul>
+ *     <li>the metadata file can be gotten from both A and G</li>
+ *     <li>the metadata file can be deleted</li>
+ *     <li>the metadata file is regenerated the second time with right content from both A and G</li>
+ * </ul>
+ */
+public class NPMReadonlyHostedDeleteMetadataTest
+                extends AbstractContentManagementTest
+{
+    private final IndyRawHttpModule httpModule = new IndyRawHttpModule();
+
+    private final IndyObjectMapper mapper = new IndyObjectMapper( true );
+
+    final String packagePath = "@babel/helper-validator-identifier";
+
+    final String tarballPath = "@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz";
+
+    final String staleMeta = "{\n" + "  \"dist-tags\" : { }\n" + "}";
+
+    final String repoName = "test";
+
+    final String groupName = "G";
+
+    @Test
+    public void test() throws Exception
+    {
+        // Prepare
+        HostedRepository repo = new HostedRepository( NPM_PKG_KEY, repoName );
+        repo = client.stores().create( repo, "adding npm hosted repo", HostedRepository.class );
+
+        StoreKey storeKey = repo.getKey();
+        client.content()
+              .store( storeKey, tarballPath, readTestResourceAsStream( "helper-validator-identifier-7.10.4.tgz" ) );
+
+        client.content().store( storeKey, packagePath, new ByteArrayInputStream( staleMeta.getBytes() ) );
+
+        // Set readonly
+        repo.setReadonly( true );
+        client.stores().update( repo, "set read-only" );
+
+        // Create group G
+        Group group = new Group( NPM_PKG_KEY, groupName, repo.getKey() );
+        client.stores().create( group, "adding npm group G", Group.class );
+
+        // get from both A and G
+        assertContent( repo, packagePath, staleMeta );
+        assertContent( group, packagePath, staleMeta );
+
+        // Extra case: delete non-metadata file is not allowed
+        try
+        {
+            client.content().delete( storeKey, tarballPath );
+        }
+        catch ( IndyClientException e )
+        {
+            assertThat( e.getStatusCode(), equalTo( ApplicationStatus.METHOD_NOT_ALLOWED.code() ) );
+        }
+
+        // Delete metadata from repo A
+        IndyClientHttp http = client.module( IndyRawHttpModule.class ).getHttp();
+        http.deleteCache( client.content().contentPath( storeKey, packagePath ) + "/package.json" );
+
+        assertExistence( repo, packagePath, false );
+        assertExistence( group, packagePath, false );
+
+        // Get metadata again
+        try (InputStream is = client.content().get( storeKey, packagePath ))
+        {
+            //String actual = IOUtils.toString( is );
+            //System.out.println( ">>>>\n" + actual );
+            assertTarballUrl( is, "/api/content/npm/hosted/test/" + tarballPath );
+        }
+
+        try (InputStream is = client.content().get( group.getKey(), packagePath ))
+        {
+            //String actual = IOUtils.toString( is );
+            //System.out.println( ">>>>\n" + actual );
+            assertTarballUrl( is, "/api/content/npm/group/G/" + tarballPath );
+        }
+    }
+
+    private void assertTarballUrl( InputStream is, String s ) throws IOException
+    {
+        PackageMetadata pkgMetadata = mapper.readValue( is, PackageMetadata.class );
+        VersionMetadata versionMetadata = pkgMetadata.getVersions().get( "7.10.4" );
+        assertNotNull( versionMetadata );
+        String tarball = versionMetadata.getDist().getTarball();
+        assertNotNull( tarball );
+        assertTrue( tarball.contains( s ) );
+    }
+
+    @Override
+    protected Collection<IndyClientModule> getAdditionalClientModules()
+    {
+        return Arrays.asList( httpModule );
+    }
+
+    @Override
+    protected boolean createStandardTestStructures()
+    {
+        return false;
+    }
+}

--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReadonlyHostedStoreFileTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMReadonlyHostedStoreFileTest.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.pkg.npm.content;
 
+import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -30,22 +31,21 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 
 /**
- * This case tests if files can be deleted in a readonly hosted repo
+ * This case tests if files can be stored in a readonly hosted repo
  * when: <br />
  * <ul>
- *      <li>creates a non-readonly hosted repo and stores file in it</li>
+ *      <li>creates a readonly hosted repo</li>
+ *      <li>stores file in hosted repo once</li>
  *      <li>updates the hosted repo to non-readonly</li>
- *      <li>deletes the file in hosted repo once</li>
- *      <li>updates the hosted repo to non-readonly</li>
- *      <li>deletes file again</li>
+ *      <li>stores file again</li>
  * </ul>
  * then: <br />
  * <ul>
- *     <li>the file can not be deleted with 405 error first time</li>
- *     <li>the file can be deleted successfully with no error second time</li>
+ *     <li>the file can not be stored with 405 error first time</li>
+ *     <li>the file can be stored successfully with no error second time</li>
  * </ul>
  */
-public class NPMReaonlyHostedDeleteFileTest
+public class NPMReadonlyHostedStoreFileTest
                 extends AbstractContentManagementTest
 {
 
@@ -55,40 +55,41 @@ public class NPMReaonlyHostedDeleteFileTest
         final String content = "This is a test: " + System.nanoTime();
         InputStream stream = new ByteArrayInputStream( content.getBytes() );
 
-        final String path = "jquery/2.1.0";
+        final String path = "jquery/-/jquery-2.1.0.tgz";
 
-        final String repoName = "test-npm-hosted";
+        final String repoName = "test-hosted";
         HostedRepository repo = new HostedRepository( NPM_PKG_KEY, repoName );
+        repo.setReadonly( true );
         repo = client.stores().create( repo, "adding npm hosted repo", HostedRepository.class );
 
         StoreKey storeKey = repo.getKey();
         assertThat( client.content().exists( storeKey, path ), equalTo( false ) );
 
-        client.content().store( storeKey, path, stream );
-
-        assertThat( client.content().exists( storeKey, path ), equalTo( true ) );
-
-        repo.setReadonly( true );
-        client.stores().update( repo, "change read-only true" );
-
         try
         {
-            client.content().delete( storeKey, path );
+            client.content().store( storeKey, path, stream );
         }
         catch ( IndyClientException e )
         {
             assertThat( e.getStatusCode(), equalTo( ApplicationStatus.METHOD_NOT_ALLOWED.code() ) );
         }
 
-        assertThat( client.content().exists( storeKey, path ), equalTo( true ) );
+        assertThat( client.content().exists( storeKey, path ), equalTo( false ) );
 
         repo.setReadonly( false );
         client.stores().update( repo, "change read-only false" );
 
-        client.content().delete( storeKey, path );
+        stream = new ByteArrayInputStream( content.getBytes() );
+        client.content().store( storeKey, path, stream );
 
-        assertThat( client.content().exists( storeKey, path ), equalTo( false ) );
+        assertThat( client.content().exists( storeKey, path ), equalTo( true ) );
 
+        final InputStream is = client.content().get( storeKey, path );
+        final String result = IOUtils.toString( is );
+
+        assertThat( result, equalTo( content ) );
+
+        is.close();
         stream.close();
     }
 

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
@@ -133,7 +133,10 @@ public class NPMContentAccessResource
             final @PathParam( "packageName" ) String packageName,
             final @ApiParam( name = CHECK_CACHE_ONLY, value = "true or false" ) @QueryParam( CHECK_CACHE_ONLY ) Boolean cacheOnly )
     {
-        return handler.doDelete( NPM_PKG_KEY, type, name, packageName, new EventMetadata() );
+        EventMetadata metadata = new EventMetadata();
+        metadata.set( CHECK_CACHE_ONLY, cacheOnly );
+
+        return handler.doDelete( NPM_PKG_KEY, type, name, packageName, metadata );
     }
 
     @ApiOperation(

--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessResource.java
@@ -126,32 +126,17 @@ public class NPMContentAccessResource
     @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
                     @ApiResponse( code = 204, message = "Content was deleted successfully" ) } )
     @DELETE
-    @Path( "/{packageName}" )
+    @Path( "/{path: (.*)}" )
     public Response doDelete(
             final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" ) String type,
             final @ApiParam( required = true ) @PathParam( "name" ) String name,
-            final @PathParam( "packageName" ) String packageName,
+            final @PathParam( "path" ) String path,
             final @ApiParam( name = CHECK_CACHE_ONLY, value = "true or false" ) @QueryParam( CHECK_CACHE_ONLY ) Boolean cacheOnly )
     {
         EventMetadata metadata = new EventMetadata();
         metadata.set( CHECK_CACHE_ONLY, cacheOnly );
 
-        return handler.doDelete( NPM_PKG_KEY, type, name, packageName, metadata );
-    }
-
-    @ApiOperation(
-            "Delete NPM package and metadata content under the given artifact store (type/name), packageName and versionTarball (/version or /-/tarball)." )
-    @ApiResponses( { @ApiResponse( code = 404, message = "Content is not available" ),
-                           @ApiResponse( code = 204, message = "Content was deleted successfully" ) } )
-    @DELETE
-    @Path( "/{packageName}/{versionTarball: (.*)}" )
-    public Response doDelete(
-            final @ApiParam( allowableValues = "hosted,group,remote", required = true ) @PathParam( "type" ) String type,
-            final @ApiParam( required = true ) @PathParam( "name" ) String name, final @PathParam( "packageName" ) String packageName,
-            final @PathParam( "versionTarball" ) String versionTarball )
-    {
-        final String path = Paths.get( packageName, versionTarball ).toString();
-        return handler.doDelete( NPM_PKG_KEY, type, name, path, new EventMetadata() );
+        return handler.doDelete( NPM_PKG_KEY, type, name, path, metadata );
     }
 
     @Override

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -455,7 +455,7 @@ public class DefaultContentManager
     {
         if ( Boolean.TRUE.equals( eventMetadata.get( CHECK_CACHE_ONLY ) ) && hosted == store.getKey().getType() )
         {
-            SpecialPathInfo info = specialPathManager.getSpecialPathInfo( path );
+            SpecialPathInfo info = specialPathManager.getSpecialPathInfo( path, store.getPackageType() );
             if ( info != null && info.isMetadata() )
             {
                 // Set ignore readonly for metadata so that we can delete stale metadata from readonly hosted repo
@@ -463,7 +463,7 @@ public class DefaultContentManager
             }
             else
             {
-                logger.info( "Can not delete from hosted {}, path: {}", store.getKey(), path );
+                logger.info( "Can not delete from hosted {}, path: {}, info: {}", store.getKey(), path, info );
                 return false;
             }
         }

--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultDownloadManager.java
@@ -1004,7 +1004,7 @@ public class DefaultDownloadManager
     {
         if ( store.getKey().getType() == hosted )
         {
-            SpecialPathInfo info = specialPathManager.getSpecialPathInfo( path );
+            SpecialPathInfo info = specialPathManager.getSpecialPathInfo( path, store.getPackageType() );
             if ( info == null || !info.isMetadata() )
             {
                 return false;


### PR DESCRIPTION
This is used when npm meta is stale and we want to remove it manually. It has no immediate need, but it is low risk. We'd better cherry pick it to 2.5.x as well.