### PR TITLE
Test to remove needTempRepo in prmotion

### DIFF
--- a/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
+++ b/addons/promote/common/src/main/java/org/commonjava/indy/promote/validate/PromotionValidator.java
@@ -326,6 +326,8 @@ public class PromotionValidator
     private boolean needTempRepo( PromoteRequest promoteRequest )
             throws PromotionValidationException
     {
+        return false;
+/*
         if ( promoteRequest instanceof GroupPromoteRequest )
         {
             return false;
@@ -339,6 +341,7 @@ public class PromotionValidator
         {
             throw new PromotionValidationException( "The promote request is not a valid request, should not happen" );
         }
+*/
     }
 
     private ArtifactStore getRequestStore( PromoteRequest promoteRequest, String baseUrl )


### PR DESCRIPTION
When doing bypath promotion, Indy creates a temp remote repo pointing to the promotion source repo before validation. Indy uses the remote repo instead of the original source repo during validation. I found old commit but it did not mention why.
https://github.com/Commonjava/indy/commit/20607c1ec32e8cdb52b08d5b5496d82540eff3b1

This might be because the validation may pollute the source repo? Anyone remember more about it?
I create this pr to test if disabling it breaks anything. It seems all tests can pass.