### PR TITLE
Revert "Bump org.keycloak:keycloak-core from 17.0.1 to 22.0.3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <asyncServletVersion>3.0.19.Final</asyncServletVersion>
     <undertowVersion>2.2.27.Final</undertowVersion>
     <xnioVersion>3.8.2.Final</xnioVersion>
-    <keycloakVersion>22.0.3</keycloakVersion>
+    <keycloakVersion>17.0.1</keycloakVersion>
     <bouncycastleVersion>1.67</bouncycastleVersion>
     <bytemanVersion>4.0.20</bytemanVersion>
     <kafkaVersion>3.1.1</kafkaVersion>


### PR DESCRIPTION
  Seems keycloak 22.0.3 has issues with our authentication.