### PR TITLE
Fix the startup of remote repo cache

### DIFF
--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
@@ -303,11 +303,6 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
     {
         final Set<ArtifactStore> allStores = getAllArtifactStores();
         allStores.stream().filter( s -> group == s.getType() ).forEach( s -> refreshAffectedBy( s, null, STORE ) );
-
-        // cache the remote koji repo
-        allStores.stream().filter( s -> remote == s.getType() && ( "koji".equals( s.getMetadata( ArtifactStore.METADATA_ORIGIN ) )
-                || "koji-binary".equals(
-                s.getMetadata( ArtifactStore.METADATA_ORIGIN) ) ) ).forEach( s -> remoteKojiStores.put( s.getKey(), s ) );
     }
 
     private DtxArtifactStore toDtxArtifactStore( StoreKey storeKey, ArtifactStore store )
@@ -572,4 +567,13 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
         return null;
     }
 
+    public void initRemoteStoresCache()
+    {
+        final Set<ArtifactStore> allStores = getAllArtifactStores();
+
+        // cache the remote koji repo
+        allStores.stream().filter( s -> remote == s.getType() && ( "koji".equals( s.getMetadata( ArtifactStore.METADATA_ORIGIN ) )
+                || "koji-binary".equals(
+                s.getMetadata(ArtifactStore.METADATA_ORIGIN ) ) ) ).forEach( s -> remoteKojiStores.put( s.getKey(), s ) );
+    }
 }

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/StoreDataStartupAction.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/StoreDataStartupAction.java
@@ -1,0 +1,45 @@
+package org.commonjava.indy.cassandra.data;
+
+import org.commonjava.indy.action.IndyLifecycleException;
+import org.commonjava.indy.action.StartupAction;
+import org.commonjava.indy.data.StoreDataManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named("Store-Cache-Initialization")
+public class StoreDataStartupAction implements StartupAction
+{
+
+    @Inject
+    StoreDataManager dataManager;
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Override
+    public String getId()
+    {
+        return "Init remote store cache based on the persistent store data.";
+    }
+
+    @Override
+    public void start() throws IndyLifecycleException
+    {
+
+        if ( dataManager instanceof CassandraStoreDataManager )
+        {
+            logger.info( "Init the cache of remote stores based on the store data" );
+
+            ( (CassandraStoreDataManager) dataManager ).initRemoteStoresCache();
+        }
+
+    }
+
+    @Override
+    public int getStartupPriority()
+    {
+        return 90;
+    }
+}


### PR DESCRIPTION
The cache for remote store is an in-memory cache that should be populated at each startup. 