### PR TITLE
Update hibernateVersion to 5.10.13.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <infinispanVersion>9.4.24.Final</infinispanVersion>
     <protostreamVersion>4.3.0.Final</protostreamVersion>
     <gsonVersion>2.9.1</gsonVersion>
-    <hibernateVersion>5.8.1.Final</hibernateVersion>
+    <hibernateVersion>5.10.13.Final</hibernateVersion>
     <resteasyVersion>3.0.12.Final</resteasyVersion>
     <jaxrsVersion>3.0.12.Final</jaxrsVersion>
     <asyncServletVersion>3.0.19.Final</asyncServletVersion>


### PR DESCRIPTION
This is to get rid of Critical | dom4j:dom4j | 1.6.1