### PR TITLE
Fix the setting of recordingEnabled

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/conf/FoloConfig.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/conf/FoloConfig.java
@@ -83,7 +83,7 @@ public class FoloConfig
     @ConfigName( "recording.enabled")
     public void setRecordingEnabled( final boolean enabled )
     {
-        this.enabled = enabled;
+        this.recordingEnabled = enabled;
     }
 
     public boolean isGroupContentTracked()


### PR DESCRIPTION
I checked the logs of stage and prod, found that this config ref the wrong value and it does not take effect at all. That means indy monolith still hit the folo db to create the records as well as tracking service. This may have no impact on the folo records, but it absolutely brings duplicate loads against folo table. 