### PR TITLE
Add repo service config refresh-token-time-skew

### DIFF
--- a/subsys/service/src/main/java/org/commonjava/indy/subsys/service/IndyClientProducer.java
+++ b/subsys/service/src/main/java/org/commonjava/indy/subsys/service/IndyClientProducer.java
@@ -83,7 +83,8 @@ public class IndyClientProducer
                         new KeycloakTokenAuthenticator( serviceConfig.getKeycloakAuthUrl(),
                                                         serviceConfig.getKeycloakAuthRealm(),
                                                         serviceConfig.getKeycloakClientId(),
-                                                        serviceConfig.getKeycloakClientSecret() );
+                                                        serviceConfig.getKeycloakClientSecret(),
+                                                        serviceConfig.getRefreshTokenTimeSkew() );
                 client = builder.setAuthenticator( authenticator ).build();
             }
             else

--- a/subsys/service/src/main/java/org/commonjava/indy/subsys/service/config/RepositoryServiceConfig.java
+++ b/subsys/service/src/main/java/org/commonjava/indy/subsys/service/config/RepositoryServiceConfig.java
@@ -27,6 +27,8 @@ import java.io.InputStream;
 public class RepositoryServiceConfig
         implements IndyConfigInfo
 {
+    private static final long DEFAULT_REFRESH_TOKEN_TIME_SKEW = 30;
+
     private Boolean enabled = Boolean.FALSE;
 
     private String serviceUrl;
@@ -42,6 +44,10 @@ public class RepositoryServiceConfig
     private String keycloakClientId;
 
     private String keycloakClientSecret;
+
+    // The refresh token time skew, in seconds. If this property is set, the configured number of seconds is added
+    // to the current time when checking if the authorization token should be refreshed.
+    private long refreshTokenTimeSkew = DEFAULT_REFRESH_TOKEN_TIME_SKEW;
 
     public Boolean isEnabled()
     {
@@ -129,6 +135,17 @@ public class RepositoryServiceConfig
     public void setKeycloakClientSecret( String keycloakClientSecret )
     {
         this.keycloakClientSecret = keycloakClientSecret;
+    }
+
+    public long getRefreshTokenTimeSkew()
+    {
+        return refreshTokenTimeSkew;
+    }
+
+    @ConfigName( "keycloak.auth.refresh-token-time-skew" )
+    public void setRefreshTokenTimeSkew(long refreshTokenTimeSkew)
+    {
+        this.refreshTokenTimeSkew = refreshTokenTimeSkew;
     }
 
     @Override

--- a/subsys/service/src/main/java/org/commonjava/indy/subsys/service/keycloak/KeycloakTokenAuthenticator.java
+++ b/subsys/service/src/main/java/org/commonjava/indy/subsys/service/keycloak/KeycloakTokenAuthenticator.java
@@ -46,6 +46,8 @@ public class KeycloakTokenAuthenticator
 
     private final String keycloakClientSecret;
 
+    private final long refreshTokenTimeSkew;
+
     private Configuration config;
 
     private String cachedToken;
@@ -53,12 +55,13 @@ public class KeycloakTokenAuthenticator
     private Long cachedTokenExpireAtInSecs;
 
     public KeycloakTokenAuthenticator( String keycloakAuthUrl, String keycloakAuthRealm, String keycloakClientId,
-                                       String keycloakClientSecret )
+                                       String keycloakClientSecret, long refreshTokenTimeSkew )
     {
         this.keycloakAuthUrl = keycloakAuthUrl;
         this.keycloakAuthRealm = keycloakAuthRealm;
         this.keycloakClientId = keycloakClientId;
         this.keycloakClientSecret = keycloakClientSecret;
+        this.refreshTokenTimeSkew = refreshTokenTimeSkew;
     }
 
     @Override
@@ -79,7 +82,7 @@ public class KeycloakTokenAuthenticator
             return false;
         }
         final long nowSecs = System.currentTimeMillis() / 1000;
-        return nowSecs > cachedTokenExpireAtInSecs;
+        return nowSecs + refreshTokenTimeSkew > cachedTokenExpireAtInSecs;
     }
 
     private Configuration getKeycloakClientCfg()


### PR DESCRIPTION
Sometimes the indy hit 401 error when sending request to repo service. This pr add a config "keycloak.auth.refresh-token-time-skew" to avoid sending soon-to-be-expired token.

fyi, Quarkus has similar config as 'quarkus.oidc.token.refresh-token-time-skew'.