### PR TITLE
Update frontend plugin to 1.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2014,7 +2014,7 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>1.1</version>
+          <version>1.11.0</version>
 
           <configuration>
             <workingDirectory>./</workingDirectory>


### PR DESCRIPTION
Apple M1 env need this version >= 1.11.0 in order to pass the mvn build.