### PR TITLE
Remove usage of o11yphant-trace-honeycomb

### DIFF
--- a/clients/core-java/pom.xml
+++ b/clients/core-java/pom.xml
@@ -34,16 +34,6 @@
     </dependency>
     <dependency>
       <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-trace-honeycomb</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.undertow</groupId>
-          <artifactId>undertow-servlet</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.util</groupId>
       <artifactId>o11yphant-trace-otel</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,6 @@
     <jgroupsVersion>4.0.4.Final</jgroupsVersion>
     <httpcoreVersion>4.4.9</httpcoreVersion>
     <httpclientVersion>4.5.9</httpclientVersion>
-    <honeycombVersion>1.5.1</honeycombVersion>
     <otelInstrumentationVersion>1.19.0-alpha</otelInstrumentationVersion>
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.11.3</datastaxVersion>
@@ -840,11 +839,6 @@
         <artifactId>jboss-logging</artifactId>
         <version>3.3.0.Final</version>
       </dependency>
-      <dependency>
-        <groupId>io.honeycomb.beeline</groupId>
-        <artifactId>beeline-core</artifactId>
-        <version>${honeycombVersion}</version>
-      </dependency>
 
       <dependency>
         <groupId>org.hibernate</groupId>
@@ -1379,11 +1373,6 @@
       <dependency>
         <groupId>org.commonjava.util</groupId>
         <artifactId>o11yphant-trace-otel</artifactId>
-        <version>${o11yphantVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.util</groupId>
-        <artifactId>o11yphant-trace-honeycomb</artifactId>
         <version>${o11yphantVersion}</version>
       </dependency>
       <dependency>

--- a/subsys/trace/pom.xml
+++ b/subsys/trace/pom.xml
@@ -41,10 +41,6 @@
       <artifactId>o11yphant-trace-otel</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.util</groupId>
-      <artifactId>o11yphant-trace-honeycomb</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/subsys/trace/src/main/conf/conf.d/trace.conf
+++ b/subsys/trace/src/main/conf/conf.d/trace.conf
@@ -2,9 +2,6 @@
 # Disabled by default
 #enabled = false
 
-#write.key = somekey
-#dataset = test
-
 # Some example span configurations
 
 #spans.include=DefaultArtifactStoreQuery,DefaultContentManager,MavenMetadataMerger,getOrderedConcreteStoresInGroup

--- a/subsys/trace/src/main/java/org/commonjava/indy/subsys/trace/TraceManagerProducer.java
+++ b/subsys/trace/src/main/java/org/commonjava/indy/subsys/trace/TraceManagerProducer.java
@@ -15,16 +15,14 @@
  */
 package org.commonjava.indy.subsys.trace;
 
-import org.commonjava.indy.subsys.trace.config.IndyTraceConfiguration;
 import org.commonjava.indy.subsys.metrics.IndyTrafficClassifier;
-import org.commonjava.o11yphant.honeycomb.HoneycombTracePlugin;
+import org.commonjava.indy.subsys.trace.config.IndyTraceConfiguration;
 import org.commonjava.o11yphant.otel.OtelTracePlugin;
 import org.commonjava.o11yphant.trace.SpanFieldsDecorator;
 import org.commonjava.o11yphant.trace.TraceManager;
 import org.commonjava.o11yphant.trace.spi.O11yphantTracePlugin;
 import org.commonjava.o11yphant.trace.spi.SpanFieldsInjector;
 import org.commonjava.o11yphant.trace.thread.TraceThreadContextualizer;
-import org.commonjava.propulsor.config.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +34,6 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @ApplicationScoped
 public class TraceManagerProducer
@@ -59,30 +56,8 @@ public class TraceManagerProducer
     @PostConstruct
     public void init()
     {
-        O11yphantTracePlugin<?> plugin;
-        if ( config.getTracer() == TracerPlugin.opentelemetry )
-        {
-            logger.info( "Initializing Opentelemetry trace plugin" );
-            plugin = new OtelTracePlugin( config, config );
-        }
-        else
-        {
-            logger.info( "Initializing Honeycomb trace plugin" );
-            if ( config.isEnabled() )
-            {
-                try
-                {
-                    config.validateForHoneycomb();
-                }
-                catch ( ConfigurationException e )
-                {
-                    logger.error( "Invalid Honeycomb configuration detected!" );
-                    throw new RuntimeException( e );
-                }
-            }
-
-            plugin = new HoneycombTracePlugin( config, config, Optional.of( trafficClassifier ) );
-        }
+        logger.info( "Initializing Opentelemetry trace plugin" );
+        O11yphantTracePlugin<?> plugin = new OtelTracePlugin( config, config );
 
         traceManager = new TraceManager<>( plugin, new SpanFieldsDecorator( getRootSpanFields() ), config );
         traceThreadContextualizer = traceManager.getTraceThreadContextualizer();

--- a/subsys/trace/src/main/java/org/commonjava/indy/subsys/trace/config/IndyTraceConfiguration.java
+++ b/subsys/trace/src/main/java/org/commonjava/indy/subsys/trace/config/IndyTraceConfiguration.java
@@ -18,7 +18,6 @@ package org.commonjava.indy.subsys.trace.config;
 import org.commonjava.indy.conf.IndyConfigInfo;
 import org.commonjava.indy.conf.IndyConfiguration;
 import org.commonjava.indy.subsys.trace.TracerPlugin;
-import org.commonjava.o11yphant.honeycomb.HoneycombConfiguration;
 import org.commonjava.o11yphant.otel.OtelConfiguration;
 import org.commonjava.o11yphant.trace.TracerConfiguration;
 import org.commonjava.propulsor.config.ConfigurationException;
@@ -36,13 +35,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-
 @SectionName( "trace" )
 @ApplicationScoped
 public class IndyTraceConfiguration
-                extends MapSectionListener
-                implements IndyConfigInfo, TracerConfiguration, OtelConfiguration, HoneycombConfiguration
+        extends MapSectionListener
+        implements IndyConfigInfo, TracerConfiguration, OtelConfiguration
 {
     private static final TracerPlugin DEFAULT_TRACER = TracerPlugin.honeycomb;
 
@@ -54,10 +51,6 @@ public class IndyTraceConfiguration
     private static final String TRACER = "tracer";
 
     private static final String CONSOLE_TRANSPORT = "console.transport";
-
-    private static final String WRITE_KEY = "honeycomb.write.key";
-
-    private static final String DATASET = "honeycomb.dataset";
 
     private static final String OTEL_GRPC_URI = "otel.grpc.uri";
 
@@ -82,10 +75,6 @@ public class IndyTraceConfiguration
     private TracerPlugin tracer;
 
     private boolean consoleTransport;
-
-    private String writeKey;
-
-    private String dataset;
 
     private Integer baseSampleRate;
 
@@ -148,12 +137,6 @@ public class IndyTraceConfiguration
             case TRACER:
                 this.tracer = TracerPlugin.valueOf( value.trim().toLowerCase() );
                 break;
-            case WRITE_KEY:
-                this.writeKey = value.trim();
-                break;
-            case DATASET:
-                this.dataset = value.trim();
-                break;
             case BASE_SAMPLE_RATE:
                 this.baseSampleRate = Integer.parseInt( value.trim() );
                 break;
@@ -198,18 +181,6 @@ public class IndyTraceConfiguration
     public TracerPlugin getTracer()
     {
         return tracer == null ? DEFAULT_TRACER : tracer;
-    }
-
-    @Override
-    public String getWriteKey()
-    {
-        return writeKey;
-    }
-
-    @Override
-    public String getDataset()
-    {
-        return dataset;
     }
 
     @Override
@@ -261,33 +232,15 @@ public class IndyTraceConfiguration
     }
 
     @Override
-    public Map<String, String> getResources(){
+    public Map<String, String> getResources()
+    {
         return grpcResources;
     }
+
     @Override
     public String getGrpcEndpointUri()
     {
         return grpcUri == null ? DEFAULT_GRPC_URI : grpcUri;
-    }
-
-    public void validateForHoneycomb() throws ConfigurationException
-    {
-        Set<String> ret = new HashSet<>();
-        if ( isEmpty( writeKey ) )
-        {
-            ret.add( WRITE_KEY );
-        }
-
-        if ( isEmpty( dataset ) )
-        {
-            ret.add( DATASET );
-        }
-
-        if ( !ret.isEmpty() )
-        {
-            throw new ConfigurationException( "Cannot initialize Honeycomb tracer. Missing configuration fields: {}",
-                                              ret );
-        }
     }
 
 }


### PR DESCRIPTION
  As we start to use opentelemetry for tracing, the honeycomb native usage is deprecated and should be removed