### PR TITLE
Add content-browse API back

### DIFF
--- a/addons/content-browse/pom.xml
+++ b/addons/content-browse/pom.xml
@@ -30,10 +30,12 @@
   <modules>
     <module>common</module>
     <module>jaxrs</module>
-    <module>ftests</module>
     <module>model-java</module>
+    <module>ftests</module>
+    <!--
     <module>ui</module>
     <module>client-java</module>
+    -->
   </modules>
 
 </project>

--- a/addons/event-audit/common/pom.xml
+++ b/addons/event-audit/common/pom.xml
@@ -37,7 +37,7 @@
       <artifactId>galley-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
+      <groupId>org.commonjava.indy.service</groupId>
       <artifactId>indy-folo-model-java</artifactId>
     </dependency>
     <dependency>

--- a/addons/event-publisher/common/pom.xml
+++ b/addons/event-publisher/common/pom.xml
@@ -37,7 +37,7 @@
             <artifactId>indy-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.commonjava.indy</groupId>
+            <groupId>org.commonjava.indy.service</groupId>
             <artifactId>indy-folo-model-java</artifactId>
         </dependency>
         <dependency>

--- a/addons/folo/client-java/pom.xml
+++ b/addons/folo/client-java/pom.xml
@@ -36,7 +36,7 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
+      <groupId>org.commonjava.indy.service</groupId>
       <artifactId>indy-folo-model-java</artifactId>
     </dependency>
     <dependency>

--- a/addons/folo/common/pom.xml
+++ b/addons/folo/common/pom.xml
@@ -28,7 +28,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
+      <groupId>org.commonjava.indy.service</groupId>
       <artifactId>indy-folo-model-java</artifactId>
     </dependency>
     <dependency>

--- a/addons/koji/ftests/pom.xml
+++ b/addons/koji/ftests/pom.xml
@@ -44,7 +44,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
+      <groupId>org.commonjava.indy.service</groupId>
       <artifactId>indy-folo-model-java</artifactId>
     </dependency>
     <dependency>

--- a/addons/pom.xml
+++ b/addons/pom.xml
@@ -41,6 +41,7 @@
     <module>repo-proxy</module>
     <module>schedule</module>
     <module>event-publisher</module>
+    <module>content-browse</module>
     <!-- DO NOT REMOVE: append::addon -->
   </modules>
 </project>

--- a/deployments/launcher/pom.xml
+++ b/deployments/launcher/pom.xml
@@ -91,6 +91,12 @@
       <type>tar.gz</type>
       <classifier>confset</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-browse-common</artifactId>
+      <type>tar.gz</type>
+      <classifier>confset</classifier>
+    </dependency>
 
     <dependency>
       <groupId>org.commonjava.indy.rest</groupId>

--- a/embedder-tests/sonar-report/pom.xml
+++ b/embedder-tests/sonar-report/pom.xml
@@ -149,10 +149,6 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-folo-model-java</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-koji-jaxrs</artifactId>
     </dependency>
     <dependency>

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -162,6 +162,14 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-browse-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-content-browse-jaxrs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-repo-proxy-common</artifactId>
     </dependency>
     <dependency>
@@ -257,6 +265,10 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-ftests-pkg-npm</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-ftests-content-browse</artifactId>
     </dependency>
 
     <dependency>
@@ -412,6 +424,7 @@
               <dependency>org.commonjava.indy:indy-ftests-pkg-maven</dependency>
               <dependency>org.commonjava.indy:indy-ftests-pkg-npm</dependency>
               <dependency>org.commonjava.indy:indy-ftests-repo-proxy</dependency>
+              <dependency>org.commonjava.indy:indy-ftests-content-browse</dependency>
             </dependenciesToScan>
             <jvm>${JAVA_11_HOME}/bin/java</jvm>
           </configuration>

--- a/ftests/core/pom.xml
+++ b/ftests/core/pom.xml
@@ -57,7 +57,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
+      <groupId>org.commonjava.indy.service</groupId>
       <artifactId>indy-folo-model-java</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,11 @@
         <version>1.3-SNAPSHOT</version>
       </dependency>
       <dependency>
+        <groupId>org.commonjava.indy.service</groupId>
+        <artifactId>indy-folo-model-java</artifactId>
+        <version>1.3-SNAPSHOT</version>
+      </dependency>
+      <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-api</artifactId>
         <version>3.3.0-SNAPSHOT</version>
@@ -396,11 +401,6 @@
       <dependency>
         <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-folo-client-java</artifactId>
-        <version>3.3.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.indy</groupId>
-        <artifactId>indy-folo-model-java</artifactId>
         <version>3.3.0-SNAPSHOT</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -567,6 +567,36 @@
 
       <dependency>
         <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-content-browse-common</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-content-browse-model-java</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-content-browse-jaxrs</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-ftests-content-browse</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
+        <artifactId>indy-content-browse-common</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+        <classifier>confset</classifier>
+        <type>tar.gz</type>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-diagnostics-jaxrs</artifactId>
         <version>3.3.0-SNAPSHOT</version>
       </dependency>

--- a/rest/api/src/test/java/org/commonjava/indy/rest/apigen/SwaggerExportTest.java
+++ b/rest/api/src/test/java/org/commonjava/indy/rest/apigen/SwaggerExportTest.java
@@ -25,7 +25,10 @@ import org.commonjava.indy.client.core.util.UrlUtils;
 import org.commonjava.indy.ftest.core.AbstractIndyFunctionalTest;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.commonjava.indy.util.ApplicationHeader;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,37 +53,46 @@ import static org.junit.Assert.fail;
 public class SwaggerExportTest
         extends AbstractIndyFunctionalTest
 {
+    private final Logger logger = LoggerFactory.getLogger( this.getClass() );
+
     @Test
+    //    @Ignore
     public void downloadApiFiles()
     {
-        CloseableHttpClient client = HttpClientBuilder.create().build();
+        try (CloseableHttpClient client = HttpClientBuilder.create().build())
+        {
+            Arrays.asList( "yaml", "json" ).forEach( ext -> {
+                HttpGet get = new HttpGet( UrlUtils.buildUrl( "http://localhost:" + fixture.getBootOptions().getPort(),
+                                                              "swagger." + ext ) );
 
-        Arrays.asList( "yaml", "json").forEach( ext->{
-            HttpGet get = new HttpGet(
-                    UrlUtils.buildUrl( "http://localhost:" + fixture.getBootOptions().getPort(), "swagger." + ext ) );
+                get.setHeader( ApplicationHeader.accept.key(), "application/" + ext );
+                try (CloseableHttpResponse response = client.execute( get ))
+                {
+                    assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
 
-            get.setHeader( ApplicationHeader.accept.key(), "application/" + ext );
-            try(CloseableHttpResponse response = client.execute( get ))
-            {
-                assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+                    String content = IOUtils.toString( response.getEntity().getContent(), Charset.defaultCharset() );
+                    FileUtils.write( new File( "target/classes/indy-rest-api." + ext ), content,
+                                     Charset.defaultCharset() );
+                }
+                catch ( IOException e )
+                {
+                    logger.error( "failed to retrieve swagger.{}", ext );
+                }
+            } );
+        }
+        catch ( IOException e )
+        {
+            logger.error( "failed to start httpclient" );
+        }
 
-                String content = IOUtils.toString( response.getEntity().getContent(), Charset.defaultCharset() );
-                FileUtils.write( new File( "target/classes/indy-rest-api." + ext ), content, Charset.defaultCharset() );
-            }
-            catch ( IOException e )
-            {
-                fail( "failed to retrieve swagger." + ext );
-            }
-        } );
     }
 
     @Override
-    protected void initTestConfig( CoreServerFixture fixture ) throws IOException
+    protected void initTestConfig( CoreServerFixture fixture )
+            throws IOException
     {
-        writeConfigFile( "main.conf", "standalone=true\n"
-                        + "[durable-state]\n"
-                        + "folo.storage=infinispan\n"
-                        + "store.storage=infinispan\n" );
+        writeConfigFile( "main.conf", "standalone=true\n" + "[durable-state]\n" + "folo.storage=infinispan\n"
+                + "store.storage=infinispan\n" );
     }
 
 }


### PR DESCRIPTION
  The content browse API is needed for content listings retrieving by
  both user side and UI service side, so still need to be in content
  service