### PR TITLE
Add Cache for ServiceStoreQuery

### DIFF
--- a/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataManager.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataManager.java
@@ -320,7 +320,7 @@ public class ServiceStoreDataManager
     @Override
     public ArtifactStoreQuery<ArtifactStore> query()
     {
-        return new ServiceStoreQuery<>( this );
+        return new ServiceStoreQuery<>( this, this.cacheProducer );
     }
 
     // This method is a replacement of the query() for internal usage of this class to avoid
@@ -329,7 +329,7 @@ public class ServiceStoreDataManager
     {
         if ( this.serviceStoreQuery == null )
         {
-            this.serviceStoreQuery = new ServiceStoreQuery<>( this );
+            this.serviceStoreQuery = new ServiceStoreQuery<>( this, this.cacheProducer );
         }
         return this.serviceStoreQuery;
     }

--- a/db/service/src/test/java/org/commonjava/indy/db/service/ServiceStoreQueryTest.java
+++ b/db/service/src/test/java/org/commonjava/indy/db/service/ServiceStoreQueryTest.java
@@ -87,7 +87,7 @@ public class ServiceStoreQueryTest
         clientProducer.init();
         Indy client = clientProducer.getClient();
         ServiceStoreDataManager dataManager = new ServiceStoreDataManager( producer, client );
-        query = new ServiceStoreQuery<>( dataManager );
+        query = new ServiceStoreQuery<>( dataManager, producer );
     }
 
     @Test


### PR DESCRIPTION
  We found there is a big performance downgrade during integration test.
  The most possible reason is bunch of the http requests for lots of
  store query during artifacts downloading. So I add cache here to cache
  some of the most commonly used queries.