### PR TITLE
Check path patterns before retrieving

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentManager.java
@@ -26,6 +26,7 @@ import org.commonjava.indy.content.StoreResource;
 import org.commonjava.indy.core.content.group.GroupRepositoryFilterManager;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.o11yphant.metrics.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
@@ -289,6 +290,11 @@ public class DefaultContentManager
         {
             logger.debug( "Content not available in repository due to store disabled for {}, path is {}", store,
                          path );
+            return null;
+        }
+
+        if ( store.getKey().getType() == StoreType.remote && !PathMaskChecker.checkMask( store, path))
+        {
             return null;
         }
 


### PR DESCRIPTION
I think we need to add this at the beginning of retrieve and generation. If the remote repo is not the right one for retrieving, there is also no need to try to generate content from it, avoid some loop checker. 