### PR TITLE
Add store_key to the cassandra folo PRIMARY keys

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/DtxTrackingRecord.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/DtxTrackingRecord.java
@@ -37,20 +37,21 @@ public class DtxTrackingRecord {
     private final static Boolean SEALED = true;
     private final static Boolean IN_PROGRESS = false;
 
-    @PartitionKey(0)
+    @PartitionKey
     @Column(name = "tracking_key")
     String trackingKey;
 
     @Column(name = "sealed")
     Boolean state;
 
+    @ClusteringColumn(0)
     @Column(name = "store_key")
     String storeKey;
 
     @Column(name = "access_channel")
     String  accessChannel;
 
-    @ClusteringColumn
+    @ClusteringColumn(1)
     @Column(name = "path")
     String  path;
 
@@ -60,7 +61,7 @@ public class DtxTrackingRecord {
     @Column(name = "local_url")
     String localUrl;
 
-    @ClusteringColumn
+    @ClusteringColumn(2)
     @Column(name = "store_effect")
     String storeEffect;
 

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
@@ -89,7 +89,7 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
                 + "size bigint,"
                 + "started bigint," // started timestamp *
                 + "timestamps set<bigint>,"
-                + "PRIMARY KEY ((tracking_key),path,store_effect)"
+                + "PRIMARY KEY ((tracking_key),store_key,path,store_effect)"
                 + ");";
     }
 
@@ -108,7 +108,7 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
         trackingMapper = mappingManager.mapper(DtxTrackingRecord.class,foloCassandraKeyspace);
 
         getTrackingRecord =
-                session.prepare("SELECT * FROM " + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=? AND path=? AND store_effect=?;");
+                session.prepare("SELECT * FROM " + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=? AND store_key=? AND path=? AND store_effect=?;");
         getTrackingKeys =
                 session.prepare("SELECT distinct tracking_key FROM " +  foloCassandraKeyspace + "." + TABLE_NAME + ";");
 
@@ -125,10 +125,11 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
     public boolean recordArtifact(TrackedContentEntry entry) throws FoloContentException, IndyWorkflowException {
 
         String buildId = entry.getTrackingKey().getId();
+        String storeKey = entry.getStoreKey().toString();
         String path = entry.getPath();
         String effect = entry.getEffect().toString();
 
-        BoundStatement bind = getTrackingRecord.bind( buildId, path, effect );
+        BoundStatement bind = getTrackingRecord.bind( buildId, storeKey, path, effect );
         ResultSet trackingRecord = session.execute(bind);
         Row one = trackingRecord.one();
 


### PR DESCRIPTION
The (path,effect) may not be good enough for the primary keys. I am not sure whether Indy will download a same path from different remote repo during a build (like pom). As build scenario is unpredictable , it is safe to add the storeKey as primary key.