### PR TITLE
Fix: Excludes the undertow-servlet from indy-clients dependencies

### DIFF
--- a/clients/core-java/pom.xml
+++ b/clients/core-java/pom.xml
@@ -35,6 +35,12 @@
     <dependency>
       <groupId>org.commonjava.util</groupId>
       <artifactId>o11yphant-trace-honeycomb</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.undertow</groupId>
+          <artifactId>undertow-servlet</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
@@ -43,10 +49,6 @@
     <dependency>
       <groupId>org.commonjava.util</groupId>
       <artifactId>o11yphant-trace-helper-jhttpc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-trace-honeycomb</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>


### PR DESCRIPTION
   We got report from client usage that the undertow-servlet will cause
   some deps duplication and timeout problem when other libs included
   some other version of undertow-servlet. The indy-clients don't need
   this servlet dpes as it is using in server-side metrics, so we
   excludes it here.