### PR TITLE
Feat: Add builder pattern for indy client setup

### DIFF
--- a/addons/diagnostics/ftests/src/main/java/org/commonjava/indy/diags/ftest/DownloadDiagBundleTest.java
+++ b/addons/diagnostics/ftests/src/main/java/org/commonjava/indy/diags/ftest/DownloadDiagBundleTest.java
@@ -65,14 +65,14 @@ public class DownloadDiagBundleTest
         try (ZipInputStream in = module.getDiagnosticBundle())
         {
             ZipEntry entry = null;
-            while( ( entry = in.getNextEntry() ) != null )
+            while ( ( entry = in.getNextEntry() ) != null )
             {
                 if ( entry.getName().equals( DiagnosticsManager.THREAD_DUMP_FILE ) )
                 {
                     logger.debug( "\n\nGot thread dump:\n\n{}\n\n", IOUtils.toString( in ) );
                     foundThreadDump = true;
                 }
-                else if ( entry.getName().startsWith( DiagnosticsManager.LOGS_DIR+ "/" ) )
+                else if ( entry.getName().startsWith( DiagnosticsManager.LOGS_DIR + "/" ) )
                 {
                     logger.debug( "\n\nGot log file: '{}'\n\n", entry.getName() );
                     logCount++;
@@ -95,8 +95,12 @@ public class DownloadDiagBundleTest
         SiteConfig config = new SiteConfigBuilder( "indy", fixture.getUrl() ).withRequestTimeoutSeconds( 120 ).build();
         Collection<IndyClientModule> modules = getAdditionalClientModules();
 
-        return new Indy( config, new MemoryPasswordManager(), new IndyObjectMapper( getAdditionalMapperModules() ),
-                         modules.toArray(new IndyClientModule[modules.size()]) );
+        return Indy.builder()
+                   .setLocation( config )
+                   .setPasswordManager( new MemoryPasswordManager() )
+                   .setObjectMapper( new IndyObjectMapper( getAdditionalMapperModules() ) )
+                   .setModules( modules.toArray( new IndyClientModule[0] ) )
+                   .build();
     }
 
     @Override

--- a/addons/folo/client-java/src/test/java/org/commonjava/indy/folo/client/IndyFoloContentClientModuleTest.java
+++ b/addons/folo/client-java/src/test/java/org/commonjava/indy/folo/client/IndyFoloContentClientModuleTest.java
@@ -17,6 +17,7 @@ package org.commonjava.indy.folo.client;
 
 import org.commonjava.indy.client.core.Indy;
 import org.commonjava.indy.client.core.IndyClientException;
+import org.commonjava.indy.client.core.IndyClientHttp;
 import org.commonjava.indy.client.core.helper.PathInfo;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.junit.Before;
@@ -44,7 +45,10 @@ public class IndyFoloContentClientModuleTest
             throws IndyClientException
     {
         module = new IndyFoloContentClientModule();
-        indy = new Indy( server.formatUrl( "api" ), module ).connect();
+        indy = Indy.builder()
+                   .setLocation( IndyClientHttp.defaultSiteConfig( server.formatUrl( "api" ) ) )
+                   .setModules( module )
+                   .build();
     }
 
     @Test

--- a/addons/promote/client-java/src/test/java/org/commonjava/indy/promote/client/IndyPromoteClientModuleUrlsTest.java
+++ b/addons/promote/client-java/src/test/java/org/commonjava/indy/promote/client/IndyPromoteClientModuleUrlsTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.commonjava.indy.client.core.Indy;
+import org.commonjava.indy.client.core.IndyClientHttp;
 import org.junit.Test;
 
 public class IndyPromoteClientModuleUrlsTest
@@ -28,22 +29,32 @@ public class IndyPromoteClientModuleUrlsTest
 
     @Test
     public void promoteUrl()
-        throws Exception
+            throws Exception
     {
-        final String url = new Indy( BASE, new IndyPromoteClientModule() ).module( IndyPromoteClientModule.class )
-                                                                            .promoteUrl();
+        try (final Indy indy = Indy.builder()
+                                   .setLocation( IndyClientHttp.defaultSiteConfig( BASE ) )
+                                   .setModules( new IndyPromoteClientModule() )
+                                   .build())
+        {
+            final String url = indy.module( IndyPromoteClientModule.class ).promoteUrl();
+            assertThat( url, equalTo( BASE + "/" + IndyPromoteClientModule.PATHS_PROMOTE_PATH ) );
+        }
 
-        assertThat( url, equalTo( BASE + "/" + IndyPromoteClientModule.PATHS_PROMOTE_PATH ) );
     }
 
     @Test
     public void rollbackUrl()
-        throws Exception
+            throws Exception
     {
-        final String url = new Indy( BASE, new IndyPromoteClientModule() ).module( IndyPromoteClientModule.class )
-                                                                            .rollbackUrl();
+        try (final Indy indy = Indy.builder()
+                                   .setLocation( IndyClientHttp.defaultSiteConfig( BASE ) )
+                                   .setModules( new IndyPromoteClientModule() )
+                                   .build())
+        {
+            final String url = indy.module( IndyPromoteClientModule.class ).rollbackUrl();
+            assertThat( url, equalTo( BASE + "/" + IndyPromoteClientModule.PATHS_ROLLBACK_PATH ) );
+        }
 
-        assertThat( url, equalTo( BASE + "/" + IndyPromoteClientModule.PATHS_ROLLBACK_PATH ) );
     }
 
 }

--- a/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentBrowseRemoteIndyListingRewriteManager.java
+++ b/addons/repo-proxy/common/src/main/java/org/commonjava/indy/repo/proxy/ContentBrowseRemoteIndyListingRewriteManager.java
@@ -83,8 +83,12 @@ public class ContentBrowseRemoteIndyListingRewriteManager
             try
             {
                 //FIXME: Here we used a MemPassMgr for simple. Maybe some changes in future for more complex cases.
-                indyClient = new Indy( siteConfig, new MemoryPasswordManager(), mapper,
-                                       new IndyContentBrowseClientModule() );
+                indyClient = Indy.builder()
+                                 .setLocation( siteConfig )
+                                 .setPasswordManager( new MemoryPasswordManager() )
+                                 .setObjectMapper( mapper )
+                                 .setModules( new IndyContentBrowseClientModule() )
+                                 .build();
             }
             catch ( IndyClientException e )
             {

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
@@ -39,13 +39,14 @@ import java.util.Set;
 
 import static org.commonjava.indy.IndyRequestConstants.HEADER_COMPONENT_ID;
 
+@SuppressWarnings( "unused" )
 public class Indy
         implements Closeable
 {
 
     private String apiVersion;
 
-    private final IndyClientHttp http;
+    private IndyClientHttp http;
 
     private final Set<IndyClientModule> moduleRegistry;
 
@@ -53,7 +54,7 @@ public class Indy
     public Indy( final String baseUrl, final IndyClientModule... modules )
             throws IndyClientException
     {
-        this( null, null, Arrays.asList( modules ), IndyClientHttp.defaultSiteConfig( baseUrl ));
+        this( null, null, Arrays.asList( modules ), IndyClientHttp.defaultSiteConfig( baseUrl ) );
     }
 
     @Deprecated
@@ -114,27 +115,31 @@ public class Indy
             throws IndyClientException
     {
         this( location, authenticator, mapper,
-              modules == null ? new IndyClientModule[0] : modules.toArray( new IndyClientModule[modules.size()] ) );
+              modules == null ? new IndyClientModule[0] : modules.toArray( new IndyClientModule[0] ) );
     }
 
     @Deprecated
-    public Indy( final SiteConfig location, final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper, final IndyClientModule... modules )
-    throws IndyClientException
+    public Indy( final SiteConfig location, final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper,
+                 final IndyClientModule... modules )
+            throws IndyClientException
     {
-        this(location, authenticator, mapper, Collections.emptyMap(), modules);
+        this( location, authenticator, mapper, Collections.emptyMap(), modules );
     }
 
     /**
      *
-     * @param location
-     * @param authenticator
-     * @param mapper
+     * @param location -
+     * @param authenticator -
+     * @param mapper -
      * @param mdcCopyMappings a map of fields to copy from LoggingMDC to http request headers where key=MDCMey and value=headerName
-     * @param modules
-     * @throws IndyClientException
+     * @param modules -
+     * @throws IndyClientException -
+     * @deprecated - since 3.1.0, we have new {@link Builder} to set up the indy client, so please use it instead in future
      */
-    public Indy( final SiteConfig location, final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper, final Map<String, String> mdcCopyMappings, final IndyClientModule... modules )
-    throws IndyClientException
+    @Deprecated
+    public Indy( final SiteConfig location, final IndyClientAuthenticator authenticator, final IndyObjectMapper mapper,
+                 final Map<String, String> mdcCopyMappings, final IndyClientModule... modules )
+            throws IndyClientException
     {
         loadApiVersion();
         this.http = new IndyClientHttp( authenticator, mapper == null ? new IndyObjectMapper( true ) : mapper, location,
@@ -148,14 +153,23 @@ public class Indy
             module.setup( this, http );
             moduleRegistry.add( module );
         }
+
     }
 
+    /**
+     * @deprecated - since 3.1.0, we have new {@link Builder} to set up the indy client, so please use it instead in future
+     */
+    @Deprecated
     public Indy( SiteConfig location, PasswordManager passwordManager, IndyClientModule... modules )
             throws IndyClientException
     {
         this( location, passwordManager, null, modules );
     }
 
+    /**
+     * @deprecated - since 3.1.0, we have new {@link Builder} to set up the indy client, so please use it instead in future
+     */
+    @Deprecated
     public Indy( SiteConfig location, PasswordManager passwordManager, IndyObjectMapper objectMapper, IndyClientModule... modules )
             throws IndyClientException
     {
@@ -171,6 +185,107 @@ public class Indy
         {
             module.setup( this, http );
             moduleRegistry.add( module );
+        }
+    }
+
+    private Indy(final Set<IndyClientModule> modules)
+    {
+        loadApiVersion();
+        this.moduleRegistry = new HashSet<>();
+        moduleRegistry.addAll( modules );
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Set<IndyClientModule> moduleRegistry;
+
+        private PasswordManager passwordManager;
+
+        private SiteConfig location;
+
+        private IndyObjectMapper objectMapper;
+
+        private IndyClientAuthenticator authenticator;
+
+        private Map<String, String> mdcCopyMappings;
+
+        private Builder()
+        {
+        }
+
+        public Builder setModules( Set<IndyClientModule> modules )
+        {
+            this.moduleRegistry = modules;
+            return this;
+        }
+
+        public Builder setModules( IndyClientModule... modules )
+        {
+            this.moduleRegistry = new HashSet<>();
+            Collections.addAll( moduleRegistry, modules );
+            return this;
+        }
+
+        public Builder setPasswordManager( PasswordManager passwordManager )
+        {
+            this.passwordManager = passwordManager;
+            return this;
+        }
+
+        public Builder setLocation( SiteConfig location )
+        {
+            this.location = location;
+            return this;
+        }
+
+        public Builder setObjectMapper( IndyObjectMapper objectMapper )
+        {
+            this.objectMapper = objectMapper;
+            return this;
+        }
+
+        public Builder setAuthenticator( IndyClientAuthenticator authenticator )
+        {
+            this.authenticator = authenticator;
+            return this;
+        }
+
+        public Builder setMdcCopyMappings( Map<String, String> mdcCopyMappings )
+        {
+            this.mdcCopyMappings = mdcCopyMappings;
+            return this;
+        }
+
+        public Indy build()
+                throws IndyClientException
+        {
+            Set<IndyClientModule> modules = this.moduleRegistry == null ? new HashSet<>() : this.moduleRegistry;
+            final Indy indy = new Indy(modules);
+            if ( this.objectMapper == null )
+            {
+                this.objectMapper = new IndyObjectMapper( true );
+            }
+
+            indy.http = IndyClientHttp.builder()
+                                      .setAuthenticator( this.authenticator )
+                                      .setApiVersion( indy.getApiVersion() )
+                                      .setLocation( this.location )
+                                      .setPasswordManager( this.passwordManager )
+                                      .setMdcCopyMappings( this.mdcCopyMappings )
+                                      .setObjectMapper( this.objectMapper )
+                                      .build();
+            indy.setupStandardModules();
+            for ( final IndyClientModule module : this.moduleRegistry )
+            {
+                module.setup( indy, indy.http );
+            }
+
+            return indy;
         }
     }
 
@@ -225,7 +340,7 @@ public class Indy
     }
 
     public IndyMaintenanceClientModule maint()
-             throws IndyClientException
+            throws IndyClientException
     {
         return module( IndyMaintenanceClientModule.class );
     }
@@ -307,7 +422,7 @@ public class Indy
         return apiVersion;
     }
 
-    private void loadApiVersion() throws IndyClientException
+    private void loadApiVersion()
     {
         this.apiVersion = new IndyVersioningProvider().getVersioningInstance().getApiVersion();
     }

--- a/subsys/service/src/main/java/org/commonjava/indy/subsys/service/IndyClientProducer.java
+++ b/subsys/service/src/main/java/org/commonjava/indy/subsys/service/IndyClientProducer.java
@@ -65,6 +65,11 @@ public class IndyClientProducer
 
         try
         {
+            final Indy.Builder builder = Indy.builder()
+                                             .setLocation( config )
+                                             .setObjectMapper( new IndyObjectMapper( Collections.emptySet() ) )
+                                             .setMdcCopyMappings( Collections.emptyMap() )
+                                             .setModules( modules.toArray( new IndyClientModule[0] ) );
             if ( serviceConfig.isAuthEnabled() )
             {
                 IndyClientAuthenticator authenticator =
@@ -72,13 +77,11 @@ public class IndyClientProducer
                                                         serviceConfig.getKeycloakAuthRealm(),
                                                         serviceConfig.getKeycloakClientId(),
                                                         serviceConfig.getKeycloakClientSecret() );
-                client = new Indy( config, authenticator, new IndyObjectMapper( Collections.emptySet() ),
-                                   Collections.emptyMap(), modules.toArray( new IndyClientModule[0] ) );
+                client = builder.setAuthenticator( authenticator ).build();
             }
             else
             {
-                client = new Indy( config, new MemoryPasswordManager(), new IndyObjectMapper( Collections.emptySet() ),
-                                   modules.toArray( new IndyClientModule[0] ) );
+                client = builder.setPasswordManager( new MemoryPasswordManager() ).build();
             }
 
         }


### PR DESCRIPTION
  Indy client setup is too complex with bunch of constructors. It is
  really prone to misunderstand which to use. Instead we should consider
  to use builder pattern to reduce this complexity.