### PR TITLE
Update to avoid the fullscan on the repository

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiMavenMetadataProvider.java
@@ -47,6 +47,7 @@ import org.commonjava.indy.koji.inject.KojiMavenVersionMetadataLocks;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.StoreKey;
+import org.commonjava.indy.pkg.PackageTypeConstants;
 import org.commonjava.indy.pkg.maven.content.MetadataCacheManager;
 import org.commonjava.indy.pkg.maven.content.group.MavenMetadataProvider;
 import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
@@ -199,9 +200,9 @@ public class KojiMavenMetadataProvider
         try
         {
             Set<Group> affected = storeDataManager.query()
-                                                  .getAll( s -> group == s.getType() && kojiConfig.isEnabledFor( s ) )
+                                                  .getAllGroups(PackageTypeConstants.PKG_TYPE_MAVEN)
                                                   .stream()
-                                                  .map( s -> (Group) s )
+                                                  .filter(s -> kojiConfig.isEnabledFor(s))
                                                   .collect( Collectors.toSet() );
 
             if ( storeDataManager instanceof AbstractStoreDataManager )

--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRepairManager.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/data/KojiRepairManager.java
@@ -43,6 +43,7 @@ import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
+import org.commonjava.indy.pkg.PackageTypeConstants;
 import org.commonjava.maven.galley.event.EventMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -639,12 +640,12 @@ public class KojiRepairManager
             throws IndyDataException
     {
         return storeManager.query()
-                           .storeTypes( remote )
-                           .stream( ( remote ) ->
+                           .getAllRemoteRepositories( PackageTypeConstants.PKG_TYPE_MAVEN )
+                           .stream()
+                           .filter( ( remote ) ->
                                             KOJI_ORIGIN.equals( remote.getMetadata( ArtifactStore.METADATA_ORIGIN ) )
                                                     || KOJI_ORIGIN_BINARY.equals(
                                                     remote.getMetadata( ArtifactStore.METADATA_ORIGIN ) ) )
-                           .map( s -> (RemoteRepository) s )
                            .filter( Objects::nonNull )
                            .collect( Collectors.toList() );
     }


### PR DESCRIPTION
I found a lot of logs to check the repo when handling the expiration of the koji maven metadata, since we had introduced the specific query earlier, we can avoid the fullscan on repository. 