### PR TITLE
Feat: Add otel tracing support for indy-client

### DIFF
--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/Indy.java
@@ -26,6 +26,7 @@ import org.commonjava.indy.client.core.module.IndyStoresClientModule;
 import org.commonjava.indy.inject.IndyVersioningProvider;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.stats.IndyVersioning;
+import org.commonjava.o11yphant.trace.TracerConfiguration;
 import org.commonjava.util.jhttpc.auth.PasswordManager;
 import org.commonjava.util.jhttpc.model.SiteConfig;
 
@@ -170,13 +171,14 @@ public class Indy
      * @deprecated - since 3.1.0, we have new {@link Builder} to set up the indy client, so please use it instead in future
      */
     @Deprecated
-    public Indy( SiteConfig location, PasswordManager passwordManager, IndyObjectMapper objectMapper, IndyClientModule... modules )
+    public Indy( SiteConfig location, PasswordManager passwordManager, IndyObjectMapper objectMapper,
+                 IndyClientModule... modules )
             throws IndyClientException
     {
         loadApiVersion();
-        this.http = new IndyClientHttp( passwordManager,
-                                        objectMapper == null ? new IndyObjectMapper( true ) : objectMapper, location,
-                                        getApiVersion() );
+        this.http =
+                new IndyClientHttp( passwordManager, objectMapper == null ? new IndyObjectMapper( true ) : objectMapper,
+                                    location, getApiVersion() );
 
         this.moduleRegistry = new HashSet<>();
 
@@ -188,7 +190,7 @@ public class Indy
         }
     }
 
-    private Indy(final Set<IndyClientModule> modules)
+    private Indy( final Set<IndyClientModule> modules )
     {
         loadApiVersion();
         this.moduleRegistry = new HashSet<>();
@@ -213,6 +215,8 @@ public class Indy
         private IndyClientAuthenticator authenticator;
 
         private Map<String, String> mdcCopyMappings;
+
+        private TracerConfiguration existedTraceConfig;
 
         private Builder()
         {
@@ -249,6 +253,12 @@ public class Indy
             return this;
         }
 
+        public Builder setExistedTraceConfig( TracerConfiguration existedTraceConfig )
+        {
+            this.existedTraceConfig = existedTraceConfig;
+            return this;
+        }
+
         public Builder setAuthenticator( IndyClientAuthenticator authenticator )
         {
             this.authenticator = authenticator;
@@ -265,7 +275,7 @@ public class Indy
                 throws IndyClientException
         {
             Set<IndyClientModule> modules = this.moduleRegistry == null ? new HashSet<>() : this.moduleRegistry;
-            final Indy indy = new Indy(modules);
+            final Indy indy = new Indy( modules );
             if ( this.objectMapper == null )
             {
                 this.objectMapper = new IndyObjectMapper( true );
@@ -276,6 +286,7 @@ public class Indy
                                       .setApiVersion( indy.getApiVersion() )
                                       .setLocation( this.location )
                                       .setPasswordManager( this.passwordManager )
+                                      .setExistedTraceConfig( this.existedTraceConfig )
                                       .setMdcCopyMappings( this.mdcCopyMappings )
                                       .setObjectMapper( this.objectMapper )
                                       .build();

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/IndyClientHttp.java
@@ -47,6 +47,7 @@ import org.commonjava.indy.inject.IndyVersioningProvider;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.o11yphant.jhttpc.SpanningHttpFactory;
+import org.commonjava.o11yphant.trace.TracerConfiguration;
 import org.commonjava.util.jhttpc.HttpFactory;
 import org.commonjava.util.jhttpc.HttpFactoryIfc;
 import org.commonjava.util.jhttpc.JHttpCException;
@@ -164,6 +165,8 @@ public class IndyClientHttp
 
         private String apiVersion;
 
+        private TracerConfiguration existedTraceConfig;
+
         private Map<String, String> mdcCopyMappings;
 
         private Builder()
@@ -199,6 +202,13 @@ public class IndyClientHttp
             this.apiVersion = apiVersion;
             return this;
         }
+
+        public Builder setExistedTraceConfig( TracerConfiguration existedTraceConfig )
+        {
+            this.existedTraceConfig = existedTraceConfig;
+            return this;
+        }
+
 
         public Builder setMdcCopyMappings( Map<String, String> mdcCopyMappings )
         {
@@ -239,7 +249,16 @@ public class IndyClientHttp
                 factory = new HttpFactory( this.passwordManager );
             }
 
-            ClientMetricManager metricManager =  new ClientMetricManager( location );
+            ClientMetricManager metricManager;
+            if ( this.existedTraceConfig != null )
+            {
+                metricManager = new ClientMetricManager( this.existedTraceConfig );
+            }
+            else
+            {
+                metricManager = new ClientMetricManager( location );
+            }
+
             client.metricManager = metricManager;
             client.factory = new SpanningHttpFactory( factory, metricManager.getTraceManager() );
 

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientMetricManager.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientMetricManager.java
@@ -15,79 +15,124 @@
  */
 package org.commonjava.indy.client.core.metric;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.commonjava.indy.client.core.inject.ClientMetricSet;
+import org.commonjava.o11yphant.honeycomb.HoneycombConfiguration;
 import org.commonjava.o11yphant.honeycomb.HoneycombTracePlugin;
+import org.commonjava.o11yphant.otel.OtelConfiguration;
+import org.commonjava.o11yphant.otel.OtelTracePlugin;
 import org.commonjava.o11yphant.trace.SpanFieldsDecorator;
 import org.commonjava.o11yphant.trace.TraceManager;
+import org.commonjava.o11yphant.trace.TracerConfiguration;
+import org.commonjava.o11yphant.trace.spi.O11yphantTracePlugin;
 import org.commonjava.util.jhttpc.model.SiteConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
-public class ClientMetricManager {
+@SuppressWarnings( { "rawtypes", "unused" } )
+public class ClientMetricManager
+{
 
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     private ClientTracerConfiguration configuration;
 
-    private Optional<TraceManager> traceManager;
+    private TraceManager traceManager;
 
     private final ClientTrafficClassifier classifier = new ClientTrafficClassifier();
 
     @ClientMetricSet
     private final ClientGoldenSignalsMetricSet metricSet = new ClientGoldenSignalsMetricSet();
 
-    public ClientMetricManager() {
+    public ClientMetricManager()
+    {
     }
 
     public ClientMetricManager( SiteConfig siteConfig )
     {
         this.configuration = buildConfig( siteConfig );
+        buildTraceManager();
+    }
+
+    public ClientMetricManager( TracerConfiguration existedTraceConfig )
+    {
+        this.configuration = new ClientTracerConfiguration();
+        this.configuration.setEnabled( existedTraceConfig.isEnabled() );
+        this.configuration.setConsoleTransport( existedTraceConfig.isConsoleTransport() );
+        this.configuration.setBaseSampleRate( existedTraceConfig.getBaseSampleRate() );
+        this.configuration.setCpNames( existedTraceConfig.getCPNames() );
+        this.configuration.setFields( existedTraceConfig.getFieldSet() );
+        this.configuration.setEnvironmentMappings( existedTraceConfig.getEnvironmentMappings() );
+        if ( existedTraceConfig instanceof OtelConfiguration )
+        {
+            OtelConfiguration existedOtelConfig = (OtelConfiguration) existedTraceConfig;
+            this.configuration.setGrpcUri( existedOtelConfig.getGrpcEndpointUri() );
+            this.configuration.setGrpcHeaders( existedOtelConfig.getGrpcHeaders() );
+            this.configuration.setGrpcResources( existedOtelConfig.getResources() );
+        }
+        else if ( existedTraceConfig instanceof HoneycombConfiguration )
+        {
+            HoneycombConfiguration existedHoneyConfig = (HoneycombConfiguration) existedTraceConfig;
+            this.configuration.setWriteKey( existedHoneyConfig.getWriteKey() );
+            this.configuration.setDataset( existedHoneyConfig.getDataset() );
+        }
+        buildTraceManager();
+    }
+    private void buildTraceManager(){
         if ( this.configuration.isEnabled() )
         {
-            this.traceManager = Optional.of( new TraceManager(
-                            new HoneycombTracePlugin( configuration, configuration, Optional.of( classifier ) ),
-                            new SpanFieldsDecorator(
-                                            Arrays.asList( new ClientGoldenSignalsSpanFieldsInjector( metricSet ) ) ),
-                            configuration ) );
-        }
-        else
-        {
-            this.traceManager = Optional.empty();
+            O11yphantTracePlugin<?> plugin =
+                    new HoneycombTracePlugin( configuration, configuration, Optional.of( classifier ) );
+            if ( StringUtils.isNotBlank( configuration.getGrpcEndpointUri() ) )
+            {
+                plugin = new OtelTracePlugin( configuration, configuration );
+            }
+            this.traceManager = new TraceManager<>( plugin, new SpanFieldsDecorator(
+                    Collections.singletonList( new ClientGoldenSignalsSpanFieldsInjector( metricSet ) ) ),
+                                                    configuration );
         }
     }
 
-    public ClientMetrics register( HttpUriRequest request ) {
+    public ClientMetrics register( HttpUriRequest request )
+    {
         logger.debug( "Client honey register: {}", request.getURI().getPath() );
         List<String> functions = classifier.calculateClassifiers( request );
 
         return new ClientMetrics( configuration.isEnabled(), request, functions, metricSet );
     }
 
-    private ClientTracerConfiguration buildConfig( SiteConfig siteConfig ) {
+    private ClientTracerConfiguration buildConfig( SiteConfig siteConfig )
+    {
         ClientTracerConfiguration config = new ClientTracerConfiguration();
         config.setEnabled( siteConfig.isMetricEnabled() );
         config.setBaseSampleRate( siteConfig.getBaseSampleRate() );
         return config;
     }
 
-    private String getEndpointName( String method, String pathInfo ) {
+    private String getEndpointName( String method, String pathInfo )
+    {
         StringBuilder sb = new StringBuilder( method + "_" );
         String[] toks = pathInfo.split( "/" );
-        for ( String s : toks ) {
-            if ( isBlank( s ) || "api".equals( s ) ) {
+        for ( String s : toks )
+        {
+            if ( isBlank( s ) || "api".equals( s ) )
+            {
                 continue;
             }
             sb.append( s );
-            if ( "admin".equals( s ) ) {
+            if ( "admin".equals( s ) )
+            {
                 sb.append( "_" );
-            } else {
+            }
+            else
+            {
                 break;
             }
         }
@@ -96,6 +141,6 @@ public class ClientMetricManager {
 
     public Optional<TraceManager> getTraceManager()
     {
-        return traceManager;
+        return traceManager == null ? Optional.empty() : Optional.of( traceManager );
     }
 }

--- a/clients/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientTracerConfiguration.java
+++ b/clients/core-java/src/main/java/org/commonjava/indy/client/core/metric/ClientTracerConfiguration.java
@@ -15,28 +15,60 @@
  */
 package org.commonjava.indy.client.core.metric;
 
+import org.apache.commons.lang3.StringUtils;
 import org.commonjava.indy.client.core.inject.ClientMetricConfig;
 import org.commonjava.o11yphant.honeycomb.HoneycombConfiguration;
 import org.commonjava.o11yphant.otel.OtelConfiguration;
 import org.commonjava.o11yphant.trace.TracerConfiguration;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@SuppressWarnings( "unused" )
 @ClientMetricConfig
 public class ClientTracerConfiguration
         implements TracerConfiguration, OtelConfiguration, HoneycombConfiguration
 {
+    private static final Integer DEFAULT_BASE_SAMPLE_RATE = 100;
+
+    private static final String DEFAULT_INDY_CLIENT_SERVICE_NAME = "indy-client";
 
     private boolean enabled;
 
-    private Integer baseSampleRate;
+    private String serviceName;
 
     private boolean consoleTransport;
 
-    private String dataset;
-
     private String writeKey;
 
+    private String dataset;
+
+    private Integer baseSampleRate;
+
+    private final Map<String, Integer> spanRates = new HashMap<>();
+
+    private Set<String> fields;
+
+    private String environmentMappings;
+
+    private String cpNames;
+
+    private String grpcUri;
+
+    private Map<String, String> grpcHeaders = new HashMap<>();
+
+    private Map<String, String> grpcResources = new HashMap<>();
+
     @Override
-    public boolean isEnabled() {
+    public Map<String, Integer> getSpanRates()
+    {
+        return spanRates;
+    }
+
+    @Override
+    public boolean isEnabled()
+    {
         return enabled;
     }
 
@@ -58,6 +90,60 @@ public class ClientTracerConfiguration
         return dataset;
     }
 
+    @Override
+    public Integer getBaseSampleRate()
+    {
+        return baseSampleRate == null ? DEFAULT_BASE_SAMPLE_RATE : baseSampleRate;
+    }
+
+    @Override
+    public Set<String> getFieldSet()
+    {
+        return fields == null ? DEFAULT_FIELDS : fields;
+    }
+
+    @Override
+    public String getEnvironmentMappings()
+    {
+        return environmentMappings;
+    }
+
+    @Override
+    public String getCPNames()
+    {
+        return cpNames;
+    }
+
+    @Override
+    public Map<String, String> getGrpcHeaders()
+    {
+        return grpcHeaders;
+    }
+
+    @Override
+    public Map<String, String> getResources()
+    {
+        return grpcResources;
+    }
+
+    @Override
+    public String getServiceName()
+    {
+        return StringUtils.isBlank( serviceName ) ? DEFAULT_INDY_CLIENT_SERVICE_NAME : serviceName;
+    }
+
+    @Override
+    public String getNodeId()
+    {
+        return null;
+    }
+
+    @Override
+    public String getGrpcEndpointUri()
+    {
+        return grpcUri == null ? DEFAULT_GRPC_URI : grpcUri;
+    }
+
     public void setDataset( String dataset )
     {
         this.dataset = dataset;
@@ -73,27 +159,48 @@ public class ClientTracerConfiguration
         this.consoleTransport = consoleTransport;
     }
 
-    public void setEnabled( boolean enabled ) {
+    public void setEnabled( boolean enabled )
+    {
         this.enabled = enabled;
     }
 
-    @Override
-    public String getServiceName() {
-        return "indy-client";
-    }
-
-    @Override
-    public String getNodeId() {
-        return null;
-    }
-
-    @Override
-    public Integer getBaseSampleRate()
+    public void setBaseSampleRate( Integer baseSampleRate )
     {
-        return baseSampleRate == null ? DEFAULT_BASE_SAMPLE_RATE : baseSampleRate;
+        this.baseSampleRate = baseSampleRate;
     }
 
-    public void setBaseSampleRate( Integer baseSampleRate ) {
-        this.baseSampleRate = baseSampleRate;
+    public void setFields( Set<String> fields )
+    {
+        this.fields = fields;
+    }
+
+    public void setEnvironmentMappings( String environmentMappings )
+    {
+        this.environmentMappings = environmentMappings;
+    }
+
+    public void setCpNames( String cpNames )
+    {
+        this.cpNames = cpNames;
+    }
+
+    public void setGrpcUri( String grpcUri )
+    {
+        this.grpcUri = grpcUri;
+    }
+
+    public void setServiceName( String serviceName )
+    {
+        this.serviceName = serviceName;
+    }
+
+    public void setGrpcHeaders( Map<String, String> grpcHeaders )
+    {
+        this.grpcHeaders = grpcHeaders;
+    }
+
+    public void setGrpcResources( Map<String, String> grpcResources )
+    {
+        this.grpcResources = grpcResources;
     }
 }

--- a/subsys/service/src/main/java/org/commonjava/indy/subsys/service/IndyClientProducer.java
+++ b/subsys/service/src/main/java/org/commonjava/indy/subsys/service/IndyClientProducer.java
@@ -22,6 +22,7 @@ import org.commonjava.indy.client.core.auth.IndyClientAuthenticator;
 import org.commonjava.indy.client.core.module.IndyStoreQueryClientModule;
 import org.commonjava.indy.client.core.module.IndyStoresClientModule;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
+import org.commonjava.indy.subsys.honeycomb.config.IndyTraceConfiguration;
 import org.commonjava.indy.subsys.service.config.RepositoryServiceConfig;
 import org.commonjava.indy.subsys.service.inject.ServiceClient;
 import org.commonjava.indy.subsys.service.keycloak.KeycloakTokenAuthenticator;
@@ -43,7 +44,12 @@ public class IndyClientProducer
     private Indy client;
 
     @Inject
-    private RepositoryServiceConfig serviceConfig;
+    RepositoryServiceConfig serviceConfig;
+
+    @Inject
+    IndyTraceConfiguration indyTraceConfig;
+
+    @SuppressWarnings( "unused" )
 
     protected IndyClientProducer()
     {
@@ -68,6 +74,7 @@ public class IndyClientProducer
             final Indy.Builder builder = Indy.builder()
                                              .setLocation( config )
                                              .setObjectMapper( new IndyObjectMapper( Collections.emptySet() ) )
+                                             .setExistedTraceConfig( indyTraceConfig )
                                              .setMdcCopyMappings( Collections.emptyMap() )
                                              .setModules( modules.toArray( new IndyClientModule[0] ) );
             if ( serviceConfig.isAuthEnabled() )


### PR DESCRIPTION
Indy client now does not support otel tracing because it lacks the trace configuration for o11yphant. This PR added the configuration support and reuse Indy's trace config for service store data retrieving. 