### PR TITLE
Fix: concrete in group store query missing enabled parameter

### DIFF
--- a/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/DefaultArtifactStoreQuery.java
@@ -557,7 +557,7 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
                                                    final boolean includeGroups, final boolean recurseGroups) throws IndyDataException
     {
 
-        if ( groupRepo == null || groupRepo.isDisabled() && Boolean.TRUE.equals(this.enabled) )
+        if ( groupRepo == null || groupRepo.isDisabled() && enabled )
         {
             return result;
         }
@@ -588,7 +588,7 @@ public class DefaultArtifactStoreQuery<T extends ArtifactStore>
                     else
                     {
                         final ArtifactStore store = dataManager.getArtifactStore( key );
-                        if (store != null && !(store.isDisabled() && Boolean.TRUE.equals( this.enabled )))
+                        if ( store != null && ( store.isDisabled() != enabled ) )
                         {
                             result.add( store );
                         }


### PR DESCRIPTION
  Seems the getOrderedConcreteStoresInGroup with "enabled" parameter is
  using a wrong refer of this "enabled" param