### PR TITLE
Fix: Let all indy related exceptions inherit from IndyException

### DIFF
--- a/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/DotMavenException.java
+++ b/addons/dot-maven/common/src/main/java/org/commonjava/indy/dotmaven/DotMavenException.java
@@ -15,10 +15,12 @@
  */
 package org.commonjava.indy.dotmaven;
 
+import org.commonjava.indy.IndyException;
+
 import java.text.MessageFormat;
 
 public class DotMavenException
-    extends Exception
+        extends IndyException
 {
 
     private static final long serialVersionUID = 1L;

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloContentException.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloContentException.java
@@ -15,11 +15,13 @@
  */
 package org.commonjava.indy.folo.data;
 
+import org.commonjava.indy.IndyException;
+
 import java.text.MessageFormat;
 import java.util.IllegalFormatException;
 
 public class FoloContentException
-    extends Exception
+        extends IndyException
 {
     private static final long serialVersionUID = 1L;
 

--- a/addons/implied-repos/model-java/src/main/java/org/commonjava/indy/implrepo/ImpliedReposException.java
+++ b/addons/implied-repos/model-java/src/main/java/org/commonjava/indy/implrepo/ImpliedReposException.java
@@ -15,11 +15,13 @@
  */
 package org.commonjava.indy.implrepo;
 
+import org.commonjava.indy.IndyException;
+
 import java.text.MessageFormat;
 import java.util.IllegalFormatException;
 
 public class ImpliedReposException
-    extends Exception
+        extends IndyException
 {
     private static final long serialVersionUID = 1L;
 

--- a/api/src/main/java/org/commonjava/indy/IndyWorkflowException.java
+++ b/api/src/main/java/org/commonjava/indy/IndyWorkflowException.java
@@ -28,7 +28,7 @@ import org.commonjava.maven.galley.TransferLocationException;
  * the default: HTTP 500).
  */
 public class IndyWorkflowException
-    extends Exception
+    extends IndyException
 {
     private Object[] params;
 
@@ -89,13 +89,7 @@ public class IndyWorkflowException
                 {
                     formattedMessage = String.format( format.replaceAll( "\\{\\}", "%s" ), params );
                 }
-                catch ( final Error e )
-                {
-                }
-                catch ( final RuntimeException e )
-                {
-                }
-                catch ( final Exception e )
+                catch ( final Error | Exception e )
                 {
                 }
 

--- a/api/src/main/java/org/commonjava/indy/action/IndyLifecycleException.java
+++ b/api/src/main/java/org/commonjava/indy/action/IndyLifecycleException.java
@@ -15,10 +15,13 @@
  */
 package org.commonjava.indy.action;
 
+import org.commonjava.indy.IndyException;
+
 import java.text.MessageFormat;
+import java.util.Objects;
 
 public class IndyLifecycleException
-    extends Exception
+        extends IndyException
 {
     private static final long serialVersionUID = 1L;
 
@@ -56,28 +59,18 @@ public class IndyLifecycleException
                 {
                     formattedMessage = String.format( format, params );
                 }
-                catch ( final Error e )
+                catch ( final Error | Exception e )
                 {
-                }
-                catch ( final RuntimeException e )
-                {
-                }
-                catch ( final Exception e )
-                {
+                    // do nothing
                 }
 
-                if ( formattedMessage == null || original == formattedMessage )
+                if ( formattedMessage == null || Objects.equals( original, formattedMessage ) )
                 {
                     try
                     {
                         formattedMessage = MessageFormat.format( format, params );
                     }
-                    catch ( final Error e )
-                    {
-                        formattedMessage = format;
-                        throw e;
-                    }
-                    catch ( final RuntimeException e )
+                    catch ( final Error | RuntimeException e )
                     {
                         formattedMessage = format;
                         throw e;

--- a/api/src/main/java/org/commonjava/indy/data/IndyDataException.java
+++ b/api/src/main/java/org/commonjava/indy/data/IndyDataException.java
@@ -19,6 +19,7 @@ import java.io.NotSerializableException;
 import java.io.Serializable;
 import java.text.MessageFormat;
 
+import org.commonjava.indy.IndyException;
 import org.commonjava.indy.model.core.ArtifactStore;
 
 /**
@@ -26,7 +27,7 @@ import org.commonjava.indy.model.core.ArtifactStore;
  * {@link ArtifactStore} instances.
  */
 public class IndyDataException
-    extends Exception
+        extends IndyException
 {
     private static final long serialVersionUID = 1L;
 

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientException.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientException.java
@@ -15,6 +15,8 @@
  */
 package org.commonjava.indy.client.core;
 
+import org.commonjava.indy.IndyException;
+
 import java.io.NotSerializableException;
 import java.io.Serializable;
 import java.text.MessageFormat;
@@ -24,7 +26,7 @@ import java.text.MessageFormat;
  * @author jdcasey
  */
 public class IndyClientException
-    extends Exception
+        extends IndyException
 {
     private Object[] params;
 

--- a/core/src/main/java/org/commonjava/indy/core/expire/IndySchedulerException.java
+++ b/core/src/main/java/org/commonjava/indy/core/expire/IndySchedulerException.java
@@ -15,10 +15,12 @@
  */
 package org.commonjava.indy.core.expire;
 
+import org.commonjava.indy.IndyException;
+
 import java.text.MessageFormat;
 
 public class IndySchedulerException
-    extends Exception
+        extends IndyException
 {
 
     private static final long serialVersionUID = 1L;

--- a/subsys/git/src/main/java/org/commonjava/indy/subsys/git/GitSubsystemException.java
+++ b/subsys/git/src/main/java/org/commonjava/indy/subsys/git/GitSubsystemException.java
@@ -15,12 +15,14 @@
  */
 package org.commonjava.indy.subsys.git;
 
+import org.commonjava.indy.IndyException;
+
 import java.io.NotSerializableException;
 import java.io.Serializable;
 import java.text.MessageFormat;
 
 public class GitSubsystemException
-    extends Exception
+        extends IndyException
 {
 
     private static final long serialVersionUID = 1L;

--- a/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/IndyGroovyException.java
+++ b/subsys/groovy/src/main/java/org/commonjava/indy/subsys/template/IndyGroovyException.java
@@ -15,10 +15,12 @@
  */
 package org.commonjava.indy.subsys.template;
 
+import org.commonjava.indy.IndyException;
+
 import java.text.MessageFormat;
 
 public class IndyGroovyException
-    extends Exception
+        extends IndyException
 {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
I think all indy related exception should inherit from "IndyException" for general purpose.