### PR TITLE
Fix NPE by store duplicated deletions and constituents UnsupportedOperationException issue

### DIFF
--- a/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataCacheUpdater.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataCacheUpdater.java
@@ -31,8 +31,10 @@ import org.slf4j.LoggerFactory;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -117,7 +119,12 @@ public class ServiceStoreDataCacheUpdater
                     cache.values()
                          .stream()
                          .filter( ( store ) -> store.getType() == StoreType.group )
-                         .forEach( ( store ) -> ( (Group) store ).getConstituents().remove( deleted.getKey() ) );
+                         .forEach( ( store ) -> {
+                             List<StoreKey> storeList = ( (Group) store ).getConstituents();
+                             List<StoreKey> stores = new ArrayList<>( storeList );
+                             stores.remove( deleted.getKey() );
+                             ( (Group) store ).setConstituents( stores );
+                         } );
                     return null;
                 } );
 

--- a/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreQuery.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreQuery.java
@@ -187,11 +187,16 @@ public class ServiceStoreQuery<T extends ArtifactStore>
     public Set<Group> getGroupsContaining( final StoreKey storeKey )
             throws IndyDataException
     {
+        Set<Group> groups = new HashSet<>();
         try
         {
-            return new HashSet<>( client.module( IndyStoreQueryClientModule.class )
-                                        .getGroupContaining( storeKey, "true" )
-                                        .getItems() );
+            StoreListingDTO<Group> groupDTO =
+                            client.module( IndyStoreQueryClientModule.class ).getGroupContaining( storeKey, "true" );
+            if ( groupDTO != null )
+            {
+                groups = groupDTO.getItems().stream().collect( Collectors.toSet() );
+            }
+            return groups;
         }
         catch ( IndyClientException e )
         {


### PR DESCRIPTION
The two issues are both found in the stage log and oc2 integration testing
1. NPE: This should be caused by the repo was removed and cleanups were done already in another pod.
2. UnsupportedOperationException: This is caused by removing on the constituents unmodifiableList.