### PR TITLE
Change No transfer to digest to Warn message

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
@@ -123,7 +123,7 @@ public class DefaultContentDigester
         final Transfer transfer = directContentAccess.getTransfer( key, path );
         if ( transfer == null || !transfer.exists() )
         {
-            logger.error( "No transfer to digest, store: {}, path: {}, transfer: {}", key, path, transfer );
+            logger.warn( "No transfer to digest, store: {}, path: {}, transfer: {}", key, path, transfer );
             return new TransferMetadata( Collections.emptyMap(), 0L );
         }
 


### PR DESCRIPTION
When Indy try to get .sha1 files from a group, it will try many places and print "No transfer to digest" err when file not found. This is actually an Info or Warn. To be safe (not to hide other maybe-important cases), we can just use Warn here.