### PR TITLE
Backport promote tracking api

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -1,0 +1,96 @@
+#
+# Copyright (C) 2011-2022 Red Hat, Inc. (https://github.com/Commonjava/indy)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: build on maven
+
+on:
+  watch:
+    types: [started]
+  pull_request:
+    types: [opened, reopened, edited, synchronize, ready_for_review]
+  push:
+    branches:
+      - main
+      - master
+      - '**'
+
+  workflow_dispatch:
+
+jobs:
+  verify:
+    name: verify with maven
+    runs-on: ubuntu-latest
+    env:
+      MAVEN_OPTS: "-Xmx4096m -Xms2048m -XX:MaxMetaspaceSize=4096m -Xss8m"
+      SKIP_NPM_CONFIG: false
+      NPMREGISTRY: https://registry.npmjs.org
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 8 & 11 for x64
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        architecture: x64
+        java-version: |
+          8
+          11
+
+    - uses: s4u/maven-settings-action@v2.8.0
+      with:
+        sonatypeSnapshots: true
+
+    - name: Build the Maven verify phase
+      run: mvn -B -V clean verify -Prun-its -Pci --global-toolchains .github/workflows/toolchains.xml
+
+  build:
+    name: Build and push
+    runs-on: ubuntu-latest
+    needs: verify
+    if: ${{ github.event_name == 'push' }}
+    env:
+      MAVEN_OPTS: "-Xmx4096m -Xms2048m -XX:MaxMetaspaceSize=4096m -Xss8m"
+      SKIP_NPM_CONFIG: false
+      NPMREGISTRY: https://registry.npmjs.org
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up JDK 8 & 11 for x64
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        architecture: x64
+        java-version: |
+          8
+          11
+
+    - uses: s4u/maven-settings-action@v2.8.0
+      with:
+        servers: |
+          [{
+              "id": "sonatype-nexus-snapshots",
+              "username": "${{ secrets.SONATYPE_BOT_USERNAME }}",
+              "password": "${{ secrets.SONATYPE_BOT_TOKEN }}"
+          }]
+
+    - name: Build with toolchains
+      run: mvn -B -V clean install -DskipNpmConfig=false --global-toolchains .github/workflows/toolchains.xml
+
+    - name: Deploy the artifact
+      run: mvn help:effective-settings -B -V -DskipTests=true -DskipNpmConfig=false deploy -e --global-toolchains .github/workflows/toolchains.xml

--- a/.github/workflows/toolchains.xml
+++ b/.github/workflows/toolchains.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF8"?>
+<!--
+
+    Copyright (C) 2011-2022 Red Hat, Inc. (https://github.com/Commonjava/indy)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>1.8</version>
+      <vendor>OpenJDK</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/usr/lib/jvm/temurin-8-jdk-amd64</jdkHome>
+    </configuration>
+  </toolchain>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>11</version>
+      <vendor>OpenJDK</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>/usr/lib/jvm/temurin-11-jdk-amd64</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>

--- a/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteAdminClientModule.java
+++ b/addons/promote/client-java/src/main/java/org/commonjava/indy/promote/client/IndyPromoteAdminClientModule.java
@@ -26,12 +26,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.commonjava.indy.client.core.util.UrlUtils.buildUrl;
+import static org.commonjava.indy.promote.client.IndyPromoteClientModule.PROMOTE_BASEPATH;
 
 public class IndyPromoteAdminClientModule
         extends IndyClientModule
 {
-
-    public static final String PROMOTE_ADMIN_BASEPATH = "admin/promotion";
+    public static final String PROMOTE_ADMIN_BASEPATH = PROMOTE_BASEPATH + "/admin";
 
     public static final String VALIDATION_BASEPATH = PROMOTE_ADMIN_BASEPATH + "/validation";
 
@@ -56,6 +56,8 @@ public class IndyPromoteAdminClientModule
     public static final String VALIDATION_RULESET_GET_BY_STOREKEY_PATH = VALIDATION_RULESET_BASEPATH + "/storekey";
 
     public static final String VALIDATION_RULESET_GET_BY_NAME_PATH = VALIDATION_RULESET_BASEPATH + "/named";
+
+    public static final String TRACKING = PROMOTE_ADMIN_BASEPATH + "/tracking";
 
     public boolean reloadRules()
             throws IndyClientException
@@ -108,5 +110,11 @@ public class IndyPromoteAdminClientModule
             throws IndyClientException
     {
         return http.get( buildUrl( VALIDATION_RULESET_GET_BY_STOREKEY_PATH, key.toString() ), ValidationRuleSet.class );
+    }
+
+    public void deleteTrackingRecords( final String trackingId )
+            throws IndyClientException
+    {
+        http.delete( buildUrl( TRACKING, trackingId ) );
     }
 }

--- a/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteAdminResource.java
+++ b/addons/promote/jaxrs/src/main/java/org/commonjava/indy/promote/bind/jaxrs/PromoteAdminResource.java
@@ -56,7 +56,7 @@ import java.util.function.Supplier;
 import static org.commonjava.indy.util.ApplicationContent.application_json;
 
 @Api( value = "Promote administration resource to manage configurations for content promotion." )
-@Path( "/api/admin/promotion" )
+@Path( "/api/promotion/admin" )
 @Produces( { application_json } )
 @REST
 public class PromoteAdminResource


### PR DESCRIPTION
PNC was using indy-client 2.5.4 and tried to update to 3.3.x but failed due to CDI issues. They will file a Jira for that. 

After talking, we decided to backport the needed promote api to old indy-client. Indy 2.5.x is too old, the 2.7.x seems a better place. So I backported the api to 2.7.x. PNC can use it as a quick fix.

PS. This pr also add the github actions to build and push the snapshot to sonatype.