### PR TITLE
Fix the url mapping for slashTolerationFilter

### DIFF
--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
@@ -205,7 +205,7 @@ public class IndyDeployment
 
                                                       .addFilter( slashTolerationFilter )
                                                       .addFilterUrlMapping( slashTolerationFilter.getName(),
-                                                                            "//*", DispatcherType.REQUEST )
+                                                                            "/api/*", DispatcherType.REQUEST )
 
                                                       .addServlet( resteasyServlet )
 


### PR DESCRIPTION
After checking the indy logs on prod, there were still request with double slash coming, that means this filter does not work. I debugged it locally, found it's caused by the url mapping config. I updated it to `/api/*` instead, or we may use `/*`. 