### PR TITLE
Update weft version to 1.20-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <kojijiVersion>2.13</kojijiVersion>
     <rwxVersion>2.3</rwxVersion>
     <jhttpcVersion>1.12</jhttpcVersion>
-    <weftVersion>1.19</weftVersion>
+    <weftVersion>1.20-SNAPSHOT</weftVersion>
     <httpTestserverVersion>1.4</httpTestserverVersion>
     <propulsorVersion>1.4</propulsorVersion>
     <auditQueryVersion>0.13.1</auditQueryVersion>


### PR DESCRIPTION
Weft 1.20-SNAPSHOT include fix for the Locker.waitForLock dead lock issue.