### PR TITLE
Fix the empty checker

### DIFF
--- a/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/inject/PathMappedGroupRepositoryFilter.java
+++ b/addons/path-mapped/common/src/main/java/org/commonjava/indy/pathmapped/inject/PathMappedGroupRepositoryFilter.java
@@ -126,7 +126,7 @@ public class PathMappedGroupRepositoryFilter
         subSets.forEach( subSet -> {
             logger.debug( "Get file system containing, strategyPath: {}, subSet: {}", strategyPath, subSet );
             Set<String> st = pathMappedFileManager.getFileSystemContainingDirectory( subSet, strategyPath );
-            if ( st == null )
+            if ( st == null || st.isEmpty() )
             {
                 // query failed but those candidates may contain the target path so we add all subSet candidates
                 logger.warn( "Get fileSystems query failed, add subSet candidates" );


### PR DESCRIPTION
Fix the issue that the members of the generic http group repo is null, causing the query against host is missing. 