### PR TITLE
Fix: remove jdom deps due to CVE warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1461,17 +1461,6 @@
       </dependency>
       
       <dependency>
-        <groupId>org.jdom</groupId>
-        <artifactId>jdom</artifactId>
-        <version>1.1.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.maven</groupId>
-        <artifactId>maven-model-jdom-support</artifactId>
-        <version>3.0.x-1.2</version>
-      </dependency>
-      
-      <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
         <version>1.14.2</version>


### PR DESCRIPTION
https://github.com/Commonjava/indy/security/dependabot/pom.xml/org.jdom:jdom/open
Seems we don't need this jdom in our code.
