### PR TITLE
FIX: update the format of response based on rfc2616

### DIFF
--- a/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
+++ b/addons/httprox/common/src/main/java/org/commonjava/indy/httprox/handler/ProxyResponseWriter.java
@@ -268,7 +268,7 @@ public final class ProxyResponseWriter
                                      PROXY_AUTHENTICATION_REQUIRED, proxy_authenticate, realmInfo );
 
                         http.writeStatus( PROXY_AUTHENTICATION_REQUIRED );
-                        http.writeHeader( proxy_authenticate, realmInfo );
+                        http.writeHeader( proxy_authenticate, String.format( "%s\n", realmInfo ) );
                     }
                     else
                     {


### PR DESCRIPTION
Looks .net client expects an extra CRLF in the response following [rfc2616](https://www.rfc-editor.org/rfc/rfc2616.html) .
`        generic-message = start-line
                          *(message-header CRLF)
                          CRLF
                          [ message-body ]
        start-line      = Request-Line | Status-Line`
I had test this in generic proxy service, and this is added for production, since we still have not switch proxy on prod. thanks.