### PR TITLE
Add store_effect to cassandra folo primary keys

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/DtxTrackingRecord.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/DtxTrackingRecord.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.folo.data;
 
 
 import com.datastax.driver.core.Row;
+import com.datastax.driver.mapping.annotations.ClusteringColumn;
 import com.datastax.driver.mapping.annotations.Column;
 import com.datastax.driver.mapping.annotations.PartitionKey;
 import com.datastax.driver.mapping.annotations.Table;
@@ -36,7 +37,6 @@ public class DtxTrackingRecord {
     private final static Boolean SEALED = true;
     private final static Boolean IN_PROGRESS = false;
 
-
     @PartitionKey(0)
     @Column(name = "tracking_key")
     String trackingKey;
@@ -50,7 +50,7 @@ public class DtxTrackingRecord {
     @Column(name = "access_channel")
     String  accessChannel;
 
-    @PartitionKey(1)
+    @ClusteringColumn
     @Column(name = "path")
     String  path;
 
@@ -60,6 +60,7 @@ public class DtxTrackingRecord {
     @Column(name = "local_url")
     String localUrl;
 
+    @ClusteringColumn
     @Column(name = "store_effect")
     String storeEffect;
 

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
@@ -70,10 +70,11 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
     private PreparedStatement getTrackingRecordsByTrackingKey;
     private PreparedStatement isTrackingRecordExist;
 
+    private static final String TABLE_NAME = "records2"; // Change from records to records2 due to primary key change
 
     private static String createFoloRecordsTable( String keyspace )
     {
-        return "CREATE TABLE IF NOT EXISTS " + keyspace + ".records ("
+        return "CREATE TABLE IF NOT EXISTS " + keyspace + "." + TABLE_NAME + " ("
                 + "tracking_key text,"
                 + "sealed boolean,"
                 + "store_key text,"
@@ -88,7 +89,7 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
                 + "size bigint,"
                 + "started bigint," // started timestamp *
                 + "timestamps set<bigint>,"
-                + "PRIMARY KEY ((tracking_key),path)"
+                + "PRIMARY KEY ((tracking_key),path,store_effect)"
                 + ");";
     }
 
@@ -107,15 +108,15 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
         trackingMapper = mappingManager.mapper(DtxTrackingRecord.class,foloCassandraKeyspace);
 
         getTrackingRecordByBuildIdAndPath =
-                session.prepare("SELECT * FROM " + foloCassandraKeyspace + ".records WHERE tracking_key=? AND path=?;");
+                session.prepare("SELECT * FROM " + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=? AND path=? AND store_effect=?;");
         getTrackingKeys =
-                session.prepare("SELECT distinct tracking_key FROM " +  foloCassandraKeyspace + ".records;");
+                session.prepare("SELECT distinct tracking_key FROM " +  foloCassandraKeyspace + "." + TABLE_NAME + ";");
 
         getTrackingRecordsByTrackingKey =
-                session.prepare("SELECT * FROM "  + foloCassandraKeyspace + ".records WHERE tracking_key=?;");
+                session.prepare("SELECT * FROM "  + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=?;");
 
         isTrackingRecordExist =
-                session.prepare("SELECT count(*) FROM "  + foloCassandraKeyspace + ".records WHERE tracking_key=?;");
+                session.prepare("SELECT count(*) FROM "  + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=?;");
 
         logger.info("-- Cassandra Folo Records Keyspace and Tables created");
     }
@@ -125,38 +126,23 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
 
         String buildId = entry.getTrackingKey().getId();
         String path = entry.getPath();
+        String effect = entry.getEffect().toString();
 
-        BoundStatement bind = getTrackingRecordByBuildIdAndPath.bind(buildId,path);
+        BoundStatement bind = getTrackingRecordByBuildIdAndPath.bind( buildId, path, effect );
         ResultSet trackingRecord = session.execute(bind);
         Row one = trackingRecord.one();
 
         if(one!=null) {
-
             DtxTrackingRecord dtxTrackingRecord = fromCassandraRow(one);
-
             Boolean state = dtxTrackingRecord.getState();
-
             if(state) {
                 throw new FoloContentException( "Tracking record: {} is already sealed!", entry.getTrackingKey() );
-            }  else {
-                DtxTrackingRecord dtxTrackingRecord1 =
-                        DtxTrackingRecord.fromTrackedContentEntry(entry,false);
-
-                if(dtxTrackingRecord.getTrackingKey().equals(dtxTrackingRecord1.getTrackingKey()) &&
-                    dtxTrackingRecord.getPath().equals(dtxTrackingRecord1.getPath())) {
-                    trackingMapper.save(dtxTrackingRecord1);
-                    return true;
-                } else {
-                    return false;
-                }
             }
-
         } else {
-
             DtxTrackingRecord dtxTrackingRecord = new DtxTrackingRecord(entry);
             trackingMapper.save(dtxTrackingRecord); //  optional Options with TTL, timestamp...
-            return true;
         }
+        return true;
     }
 
     @Override

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
@@ -65,7 +65,7 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
     private Session session;
     private Mapper<DtxTrackingRecord> trackingMapper;
 
-    private PreparedStatement getTrackingRecordByBuildIdAndPath;
+    private PreparedStatement getTrackingRecord;
     private PreparedStatement getTrackingKeys;
     private PreparedStatement getTrackingRecordsByTrackingKey;
     private PreparedStatement isTrackingRecordExist;
@@ -107,7 +107,7 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
         MappingManager mappingManager = new MappingManager(session);
         trackingMapper = mappingManager.mapper(DtxTrackingRecord.class,foloCassandraKeyspace);
 
-        getTrackingRecordByBuildIdAndPath =
+        getTrackingRecord =
                 session.prepare("SELECT * FROM " + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=? AND path=? AND store_effect=?;");
         getTrackingKeys =
                 session.prepare("SELECT distinct tracking_key FROM " +  foloCassandraKeyspace + "." + TABLE_NAME + ";");
@@ -128,7 +128,7 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
         String path = entry.getPath();
         String effect = entry.getEffect().toString();
 
-        BoundStatement bind = getTrackingRecordByBuildIdAndPath.bind( buildId, path, effect );
+        BoundStatement bind = getTrackingRecord.bind( buildId, path, effect );
         ResultSet trackingRecord = session.execute(bind);
         Row one = trackingRecord.one();
 


### PR DESCRIPTION
This is fix for [Indy is still producing partial tracking reports even though there are no restarts](https://issues.redhat.com/browse/MMENG-2546). 
We need to add the store_effect to primary key because sometimes a path appears in both DOWNLOADS and UPLOADS.