### PR TITLE
Remove the trace using for indy http injection for galley

### DIFF
--- a/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpProvider.java
+++ b/subsys/http/src/main/java/org/commonjava/indy/subsys/http/IndyHttpProvider.java
@@ -23,8 +23,6 @@ import org.commonjava.indy.subsys.http.util.IndySiteConfigLookup;
 import org.commonjava.maven.galley.spi.auth.PasswordManager;
 import org.commonjava.maven.galley.transport.htcli.Http;
 import org.commonjava.maven.galley.transport.htcli.HttpImpl;
-import org.commonjava.o11yphant.jhttpc.SpanningHttpFactory;
-import org.commonjava.o11yphant.trace.TraceManager;
 import org.commonjava.util.jhttpc.HttpFactory;
 import org.commonjava.util.jhttpc.HttpFactoryIfc;
 import org.commonjava.util.jhttpc.INTERNAL.util.HttpUtils;
@@ -37,7 +35,6 @@ import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.Optional;
 
 @ApplicationScoped
 public class IndyHttpProvider
@@ -50,8 +47,6 @@ public class IndyHttpProvider
     @Inject
     private IndySiteConfigLookup siteConfigLookup;
 
-    @Inject
-    private TraceManager traceManager;
 
     private PasswordManager passwordManager;
 
@@ -69,10 +64,9 @@ public class IndyHttpProvider
     public void setup()
     {
         passwordManager = new org.commonjava.maven.galley.auth.AttributePasswordManager();
-        Optional<TraceManager> traceManagerOptional = traceManager == null ? Optional.empty() : Optional.of( traceManager );
-        http = new HttpImpl( passwordManager, traceManagerOptional );
+        http = new HttpImpl( passwordManager );
 
-        httpFactory = new SpanningHttpFactory( new HttpFactory( new AttributePasswordManager( siteConfigLookup ) ), traceManagerOptional );
+        httpFactory = new HttpFactory( new AttributePasswordManager( siteConfigLookup ) );
     }
 
     @Produces


### PR DESCRIPTION
   This PR will remove the trace injection into galley through http
   client from Indy, because this http is serving for galley http
   functions which are used for external http communication(e.g. remote
   artifacts download). I don't think we need to start a tracing span on
   this type of work.