### PR TITLE
Upgrade galley to 1.12-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.1</atlasVersion>
-    <galleyVersion>1.11</galleyVersion>
+    <galleyVersion>1.12-SNAPSHOT</galleyVersion>
     <weftVersion>1.21</weftVersion>
     <bomVersion>28</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>


### PR DESCRIPTION
Upgrade galley that includes the timeout fix. 