### PR TITLE
upgrade honeycomb to be compatible with o11yphant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <jgroupsVersion>4.0.4.Final</jgroupsVersion>
     <httpcoreVersion>4.4.9</httpcoreVersion>
     <httpclientVersion>4.5.9</httpclientVersion>
-    <honeycombVersion>1.1.0</honeycombVersion>
+    <honeycombVersion>1.5.1</honeycombVersion>
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.7.2</datastaxVersion>
     <pathmappedStorageVersion>1.8</pathmappedStorageVersion>


### PR DESCRIPTION
Upgraded from 1.1.0 to 1.5.1. This fixes `java.lang.NoClassDefFoundError: io/honeycomb/beeline/tracing/propagation/W3CPropagationCodec`