### PR TITLE
Fix Jackson max length limitation issue for npm package metadata

### DIFF
--- a/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
+++ b/addons/pkg-npm/jaxrs/src/main/java/org/commonjava/indy/pkg/npm/jaxrs/NPMContentAccessHandler.java
@@ -15,6 +15,7 @@
  */
 package org.commonjava.indy.pkg.npm.jaxrs;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.codec.binary.Base64;
@@ -475,6 +476,10 @@ public class NPMContentAccessHandler
         try
         {
             ObjectMapper mapper = new ObjectMapper();
+            // Enlarge the max length for a single string value inside of the json
+            mapper.getFactory()
+                  .setStreamReadConstraints(
+                          StreamReadConstraints.builder().maxStringLength( Integer.MAX_VALUE ).build() );
             JsonNode root = mapper.readTree( transfer.openInputStream( true ) );
 
             String versionPath = null;

--- a/addons/pkg-npm/model-java/src/test/java/org/commonjava/indy/pkg/npm/model/PackageMetadataTest.java
+++ b/addons/pkg-npm/model-java/src/test/java/org/commonjava/indy/pkg/npm/model/PackageMetadataTest.java
@@ -15,9 +15,15 @@
  */
 package org.commonjava.indy.pkg.npm.model;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -71,5 +77,21 @@ public class PackageMetadataTest
         assertThat( jsonResult.contains( "_rev" ), equalTo( false ) );
         assertThat( jsonResult.contains( "_id" ), equalTo( false ) );
         assertThat( jsonResult.contains( "_attachments" ), equalTo( false ) );
+    }
+
+    @Test
+    public void testLargeJson() throws IOException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        // read ~40MB json file
+        try (InputStream input = this.getClass().getClassLoader().getResourceAsStream( "large-stream.json"))
+        {
+            mapper.getFactory()
+                  .setStreamReadConstraints(
+                          StreamReadConstraints.builder().maxStringLength( Integer.MAX_VALUE ).build() );
+            JsonNode root = mapper.readTree( input );
+            JsonNode idnode = root.path( "_id" );
+            assertThat( idnode.asText(), equalTo( "@janus-idp/backstage-plugin-orchestrator" ));
+        }
     }
 }


### PR DESCRIPTION
It looks like Jackson 2.15 introduced a max length for a single string value inside of the JSON document which defaults to 20 million. We need to enlarge this sort of limitation, or the following version and tarball stream writing out would have trouble since no proper JSON node data would be extracted and constructed for use.

See detail on https://issues.redhat.com/browse/MMENG-4057