### PR TITLE
Revert Galley to 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.1</atlasVersion>
-    <galleyVersion>1.7-SNAPSHOT</galleyVersion>
+    <galleyVersion>1.6</galleyVersion>
     <bomVersion>25</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <partylineVersion>1.16</partylineVersion>


### PR DESCRIPTION
Galley 1.7-snapshot has a serious bug which cause files loss. The calculation of timeout has problem which return true for any files.