### PR TITLE
Add simple response for disabled UI root

### DIFF
--- a/api/src/main/java/org/commonjava/indy/conf/UIConfiguration.java
+++ b/api/src/main/java/org/commonjava/indy/conf/UIConfiguration.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.conf;
 
+import org.apache.commons.lang3.StringUtils;
 import org.commonjava.propulsor.config.annotation.ConfigName;
 import org.commonjava.propulsor.config.annotation.SectionName;
 
@@ -36,9 +37,13 @@ public class UIConfiguration
 
     private static final Boolean DEFAULT_ENABLED = Boolean.TRUE;
 
+    private static final String DEFAULT_DISABLED_UI_RESPONSE = "Indy content service UI is disabled";
+
     private Boolean enabled;
 
     private File uiDir;
+
+    private String disabledUIResponse;
 
     public UIConfiguration()
     {
@@ -77,6 +82,17 @@ public class UIConfiguration
     public Boolean getEnabled()
     {
         return enabled == null ? DEFAULT_ENABLED : enabled;
+    }
+
+    @ConfigName( "ui.disabled.response" )
+    public void setDisabledUIResponse( final String disabledResponse )
+    {
+        this.disabledUIResponse = disabledResponse;
+    }
+
+    public String getDisabledUIResponse()
+    {
+        return StringUtils.isEmpty( disabledUIResponse ) ? DEFAULT_DISABLED_UI_RESPONSE : disabledUIResponse;
     }
 
     @ConfigName( "enabled" )

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/IndyDeployment.java
@@ -254,17 +254,14 @@ public class IndyDeployment
             DeploymentInfoUtils.mergeFromProviders( di, deploymentProviders, contextRoot, application );
         }
 
-        if ( uiConfiguration.getEnabled() )
-        {
-            // Add UI servlet at the end so its mappings don't obscure any from add-ons.
-            final ServletInfo uiServlet = Servlets.servlet( "UI", UIServlet.class )
-                                                  .setAsyncSupported( true )
-                                                  .setLoadOnStartup( 99 )
-                                                  .addMappings( UIServlet.PATHS );
+        // Add UI servlet at the end so its mappings don't obscure any from add-ons.
+        final ServletInfo uiServlet = Servlets.servlet( "UI", UIServlet.class )
+                                              .setAsyncSupported( true )
+                                              .setLoadOnStartup( 99 )
+                                              .addMappings( UIServlet.PATHS );
 
-            uiServlet.setInstanceFactory( new ImmediateInstanceFactory<Servlet>( ui ) );
-            di.addServlet( uiServlet );
-        }
+        uiServlet.setInstanceFactory( new ImmediateInstanceFactory<Servlet>( ui ) );
+        di.addServlet( uiServlet );
 
 
         return di;

--- a/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ui/AbstractUIServlet.java
+++ b/subsys/jaxrs/src/main/java/org/commonjava/indy/bind/jaxrs/ui/AbstractUIServlet.java
@@ -31,6 +31,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;

--- a/subsys/jaxrs/src/main/resources/default_index.html
+++ b/subsys/jaxrs/src/main/resources/default_index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <title>Indy Content Service</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/wingcss/0.1.9/wing.min.css"/>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/1.6.0/axios.min.js"></script>
+</head>
+<body>
+
+<div class="container">
+  <h1>Indy Content Service</h1>
+  <hr/>
+
+  <div class="cards">
+    <div class="card">
+      <h5 class="card-header">About</h5>
+      <p class="card-body"><b>Indy Content Service</b> provides REST endpoints for all indy artifacts content.</p>
+    </div>
+    <div class="card">
+      <h5 class="card-header">Content retrieval</h5>
+      <p class="card-body">Content retrieval can be accessed through /api/content endpoint, for example: <a id="content-retrieval-example" href="/api/content/maven/remote/central/org/apache/maven/maven-metadata.xml"></a></p>
+    </div>
+    <div class="card">
+      <h5 class="card-header">Content listing</h5>
+      <p class="card-body">Content listing can be accessed through /browse endpoint, for example: <a id="content-list-example" href="/browse/maven/remote/central/"></a></p>
+    </div>
+  </div>
+
+
+  <div id="stats-info" style="position: fixed; bottom: 5%; text-align: center;">
+    <hr/>
+    <a target="_new" href="https://github.com/Commonjava/indy">Github Project</a> |
+    <span id="version">Version: {{ stats.version }}</span> |
+    Commit ID: <a id="commitId" target="_new" href="http://github.com/Commonjava/indy/commit/{{stats['commit-id']}}">{{ stats["commit-id"] }}</a> |
+    <span id="timestamp">Built on {{ stats["timestamp"] }} by {{ stats["builder"] }}</span>
+  </div>
+
+</div>
+
+<script type="text/javascript">
+  const setStats = stats => {
+    const versionSpan = document.getElementById('version');
+    versionSpan.innerHTML = `Version: ${stats.version}`;
+    const commitIdAnchor = document.getElementById('commitId');
+    commitIdAnchor.href = `http://github.com/Commonjava/indy/commit/${stats['commit-id']}`;
+    commitIdAnchor.innerHTML = stats['commit-id'];
+    const timestampSpan = document.getElementById('timestamp');
+    timestampSpan.innerHTML = `Built on ${stats["timestamp"]} by ${stats["builder"]}`;
+  };
+  const resetExamples = () => {
+    const host = window.location.origin
+    const contentRetrievalExam = document.getElementById("content-retrieval-example");
+    contentRetrievalExam.innerHTML = `${host}/api/content/maven/remote/central/org/apache/maven/maven-metadata.xml`;
+    const contentListExam = document.getElementById("content-list-example");
+    contentListExam.innerHTML = `${host}/browse/maven/remote/central/`;
+  };
+  const fetchStats = async () => {
+    const response = await axios.get("/api/stats/version-info");
+    if(response.status === 200){
+      const stats= response.data;
+      setStats(stats);
+    }
+  };
+  resetExamples();
+  fetchStats();
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
  When UI for indy is disabled, we should not let the request to root
  path return a simple 404. Instead, we should provide a simple UI page
  to tell that the server is still available.