### PR TITLE
Alway override the prev folo records

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
@@ -155,10 +155,10 @@ public class FoloRecordCassandra implements FoloRecord,StartupAction {
             if(state) {
                 throw new FoloContentException( "Tracking record: {} is already sealed!", entry.getTrackingKey() );
             }
-        } else {
-            DtxTrackingRecord dtxTrackingRecord = new DtxTrackingRecord(entry);
-            trackingMapper.save(dtxTrackingRecord); //  optional Options with TTL, timestamp...
         }
+        // Always override prev one since some builds may upload artifact more than once
+        DtxTrackingRecord dtxTrackingRecord = new DtxTrackingRecord(entry);
+        trackingMapper.save(dtxTrackingRecord); //  optional Options with TTL, timestamp...
         return true;
     }
 


### PR DESCRIPTION
Sometimes one build may upload a same artifact more than once, thus we need to always override the prev record.