### PR TITLE
Fix the NPE issue for querying affected stores

### DIFF
--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
@@ -268,6 +268,7 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
 
                             if ( store == null )
                             {
+                                logger.error( "Error: the group {} does not exist as affected by for store {}", gKey, key );
                                 processed.add( gKey );
                                 continue;
                             }

--- a/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
+++ b/db/cassandra/src/main/java/org/commonjava/indy/cassandra/data/CassandraStoreDataManager.java
@@ -266,6 +266,12 @@ public class CassandraStoreDataManager extends AbstractStoreDataManager
                         {
                             ArtifactStore store = getArtifactStoreInternal( gKey );
 
+                            if ( store == null )
+                            {
+                                processed.add( gKey );
+                                continue;
+                            }
+
                             // if this group is disabled, we don't want to keep loading it again and again.
                             if ( store.isDisabled() )
                             {


### PR DESCRIPTION
Not sure why the affected stores are not updated when some stores are removed. Let's adding this to avoid the NPE, which is happening on devel-master, blocking the promotion. 