### PR TITLE
[cherry-pick]Remove quarkus deps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -846,7 +846,7 @@
       <dependency>
         <groupId>org.commonjava.indy.service</groupId>
         <artifactId>indy-event-model</artifactId>
-        <version>1.0</version>
+        <version>1.2-SNAPSHOT</version>
         <exclusions>
           <exclusion>
             <groupId>org.jboss.slf4j</groupId>


### PR DESCRIPTION
I found that the indy-subsys-kafka introduced quarkus deps. This is  not needed by indy-monolith now. So this commit did some refactor to  remove this deps.