### PR TITLE
Fix: avoid duplicate membering store in query

### DIFF
--- a/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
@@ -19,7 +19,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.commonjava.indy.data.ArtifactStoreQuery;
 import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.StoreDataManager;
-import org.commonjava.o11yphant.metrics.annotation.Measure;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
@@ -29,6 +28,7 @@ import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.pkg.maven.model.MavenPackageTypeDescriptor;
 import org.commonjava.indy.util.UrlInfo;
+import org.commonjava.o11yphant.metrics.annotation.Measure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -563,7 +562,7 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
             return result;
         }
 
-        Set<StoreKey> seen = new HashSet<>();
+        Set<StoreKey> seen = result.stream().map( ArtifactStore::getKey ).collect( Collectors.toSet() );
         AtomicReference<IndyDataException> errorRef = new AtomicReference<>();
 
         List<StoreKey> members = new ArrayList<>( groupRepo.getConstituents() );


### PR DESCRIPTION
   When migrating changes from indy-monolith to indy-repository-service,
   I found a change in this DefaultArtifactStoreQuery will cause a
   duplicated stores. So gave this fix to address.