### PR TITLE
Update checker before rewriting the request

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloGenericContentAccessResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloGenericContentAccessResource.java
@@ -92,7 +92,7 @@ public class FoloGenericContentAccessResource
 
     @ApiOperation( "Store and track file/artifact content under the given artifact store (type/name) and path." )
     @ApiResponses( { @ApiResponse( code=404, message = "Content is not available" ), @ApiResponse( code = 200,
-            message = "Header metadata for content (or rendered listing when path ends with '/index.html' or '/'" ), } )
+            message = "Header metadata for content" ), } )
     @HEAD
     @Path( "/{path: (.*)}" )
     public Response doHead( @ApiParam( "User-assigned tracking session key" ) @PathParam( "id" ) final String id,
@@ -111,12 +111,11 @@ public class FoloGenericContentAccessResource
 
         RequestContextHelper.setContext( CONTENT_TRACKING_ID, id );
 
-        return handler.doHead( PKG_TYPE_GENERIC_HTTP, type, name, path, cacheOnly, baseUri, request, metadata );
+        return handler.doHead( PKG_TYPE_GENERIC_HTTP, type, name, path, cacheOnly, baseUri, request, metadata, null, Boolean.FALSE );
     }
 
     @ApiOperation( "Retrieve and track file/artifact content under the given artifact store (type/name) and path." )
-    @ApiResponses( { @ApiResponse( code=404, message = "Content is not available" ), @ApiResponse( code = 200, response = String.class,
-            message = "Rendered content listing (when path ends with '/index.html' or '/')" ),
+    @ApiResponses( { @ApiResponse( code=404, message = "Content is not available" ),
             @ApiResponse( code = 200, response = StreamingOutput.class, message = "Content stream" ), } )
     @GET
     @Path( "/{path: (.*)}" )
@@ -134,7 +133,7 @@ public class FoloGenericContentAccessResource
 
         RequestContextHelper.setContext( CONTENT_TRACKING_ID, id );
 
-        return handler.doGet( PKG_TYPE_GENERIC_HTTP, type, name, path, baseUri, request, metadata );
+        return handler.doGet( PKG_TYPE_GENERIC_HTTP, type, name, path, baseUri, request, metadata, null, Boolean.FALSE );
     }
 
 }

--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/ContentAccessHandler.java
@@ -287,6 +287,13 @@ public class ContentAccessHandler
                             final Boolean cacheOnly, final String baseUri, final HttpServletRequest request,
                             EventMetadata eventMetadata, final Consumer<ResponseBuilder> builderModifier )
     {
+        return doHead( packageType, type, name, path, cacheOnly, baseUri, request, eventMetadata, builderModifier, Boolean.TRUE );
+    }
+
+    public Response doHead( final String packageType, final String type, final String name, final String path,
+                            final Boolean cacheOnly, final String baseUri, final HttpServletRequest request,
+                            EventMetadata eventMetadata, final Consumer<ResponseBuilder> builderModifier, final Boolean allowRedirect )
+    {
         setContext( PACKAGE_TYPE, packageType );
         setContext( PATH, path );
 
@@ -308,7 +315,7 @@ public class ContentAccessHandler
 
         Response response = null;
 
-        if ( isDirectoryPath( path, request ) )
+        if ( allowRedirect && isDirectoryPath( path, request ) )
         {
             response = RequestUtils.redirectContentListing( packageType, type, name, path, request, builderModifier );
         }
@@ -432,6 +439,13 @@ public class ContentAccessHandler
                            final String baseUri, final HttpServletRequest request, EventMetadata eventMetadata,
                            final Consumer<ResponseBuilder> builderModifier )
     {
+        return doGet( packageType, type, name, path, baseUri, request, eventMetadata, builderModifier, Boolean.TRUE );
+    }
+
+    public Response doGet( final String packageType, final String type, final String name, String path,
+                           final String baseUri, final HttpServletRequest request, EventMetadata eventMetadata,
+                           final Consumer<ResponseBuilder> builderModifier, final Boolean allowRedirect )
+    {
         setContext( PACKAGE_TYPE, packageType );
         setContext( PATH, path );
 
@@ -460,7 +474,7 @@ public class ContentAccessHandler
                 "GET path: '{}' (RAW: '{}')\nIn store: '{}'\nUser addMetadata header is: '{}'\nStandard addMetadata header for that is: '{}'",
                 path, request.getPathInfo(), sk, acceptInfo.getRawAccept(), standardAccept );
 
-        if ( isDirectoryPath( path, request ) )
+        if ( allowRedirect && isDirectoryPath( path, request ) )
         {
             response = RequestUtils.redirectContentListing( packageType, type, name, path, request, builderModifier );
         }


### PR DESCRIPTION
update the handler to allow generic proxy to request the content directly, that means without rewriting for cases `when path ends with '/index.html' or '/' `