### PR TITLE
Enable the token authentication locally for builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1234,6 +1234,12 @@
         <version>1.15.3</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.jsonwebtoken</groupId>
+        <artifactId>jjwt</artifactId>
+        <version>0.9.1</version>
+      </dependency>
+
       <!-- Define Keycloak deps -->
       <dependency>
         <groupId>org.keycloak</groupId>

--- a/subsys/jaxrs/pom.xml
+++ b/subsys/jaxrs/pom.xml
@@ -109,5 +109,10 @@
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-subsys-metrics</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/AuthConfig.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/AuthConfig.java
@@ -1,0 +1,92 @@
+package org.commonjava.indy.bind.jaxrs.keycloak;
+
+import org.commonjava.indy.conf.IndyConfigInfo;
+import org.commonjava.propulsor.config.annotation.ConfigName;
+import org.commonjava.propulsor.config.annotation.SectionName;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.io.InputStream;
+
+@ApplicationScoped
+@SectionName( AuthConfig.SECTION_NAME )
+public class AuthConfig
+        implements IndyConfigInfo
+{
+    public static final String SECTION_NAME = "auth.local";
+
+    private static final String ENABLED_PROP = "enabled";
+
+    private static final boolean DEFAULT_ENABLED = true;
+
+    private static final String DEFAULT_SECRET = "indy_default";
+
+    private static final Integer DEFAULT_TOKEN_VALIDITY = 12 * 60 * 60;
+
+    private Boolean enabled;
+
+    private Integer tokenExpirationHours;
+
+    private String secret;
+
+    private String roles;
+
+    public AuthConfig() {}
+
+    public boolean isEnabled()
+    {
+        return enabled == null ? DEFAULT_ENABLED : enabled;
+    }
+
+    @ConfigName( ENABLED_PROP )
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public Integer getTokenExpirationHours()
+    {
+        return tokenExpirationHours != null ? tokenExpirationHours * 60 * 60 : DEFAULT_TOKEN_VALIDITY;
+    }
+
+    @ConfigName( "token.expiration.hours" )
+    public void setTokenExpirationHours(Integer tokenExpirationHours)
+    {
+        this.tokenExpirationHours = tokenExpirationHours;
+    }
+
+    public String getRoles()
+    {
+        return roles;
+    }
+
+    @ConfigName( "token.roles" )
+    public void setRoles(String roles)
+    {
+        this.roles = roles;
+    }
+
+    public String getSecret()
+    {
+        return secret != null ? secret : DEFAULT_SECRET;
+    }
+
+    @ConfigName( "token.secret" )
+    public void setSecret(String secret)
+    {
+        this.secret = secret;
+    }
+
+    @Override
+    public String getDefaultConfigFileName()
+    {
+        return "conf.d/auth.conf";
+    }
+
+    @Override
+    public InputStream getDefaultConfig()
+    {
+        return Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream( "default-auth.conf" );
+    }
+
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/AuthConfig.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/AuthConfig.java
@@ -20,7 +20,7 @@ public class AuthConfig
 
     private static final String DEFAULT_SECRET = "indy_default";
 
-    private static final Integer DEFAULT_TOKEN_VALIDITY = 12 * 60 * 60;
+    private static final Integer DEFAULT_TOKEN_VALIDITY = 12;
 
     private Boolean enabled;
 
@@ -44,7 +44,7 @@ public class AuthConfig
 
     public Integer getTokenExpirationHours()
     {
-        return tokenExpirationHours != null ? tokenExpirationHours * 60 * 60 : DEFAULT_TOKEN_VALIDITY;
+        return tokenExpirationHours != null ? tokenExpirationHours : DEFAULT_TOKEN_VALIDITY;
     }
 
     @ConfigName( "token.expiration.hours" )

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/IndyIdentityManager.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/IndyIdentityManager.java
@@ -1,0 +1,93 @@
+package org.commonjava.indy.bind.jaxrs.keycloak;
+
+import io.undertow.security.idm.Account;
+import io.undertow.security.idm.Credential;
+import io.undertow.security.idm.IdentityManager;
+import org.commonjava.indy.bind.jaxrs.util.JwtTokenUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.security.Principal;
+import java.util.*;
+
+@ApplicationScoped
+public class IndyIdentityManager implements IdentityManager
+{
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    @Inject
+    private JwtTokenUtils tokenUtils;
+
+    @Inject
+    private AuthConfig authConfig;
+
+    public Account verify( String token )
+    {
+        if ( !tokenUtils.isExpired(token) )
+        {
+            LocalAccount account = new LocalAccount();
+            logger.info("Authenticated as {}, roles [{}]", account.name, account.roles );
+            return account;
+        }
+        return null;
+    }
+
+    @Override
+    public Account verify( Account account ) {
+        return account;
+    }
+
+    @Override
+    public Account verify( String id, Credential credential ) {
+        return null;
+    }
+
+    @Override
+    public Account verify(Credential credential) {
+        return null;
+    }
+
+    private class LocalAccount implements Account {
+
+        String name;
+        Set<String> roles;
+
+        public LocalAccount()
+        {
+            name = UUID.randomUUID().toString();
+            if ( roles == null )
+            {
+                roles = new HashSet<>();
+                String roleStr = authConfig.getRoles();
+                if ( !roleStr.isBlank() )
+                {
+                    for ( String role : roleStr.split(",") )
+                    {
+                        roles.add( role );
+                    }
+                }
+            }
+        }
+
+        private final Principal principal = new Principal() {
+            @Override
+            public String getName() {
+                return name;
+            }
+        };
+
+        @Override
+        public Principal getPrincipal() {
+            return principal;
+        }
+
+        @Override
+        public Set<String> getRoles() {
+            return roles;
+        }
+
+    }
+
+}

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/KeycloakDeploymentProvider.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/KeycloakDeploymentProvider.java
@@ -54,6 +54,9 @@ public class KeycloakDeploymentProvider
     @Inject
     private BasicAuthenticationOAuthTranslator basicAuthInjector;
 
+    @Inject
+    private IndyIdentityManager identityManager;
+
     @Override
     public DeploymentInfo getDeploymentInfo( String contextRoot, Application application )
     {
@@ -99,6 +102,8 @@ public class KeycloakDeploymentProvider
                 logger.debug( "Keycloak Security Constraint: {}", sc );
                 di.addSecurityConstraint( sc );
             }
+
+            di.setIdentityManager(identityManager);
 
             logger.debug( "Using keycloak.json: {} (exists? {})", config.getKeycloakJson(),
                           new File( config.getKeycloakJson() ).exists() );

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/SecurityResource.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/keycloak/SecurityResource.java
@@ -21,9 +21,11 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.commonjava.indy.IndyWorkflowException;
 import org.commonjava.indy.bind.jaxrs.IndyResources;
+import org.commonjava.indy.bind.jaxrs.util.JwtTokenUtils;
 import org.commonjava.indy.bind.jaxrs.util.REST;
 import org.commonjava.indy.bind.jaxrs.util.ResponseHelper;
 import org.commonjava.indy.subsys.keycloak.rest.SecurityController;
+import org.commonjava.indy.util.ApplicationContent;
 import org.commonjava.indy.util.ApplicationHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +38,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Api( "Security Infrastructure" )
 @Path( "/api/security" )
@@ -55,6 +59,9 @@ public class SecurityResource
 
     @Inject
     private ResponseHelper responseHelper;
+
+    @Inject
+    private JwtTokenUtils jwtTokenUtils;
 
     @ApiOperation( "Retrieve the keycloak JSON configuration (for use by the UI)" )
     @ApiResponses( { @ApiResponse( code = 400, message = "Keycloak is disabled" ),
@@ -146,6 +153,21 @@ public class SecurityResource
         }
 
         return response;
+    }
+
+    @Path("/auth/token")
+    @Produces(ApplicationContent.application_json)
+    @GET
+    public Response getBuilderToken()
+    {
+
+        Map<String, String> results = new HashMap<>();
+
+        final String token = jwtTokenUtils.generateToken();
+        results.put("token", token);
+
+        Response.ResponseBuilder builder = Response.status( 200 );
+        return builder.entity( results ).build();
     }
 
 }

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JwtTokenUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JwtTokenUtils.java
@@ -40,7 +40,7 @@ public class JwtTokenUtils
                 .setClaims( claims )
                 .setSubject( DEFAULT_SUBJECT )
                 .setIssuedAt( new Date( currentTimeMillis ) )
-                .setExpiration( new Date( currentTimeMillis + authConfig.getTokenExpirationHours() * 1000 ) )
+                .setExpiration( new Date( currentTimeMillis + authConfig.getTokenExpirationHours() * 60 * 60 * 1000 ) )
                 //Sign the JWT using the HS512 algorithm and secret key.
                 .signWith( SignatureAlgorithm.HS512, authConfig.getSecret().getBytes())
                 .compact();

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JwtTokenUtils.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/util/JwtTokenUtils.java
@@ -1,0 +1,71 @@
+package org.commonjava.indy.bind.jaxrs.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.impl.DefaultClaims;
+import org.commonjava.indy.bind.jaxrs.keycloak.AuthConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@ApplicationScoped
+public class JwtTokenUtils
+{
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+    
+    private static final String DEFAULT_SUBJECT = "sub";
+
+    @Inject
+    private AuthConfig authConfig;
+
+    public String generateToken()
+    {
+        Map<String, Object> claims = new HashMap<>();
+        return doGenerateToken( claims );
+    }
+
+    private synchronized String doGenerateToken( Map<String, Object> claims ) {
+
+        long currentTimeMillis = System.currentTimeMillis();
+
+        return Jwts.builder()
+                .setClaims( claims )
+                .setSubject( DEFAULT_SUBJECT )
+                .setIssuedAt( new Date( currentTimeMillis ) )
+                .setExpiration( new Date( currentTimeMillis + authConfig.getTokenExpirationHours() * 1000 ) )
+                //Sign the JWT using the HS512 algorithm and secret key.
+                .signWith( SignatureAlgorithm.HS512, authConfig.getSecret().getBytes())
+                .compact();
+    }
+
+    public Boolean isExpired( String token )
+    {
+        Boolean tokenExpired = Boolean.TRUE;
+        try
+        {
+            Claims claims = Jwts.parser().setSigningKey( authConfig.getSecret().getBytes() )
+                    .parseClaimsJws( token ).getBody();
+            tokenExpired = claims.getExpiration().before( new Date() );
+        }
+        catch ( ExpiredJwtException ex )
+        {
+            DefaultClaims claims = (DefaultClaims) ex.getClaims();
+            tokenExpired = claims.getExpiration().before( new Date() );
+        }
+        catch ( Exception e )
+        {
+            logger.warn( "Validate token failed: {}", e.getMessage() );
+        }
+
+        return tokenExpired;
+    }
+
+}

--- a/subsys/jaxrs/src/main/resources/default-auth.conf
+++ b/subsys/jaxrs/src/main/resources/default-auth.conf
@@ -1,0 +1,15 @@
+[auth.local]
+# enabled: By default, the local auth is enabled.
+#
+#enabled=true
+
+# Token cache expiration in hours. Default 12.
+#
+token.expiration.hours=12
+
+# The roles assigned to the token, required for accessing the protected endpoints
+#
+token.roles=pncindyuser
+
+# The secret used to signing the token
+token.secret=default


### PR DESCRIPTION
As agreement, indy introduces the endpoint to provide the token which has longer lifespan for maven build, and still handle off the authentication to SSO if this validation failed. 
