### PR TITLE
Fix: Add missing digisting metadata files to merger

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/ArchetypeCatalogGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/ArchetypeCatalogGenerator.java
@@ -55,6 +55,9 @@ public class ArchetypeCatalogGenerator
             add( ArchetypeCatalogMerger.CATALOG_NAME );
             add( ArchetypeCatalogMerger.CATALOG_MD5_NAME );
             add( ArchetypeCatalogMerger.CATALOG_SHA_NAME );
+            add( ArchetypeCatalogMerger.CATALOG_SHA256_NAME );
+            add( ArchetypeCatalogMerger.CATALOG_SHA384_NAME );
+            add( ArchetypeCatalogMerger.CATALOG_SHA512_NAME );
         }
 
         private static final long serialVersionUID = 1L;

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -142,6 +142,8 @@ public class MavenMetadataGenerator
             add( MavenMetadataMerger.METADATA_MD5_NAME );
             add( MavenMetadataMerger.METADATA_SHA_NAME );
             add( MavenMetadataMerger.METADATA_SHA256_NAME );
+            add( MavenMetadataMerger.METADATA_SHA384_NAME );
+            add( MavenMetadataMerger.METADATA_SHA512_NAME );
         }
 
         private static final long serialVersionUID = 1L;

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/ArchetypeCatalogMerger.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/ArchetypeCatalogMerger.java
@@ -36,6 +36,7 @@ import java.util.Set;
 
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.indy.util.LocationUtils.getKey;
+import static org.commonjava.maven.galley.io.checksum.ChecksumAlgorithm.*;
 
 @javax.enterprise.context.ApplicationScoped
 public class ArchetypeCatalogMerger
@@ -45,9 +46,15 @@ public class ArchetypeCatalogMerger
 
     public static final String CATALOG_MERGEINFO_SUFFIX = ".info";
 
-    public static final String CATALOG_SHA_NAME = CATALOG_NAME + ".sha1";
+    public static final String CATALOG_SHA_NAME = CATALOG_NAME + SHA1.getExtension();
 
-    public static final String CATALOG_MD5_NAME = CATALOG_NAME + ".md5";
+    public static final String CATALOG_SHA256_NAME = CATALOG_NAME + SHA256.getExtension();
+
+    public static final String CATALOG_SHA384_NAME = CATALOG_NAME + SHA384.getExtension();
+
+    public static final String CATALOG_SHA512_NAME = CATALOG_NAME + SHA512.getExtension();
+
+    public static final String CATALOG_MD5_NAME = CATALOG_NAME + MD5.getExtension();
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
@@ -58,7 +65,7 @@ public class ArchetypeCatalogMerger
         final FileReader fr = null;
         boolean merged = false;
 
-        final Set<String> seen = new HashSet<String>();
+        final Set<String> seen = new HashSet<>();
         for ( final Transfer src : sources )
         {
             try(InputStream stream = src.openInputStream())

--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMerger.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/group/MavenMetadataMerger.java
@@ -26,7 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -34,6 +33,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.commonjava.atlas.maven.ident.util.SnapshotUtils.LOCAL_SNAPSHOT_VERSION_PART;
+import static org.commonjava.maven.galley.io.checksum.ChecksumAlgorithm.*;
 
 @ApplicationScoped
 public class MavenMetadataMerger
@@ -59,11 +59,15 @@ public class MavenMetadataMerger
 
     public static final String METADATA_NAME = "maven-metadata.xml";
 
-    public static final String METADATA_SHA_NAME = METADATA_NAME + ".sha1";
+    public static final String METADATA_SHA_NAME = METADATA_NAME + SHA1.getExtension();
 
-    public static final String METADATA_SHA256_NAME = METADATA_NAME + ".sha256";
+    public static final String METADATA_SHA256_NAME = METADATA_NAME + SHA256.getExtension();
 
-    public static final String METADATA_MD5_NAME = METADATA_NAME + ".md5";
+    public static final String METADATA_SHA384_NAME = METADATA_NAME + SHA384.getExtension();
+
+    public static final String METADATA_SHA512_NAME = METADATA_NAME + SHA512.getExtension();
+
+    public static final String METADATA_MD5_NAME = METADATA_NAME + MD5.getExtension();
 
     public Metadata merge( final Metadata master, final Metadata src, final Group group, final String path )
     {


### PR DESCRIPTION
    Seems the archetype-catalog and maven-metadata merger missed some
    type of the digesting files on group level merging.