### PR TITLE
Add trackingId to PromoteRequest

### DIFF
--- a/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/AbstractPromoteRequest.java
+++ b/addons/promote/model-java/src/main/java/org/commonjava/indy/promote/model/AbstractPromoteRequest.java
@@ -30,8 +30,22 @@ public abstract class AbstractPromoteRequest<T extends PromoteRequest> implement
     @ApiModelProperty( "Optional promotion Id" )
     protected String promotionId = UUID.randomUUID().toString(); // default
 
+    @ApiModelProperty( "Optional tracking Id" )
+    protected String trackingId;
+
     @ApiModelProperty( value="Callback which is used to send the promotion result." )
     protected CallbackTarget callback;
+
+    public String getTrackingId()
+    {
+        return trackingId;
+    }
+
+    public T setTrackingId(String trackingId)
+    {
+        this.trackingId = trackingId;
+        return (T) this;
+    }
 
     @Override
     public boolean isAsync()


### PR DESCRIPTION
Adding the trackingId to promote request is backward compatible. PNC can set it when they are ready. Same change is made on promote service side https://github.com/Commonjava/indy-promote-service/pull/61