### PR TITLE
Deps upgrade

### DIFF
--- a/addons/changelog/jaxrs/pom.xml
+++ b/addons/changelog/jaxrs/pom.xml
@@ -50,7 +50,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/content-browse/jaxrs/pom.xml
+++ b/addons/content-browse/jaxrs/pom.xml
@@ -45,7 +45,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/content-index/pom.xml
+++ b/addons/content-index/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.cdi.util</groupId>

--- a/addons/diagnostics/jaxrs/pom.xml
+++ b/addons/diagnostics/jaxrs/pom.xml
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/dot-maven/jaxrs/pom.xml
+++ b/addons/dot-maven/jaxrs/pom.xml
@@ -51,7 +51,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/folo/jaxrs/pom.xml
+++ b/addons/folo/jaxrs/pom.xml
@@ -53,7 +53,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/hosted-by-archive/jaxrs/pom.xml
+++ b/addons/hosted-by-archive/jaxrs/pom.xml
@@ -45,7 +45,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/koji/jaxrs/pom.xml
+++ b/addons/koji/jaxrs/pom.xml
@@ -45,7 +45,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/path-mapped/jaxrs/pom.xml
+++ b/addons/path-mapped/jaxrs/pom.xml
@@ -50,7 +50,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/pkg-maven/common/pom.xml
+++ b/addons/pkg-maven/common/pom.xml
@@ -103,10 +103,6 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-metrics</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-subsys-trace</artifactId>
-    </dependency>
   </dependencies>
 
 </project>

--- a/addons/promote/jaxrs/pom.xml
+++ b/addons/promote/jaxrs/pom.xml
@@ -45,7 +45,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/repo-proxy/common/pom.xml
+++ b/addons/repo-proxy/common/pom.xml
@@ -38,12 +38,6 @@
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-jaxrs</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.servlet</groupId>
-          <artifactId>jboss-servlet-api_4.0_spec</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
@@ -60,16 +54,10 @@
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-bindings-jaxrs</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jboss.spec.javax.servlet</groupId>
-          <artifactId>jboss-servlet-api_4.0_spec</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
 
   </dependencies>

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingOutputStream.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentReplacingOutputStream.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import java.io.IOException;
 import java.util.Map;
 
@@ -78,6 +79,18 @@ class ContentReplacingOutputStream
             throws IOException
     {
         flush();
-        IOUtils.closeQuietly( originalStream );
+        IOUtils.closeQuietly( originalStream, null );
+    }
+
+    @Override
+    public boolean isReady()
+    {
+        return originalStream.isReady();
+    }
+
+    @Override
+    public void setWriteListener( WriteListener writeListener )
+    {
+        originalStream.setWriteListener( writeListener );
     }
 }

--- a/addons/repo-proxy/jaxrs/pom.xml
+++ b/addons/repo-proxy/jaxrs/pom.xml
@@ -45,7 +45,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/revisions/jaxrs/pom.xml
+++ b/addons/revisions/jaxrs/pom.xml
@@ -45,7 +45,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/addons/sli/pom.xml
+++ b/addons/sli/pom.xml
@@ -58,7 +58,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
   </dependencies>
 

--- a/addons/template/jaxrs/pom.xml
+++ b/addons/template/jaxrs/pom.xml
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/bindings/jaxrs/pom.xml
+++ b/bindings/jaxrs/pom.xml
@@ -38,7 +38,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/boot/jaxrs/pom.xml
+++ b/boot/jaxrs/pom.xml
@@ -56,12 +56,12 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,7 +90,7 @@
 
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
@@ -140,7 +140,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/AbstractMergedContentGenerator.java
@@ -88,7 +88,7 @@ public abstract class AbstractMergedContentGenerator
     }
 
     @Override
-    public final void handleContentDeletion( final ArtifactStore store, final String path,
+    public void handleContentDeletion( final ArtifactStore store, final String path,
                                              final EventMetadata eventMetadata )
         throws IndyWorkflowException
     {
@@ -99,7 +99,7 @@ public abstract class AbstractMergedContentGenerator
     }
 
     @Override
-    public final void handleContentStorage( final ArtifactStore store, final String path, final Transfer result,
+    public void handleContentStorage( final ArtifactStore store, final String path, final Transfer result,
                                             final EventMetadata eventMetadata )
         throws IndyWorkflowException
     {

--- a/ftests/core/pom.xml
+++ b/ftests/core/pom.xml
@@ -92,7 +92,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>commonjava</artifactId>
-    <version>16</version>
+    <version>17</version>
   </parent>
 
   <groupId>org.commonjava.indy</groupId>
@@ -89,9 +89,9 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.1</atlasVersion>
-    <galleyVersion>1.10</galleyVersion>
-    <weftVersion>1.20</weftVersion>
-    <bomVersion>27</bomVersion>
+    <galleyVersion>1.11-SNAPSHOT</galleyVersion>
+    <weftVersion>1.21-SNAPSHOT</weftVersion>
+    <bomVersion>28-SNAPSHOT</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>
     <!-- TODO: partyline is still needed for standalone mode, may be removed in future -->
     <partylineVersion>1.16</partylineVersion>
@@ -99,7 +99,7 @@
     <rwxVersion>2.3</rwxVersion>
     <jhttpcVersion>1.12</jhttpcVersion>
     <httpTestserverVersion>1.4</httpTestserverVersion>
-    <propulsorVersion>1.4</propulsorVersion>
+    <propulsorVersion>1.5-SNAPSHOT</propulsorVersion>
     <auditQueryVersion>0.13.1</auditQueryVersion>
     <annotationVersion>1.3.2</annotationVersion>
     <activationVersion>1.2.0</activationVersion>
@@ -1218,8 +1218,8 @@
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.servlet</groupId>
-        <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-        <version>1.0.1.Final</version>
+        <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+        <version>2.0.0.Final</version>
       </dependency>
       <!-- END: JAX-RS support -->
 
@@ -1425,7 +1425,7 @@
       <dependency>
         <groupId>javax.enterprise</groupId>
         <artifactId>cdi-api</artifactId>
-        <version>1.2</version>
+        <version>2.0</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -1928,6 +1928,9 @@
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
+          <configuration>
+            <tarLongFileMode>posix</tarLongFileMode>
+          </configuration>
           <dependencies>
             <dependency>
               <groupId>org.commonjava.indy.tools</groupId>
@@ -1967,6 +1970,7 @@
             <skipTests>${skipSurefire}</skipTests>
             <redirectTestOutputToFile>${test-redirectOutput}</redirectTestOutputToFile>
             <forkCount>${test-forkCount}</forkCount>
+            <forkedProcessTimeoutInSeconds>300</forkedProcessTimeoutInSeconds>
             <reportsDirectory>${junit.report.dir}</reportsDirectory>
             <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
           </configuration>

--- a/rest/api/pom.xml
+++ b/rest/api/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/subsys/cpool/pom.xml
+++ b/subsys/cpool/pom.xml
@@ -48,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
     </dependency>
   </dependencies>
 

--- a/subsys/flatfile/pom.xml
+++ b/subsys/flatfile/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.maven.galley</groupId>

--- a/subsys/git/pom.xml
+++ b/subsys/git/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>

--- a/subsys/groovy/pom.xml
+++ b/subsys/groovy/pom.xml
@@ -49,7 +49,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>

--- a/subsys/http/pom.xml
+++ b/subsys/http/pom.xml
@@ -35,7 +35,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>

--- a/subsys/infinispan/pom.xml
+++ b/subsys/infinispan/pom.xml
@@ -79,7 +79,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/subsys/jaxrs/pom.xml
+++ b/subsys/jaxrs/pom.xml
@@ -30,7 +30,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
-      <artifactId>jboss-servlet-api_3.0_spec</artifactId>
+      <artifactId>jboss-servlet-api_4.0_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/test/fixtures-core/pom.xml
+++ b/test/fixtures-core/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/test/providers-core/pom.xml
+++ b/test/providers-core/pom.xml
@@ -39,7 +39,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/test/utils/pom.xml
+++ b/test/utils/pom.xml
@@ -30,7 +30,7 @@
   <dependencies>
     <dependency>
       <groupId>org.jboss.weld.se</groupId>
-      <artifactId>weld-se-core</artifactId>
+      <artifactId>weld-se-shaded</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
   * Use weld-se-shaded instead of weld-se-core as it has been merged into weld-se-shaded
   * jboss-servlet-api_3.0_spec to jboss-servlet-api_4.0_spec
   * Fix a WELD-001524 error with new weld-se-shaded
   * Remove a duplicate maven dep declaration
   * Other upgrades:
      * parent to 17
      * galley to 1.11-SNAPSHOT
      * weft to 1.21-SNAPSHOT
      * web-commons to 28-SNAPSHOT
      * propulsor to 1.5-SNAPSHOT
      * cdi-api to 2.0