### PR TITLE
Re-enable RecalculateMissingChecksumForTrackingRecordTest

### DIFF
--- a/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RecalculateMissingChecksumForTrackingRecordTest.java
+++ b/addons/folo/ftests/src/main/java/org/commonjava/indy/folo/ftest/report/RecalculateMissingChecksumForTrackingRecordTest.java
@@ -17,13 +17,11 @@ package org.commonjava.indy.folo.ftest.report;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.IOUtils;
-import org.commonjava.indy.client.core.util.UrlUtils;
 import org.commonjava.indy.folo.client.IndyFoloAdminClientModule;
 import org.commonjava.indy.folo.client.IndyFoloContentClientModule;
 import org.commonjava.indy.folo.dto.TrackedContentDTO;
 import org.commonjava.indy.folo.dto.TrackedContentEntryDTO;
 import org.commonjava.indy.ftest.core.category.BytemanTest;
-import org.commonjava.indy.ftest.core.category.TimingDependent;
 import org.commonjava.indy.model.core.RemoteRepository;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.test.http.expect.ExpectationServer;
@@ -31,7 +29,6 @@ import org.jboss.byteman.contrib.bmunit.BMRule;
 import org.jboss.byteman.contrib.bmunit.BMRules;
 import org.jboss.byteman.contrib.bmunit.BMUnitConfig;
 import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -50,9 +47,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @RunWith( BMUnitRunner.class )
 @BMUnitConfig( debug = true )
 @Category( BytemanTest.class )
-@Ignore(
-        "Warning: this test always fails in integration testing env with docker+ocp, but can pass in local with IT mode. "
-                + "So ignore now and check the reason in future." )
+//@Ignore(
+//        "Warning: this test always fails in integration testing env with docker+ocp, but can pass in local with IT mode. "
+//                + "So ignore now and check the reason in future." )
 public class RecalculateMissingChecksumForTrackingRecordTest
         extends AbstractTrackingReportTest
 {


### PR DESCRIPTION
  Not sure if this it test always failed because of env issue. Re-enable
  to have a test.