### PR TITLE
Add back the indy-version.properties generation

### DIFF
--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -477,6 +477,41 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cassandra-maven-plugin</artifactId>
       </plugin>
+      <!-- These two plugin are used to generate indy-version.properties versioning info -->
+      <plugin>
+        <groupId>ru.concerteza.buildnumber</groupId>
+        <artifactId>maven-jgit-buildnumber-plugin</artifactId>
+        <version>1.2.9</version>
+        <executions>
+          <execution>
+            <id>git-buildnumber</id>
+            <goals>
+              <goal>extract-buildnumber</goal>
+            </goals>
+            <phase>initialize</phase>
+            <configuration>
+              <runOnlyAtExecutionRoot>false</runOnlyAtExecutionRoot>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.1</version>
+        <executions>
+          <execution>
+            <id>buildnumbers</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+            <configuration>
+              <timestampFormat>{0,date,yyyy-MM-dd HH:mm Z}</timestampFormat>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/embedder/src/main/resources/indy-version.properties
+++ b/embedder/src/main/resources/indy-version.properties
@@ -1,0 +1,5 @@
+version=@project.version@
+builder=@user.name@
+commit.id=@git.shortRevision@
+timestamp=@timestamp@
+api-version=@apiVersion@


### PR DESCRIPTION
  The indy-version.properties is used to provide indy versioning info
  through /api/stats/version-info API