### PR TITLE
Use the name of the StoreType to do hashcode

### DIFF
--- a/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
+++ b/models/core-java/src/main/java/org/commonjava/indy/model/core/StoreKey.java
@@ -90,7 +90,7 @@ public final class StoreKey
         int result = 1;
         result = prime * result + ( ( packageType == null ) ? 7 : packageType.hashCode() );
         result = prime * result + ( ( name == null ) ? 13 : name.hashCode() );
-        result = prime * result + ( ( type == null ) ? 17 : type.hashCode() );
+        result = prime * result + ( ( type == null ) ? 17 : type.name().hashCode() );
         return result;
     }
 


### PR DESCRIPTION
The following logs are from stage, which shows two transfers with the same uri and path but different hashcode, that causes the duplicated download jobs for the same transfer, let's use the name of StoreType to do hashcode instead.
```
Transfer uri: https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/
Transfer path: glob/-/glob-7.1.6.tgz
Transfer hashCode: 1913094049
----------------
Transfer uri: https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/
Transfer path: glob/-/glob-7.1.6.tgz
Transfer hashCode: 159836173
```