### PR TITLE
Fix to query through store query client if query cache is empty

### DIFF
--- a/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataCacheUpdater.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataCacheUpdater.java
@@ -150,6 +150,7 @@ public class ServiceStoreDataCacheUpdater
             // This is for affectedGroups' getOrderedConcreteStoresInGroup query cache
             for ( ArtifactStore group : affectedGroups )
             {
+                logger.info( "Fresh the store query cache for affectedGroups, removed: {}", storeKey );
                 for ( Map.Entry<Object, Collection<ArtifactStore>> entry : cache.entrySet() )
                 {
                     Object key = entry.getKey();

--- a/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreQuery.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreQuery.java
@@ -506,13 +506,13 @@ public class ServiceStoreQuery<T extends ArtifactStore>
 
         BasicCacheHandle<Object, Collection<ArtifactStore>> cache = cacheProducer.getBasicCache( ARTIFACT_STORE_QUERY );
         Collection<ArtifactStore> stores = cache.get( key );
-        if ( stores == null || forceQuery )
+        if ( stores == null || stores.isEmpty() || forceQuery )
         {
             logger.trace( "Entry not found, run put, expirationMins: {}", expirationMins );
 
             stores = storeProvider.get();
 
-            if ( stores != null )
+            if ( stores != null && !stores.isEmpty() )
             {
                 if ( expirationMins > 0 )
                 {


### PR DESCRIPTION
Fix this because the provider for computeIfAbsent method might return Collections.emptySet() result, and make related query cache(e.g. affectedGroups) to retrun {}.