### PR TITLE
Add query for legacy folo table

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloConstants.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/ctl/FoloConstants.java
@@ -24,6 +24,8 @@ public class FoloConstants
 
     public static final String ALL = "all";
 
+    public static final String LEGACY = "legacy";
+
     public enum TRACKING_TYPE
     {
         IN_PROGRESS("in_progress"),

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
@@ -67,11 +67,15 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
 
     private PreparedStatement getTrackingRecord;
     private PreparedStatement getTrackingKeys;
+    private PreparedStatement getLegacyTrackingKeys;
     private PreparedStatement getTrackingRecordsByTrackingKey;
+    private PreparedStatement getLegacyTrackingRecordsByTrackingKey;
     private PreparedStatement isTrackingRecordExist;
     private PreparedStatement deleteTrackingRecordsByTrackingKey;
 
     static final String TABLE_NAME = "records2"; // Change from records to records2 due to primary key change
+
+    static final String LEGACY_TABLE_NAME = "records";
 
     private static String createFoloRecordsTable( String keyspace )
     {
@@ -110,11 +114,18 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
 
         getTrackingRecord =
                 session.prepare("SELECT * FROM " + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=? AND store_key=? AND path=? AND store_effect=?;");
+
         getTrackingKeys =
                 session.prepare("SELECT distinct tracking_key FROM " +  foloCassandraKeyspace + "." + TABLE_NAME + ";");
 
+        getLegacyTrackingKeys =
+                session.prepare("SELECT distinct tracking_key FROM " +  foloCassandraKeyspace + "." + LEGACY_TABLE_NAME + ";");
+
         getTrackingRecordsByTrackingKey =
                 session.prepare("SELECT * FROM "  + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=?;");
+
+        getLegacyTrackingRecordsByTrackingKey =
+                session.prepare("SELECT * FROM "  + foloCassandraKeyspace + "." + LEGACY_TABLE_NAME + " WHERE tracking_key=?;");
 
         isTrackingRecordExist =
                 session.prepare("SELECT count(*) FROM "  + foloCassandraKeyspace + "." + TABLE_NAME + " WHERE tracking_key=?;");
@@ -179,7 +190,11 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
 
     @Override
     public TrackedContent get(TrackingKey key) {
-        List<DtxTrackingRecord> trackingRecords =  getDtxTrackingRecordsFromDb(key);
+        List<DtxTrackingRecord> trackingRecords = getDtxTrackingRecordsFromDb(key);
+        if (trackingRecords == null || trackingRecords.isEmpty())
+        {
+            return null;
+        }
         return transformDtxTrackingRecordToTrackingContent(key,trackingRecords);
     }
 
@@ -277,17 +292,23 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
 
     }
 
+    private List<DtxTrackingRecord>  getLegacyDtxTrackingRecordsFromDb(TrackingKey trackingKey) {
+        BoundStatement bind = getLegacyTrackingRecordsByTrackingKey.bind(trackingKey.getId());
+        ResultSet execute = session.execute(bind);
+        List<Row> rows = execute.all();
+        return fetchRecordsFromRows(rows);
+    }
+
     private List<DtxTrackingRecord>  getDtxTrackingRecordsFromDb(TrackingKey trackingKey)  {
-
-        List<DtxTrackingRecord> trackingRecords =  new ArrayList<>();
-
         BoundStatement bind = getTrackingRecordsByTrackingKey.bind(trackingKey.getId());
         ResultSet execute = session.execute(bind);
-        List<Row> allTrackingRecordsByTrackingKey = execute.all();
+        List<Row> rows = execute.all();
+        return fetchRecordsFromRows(rows);
+    }
 
-//        logger.warn("-- Fetched {} tracking  records from key {}",allTrackingRecordsByTrackingKey.size(),trackingKey);
-
-        Iterator<Row> iteratorDtxTrackingRecords = allTrackingRecordsByTrackingKey.iterator();
+    private List<DtxTrackingRecord> fetchRecordsFromRows(List<Row> rows) {
+        List<DtxTrackingRecord> trackingRecords = new ArrayList<>();
+        Iterator<Row> iteratorDtxTrackingRecords = rows.iterator();
         while (iteratorDtxTrackingRecords.hasNext()) {
             Row next = iteratorDtxTrackingRecords.next();
             DtxTrackingRecord dtxTrackingRecord = new DtxTrackingRecord();
@@ -327,8 +348,26 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
         }
     }
 
+    public TrackedContent getLegacy(TrackingKey key) {
+        List<DtxTrackingRecord> trackingRecords = getLegacyDtxTrackingRecordsFromDb(key);
+        if (trackingRecords == null || trackingRecords.isEmpty())
+        {
+            return null;
+        }
+        return transformDtxTrackingRecordToTrackingContent(key,trackingRecords);
+    }
+
+    public Set<TrackingKey> getLegacyTrackingKeys() {
+        BoundStatement statement = getLegacyTrackingKeys.bind();
+        return getTrackingKeys(statement);
+    }
+
     private Set<TrackingKey> getTrackingKeys() {
         BoundStatement statement = getTrackingKeys.bind();
+        return getTrackingKeys(statement);
+    }
+
+    private Set<TrackingKey> getTrackingKeys(BoundStatement statement) {
         ResultSet resultSet = session.execute(statement);
         List<Row> all = resultSet.all();
         Iterator<Row> iterator = all.iterator();


### PR DESCRIPTION
As suggested in JIRA, this pr is to query legacy Folo table. Two functions here: 1. get all legacy ids; 2. get legacy records by id. 

From user's perspective, the only change is "report/ids/{type}". By passing the "legacy" as the type, it will fetch the legacy ids. The api to get records by tracking-id does not change. The code will query the new table first, if not found, it will try the legacy table.
