### PR TITLE
Include the content stored in group into folo track

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/change/FoloTrackingListener.java
@@ -104,13 +104,13 @@ public class FoloTrackingListener
         try
         {
             final KeyedLocation keyedLocation = (KeyedLocation) location;
-            if ( !foloConfig.isGroupContentTracked() && keyedLocation.getKey().getType() == group )
+            /*if ( !foloConfig.isGroupContentTracked() && keyedLocation.getKey().getType() == group )
             {
                 logger.trace(
                         "NOT tracking content stored directly in group: {}. This content is generally aggregated metadata, and can be recalculated. Groups may not be stable in some build environments",
                         keyedLocation.getKey() );
                 return;
-            }
+            }*/
 
             logger.trace( "Tracking report: {} += {} in {} (DOWNLOAD)", trackingKey, transfer.getPath(),
                           keyedLocation.getKey() );
@@ -164,13 +164,13 @@ public class FoloTrackingListener
             logger.trace( "Invalid transfer source location: {}. Not recording.", location );
             return;
         }
-        else if ( !foloConfig.isGroupContentTracked() && ( (KeyedLocation) location ).getKey().getType() == group )
+        /*else if ( !foloConfig.isGroupContentTracked() && ( (KeyedLocation) location ).getKey().getType() == group )
         {
             logger.trace(
                     "NOT tracking content stored directly in group: {}. This content is generally aggregated metadata, and can be recalculated. Groups may not be stable in some build environments",
                     ( (KeyedLocation) location ).getKey() );
             return;
-        }
+        }*/
 
 
         final TransferOperation op = event.getType();

--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/GroupMetadataExcludedFromTrackingReportTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/content/GroupMetadataExcludedFromTrackingReportTest.java
@@ -64,7 +64,7 @@ public class GroupMetadataExcludedFromTrackingReportTest
                 client.module( IndyFoloAdminClientModule.class ).getTrackingReport( trackingId );
 
         Set<TrackedContentEntryDTO> downloads = trackingReport.getDownloads();
-        assertThat( downloads == null || downloads.isEmpty(), equalTo( true ) );
+        assertThat( downloads == null || downloads.isEmpty(), equalTo( false ) );
     }
 
 }


### PR DESCRIPTION
As the discussion on https://issues.redhat.com/browse/MMENG-2386, looks it does not matter to track the content which stored directly in group, even it's generally aggregated metadata. Let's remove this checker for both download and upload. 