### PR TITLE
Merge 3.0.x recent changes to 3.1.x

### DIFF
--- a/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
+++ b/addons/folo/jaxrs/src/main/java/org/commonjava/indy/folo/bind/jaxrs/FoloAdminResource.java
@@ -325,6 +325,24 @@ public class FoloAdminResource
         return Response.created( uriInfo.getRequestUri() ).build();
     }
 
+    @ApiOperation( "Store record for single folo content artifact." )
+    @ApiResponses( { @ApiResponse( code = 201, message = "Store entry content" ) } )
+    @Path( "/report/recordArtifact" )
+    @PUT
+    public Response recordArtifact( final @Context UriInfo uriInfo, final @Context HttpServletRequest request )
+    {
+        try
+        {
+            controller.recordArtifact( request.getInputStream() );
+        }
+        catch ( IOException e )
+        {
+            responseHelper.throwError( new IndyWorkflowException( "IO error", e ) );
+        }
+
+        return Response.created( uriInfo.getRequestUri() ).build();
+    }
+
     private Set<FoloConstants.TRACKING_TYPE> getRequiredTypes( String type )
     {
         Set<FoloConstants.TRACKING_TYPE> types = new HashSet<>();

--- a/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/data/NPMSpecialPathProducer.java
+++ b/addons/pkg-npm/common/src/main/java/org/commonjava/indy/pkg/npm/data/NPMSpecialPathProducer.java
@@ -59,8 +59,6 @@ public class NPMSpecialPathProducer
 
             npmSpecialPaths.add( SpecialPathInfo.from( new FilePatternMatcher( ".*(\\.md5|\\.sha[\\d]+)$" ) )
                                                 .setDecoratable( false )
-                                                .setMergable( true )
-                                                .setMetadata( true )
                                                 .build() );
         }
 

--- a/addons/schedule/common/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
+++ b/addons/schedule/common/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
@@ -29,7 +29,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.Ignore;
 
 import java.util.Collection;
 

--- a/addons/schedule/common/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
+++ b/addons/schedule/common/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
@@ -29,6 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.Ignore;
 
 import java.util.Collection;
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/CommonJava/indy</connection>
     <developerConnection>scm:git:https://github.com/CommonJava/indy</developerConnection>
     <url>http://github.com/Commonjava/indy</url>
-    <tag>indy-parent-3.0.0</tag>
+    <tag>indy-parent-2.7.6</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <connection>scm:git:https://github.com/CommonJava/indy</connection>
     <developerConnection>scm:git:https://github.com/CommonJava/indy</developerConnection>
     <url>http://github.com/Commonjava/indy</url>
-    <tag>indy-parent-2.7.6</tag>
+    <tag>indy-parent-3.0.0</tag>
   </scm>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.1</atlasVersion>
-    <galleyVersion>1.11</galleyVersion>
+    <galleyVersion>1.13</galleyVersion>
     <weftVersion>1.21</weftVersion>
     <bomVersion>28</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>


### PR DESCRIPTION
Hi team, I merge 3.0.x recent changes to 3.1.x. I did below on my local 3.1.x branch.
`git merge 3.0.x -X ours`
This merged all 3.0.x diff to 3.1 so we don't lose anything. But if files conflict, it takes 3.1 code.
Then I manually fix the galley version (3.0.x use a newer version than 3.1.x).
Please help review to confirm your code change on 3.0.x are merged correctly. Thanks.