### PR TITLE
[ui] not call StoreDisableSvc.setDisabledMap when listing repos

### DIFF
--- a/uis/layover/app/js/controllers.js
+++ b/uis/layover/app/js/controllers.js
@@ -46,7 +46,7 @@ indyControllers.controller('NavCtl', ['$scope', function($scope){
 indyControllers.controller('RemoteListCtl', ['$scope', '$location', 'RemoteSvc', 'StoreUtilSvc', 'ControlSvc', 'StoreDisableSvc', function($scope, $location, RemoteSvc, StoreUtilSvc, ControlSvc, StoreDisableSvc) {
     ControlSvc.addListingControlHrefs($scope, $location);
   
-    StoreDisableSvc.setDisabledMap($scope);
+    //StoreDisableSvc.setDisabledMap($scope);
 
     $scope.remoteOptionLegend = StoreUtilSvc.remoteOptionLegend();
     $scope.packageType = packageType($location.$$path);
@@ -147,7 +147,7 @@ indyControllers.controller('RemoteCtl', ['$scope', '$routeParams', '$location', 
 indyControllers.controller('HostedListCtl', ['$scope', '$location', 'HostedSvc', 'StoreUtilSvc', 'ControlSvc', 'StoreDisableSvc', function($scope, $location, HostedSvc, StoreUtilSvc, ControlSvc, StoreDisableSvc) {
     ControlSvc.addListingControlHrefs($scope, $location);
     
-    StoreDisableSvc.setDisabledMap($scope);
+    //StoreDisableSvc.setDisabledMap($scope);
 
     $scope.hostedOptionLegend = StoreUtilSvc.hostedOptionLegend();
     $scope.packageType = packageType($location.$$path);
@@ -231,7 +231,7 @@ indyControllers.controller('HostedCtl', ['$scope', '$routeParams', '$location', 
 
 indyControllers.controller('GroupListCtl', ['$q', '$scope', '$location', 'GroupSvc', 'StoreUtilSvc', 'ControlSvc', 'StoreDisableSvc', 'AllStoreDisableSvc', 'PackageTypeSvc', function($q, $scope, $location, GroupSvc, StoreUtilSvc, ControlSvc, StoreDisableSvc, AllStoreDisableSvc, PackageTypeSvc) {
     ControlSvc.addListingControlHrefs($scope, $location);
-    StoreDisableSvc.setDisabledMap($scope);
+    //StoreDisableSvc.setDisabledMap($scope);
 
     $scope.packageType = packageType($location.$$path);
     $scope.listing = GroupSvc.resource.query({packageType: $scope.packageType}, function(listing){

--- a/uis/layover/app/partials/group-list.html
+++ b/uis/layover/app/partials/group-list.html
@@ -41,8 +41,11 @@
         <div ng-repeat="store in listing.items | filter:query | orderBy:orderProp" class="list-item store-listing-item listing-item-start">
 					<div class="fieldset-caption">
 					    <a href="#/group/{{store.packageType}}/view/{{store.name}}">
+                            <span class="enabled-store">{{store.packageType}}-{{store.name}}</span>
+<!--
                             <span class="enabled-store" ng-if="!isDisabled(store.key)">{{store.packageType}}-{{store.name}}</span>
                             <span class="disabled-store" ng-if="isDisabled(store.key)">{{store.packageType}}-{{store.name}}</span>
+-->
                         </a>
 					</div>
 					<div class="fieldset">
@@ -67,8 +70,11 @@
 					      <ol ng-if="store.display" class="content-panel item-expanded subsection">
 					        <li ng-repeat="item in store.constituents">
 					          <a href="#/{{item.type}}/{{item.packageType}}/view/{{item.name}}">
+                                  <span class="enabled-store">{{item.key}}</span>
+<!--
                                   <span class="enabled-store" ng-if="!isDisabled(item.key)">{{item.key}}</span>
                                   <span class="disabled-store" ng-if="isDisabled(item.key)">{{item.key}}</span>
+-->
                               </a>
 					          <div ng-if="item.type == 'remote'" class="subfields">
 					           <span class="description field">(Remote URL: <a target="_new" href="{{item.storeHref}}">{{item.storeHref}}</a>)</span>

--- a/uis/layover/app/partials/hosted-list.html
+++ b/uis/layover/app/partials/hosted-list.html
@@ -51,8 +51,11 @@
         <div ng-repeat="store in listing.items | filter:query | orderBy:orderProp" class="listing-item list-item store-listing-item listing-item-start">
           <div class="fieldset-caption">
               <a href="#/hosted/{{store.packageType}}/view/{{store.name}}">
+                  <span class="enabled-store">{{store.packageType}}-{{store.name}}</span>
+<!--
                   <span class="enabled-store" ng-if="!isDisabled(store.key)">{{store.packageType}}-{{store.name}}</span>
                   <span class="disabled-store" ng-if="isDisabled(store.key)">{{store.packageType}}-{{store.name}}</span>
+-->
               </a>
           </div>
           <div class="fieldset">

--- a/uis/layover/app/partials/remote-list.html
+++ b/uis/layover/app/partials/remote-list.html
@@ -50,8 +50,11 @@
         <div ng-repeat="store in listing.items | filter:query | orderBy:orderProp" class="listing-item list-item store-listing-item listing-item-start">
           <div class="fieldset-caption">
               <a href="#/remote/{{store.packageType}}/view/{{store.name}}">
+                  <span class="enabled-store">{{store.packageType}}-{{store.name}}</span>
+<!--
                   <span class="enabled-store" ng-if="!isDisabled(store.key)">{{store.packageType}}-{{store.name}}</span>
                   <span class="disabled-store" ng-if="isDisabled(store.key)">{{store.packageType}}-{{store.name}}</span>
+-->
               </a>
           </div>
           <div class="fieldset two-col">


### PR DESCRIPTION
When listing repos on UI, it wants to get disabled stores so to show them by different style. 
However it calls SchedulerController.getDisabledStores which in turn calls 
`// TODO: This seems REALLY inefficient...
storeDataManager.getAllArtifactStores().forEach( (store)->{`  
As the old comment says, this is very slow, especially when we have huge numbers of repos. 
This pr disables it from UI. Until we fix the slowness, we have to disable this tiny UI feature, which costs a lot.
I tested on local, the listing is Ok.