### PR TITLE
Fix: upgrade agroal to 1.16 to support enhancedLeakReport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
     <pathmappedStorageVersion>2.1</pathmappedStorageVersion>
     <o11yphantVersion>1.5</o11yphantVersion>
     <swaggerVersion>1.6.4</swaggerVersion>
+    <agroalVersion>1.16</agroalVersion>
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.1</atlasVersion>
@@ -815,12 +816,12 @@
       <dependency>
         <groupId>io.agroal</groupId>
         <artifactId>agroal-api</artifactId>
-        <version>1.8</version>
+        <version>${agroalVersion}</version>
       </dependency>
       <dependency>
         <groupId>io.agroal</groupId>
         <artifactId>agroal-pool</artifactId>
-        <version>1.8</version>
+        <version>${agroalVersion}</version>
       </dependency>
 
       <dependency>

--- a/subsys/cpool/src/main/conf/conf.d/connection-pools.conf
+++ b/subsys/cpool/src/main/conf/conf.d/connection-pools.conf
@@ -30,6 +30,7 @@
 #                  dataSource.reapTimeout_m=10,\
 #                  dataSource.maxLifetime_m=28,\
 #                  dataSource.leakTimeout_s=5,\
+#                  dataSource.enhancedLeakReport=true,\
 #                  metrics=true,\
 #                  healthChecks=true
 

--- a/uis/layover/package-lock.json
+++ b/uis/layover/package-lock.json
@@ -1513,12 +1513,6 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
-    "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-      "dev": true
-    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -2719,14 +2713,22 @@
       "dev": true
     },
     "http-proxy": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^3.0.0",
+        "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+          "dev": true
+        }
       }
     },
     "http-proxy-middleware": {


### PR DESCRIPTION
  We found that the agroal connection pool is reporting leak connection
  for several times. As agroal has supported a new configuration of
  "enhancedLeakReport" to tell more details of leaking problem, so this
  will upgrade to use it