### PR TITLE
Fix: Upgrade undertow to 2.1.8 for CVE warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <gsonVersion>2.8.2</gsonVersion>
     <hibernateVersion>5.8.1.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>
-    <undertowVersion>2.1.0.Final</undertowVersion>
+    <undertowVersion>2.1.8.Final</undertowVersion>
     <xnioVersion>3.8.0.Final</xnioVersion>
     <keycloakVersion>7.0.1</keycloakVersion>
     <bouncycastleVersion>1.64</bouncycastleVersion>


### PR DESCRIPTION
https://github.com/Commonjava/indy/security/dependabot/pom.xml/io.undertow:undertow-core/open