### PR TITLE
Fix Cannot deserialize o.c.i.p.npm.model.License from Array value

### DIFF
--- a/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/VersionMetaReadTest.java
+++ b/addons/pkg-npm/common/src/test/java/org/commonjava/indy/pkg/npm/content/VersionMetaReadTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2011-2020 Red Hat, Inc. (https://github.com/Commonjava/indy)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.indy.pkg.npm.content;
+
+import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.pkg.npm.model.VersionMetadata;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+
+public class VersionMetaReadTest
+{
+    final IndyObjectMapper mapper = new IndyObjectMapper( true );
+
+    @Test
+    public void testNormalLicense() throws IOException {
+        try (InputStream input = this.getClass().getClassLoader().getResourceAsStream("metadata/package-2.json")) {
+            VersionMetadata versionMetadata = mapper.readValue(input, VersionMetadata.class);
+            assertTrue(versionMetadata.getLicense().getType().equals("MIT"));
+        }
+    }
+
+    @Test
+    public void testMultipleLicense() throws IOException {
+        try (InputStream input = this.getClass().getClassLoader().getResourceAsStream("metadata/pause-stream.json")) {
+            VersionMetadata versionMetadata = mapper.readValue(input, VersionMetadata.class);
+            assertTrue(versionMetadata.getLicense().getType().equals("(MIT OR Apache2)"));
+        }
+    }
+}

--- a/addons/pkg-npm/common/src/test/resources/metadata/pause-stream.json
+++ b/addons/pkg-npm/common/src/test/resources/metadata/pause-stream.json
@@ -1,0 +1,35 @@
+{
+  "name": "pause-stream",
+  "version": "0.0.11",
+  "description": "a ThroughStream that strictly buffers all readable events when paused.",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "devDependencies": {
+    "stream-tester": "0.0.2",
+    "stream-spec": "~0.2.0"
+  },
+  "scripts": {
+    "test": "node test/index.js && node test/pause-end.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/dominictarr/pause-stream.git"
+  },
+  "keywords": [
+    "stream",
+    "pipe",
+    "pause",
+    "drain",
+    "buffer"
+  ],
+  "author": "Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)",
+  "license": [
+    "MIT",
+    "Apache2"
+  ],
+  "dependencies": {
+    "through": "~2.3"
+  }
+}

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/VersionMetadata.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/VersionMetadata.java
@@ -17,8 +17,10 @@ package org.commonjava.indy.pkg.npm.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import org.commonjava.indy.pkg.npm.model.converter.ObjectToLicenseConverter;
 
 import java.io.Serializable;
 import java.util.List;
@@ -65,6 +67,7 @@ public class VersionMetadata
     @ApiModelProperty( value = "These styles are now deprecated. Instead, use SPDX expressions." )
     private List<License> licenses;
 
+    @JsonDeserialize(converter = ObjectToLicenseConverter.class)
     private License license;
 
     private Map<String, String> dependencies;

--- a/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/converter/ObjectToLicenseConverter.java
+++ b/addons/pkg-npm/model-java/src/main/java/org/commonjava/indy/pkg/npm/model/converter/ObjectToLicenseConverter.java
@@ -1,0 +1,21 @@
+package org.commonjava.indy.pkg.npm.model.converter;
+
+import com.fasterxml.jackson.databind.util.StdConverter;
+import org.commonjava.indy.pkg.npm.model.License;
+
+import java.util.List;
+
+public class ObjectToLicenseConverter extends StdConverter<Object, License> {
+
+    @Override
+    public License convert(Object o) {
+        if (o instanceof List)
+        {
+            // Use SPDX expressions, ref https://docs.npmjs.com/cli/v7/configuring-npm/package-json
+            // e.g, parse "[MIT, Apache2]" to "(MIT OR Apache2)"
+            String license = o.toString().replaceAll("\\[|\\]", "");
+            return new License("(" + license.replaceAll(",", " OR") + ")");
+        }
+        return new License(o.toString());
+    }
+}


### PR DESCRIPTION
This is to fix [MMENG-2775](https://issues.redhat.com/browse/MMENG-2775) where the deserialization failed if the NPM license has multiple values, like
  "license": [
    "MIT",
    "Apache2"
  ]
I use a Jackson converter to handle that case.