### PR TITLE
[cherry-pick] Fix: Kafka store event can not be received correctly

### DIFF
--- a/deployments/cache-migrator/test-env/indy-env/conf.d/kafka.conf
+++ b/deployments/cache-migrator/test-env/indy-env/conf.d/kafka.conf
@@ -5,3 +5,5 @@ enabled=true
 kafka.bootstrap.servers=127.0.0.1:9092
 kafka.topics=store-event
 kafka.group=kstreams-group
+# By default, we will not enable kafka tracing
+kafka.trace=false

--- a/subsys/kafka/pom.xml
+++ b/subsys/kafka/pom.xml
@@ -55,10 +55,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-subsys-trace</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
     </dependency>
@@ -70,6 +66,14 @@
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-streams-test-utils</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.indy</groupId>
+      <artifactId>indy-subsys-trace</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>o11yphant-trace-otel</artifactId>
     </dependency>
     <dependency>
       <groupId>io.opentelemetry.instrumentation</groupId>

--- a/subsys/kafka/src/main/conf/conf.d/kafka.conf
+++ b/subsys/kafka/src/main/conf/conf.d/kafka.conf
@@ -5,3 +5,5 @@ enabled=true
 kafka.bootstrap.servers=127.0.0.1:9092
 kafka.topics=store-event,promote-complete-event
 kafka.group=kstreams-group
+# By default, we will not enable kafka tracing
+kafka.trace=false

--- a/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/conf/KafkaConfig.java
+++ b/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/conf/KafkaConfig.java
@@ -31,7 +31,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 @SectionName( "kafka" )
 @ApplicationScoped
 public class KafkaConfig
-                implements IndyConfigInfo
+        implements IndyConfigInfo
 {
 
     private static final String DEFAULT_BOOTSTRP_SERVERS = "127.0.0.1:9092";
@@ -41,6 +41,8 @@ public class KafkaConfig
     private static final Integer DEFAULT_RECORDS_PER_PARTITION = 1000;
 
     private static final boolean DEFAULT_ENABLED = true;
+
+    private static final boolean DEFAULT_TRACE = false;
 
     private Boolean enabled;
 
@@ -53,6 +55,8 @@ public class KafkaConfig
     private Integer recordsPerPartition;
 
     private String fileEventTopic;
+
+    private Boolean tracing;
 
     public KafkaConfig()
     {
@@ -119,6 +123,7 @@ public class KafkaConfig
     {
         this.recordsPerPartition = recordsPerPartition;
     }
+
     public String getFileEventTopic()
     {
         return fileEventTopic;
@@ -130,6 +135,16 @@ public class KafkaConfig
         this.fileEventTopic = fileEventTopic;
     }
 
+    public boolean isTracing()
+    {
+        return tracing == null ? DEFAULT_TRACE : tracing;
+    }
+
+    @ConfigName( "kafka.trace" )
+    public void setTracing( boolean tracing )
+    {
+        this.tracing = tracing;
+    }
 
     @Override
     public String getDefaultConfigFileName()

--- a/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/handler/PromoteServiceEventHandler.java
+++ b/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/handler/PromoteServiceEventHandler.java
@@ -93,7 +93,7 @@ public class PromoteServiceEventHandler
                 return;
             }
 
-            Set<String> clearPaths = new HashSet();
+            Set<String> clearPaths = new HashSet<>();
             addClearPaths(clearPaths, completeEvent.getCompletedPaths());
             addClearPaths(clearPaths, completeEvent.getSkippedPaths());
 

--- a/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/trace/TracingKafkaClientSupplier.java
+++ b/subsys/kafka/src/main/java/org/commonjava/indy/subsys/kafka/trace/TracingKafkaClientSupplier.java
@@ -16,27 +16,37 @@
 package org.commonjava.indy.subsys.kafka.trace;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.kafkaclients.KafkaTelemetry;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+import org.commonjava.indy.subsys.kafka.conf.KafkaConfig;
+import org.commonjava.indy.subsys.trace.config.IndyTraceConfiguration;
+import org.commonjava.o11yphant.otel.OtelUtil;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import java.util.Map;
 
+@ApplicationScoped
 public class TracingKafkaClientSupplier
         extends DefaultKafkaClientSupplier
 {
+    @Inject
+    IndyTraceConfiguration traceConfiguration;
+
     @Override
     public Producer<byte[], byte[]> getProducer( Map<String, Object> config )
     {
-        KafkaTelemetry telemetry = KafkaTelemetry.create( GlobalOpenTelemetry.get() );
+        KafkaTelemetry telemetry = KafkaTelemetry.create( getOpentelemetry() );
         return telemetry.wrap( super.getProducer( config ) );
     }
 
     @Override
     public Consumer<byte[], byte[]> getConsumer( Map<String, Object> config )
     {
-        KafkaTelemetry telemetry = KafkaTelemetry.create( GlobalOpenTelemetry.get() );
+        KafkaTelemetry telemetry = KafkaTelemetry.create( getOpentelemetry() );
         return telemetry.wrap( super.getConsumer( config ) );
     }
 
@@ -50,5 +60,10 @@ public class TracingKafkaClientSupplier
     public Consumer<byte[], byte[]> getGlobalConsumer( Map<String, Object> config )
     {
         return this.getConsumer( config );
+    }
+
+    private OpenTelemetry getOpentelemetry()
+    {
+        return OtelUtil.getOpenTelemetry( traceConfiguration, traceConfiguration );
     }
 }


### PR DESCRIPTION
   During testing I found that the store event can not be received
   correctly through Kafka. After checking, found the reason is the
   KafkaStream is not set up correctly. It should be started with a long
   running state but not close immediately. So this PR makes it close in
   shutdown action but not immediately

   And add config to turn on/off kafka tracing