### PR TITLE
Fix: Upgrade jsoup to 1.14.2 by CVE warning

### DIFF
--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/content/NPMPackageMaskingTransferDecorator.java
@@ -39,7 +39,7 @@ import static org.commonjava.indy.content.ContentManager.ENTRY_POINT_BASE_URI;
 import static org.commonjava.indy.pkg.PackageTypeConstants.PKG_TYPE_NPM;
 import static org.commonjava.indy.pkg.npm.content.DecoratorUtils.updatePackageJson;
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_METADATA_NAME;
-import static org.jsoup.helper.StringUtil.isBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @ApplicationScoped
 public class NPMPackageMaskingTransferDecorator

--- a/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
+++ b/core/src/main/java/org/commonjava/indy/core/ctl/ContentController.java
@@ -63,7 +63,7 @@ import java.util.regex.Pattern;
 import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.maven.galley.util.PathUtils.normalize;
 import static org.commonjava.maven.galley.util.PathUtils.parentPath;
-import static org.jsoup.helper.StringUtil.isBlank;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @ApplicationScoped
 public class ContentController

--- a/pom.xml
+++ b/pom.xml
@@ -1474,7 +1474,7 @@
       <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
-        <version>1.8.3</version>
+        <version>1.14.2</version>
       </dependency>
 
       <!--


### PR DESCRIPTION
   And change some jsoup isBlank refer to commons-lang3 as jsoup should
   only be used in ftests module
   See: https://github.com/Commonjava/indy/security/dependabot/pom.xml/org.jsoup:jsoup/open