### PR TITLE
hide the package.json and the checksum files

### DIFF
--- a/addons/content-browse/common/src/main/java/org/commonjava/indy/content/browse/ContentBrowseController.java
+++ b/addons/content-browse/common/src/main/java/org/commonjava/indy/content/browse/ContentBrowseController.java
@@ -126,7 +126,7 @@ public class ContentBrowseController
                         //skip npm adduser path to avoid the sensitive info showing.
                         //continue;
                     }
-                    if ( p.endsWith( NPM_METADATA_NAME ) )
+                    if ( p.contains( NPM_METADATA_NAME ) )
                     {
                         //the package.json should not be visible for user
                         continue;


### PR DESCRIPTION
previously we check if the file is package.json on listing requests, it should filter the checksum files out as well. 