### PR TITLE
Fix the response header

### DIFF
--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseHelper.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/ResponseHelper.java
@@ -201,6 +201,10 @@ public class ResponseHelper
                 logger.debug( "Adding Content-Length header: {}", item.length() );
 
                 builder.header( ApplicationHeader.content_length.key(), item.length() );
+
+                logger.debug( "Removing Transfer-Encoding header if Content-Length header already set." );
+
+                builder.header( ApplicationHeader.transfer_encoding.key(), null );
             }
 
             if ( !conTypeSet )


### PR DESCRIPTION
As the [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt) mentioned, _"If a message is received with both a Transfer-Encoding header field and a Content-Length header field, the latter MUST be ignored."_

So the fix is trying to avoid to set the above two headers together, if we set the `Content-Length` header explicitly, we should remove the `Transfer-Encoding` header. 