### PR TITLE
Remove revision addon

### DIFF
--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -38,7 +38,9 @@
     <module>implied-repos</module>
     <module>koji</module>
     <module>promote</module>
+    <!--
     <module>revisions</module>
+    -->
     <module>pkg-maven</module>
     <module>diagnostics</module>
     <module>pkg-npm</module>

--- a/deployments/launcher/pom.xml
+++ b/deployments/launcher/pom.xml
@@ -51,6 +51,7 @@
       <type>tar.gz</type>
       <classifier>dataset</classifier>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-revisions-common</artifactId>
@@ -63,6 +64,7 @@
       <type>tar.gz</type>
       <classifier>uiset</classifier>
     </dependency>
+    -->
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-folo-common</artifactId>

--- a/embedder-tests/sonar-report/pom.xml
+++ b/embedder-tests/sonar-report/pom.xml
@@ -140,14 +140,6 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-revisions-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-revisions-common</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-diagnostics-jaxrs</artifactId>
     </dependency>
     <dependency>

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -111,6 +111,7 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-dot-maven-jaxrs</artifactId>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-revisions-jaxrs</artifactId>
@@ -119,6 +120,7 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-revisions-common</artifactId>
     </dependency>
+    -->
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-diagnostics-jaxrs</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -282,6 +282,7 @@
         <scope>provided</scope>
       </dependency>
 
+      <!--
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-revisions-jaxrs</artifactId>
@@ -308,6 +309,7 @@
         <classifier>uiset</classifier>
         <scope>provided</scope>
       </dependency>
+      -->
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-dot-maven-common</artifactId>
@@ -442,11 +444,13 @@
         <artifactId>indy-subsys-http</artifactId>
         <version>2.7.7-SNAPSHOT</version>
       </dependency>
+      <!--
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-git</artifactId>
         <version>2.7.7-SNAPSHOT</version>
       </dependency>
+      -->
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-subsys-groovy</artifactId>
@@ -1293,11 +1297,13 @@
         <version>${webdavVersion}</version>
       </dependency>
 
+      <!--
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
         <artifactId>org.eclipse.jgit</artifactId>
         <version>3.4.1.201406201815-r</version>
       </dependency>
+      -->
 
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/subsys/pom.xml
+++ b/subsys/pom.xml
@@ -32,7 +32,6 @@
   <modules>
     <module>cassandra</module>
     <module>flatfile</module>
-    <module>git</module>
     <module>groovy</module>
     <module>trace</module>
     <module>http</module>
@@ -43,6 +42,9 @@
     <module>prefetch</module>
     <module>kafka</module>
     <module>cpool</module>
+    <!--
+    <module>git</module>
+    -->
   </modules>
 
 </project>


### PR DESCRIPTION
As revision is deprecated in new indy releases, I'll remove it from current maven dependency trees, but just leave all codes there for a while in coming releases. 