### PR TITLE
Merge 3.0.2 recent changes to 3.1.x 

### DIFF
--- a/addons/schedule/common/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
+++ b/addons/schedule/common/src/test/java/org/commonjava/indy/schedule/ScheduleTest.java
@@ -29,7 +29,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.Ignore;
 
 import java.util.Collection;
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.1</atlasVersion>
-    <galleyVersion>1.11</galleyVersion>
+    <galleyVersion>1.13</galleyVersion>
     <weftVersion>1.21</weftVersion>
     <bomVersion>28</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>


### PR DESCRIPTION
I checked out 3.0.2, and did below on my local 3.1.x branch.
git merge 3.0.2 -X ours
This merged all 3.0.2 diff to 3.1 so we don't lose anything. But if files conflict, it takes 3.1 code.
Then I manually fix the galley version.