### PR TITLE
Fix Cassandra store manager toArtifactStore pathstyle missing issue

### DIFF
--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
@@ -24,6 +24,7 @@ import org.commonjava.indy.model.core.AbstractRepository;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
+import org.commonjava.indy.model.core.PathStyle;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
@@ -412,6 +413,7 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
             store.setPathMaskPatterns( dtxArtifactStore.getPathMaskPatterns() );
             store.setDisableTimeout( dtxArtifactStore.getDisableTimeout() );
             store.setAuthoritativeIndex( dtxArtifactStore.getAuthoritativeIndex() );
+            store.setPathStyle( PathStyle.valueOf( dtxArtifactStore.getPathStyle() ) );
         }
         return store;
     }

--- a/models/core-java/src/test/java/org/commonjava/indy/model/model/RemoteRepositoryTest.java
+++ b/models/core-java/src/test/java/org/commonjava/indy/model/model/RemoteRepositoryTest.java
@@ -22,12 +22,14 @@ import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
 import java.util.stream.Stream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -59,6 +61,23 @@ public class RemoteRepositoryTest
         String json = new IndyObjectMapper( true ).writeValueAsString( remote );
 
         System.out.println( json );
+    }
+
+    @Test
+    public void serializeRemoteWithPathStyle() throws IOException
+    {
+        RemoteRepository remote = new RemoteRepository( "generic-http", "test", "http://test.com/repo" );
+        remote.setPathStyle( PathStyle.hashed );
+        IndyObjectMapper mapper = new IndyObjectMapper( true );
+        mapper.init();
+
+        String json = mapper.writeValueAsString( remote );
+
+        System.out.println( json );
+
+        RemoteRepository ret = mapper.readValue( json.getBytes(), RemoteRepository.class );
+        System.out.println( ret.getPathStyle() );
+        assertTrue( ret.getPathStyle() == PathStyle.hashed );
     }
 
     @Test


### PR DESCRIPTION
The pathstyle is missing which caused the hashed path 404 issue.