### PR TITLE
Enable RESET of metrics via REST. Improve latency pause calc for tracing

### DIFF
--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -63,6 +63,8 @@ import java.util.function.Supplier;
 
 import static java.lang.Thread.sleep;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.commonjava.indy.IndyRequestConstants.TRANSFER_SIZE;
+import static org.commonjava.o11yphant.trace.TraceManager.addFieldToActiveSpan;
 
 @ApplicationScoped
 @NPMContentHandler
@@ -110,6 +112,7 @@ public class NPMContentAccessHandler
         {
             // store the transfer of new request package.json
             final Transfer metadataFile = contentController.store( sk, path, request.getInputStream(), eventMetadata );
+            addFieldToActiveSpan( TRANSFER_SIZE, metadataFile.length() );
 
             // generate its relevant files from the metadata file package.json
             List<Transfer> generated = generateNPMContentsFromTransfer( metadataFile, eventMetadata );
@@ -353,6 +356,7 @@ public class NPMContentAccessHandler
                         // open the stream here to prevent deletion while waiting for the transfer back to the user to start...
                         InputStream in = openInputStreamSafe( item, eventMetadata );
 
+                        addFieldToActiveSpan( TRANSFER_SIZE, item.length() );
                         final Response.ResponseBuilder builder =
                                 Response.ok( new TransferStreamingOutput( in, metricsManager, metricsConfig ) );
 

--- a/addons/sli/src/main/java/org/commonjava/indy/sli/metrics/IndyGoldenSignalsMetricSetProvider.java
+++ b/addons/sli/src/main/java/org/commonjava/indy/sli/metrics/IndyGoldenSignalsMetricSetProvider.java
@@ -39,4 +39,10 @@ public class IndyGoldenSignalsMetricSetProvider
     {
         return "sli.golden";
     }
+
+    @Override
+    public void reset()
+    {
+        metricSet.reset();
+    }
 }

--- a/api/src/main/java/org/commonjava/indy/conf/InternalFeatureConfig.java
+++ b/api/src/main/java/org/commonjava/indy/conf/InternalFeatureConfig.java
@@ -35,9 +35,22 @@ public class InternalFeatureConfig implements IndyConfigInfo {
 
     private Boolean fileChangeTracking;
 
+    private Boolean testFeatures;
+
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     public InternalFeatureConfig() {
+    }
+
+    public Boolean getTestFeatures()
+    {
+        return testFeatures;
+    }
+
+    @ConfigName( "test.features.enabled" )
+    public void setTestFeatures( Boolean testFeatures )
+    {
+        this.testFeatures = testFeatures;
     }
 
     public Boolean getFileChangeTracking()

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
@@ -40,8 +40,8 @@ import static org.commonjava.o11yphant.metrics.MetricsConstants.METER;
 import static org.commonjava.o11yphant.metrics.RequestContextConstants.RAW_IO_WRITE_NANOS;
 import static org.commonjava.o11yphant.metrics.util.NameUtils.getDefaultName;
 import static org.commonjava.o11yphant.metrics.util.NameUtils.getName;
-import static org.commonjava.o11yphant.trace.TraceManager.addFieldToActiveSpan;
 import static org.commonjava.o11yphant.trace.TraceManager.getActiveSpan;
+import static org.commonjava.o11yphant.trace.TracingConstants.LATENCY_TIMER_PAUSE_KEY;
 
 public class TransferStreamingOutput
     implements StreamingOutput
@@ -105,6 +105,10 @@ public class TransferStreamingOutput
             RequestContextHelper.setContext( RAW_IO_WRITE_NANOS, end - start );
 
             double elapsed = (end-start)/NANOS_PER_SEC;
+
+            TraceManager.getActiveSpan()
+                        .ifPresent( s -> s.setInProgressField( LATENCY_TIMER_PAUSE_KEY,
+                                                               s.getInProgressField( LATENCY_TIMER_PAUSE_KEY, 0.0 ) + (end-start) ) );
 
             String rateName = getName( metricsConfig.getNodePrefix(), TRANSFER_METRIC_NAME + WRITE_SPEED,
                                        getDefaultName( TransferStreamingOutput.class, WRITE_SPEED ), METER );

--- a/core/src/main/conf/conf.d/internal-features.conf
+++ b/core/src/main/conf/conf.d/internal-features.conf
@@ -2,3 +2,10 @@
 # By default, we disable ArtifactStore validation when repos are stored / updated. This is a feature flag for that
 # behavior, and we'll change this value when we change the default value in the InternalFeatureConfig class.
 #store.validation.enabled=false
+
+# By default, tracking of changed files (for auditing or backup assistance purposes) is disabled
+#file.change.tracking.enabled=false
+
+# By default, we disable test features like metrics reset, which are only useful when conducting long-running test
+# scenarios.
+#test.features.enabled=false

--- a/core/src/main/resources/default-internal-features.conf
+++ b/core/src/main/resources/default-internal-features.conf
@@ -2,3 +2,10 @@
 # By default, we disable ArtifactStore validation when repos are stored / updated. This is a feature flag for that
 # behavior, and we'll change this value when we change the default value in the InternalFeatureConfig class.
 #store.validation.enabled=false
+
+# By default, tracking of changed files (for auditing or backup assistance purposes) is disabled
+#file.change.tracking.enabled=false
+
+# By default, we disable test features like metrics reset, which are only useful when conducting long-running test
+# scenarios.
+#test.features.enabled=false

--- a/models/core-java/src/main/java/org/commonjava/indy/IndyRequestConstants.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/IndyRequestConstants.java
@@ -22,4 +22,6 @@ public final class IndyRequestConstants
 
     public static final String HEADER_COMPONENT_ID = "component-id";
 
+    public static final String TRANSFER_SIZE = "transfer-size";
+
 }

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/CacheProducer.java
@@ -403,7 +403,9 @@ public class CacheProducer
 
     private String getCacheMetricPrefix( String named )
     {
-        return metricsManager == null ? null : getSupername( metricsConfig.getNodePrefix(), INDY_METRIC_ISPN, named );
+        String prefix = metricsManager == null ? null : getSupername( metricsConfig.getNodePrefix(), INDY_METRIC_ISPN, named );
+        logger.trace( "Cache prefix for: '{}' is: '{}'", named, prefix );
+        return prefix;
     }
 
     public synchronized Configuration getCacheConfiguration( String name )

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCheckRegistrySet.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCheckRegistrySet.java
@@ -92,8 +92,9 @@ public class IspnCheckRegistrySet
     @Override
     public Map<String, Metric> getMetrics()
     {
-        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+        final Map<String, Metric> gauges = new HashMap<>();
         Set<String> names = cacheManager.getCacheNames();
+        logger.trace( "Finding metrics related to Infinispan caches: {}", names );
         names.forEach( n ->
            {
                Cache<Object, Object> cache = cacheManager.getCache( n );
@@ -197,7 +198,14 @@ public class IspnCheckRegistrySet
                }
            } );
 
+        logger.trace( "Got ISPN cache gauges: {}", gauges.keySet() );
         return gauges;
+    }
+
+    @Override
+    public void reset()
+    {
+        // No-op
     }
 
     private <T> T noExceptions( final Supplier<T> task )

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
@@ -29,6 +29,7 @@ import org.commonjava.indy.bind.jaxrs.util.DeploymentInfoUtils;
 import org.commonjava.indy.bind.jaxrs.util.RequestScopeListener;
 import org.commonjava.indy.conf.UIConfiguration;
 import org.commonjava.indy.stats.IndyVersioning;
+import org.commonjava.indy.subsys.honeycomb.TraceManagerProducer;
 import org.commonjava.o11yphant.metrics.GoldenSignalsFilter;
 import org.commonjava.o11yphant.trace.servlet.TraceFilter;
 import org.jboss.resteasy.plugins.server.servlet.HttpServlet30Dispatcher;
@@ -85,6 +86,10 @@ public class IndyDeployment
 
     @Inject
     private TraceFilter traceFilter;
+
+    // Adding to ensure it gets initialized
+    @Inject
+    private TraceManagerProducer traceManagerProducer;
 
     @Inject
     private GoldenSignalsFilter goldenSignalsFilter;

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/TestAdminResource.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/TestAdminResource.java
@@ -1,0 +1,36 @@
+package org.commonjava.indy.bind.jaxrs;
+
+import org.commonjava.indy.conf.InternalFeatureConfig;
+import org.commonjava.o11yphant.metrics.MetricsManager;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+@ApplicationScoped
+@Path( "/api/admin/test" )
+public class TestAdminResource
+                implements IndyResources
+{
+    @Inject
+    private MetricsManager metricsManager;
+
+    @Inject
+    private InternalFeatureConfig internalFeatureConfig;
+
+    @Path( "metrics/reset" )
+    @POST
+    public Response resetMetrics()
+    {
+        if ( internalFeatureConfig.getTestFeatures() != Boolean.TRUE )
+        {
+            return Response.notModified().build();
+        }
+
+        metricsManager.reset();
+        return Response.ok().build();
+    }
+
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ThreadContextFilter.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ThreadContextFilter.java
@@ -16,31 +16,20 @@
 package org.commonjava.indy.bind.jaxrs;
 
 import org.commonjava.cdi.util.weft.ThreadContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-
-import static org.commonjava.indy.util.RequestContextHelper.X_FORWARDED_FOR;
 
 @ApplicationScoped
 public class ThreadContextFilter
         implements Filter
 {
-    @Inject
-    private MDCManager mdcManager;
-
-    private final Logger logger = LoggerFactory.getLogger( getClass() );
-
     @Override
     public void init( final FilterConfig filterConfig )
             throws ServletException
@@ -56,28 +45,11 @@ public class ThreadContextFilter
             ThreadContext.clearContext();
             ThreadContext.getContext( true );
 
-            if ( request instanceof HttpServletRequest )
-            {
-                HttpServletRequest hsr = (HttpServletRequest) request;
-
-                String clientAddr = request.getRemoteAddr();
-                final String xForwardFor = hsr.getHeader( X_FORWARDED_FOR );
-                if ( xForwardFor != null )
-                {
-                    clientAddr = xForwardFor; // OSE proxy use HTTP header 'x-forwarded-for' to represent user IP
-                }
-
-                mdcManager.putUserIP( clientAddr );
-                mdcManager.putExtraHeaders( hsr );
-                mdcManager.putRequestIDs( hsr );
-            }
-
             chain.doFilter( request, response );
         }
         finally
         {
             ThreadContext.clearContext();
-            mdcManager.clear();
         }
     }
 

--- a/subsys/trace/src/main/java/org/commonjava/indy/subsys/honeycomb/TraceManagerProducer.java
+++ b/subsys/trace/src/main/java/org/commonjava/indy/subsys/honeycomb/TraceManagerProducer.java
@@ -110,6 +110,8 @@ public class TraceManagerProducer
         {
             rsfInstance.forEach( result::add );
         }
+
+        logger.trace( "Adding root-span field injectors: {}", result );
         return result;
     }
 }


### PR DESCRIPTION
This provides a feature for testing, which when enabled will allow us to reset metrics on the running Indy instance, without rebooting. That will be useful when paired with the new statistical performance regression testing code elsewhere, so we can extract metrics that pertain ONLY to the test we just executed, and not require any external infrastructure for storing it.

I've also improved the latency-pause calculation, to remove file transfer times from upload / download actions from the overall latency we log in our traces. This should help us focus more on the in-code latency, and reduce noise from network sources, upstream servers, or downstream clients. 