### PR TITLE
Add in-memory cache for remote koji stores

### DIFF
--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
@@ -28,6 +28,7 @@ import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
 import org.commonjava.o11yphant.metrics.annotation.Measure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,7 @@ import java.util.stream.Stream;
 
 import static org.commonjava.indy.db.common.StoreUpdateAction.STORE;
 import static org.commonjava.indy.model.core.StoreType.group;
+import static org.commonjava.indy.model.core.StoreType.remote;
 
 @ApplicationScoped
 @ClusterStoreDataManager
@@ -60,6 +62,10 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
 
     @Inject
     IndyObjectMapper objectMapper;
+
+    @Inject
+    @RemoteKojiStoreDataCache
+    private CacheHandle<StoreKey, ArtifactStore> remoteKojiStores;
 
     protected CassandraStoreDataManager()
     {
@@ -82,6 +88,15 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
     {
 
         logger.trace( "Get artifact store: {}", key.toString() );
+
+        if ( remote.equals( key.getType()) && key.getName().startsWith( "koji-" ) )
+        {
+            ArtifactStore store = remoteKojiStores.get( key );
+            if ( store != null )
+            {
+                return store;
+            }
+        }
 
         DtxArtifactStore dtxArtifactStore = storeQuery.getArtifactStore( key.getPackageType(), key.getType(), key.getName() );
 
@@ -288,6 +303,11 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
     {
         final Set<ArtifactStore> allStores = getAllArtifactStores();
         allStores.stream().filter( s -> group == s.getType() ).forEach( s -> refreshAffectedBy( s, null, STORE ) );
+
+        // cache the remote koji repo
+        allStores.stream().filter( s -> remote == s.getType() && ( "koji".equals( s.getMetadata( ArtifactStore.METADATA_ORIGIN ) )
+                || "koji-binary".equals(
+                s.getMetadata( ArtifactStore.METADATA_ORIGIN) ) ) ).forEach( s -> remoteKojiStores.put( s.getKey(), s ) );
     }
 
     private DtxArtifactStore toDtxArtifactStore( StoreKey storeKey, ArtifactStore store )
@@ -428,7 +448,7 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
                     ( (HostedRepository) store ).setAllowSnapshots( allowSnapshots );
                 }
             }
-            else if ( dtxArtifactStore.getStoreType().equals( StoreType.remote.name() ) )
+            else if ( dtxArtifactStore.getStoreType().equals( remote.name() ) )
             {
                 store = new RemoteRepository( dtxArtifactStore.getPackageType(), dtxArtifactStore.getName(),
                                               readStrValueFromExtra( CassandraStoreUtil.URL, extras ));

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/RemoteKojiStoreDataCache.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/RemoteKojiStoreDataCache.java
@@ -1,0 +1,12 @@
+package org.commonjava.indy.cassandra.data;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.*;
+
+@Qualifier
+@Target( { ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+@Retention( RetentionPolicy.RUNTIME)
+@Documented
+public @interface RemoteKojiStoreDataCache
+{
+}

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/StoreDataCacheProducer.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/StoreDataCacheProducer.java
@@ -1,0 +1,28 @@
+package org.commonjava.indy.cassandra.data;
+
+import org.commonjava.indy.model.core.ArtifactStore;
+import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.subsys.infinispan.CacheHandle;
+import org.commonjava.indy.subsys.infinispan.CacheProducer;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+public class StoreDataCacheProducer
+{
+
+    public static final String REMOTE_KOJI_STORE = "remote-koji-stores";
+
+    @Inject
+    private CacheProducer cacheProducer;
+
+    @RemoteKojiStoreDataCache
+    @Produces
+    @ApplicationScoped
+    public CacheHandle<StoreKey, ArtifactStore> getRemoteKojiStoreDataCache()
+    {
+        return cacheProducer.getCache(REMOTE_KOJI_STORE);
+    }
+
+}

--- a/subsys/infinispan/src/main/resources/infinispan.xml
+++ b/subsys/infinispan/src/main/resources/infinispan.xml
@@ -144,6 +144,9 @@
     <local-cache name="affected-by-stores" configuration="local-template">
     </local-cache>
 
+    <local-cache name="remote-koji-stores" configuration="local-template">
+    </local-cache>
+
     <!--
     A clustered lock is a lock which is distributed and shared among all nodes in the Infinispan cluster and
     provides a way to execute code that will be synchronized between the nodes. Since 9.x.


### PR DESCRIPTION
This is for issue: https://issues.redhat.com/browse/MMENG-1932
Adding the temporary in-memory cache remote-koji-stores , to avoid to iterate the remote koji repositories under group brew-proxies from C*, the count of that type repo is 750+ in stage and 2300+ in prod, which slows the retrieve request down most, more details please ref the issue. thanks.