### PR TITLE
Fix the order of getting members in group

### DIFF
--- a/test/db/src/main/java/org/commonjava/indy/core/data/GroupDataManagerTCK.java
+++ b/test/db/src/main/java/org/commonjava/indy/core/data/GroupDataManagerTCK.java
@@ -16,6 +16,7 @@
 package org.commonjava.indy.core.data;
 
 import static java.util.Arrays.asList;
+import static org.commonjava.indy.model.core.StoreType.hosted;
 import static org.commonjava.indy.model.core.StoreType.remote;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_MAVEN;
 import static org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor.MAVEN_PKG_KEY;
@@ -171,20 +172,26 @@ public abstract class GroupDataManagerTCK
     {
         final StoreDataManager manager = getFixtureProvider().getDataManager();
 
-        final Group grp =
-            new Group( "test", new StoreKey( remote, "repo2" ), new StoreKey( remote, "central" ) );
+        manager.storeArtifactStore( new HostedRepository("pnc-builds"), summary, false, false, new EventMetadata() );
 
-        store( grp );
+        final Group subGrp = new Group( "subGroup", new StoreKey( hosted, "pnc-builds" ) );
+
+        final Group grp =
+            new Group( "test",  subGrp.getKey(), new StoreKey( remote, "repo2" ), new StoreKey( remote, "central" ) );
+
+        store( grp, subGrp );
 
         final List<ArtifactStore> repos = manager.query().getOrderedConcreteStoresInGroup( MAVEN_PKG_KEY, grp.getName() );
 
         assertThat( repos, notNullValue() );
-        assertThat( repos.size(), equalTo( 2 ) );
+        assertThat( repos.size(), equalTo( 3 ) );
 
         assertThat( repos.get( 0 )
-                         .getName(), equalTo( "repo2" ) );
+                         .getName(), equalTo( "pnc-builds" ) );
         assertThat( repos.get( 1 )
-                         .getName(), equalTo( "central" ) );
+                         .getName(), equalTo( "repo2" ) );
+        assertThat( repos.get( 2 )
+                .getName(), equalTo( "central" ) );
     }
 
     @Test


### PR DESCRIPTION
When checking the issue MMENG-2055, we found that the order of members of the group is not the ones as expected, Indy returns the non-group ones as first. for example: if the group `A` contains 1. `group_pnc-builds` and 2. `remote_mrrc-ga`, it should return the members in group `pnc-builds` first and then `remote_mrrc-ga`. Instead it returns the remote first and then the ones under group `pnc-builds`. The PR aims to fix it, recursing the group and adding its member first and then repeat the operation against next element. 

More details see: https://issues.redhat.com/browse/MMENG-2055