### PR TITLE
Update galley to 1.15 and pathmap to 2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <otelInstrumentationVersion>1.19.0-alpha</otelInstrumentationVersion>
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.11.3</datastaxVersion>
-    <pathmappedStorageVersion>2.4</pathmappedStorageVersion>
+    <pathmappedStorageVersion>2.5</pathmappedStorageVersion>
     <o11yphantVersion>1.9</o11yphantVersion>
     <swaggerVersion>1.6.6</swaggerVersion>
     <agroalVersion>1.16</agroalVersion>
@@ -90,7 +90,7 @@
 
     <!-- commonjava/redhat projects -->
     <atlasVersion>1.1.1</atlasVersion>
-    <galleyVersion>1.14</galleyVersion>
+    <galleyVersion>1.15</galleyVersion>
     <weftVersion>1.22</weftVersion>
     <bomVersion>28</bomVersion>
     <webdavVersion>3.2.1</webdavVersion>


### PR DESCRIPTION
Update path-mapped-storage to 2.5 that include:

1. Extend file timeout for accessing
2. Copy entry with specified creation and expiration
3. Safe storage gc