### PR TITLE
Merge from 3.0.x for CVE fix

### DIFF
--- a/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataTimeoutNoSchedulerTest.java
+++ b/addons/pkg-npm/ftests/src/main/java/org/commonjava/indy/pkg/npm/content/NPMMetadataTimeoutNoSchedulerTest.java
@@ -28,11 +28,12 @@ import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 
 import static org.commonjava.indy.pkg.npm.model.NPMPackageTypeDescriptor.NPM_PKG_KEY;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * This case tests if remote package.json will time out by using ONLY storage level timeout.
@@ -143,7 +144,7 @@ public class NPMMetadataTimeoutNoSchedulerTest
         try (InputStream remote = client.content().get( repo.getKey(), path ))
         {
             assertThat( remote, notNullValue() );
-            String json = IOUtils.toString( remote );
+            String json = IOUtils.toString( remote, Charset.defaultCharset() );
             PackageMetadata merged =
                     new IndyObjectMapper( true ).readValue( json, PackageMetadata.class );
 

--- a/addons/sli/src/main/java/org/commonjava/indy/sli/metrics/IndyGoldenSignalsMetricSetProvider.java
+++ b/addons/sli/src/main/java/org/commonjava/indy/sli/metrics/IndyGoldenSignalsMetricSetProvider.java
@@ -39,4 +39,10 @@ public class IndyGoldenSignalsMetricSetProvider
     {
         return "sli.golden";
     }
+
+    @Override
+    public void reset()
+    {
+        getMetricSet().reset();
+    }
 }

--- a/deployments/cache-migrator/test-env/indy-env/conf.d/metrics.conf
+++ b/deployments/cache-migrator/test-env/indy-env/conf.d/metrics.conf
@@ -1,6 +1,6 @@
 [metrics]
 enabled = false
-reporter.enabled = true
+reporter.enabled = false
 
 # Specify node prefix (on cluster). This prefix will be prepended to all metric names. Default empty.
 #

--- a/pom.xml
+++ b/pom.xml
@@ -1130,12 +1130,12 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.10</version>
+        <version>1.15</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.19</version>
+        <version>1.21</version>
       </dependency>
 
       <!-- START: JAX-RS support -->
@@ -1313,7 +1313,7 @@
       <dependency>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-catalog</artifactId>
-        <version>2.4</version>
+        <version>3.2.1</version>
       </dependency>
       <!-- Some dependency problems caused a old plexus-utils(2.0.6) is used which have cve, so forced to 3.0.21 -->
       <dependency>
@@ -1336,7 +1336,7 @@
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
-        <version>2.2.1</version>
+        <version>2.4.21</version>
       </dependency>
       
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <!-- thirdparty projects -->
     <javaVersion>1.8</javaVersion>
     <slf4j-version>1.7.36</slf4j-version>
-    <infinispanVersion>9.4.23.Final</infinispanVersion>
+    <infinispanVersion>9.4.24.Final</infinispanVersion>
     <!--<luceneVersion>7.3.0</luceneVersion>-->
     <protostreamVersion>4.3.0.Final</protostreamVersion>
     <gsonVersion>2.8.9</gsonVersion>
@@ -71,7 +71,7 @@
     <keycloakVersion>7.0.1</keycloakVersion>
     <bouncycastleVersion>1.64</bouncycastleVersion>
     <bytemanVersion>4.0.13</bytemanVersion>
-    <kafkaVersion>1.1.0</kafkaVersion>
+    <kafkaVersion>3.1.1</kafkaVersion>
     <logbackVersion>1.2.9</logbackVersion>
     <logbackContribVersion>0.1.5</logbackContribVersion>
     <weldVersion>2.4.6.Final</weldVersion>
@@ -83,7 +83,7 @@
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.7.2</datastaxVersion>
     <pathmappedStorageVersion>2.1</pathmappedStorageVersion>
-    <o11yphantVersion>1.4</o11yphantVersion>
+    <o11yphantVersion>1.5-SNAPSHOT</o11yphantVersion>
     <swaggerVersion>1.6.4</swaggerVersion>
 
     <!-- commonjava/redhat projects -->
@@ -1571,11 +1571,13 @@
         <artifactId>logback-core</artifactId>
         <version>${logbackVersion}</version>
       </dependency>
+      <!--
       <dependency>
         <groupId>com.github.danielwegener</groupId>
         <artifactId>logback-kafka-appender</artifactId>
         <version>0.2.0-RC2</version>
       </dependency>
+      -->
       <dependency>
         <groupId>ch.qos.logback.contrib</groupId>
         <artifactId>logback-json-classic</artifactId>
@@ -1724,10 +1726,12 @@
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
     </dependency>
+    <!--
     <dependency>
       <groupId>com.github.danielwegener</groupId>
       <artifactId>logback-kafka-appender</artifactId>
     </dependency>
+    -->
     <dependency>
       <groupId>ch.qos.logback.contrib</groupId>
       <artifactId>logback-json-classic</artifactId>

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCheckRegistrySet.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnCheckRegistrySet.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.subsys.infinispan.metrics;
 import org.commonjava.o11yphant.metrics.api.Gauge;
 import org.commonjava.o11yphant.metrics.api.Metric;
 import org.commonjava.o11yphant.metrics.api.MetricSet;
+import org.commonjava.o11yphant.metrics.sli.GoldenSignalsFunctionMetrics;
 import org.infinispan.AdvancedCache;
 import org.infinispan.Cache;
 import org.infinispan.manager.EmbeddedCacheManager;
@@ -198,6 +199,11 @@ public class IspnCheckRegistrySet
            } );
 
         return gauges;
+    }
+
+    @Override
+    public void reset()
+    {
     }
 
     private <T> T noExceptions( final Supplier<T> task )

--- a/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnRegistrySetProvider.java
+++ b/subsys/infinispan/src/main/java/org/commonjava/indy/subsys/infinispan/metrics/IspnRegistrySetProvider.java
@@ -80,4 +80,10 @@ public class IspnRegistrySetProvider
     {
         return metricsConfig.isIspnMetricsEnabled();
     }
+
+    @Override
+    public void reset()
+    {
+        getMetricSet().reset();
+    }
 }


### PR DESCRIPTION
      * commons-codec: 1.10 -> 1.15
      * commons-compress: 1.19 -> 1.21
      * archetype-catalog: 2.4 -> 3.2.1
      * groovy: 2.2.1 -> 2.4.21
      * Remove kafka-log-appender as useless
      * Upgrade kafka-clients to 3.1.1 due to cve
      * Upgrade infinispan to 9.4.24.Final
      * o11yphant to 1.5-SNAPSHOT for cascading amqp-client upgrade.
