### PR TITLE
Bump deps version

### DIFF
--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/conf/FoloConfig.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/conf/FoloConfig.java
@@ -25,6 +25,10 @@ import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
 import java.io.InputStream;
 
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 @SectionName( "folo" )
 @ApplicationScoped
 public class FoloConfig
@@ -34,15 +38,12 @@ public class FoloConfig
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     public static final boolean DEFAULT_ENABLED = true;
-    public static final boolean DEFAULT_DISABLED =  false;
     public static final String DEFAULT_FOLO_CASSANDRA_KEYSPACE =  "folo";
     public static final String DEFAULT_FOLO_CASSANDRA_TABLENAME =  "records";
 
     private Boolean enabled;
 
     private Boolean recordingEnabled;
-
-    private Boolean storeToCassandra;
 
     private Boolean trackGroupContent;
 
@@ -70,55 +71,65 @@ public class FoloConfig
         this.enabled = enabled;
     }
 
-    public boolean isRecordingEnabled()
-    {
-        return recordingEnabled == null ? DEFAULT_ENABLED : recordingEnabled;
-    }
-
-    public Boolean getRecordingEnabled()
-    {
-        return recordingEnabled;
-    }
-
-    @ConfigName( "recording.enabled")
-    public void setRecordingEnabled( final boolean enabled )
-    {
-        this.recordingEnabled = enabled;
-    }
-
-    public boolean isGroupContentTracked()
-    {
-        return Boolean.TRUE.equals( trackGroupContent );
-    }
-
-    @ConfigName( "track.group.content" )
-    public void setTrackGroupContent( final Boolean trackGroupContent )
-    {
-        this.trackGroupContent = trackGroupContent;
-    }
-
-    public Boolean getTrackGroupContent()
-    {
-        return trackGroupContent;
-    }
-
+    @Deprecated(since = "3.3.0")
     public String getFoloCassandraKeyspace() {
         return foloCassandraKeyspace == null ?  DEFAULT_FOLO_CASSANDRA_KEYSPACE : foloCassandraKeyspace;
     }
 
+    @Deprecated(since = "3.3.0")
     @ConfigName("folo.cassandra.keyspace")
     public void setFoloCassandraKeyspace(String foloCassandraKeyspace) {
         logger.warn("\n\n-- SETING FOLO KEYSPACE NAME: "  + foloCassandraKeyspace);
         this.foloCassandraKeyspace = foloCassandraKeyspace;
     }
 
+    @Deprecated(since = "3.3.0")
     public String getFoloCassandraTablename() {
         return foloCassandraTablename == null ? DEFAULT_FOLO_CASSANDRA_TABLENAME : foloCassandraTablename;
     }
 
+    @Deprecated(since = "3.3.0")
     @ConfigName("folo.cassandra.tablename")
     public void setFoloCassandraTablename(String foloCassandraTablename) {
         this.foloCassandraTablename = foloCassandraTablename;
+    }
+
+    @Deprecated(since = "3.3.0")
+    public boolean isRecordingEnabled()
+    {
+        return recordingEnabled == null ? DEFAULT_ENABLED : recordingEnabled;
+    }
+
+    @Deprecated(since = "3.3.0")
+    public Boolean getRecordingEnabled()
+    {
+        return recordingEnabled;
+    }
+
+    @Deprecated(since = "3.3.0")
+    @ConfigName( "recording.enabled")
+    public void setRecordingEnabled( final boolean enabled )
+    {
+        this.recordingEnabled = enabled;
+    }
+
+    @Deprecated(since = "3.3.0")
+    public boolean isGroupContentTracked()
+    {
+        return Boolean.TRUE.equals( trackGroupContent );
+    }
+
+    @Deprecated(since = "3.3.0")
+    @ConfigName( "track.group.content" )
+    public void setTrackGroupContent( final Boolean trackGroupContent )
+    {
+        this.trackGroupContent = trackGroupContent;
+    }
+
+    @Deprecated(since = "3.3.0")
+    public Boolean getTrackGroupContent()
+    {
+        return trackGroupContent;
     }
 
     @Override

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/conf/FoloConfig.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/conf/FoloConfig.java
@@ -83,7 +83,7 @@ public class FoloConfig
     @ConfigName( "recording.enabled")
     public void setRecordingEnabled( final boolean enabled )
     {
-        this.enabled = enabled;
+        this.recordingEnabled = enabled;
     }
 
     public boolean isGroupContentTracked()

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/DtxTrackingRecord.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/DtxTrackingRecord.java
@@ -33,6 +33,10 @@ import java.util.concurrent.TimeUnit;
 
 import static org.commonjava.indy.folo.data.FoloRecordCassandra.TABLE_NAME;
 
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 @Table(name = TABLE_NAME )
 public class DtxTrackingRecord {
 

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloCacheProducer.java
@@ -39,7 +39,10 @@ import java.lang.annotation.ElementType;
  * This ISPN cache producer has some self-defined indexing logic. This directly uses ISPN/hibernate search api
  * to configure the indexable keys used in folo-sealed cache to decouple the folo/model-java dependency on ISPN
  * libraries.
+ *
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
  */
+@Deprecated(since = "3.3.0")
 public class FoloCacheProducer
 {
 

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloContentException.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloContentException.java
@@ -20,6 +20,10 @@ import org.commonjava.indy.IndyException;
 import java.text.MessageFormat;
 import java.util.IllegalFormatException;
 
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 public class FoloContentException
         extends IndyException
 {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloFileTypes.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloFileTypes.java
@@ -22,7 +22,10 @@ import java.util.Set;
 
 /**
  * Created by jdcasey on 9/9/15.
+ *
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
  */
+@Deprecated(since = "3.3.0")
 public final class FoloFileTypes
 {
 

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloFiler.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloFiler.java
@@ -24,7 +24,10 @@ import java.io.File;
 
 /**
  * Created by jdcasey on 9/9/15.
+ *
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
  */
+@Deprecated(since = "3.3.0")
 public class FoloFiler
 {
     public static final String BAK_DIR = "bak";

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloInprogressCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloInprogressCache.java
@@ -24,7 +24,10 @@ import java.lang.annotation.Target;
 
 /**
  * Qualifier used to supply "folo-in-progress" cache in infinispan.xml.
+ *
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
  */
+@Deprecated(since = "3.3.0")
 @Qualifier
 @Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
 @Retention( RetentionPolicy.RUNTIME)

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloProducer.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloProducer.java
@@ -23,7 +23,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
-
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 @ApplicationScoped
 public class FoloProducer {
 

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecord.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecord.java
@@ -22,7 +22,10 @@ import org.commonjava.indy.folo.model.TrackingKey;
 import org.commonjava.o11yphant.metrics.annotation.Measure;
 
 import java.util.Set;
-
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 public interface FoloRecord {
     @Measure
     boolean recordArtifact(TrackedContentEntry entry)

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCache.java
@@ -44,6 +44,10 @@ import java.util.TreeSet;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 @ApplicationScoped
 @FoloStoretoInfinispan
 public class FoloRecordCache implements FoloRecord {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloRecordCassandra.java
@@ -41,6 +41,10 @@ import java.util.stream.Collectors;
 
 import static org.commonjava.indy.folo.data.DtxTrackingRecord.fromCassandraRow;
 
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 @ApplicationScoped
 @FoloStoreToCassandra
 public class FoloRecordCassandra implements FoloRecord,StartupAction {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloSealedCache.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloSealedCache.java
@@ -24,7 +24,10 @@ import java.lang.annotation.Target;
 
 /**
  * Qualifier used to supply "folo-sealed" cache in infinispan.xml.
+ *
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
  */
+@Deprecated(since = "3.3.0")
 @Qualifier
 @Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
 @Retention( RetentionPolicy.RUNTIME)

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloStoreToCassandra.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloStoreToCassandra.java
@@ -15,13 +15,16 @@
  */
 package org.commonjava.indy.folo.data;
 
-
 import javax.inject.Qualifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 @Qualifier
 @Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD,ElementType.TYPE})
 @Retention( RetentionPolicy.RUNTIME)

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloStoretoInfinispan.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/FoloStoretoInfinispan.java
@@ -15,13 +15,16 @@
  */
 package org.commonjava.indy.folo.data;
 
-
 import javax.inject.Qualifier;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 @Qualifier
 @Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD,ElementType.TYPE})
 @Retention( RetentionPolicy.RUNTIME)

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/StoreKeyFieldBridge.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/StoreKeyFieldBridge.java
@@ -29,7 +29,10 @@ import java.io.IOException;
 /**
  * A FieldBridge used for {@link TrackedContentEntry} storeKey field when do indexing by hibernate search.
  * Used json as the ser/de-ser way
+ *
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
  */
+@Deprecated(since = "3.3.0")
 public class StoreKeyFieldBridge
         implements TwoWayStringBridge
 {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/TrackedContentEntry2StringMapper.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/TrackedContentEntry2StringMapper.java
@@ -26,7 +26,10 @@ import org.commonjava.indy.subsys.infinispan.AbstractIndyKey2StringMapper;
  * The key2string mapper for {@link TrackedContentEntry} working for ISPN jdbc persistence. Note that this mapper only
  * cares about the fields that used in equals() method which follows {@link org.infinispan.persistence.keymappers.Key2StringMapper}
  * rules, so will ignore other fields
+ *
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
  */
+@Deprecated(since = "3.3.0")
 public class TrackedContentEntry2StringMapper
         extends AbstractIndyKey2StringMapper<TrackedContentEntry>
 {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/TrackedContentEntryTransformer.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/TrackedContentEntryTransformer.java
@@ -27,7 +27,10 @@ import java.io.IOException;
 /**
  * A customized infinispan {@link Transformer} used for {@link TrackedContentEntry}
  * to support it to be used as infinispan cache key in indexing.
+ *
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
  */
+@Deprecated(since = "3.3.0")
 public class TrackedContentEntryTransformer
         implements Transformer
 {

--- a/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/TrackingKey2StringMapper.java
+++ b/addons/folo/common/src/main/java/org/commonjava/indy/folo/data/idxmodel/TrackingKey2StringMapper.java
@@ -21,6 +21,10 @@ import org.commonjava.indy.subsys.infinispan.AbstractIndyKey2StringMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated As folo recording function has been moved to tracking service, we don't need this storage anymore
+ */
+@Deprecated(since = "3.3.0")
 public class TrackingKey2StringMapper
         extends AbstractIndyKey2StringMapper<TrackingKey>
 {

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>commonjava</artifactId>
-    <version>17</version>
+    <version>18</version>
   </parent>
 
   <groupId>org.commonjava.indy</groupId>
@@ -61,21 +61,22 @@
     <javaVersion>11</javaVersion>
     <slf4j-version>1.7.36</slf4j-version>
     <infinispanVersion>9.4.24.Final</infinispanVersion>
-    <!--<luceneVersion>7.3.0</luceneVersion>-->
     <protostreamVersion>4.3.0.Final</protostreamVersion>
-    <gsonVersion>2.8.9</gsonVersion>
+    <gsonVersion>2.9.1</gsonVersion>
     <hibernateVersion>5.8.1.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>
-    <undertowVersion>2.2.24.Final</undertowVersion>
+    <jaxrsVersion>3.0.12.Final</jaxrsVersion>
+    <asyncServletVersion>3.0.19.Final</asyncServletVersion>
+    <undertowVersion>2.2.26.Final</undertowVersion>
     <xnioVersion>3.8.2.Final</xnioVersion>
     <keycloakVersion>17.0.1</keycloakVersion>
     <bouncycastleVersion>1.67</bouncycastleVersion>
     <bytemanVersion>4.0.20</bytemanVersion>
     <kafkaVersion>3.1.1</kafkaVersion>
-    <logbackVersion>1.2.9</logbackVersion>
+    <logbackVersion>1.2.12</logbackVersion>
     <logbackContribVersion>0.1.5</logbackContribVersion>
     <weldVersion>3.1.9.Final</weldVersion>
-    <jacksonVersion>2.13.3</jacksonVersion>
+    <jacksonVersion>2.15.2</jacksonVersion>
     <jgroupsVersion>4.0.4.Final</jgroupsVersion>
     <httpcoreVersion>4.4.9</httpcoreVersion>
     <httpclientVersion>4.5.13</httpclientVersion>
@@ -925,12 +926,12 @@
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>jaxrs-api</artifactId>
-        <version>${resteasyVersion}</version>
+        <version>${jaxrsVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>async-http-servlet-3.0</artifactId>
-        <version>${resteasyVersion}</version>
+        <version>${asyncServletVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.jboss.spec.javax.servlet</groupId>


### PR DESCRIPTION
  * commonjava -> 18
  * gson -> 2.9.1
  * undertow -> 2.2.26.Final
  * Resteasy jaxrs-api -> splitted and set to 3.0.12.Final
  * Resteasy async-servlet -> splitted and set to 3.0.19.Final
  * logback -> 1.2.12
  * jackson -> 2.15.2

And also marked some folo api to deprecated