### PR TITLE
Fix cleanup the affected groups's related orderedConcreteStoresInGroup query cache

### DIFF
--- a/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataCacheUpdater.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataCacheUpdater.java
@@ -26,6 +26,7 @@ import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
 import org.commonjava.indy.subsys.infinispan.BasicCacheHandle;
 import org.commonjava.indy.subsys.infinispan.CacheProducer;
+import org.infinispan.commons.api.BasicCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,6 +34,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -63,8 +65,6 @@ public class ServiceStoreDataCacheUpdater
         logger.info( "Start cache updater for store post update event: {}", updateEvent );
         final BasicCacheHandle<StoreKey, ArtifactStore> storeCache =
                 cacheProducer.getBasicCache( ServiceStoreDataManager.ARTIFACT_STORE );
-        final BasicCacheHandle<Object, Collection<ArtifactStore>> queryCache =
-                cacheProducer.getBasicCache( ServiceStoreQuery.ARTIFACT_STORE_QUERY );
         cacheUpdateExecutor.execute( () -> {
             if ( updateEvent.getType().equals( ADD ) )
             {
@@ -102,8 +102,6 @@ public class ServiceStoreDataCacheUpdater
         logger.info( "Start cache updater for store delete post event: {}", deleteEvent );
         final BasicCacheHandle<StoreKey, ArtifactStore> storeCache =
                 cacheProducer.getBasicCache( ServiceStoreDataManager.ARTIFACT_STORE );
-        final BasicCacheHandle<Object, Collection<ArtifactStore>> queryCache =
-                cacheProducer.getBasicCache( ServiceStoreQuery.ARTIFACT_STORE_QUERY );
         cacheUpdateExecutor.execute( () -> {
             for ( ArtifactStore deleted : deleteEvent.getStores() )
             {
@@ -137,22 +135,34 @@ public class ServiceStoreDataCacheUpdater
             for ( Map.Entry<Object, Collection<ArtifactStore>> entry : cache.entrySet() )
             {
                 Object key = entry.getKey();
+                Collection<ArtifactStore> affectedGroups = new HashSet<>();
                 // This is for getGroupsAffectedBy query cache
                 if ( key instanceof Set && ( (Set) key ).contains( storeKey ) )
                 {
                     logger.info( "Fresh the store query cache, removed: {}", storeKey );
+                    affectedGroups = cache.get( key );
                     cache.remove( key );
+                }
+                // This is for affectedGroups' getOrderedConcreteStoresInGroup query cache
+                for ( ArtifactStore group : affectedGroups )
+                {
+                    clearOrderedConcreteStoresCache( key, group.getKey(), cache );
                 }
                 // This is for getOrderedConcreteStoresInGroup query cache
-                if ( storeKey.getType() == StoreType.group && key instanceof String && ( (String) key ).indexOf(
-                        String.format( "%s:%s", storeKey.getPackageType(), storeKey.getName() ) ) > 0 )
-                {
-                    logger.info( "Fresh the concrete stores query cache, removed: {}", storeKey );
-                    cache.remove( key );
-                }
-
+                clearOrderedConcreteStoresCache( key, storeKey, cache );
             }
             return null;
         } );
+    }
+
+    private void clearOrderedConcreteStoresCache( Object key, StoreKey storeKey,
+                                                  BasicCache<Object, Collection<ArtifactStore>> cache )
+    {
+        if ( storeKey.getType() == StoreType.group && key instanceof String && ( (String) key ).indexOf(
+                        String.format( "%s:%s", storeKey.getPackageType(), storeKey.getName() ) ) > 0 )
+        {
+            logger.info( "Fresh the concrete stores query cache, removed: {}", storeKey );
+            cache.remove( key );
+        }
     }
 }

--- a/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreQuery.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreQuery.java
@@ -267,11 +267,13 @@ public class ServiceStoreQuery<T extends ArtifactStore>
         final Collection<ArtifactStore> stores = computeIfAbsent( queryKey, () -> {
             try
             {
+                logger.trace( "Get OrderedConcrete StoreListingDTO from store query client." );
                 StoreListingDTO<ArtifactStore> dto = client.module( IndyStoreQueryClientModule.class )
                                                            .getOrderedConcreteStoresInGroup( packageType, groupName,
                                                                                              enabled.toString() );
                 if ( dto != null )
                 {
+                    logger.trace( "OrderedConcrete StoreListingDTO {}", dto );
                     return dto.getItems();
                 }
                 return Collections.emptyList();
@@ -337,12 +339,12 @@ public class ServiceStoreQuery<T extends ArtifactStore>
         Collection<ArtifactStore> stores = computeIfAbsent( queryKeys, () -> {
             try
             {
-                logger.trace( "Get StoreListingDTO from store query client." );
+                logger.trace( "Get GroupsAffected StoreListingDTO from store query client." );
                 StoreListingDTO<Group> dto =
                         client.module( IndyStoreQueryClientModule.class ).getGroupsAffectedBy( new HashSet<>( keys ) );
                 if ( dto != null )
                 {
-                    logger.trace( "StoreListingDTO {}", dto );
+                    logger.trace( "GroupsAffected StoreListingDTO {}", dto );
                     return new HashSet<>( dto.getItems() );
                 }
                 return Collections.emptySet();


### PR DESCRIPTION
We need to cleanup the affected groups' related orderedConcreteStoresInGroup query cache if the constituent store is updated.

For example: if the hosted repo is disabled, we also need to clean its affected groups' orderedConcreteStoresInGroup cache. After this, if Indy needs to retrieve this group's orderedConcreteStoresInGroup cache when generating the group maven-metadata.xml, enabled concrete stores will be fetching correctly from the query cache.