### PR TITLE
Ignore the zip file on compressing

### DIFF
--- a/boot/jaxrs/src/main/java/org/commonjava/indy/boot/jaxrs/IndyDeployer.java
+++ b/boot/jaxrs/src/main/java/org/commonjava/indy/boot/jaxrs/IndyDeployer.java
@@ -152,6 +152,7 @@ public class IndyDeployer
     static
     {
         NO_NEED_GZIPPED_CONTENT.add( ApplicationContent.application_gzip );
+        NO_NEED_GZIPPED_CONTENT.add( ApplicationContent.application_zip );
     }
 
     private EncodingHandler getGzipEncodeHandler( final DeploymentManager dm )


### PR DESCRIPTION
let's try to ignore compressing the zip file for transporting to see if it's helpful for the issue of downloading the larger file. 