### PR TITLE
Fix user token leak

### DIFF
--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/UserPass.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/util/UserPass.java
@@ -46,7 +46,7 @@ public final class UserPass
                     {
                         final String[] authParts = value.split( " " );
                         userpass = new String( Base64.decodeBase64( authParts[1] ) );
-                        logger.info( "userpass is: '{}'", userpass );
+                        logger.info( "Basic userpass is: '{}'", mask(userpass) );
                         break;
                     }
                 }
@@ -56,17 +56,25 @@ public final class UserPass
         if ( userpass != null )
         {
             final String[] upStr = userpass.split( ":" );
-            logger.info( "Split userpass into:\n  {}", StringUtils.join( upStr, "\n  " ) );
-
             if ( upStr.length < 1 )
             {
                 return null;
             }
-
+            logger.debug( "Split user: {}, pass: ******", upStr[0] );
             return new UserPass( upStr[0], upStr.length > 1 ? upStr[1] : null );
         }
 
         return null;
+    }
+
+    private static String mask(String userpass)
+    {
+        int index = userpass.indexOf(":");
+        if ( index > 0 )
+        {
+            return userpass.substring( 0, index ) + ":******";
+        }
+        return "unknown";
     }
 
     public static UserPass parse( final String headerValue )


### PR DESCRIPTION
Indy httproxy log print user token like below. It is security leak.
`[INFO ] [PROXY-GET http://indy-admin.psi.redhat.com/api/folo/track/build-AYEGCYVZWLYAC/npm/group/shared-imports+yarn-public/semver/-/sem
ver-5.7.1.tgz HTTP/1.1] o.c.indy.subsys.http.util.UserPass no no - userpass is: 'build-AYEGCYVZWLYAC+tracking:eyJhbGc
`
This pr fix it.