### PR TITLE
Fix ClassCastException during location metadata value type cast

### DIFF
--- a/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
+++ b/api/src/main/java/org/commonjava/indy/model/galley/CacheOnlyLocation.java
@@ -19,7 +19,11 @@ import org.commonjava.indy.content.IndyLocationExpander;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.maven.galley.model.Location;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +32,7 @@ import java.util.Map;
  * store-related {@link KeyedLocation} types, assuming it's not referencing a {@link HostedRepository}, via the {@link IndyLocationExpander} component.
  */
 public class CacheOnlyLocation
-    implements KeyedLocation
+                implements KeyedLocation
 {
 
     private final Map<String, Object> attributes = new HashMap<String, Object>();
@@ -150,7 +154,47 @@ public class CacheOnlyLocation
     public <T> T getAttribute( final String key, final Class<T> type, final T defaultValue )
     {
         final Object value = attributes.get( key );
-        return value == null ? defaultValue : type.cast( value );
+        if ( value == null )
+        {
+            return defaultValue;
+        }
+        else if ( type.isAssignableFrom( value.getClass() ) )
+        {
+            return type.cast( value );
+        }
+        else if ( value.getClass() == String.class && Number.class.isAssignableFrom( type ) )
+        {
+            Number n = null;
+            try
+            {
+                n = NumberFormat.getInstance().parse( (String) value );
+            }
+            catch ( ParseException e )
+            {
+                Logger logger = LoggerFactory.getLogger( getClass() );
+                logger.error( "Failed to get attribute, key: {}, value: {}", key, value, e );
+            }
+            // convert, e.g., n might be Long while the T is Integer
+            Object ret;
+            if ( type == Long.TYPE )
+            {
+                ret = new Long( n.longValue() );
+            }
+            else if ( type == Float.TYPE )
+            {
+                ret = new Float( n.floatValue() );
+            }
+            else if ( type == Double.TYPE )
+            {
+                ret = new Double( n.doubleValue() );
+            }
+            else
+            {
+                ret = new Integer( n.intValue() ); // default int
+            }
+            return (T) ret;
+        }
+        return defaultValue;
     }
 
     @Override

--- a/api/src/test/java/org/commonjava/indy/model/galley/CacheOnlyLocationTest.java
+++ b/api/src/test/java/org/commonjava/indy/model/galley/CacheOnlyLocationTest.java
@@ -1,0 +1,21 @@
+package org.commonjava.indy.model.galley;
+
+import org.commonjava.indy.model.core.Group;
+import org.commonjava.indy.util.LocationUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CacheOnlyLocationTest
+{
+
+    @Test
+    public void testGetAttribute()
+    {
+        Group group = new Group( "maven", "test" );
+        group.setMetadata( "metadata-timeout", "3600" );
+        CacheOnlyLocation location = (CacheOnlyLocation) LocationUtils.toLocation( group );
+        int value = location.getAttribute( "metadata-timeout", Integer.class, 60 );
+        assertEquals( 3600, value );
+    }
+}


### PR DESCRIPTION
java.lang.ClassCastException: Cannot cast java.lang.String to java.lang.Integer
This error will occur when parsing repo "metadata" meta with number value.
Should also be fixed in the current Indy running version.