### PR TITLE
Remove indy-db-infinispan module

### DIFF
--- a/core/src/main/conf/conf.d/durable-state.conf
+++ b/core/src/main/conf/conf.d/durable-state.conf
@@ -1,4 +1,4 @@
 [durable-state]
 folo.storage=infinispan
-store.storage=infinispan
+store.storage=standalone
 schedule.storage=infinispan

--- a/core/src/main/java/org/commonjava/indy/core/conf/IndyDurableStateConfig.java
+++ b/core/src/main/java/org/commonjava/indy/core/conf/IndyDurableStateConfig.java
@@ -33,11 +33,15 @@ public class IndyDurableStateConfig
 
     public static final String SECTION_NAME = "durable-state";
 
+    @Deprecated
     public static final String STORAGE_INFINISPAN = "infinispan";
 
+    @Deprecated
     public static final String STORAGE_CASSANDRA = "cassandra";
 
     public static final String STORAGE_SERVICE = "service";
+
+    public static final String STORAGE_STANDALONE = "standalone";
 
     private String foloStorage;
 

--- a/core/src/main/resources/default-durable-state.conf
+++ b/core/src/main/resources/default-durable-state.conf
@@ -1,4 +1,4 @@
 [durable-state]
 folo.storage=infinispan
-store.storage=infinispan
+store.storage=standalone
 schedule.storage=infinispan

--- a/core/src/test/java/org/commonjava/indy/fixture/MockTestProvider.java
+++ b/core/src/test/java/org/commonjava/indy/fixture/MockTestProvider.java
@@ -18,6 +18,9 @@ package org.commonjava.indy.fixture;
 import org.commonjava.atlas.maven.ident.ref.ProjectRef;
 import org.commonjava.cdi.util.weft.config.DefaultWeftConfig;
 import org.commonjava.cdi.util.weft.config.WeftConfig;
+import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.db.common.inject.Standalone;
+import org.commonjava.indy.mem.data.MemoryStoreDataManager;
 import org.commonjava.maven.galley.config.TransportManagerConfig;
 import org.commonjava.maven.galley.maven.spi.defaults.MavenPluginDefaults;
 import org.commonjava.maven.galley.maven.spi.defaults.MavenPluginImplications;
@@ -26,8 +29,10 @@ import org.commonjava.o11yphant.metrics.TrafficClassifier;
 import org.commonjava.o11yphant.metrics.sli.GoldenSignalsMetricSet;
 import org.commonjava.o11yphant.trace.TracerConfiguration;
 
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 
 @ApplicationScoped
@@ -99,5 +104,13 @@ public class MockTestProvider
     public TrafficClassifier getTrafficClassifier()
     {
         return null;
+    }
+
+    @Produces
+    @Standalone
+    @Default
+    public StoreDataManager getStoreDataManager()
+    {
+        return new MemoryStoreDataManager( true );
     }
 }

--- a/core/src/test/resources/META-INF/beans.xml
+++ b/core/src/test/resources/META-INF/beans.xml
@@ -16,7 +16,6 @@
       
   <alternatives>
     <!--<stereotype>org.commonjava.indy.inject.TestData</stereotype>-->
-    <class>org.commonjava.indy.mem.data.MemoryStoreDataManager</class>
     <class>org.commonjava.indy.fixture.MockTestProvider</class>
     <class>org.commonjava.indy.fixture.MockContentAdvisor</class>
   </alternatives>

--- a/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
+++ b/db/memory/src/main/java/org/commonjava/indy/mem/data/MemoryStoreDataManager.java
@@ -21,6 +21,7 @@ import org.commonjava.indy.data.IndyDataException;
 import org.commonjava.indy.data.NoOpStoreEventDispatcher;
 import org.commonjava.indy.data.StoreEventDispatcher;
 import org.commonjava.indy.db.common.AbstractStoreDataManager;
+import org.commonjava.indy.db.common.inject.Standalone;
 import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.StoreKey;
 import org.commonjava.indy.model.core.StoreType;
@@ -40,7 +41,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @ApplicationScoped
-@Alternative
+@Standalone
 public class MemoryStoreDataManager
         extends AbstractStoreDataManager
 {

--- a/db/pom.xml
+++ b/db/pom.xml
@@ -32,7 +32,6 @@
   <modules>
     <module>common</module>
     <module>memory</module>
-    <module>infinispan</module>
     <module>service</module>
   </modules>
 

--- a/db/service/src/main/java/org/commonjava/indy/db/service/StoreDataManagerProvider.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/StoreDataManagerProvider.java
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.commonjava.indy.infinispan.data;
+package org.commonjava.indy.db.service;
 
 import org.commonjava.indy.core.conf.IndyDurableStateConfig;
 import org.commonjava.indy.data.StoreDataManager;
-import org.commonjava.indy.db.common.inject.Clustered;
 import org.commonjava.indy.db.common.inject.Serviced;
 import org.commonjava.indy.db.common.inject.Standalone;
 
@@ -26,10 +25,6 @@ import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
-/**
- * @deprecated The store management functions has been extracted into Repository Service, which is maintained in "ServiceStoreDataManager"
- */
-@Deprecated
 @ApplicationScoped
 public class StoreDataManagerProvider
 {
@@ -39,22 +34,21 @@ public class StoreDataManagerProvider
 
     @Produces
     @Default
-    public StoreDataManager getStoreDataManager(
-            @Standalone StoreDataManager ispnStoreDataManager,
-            @Serviced StoreDataManager serviceStoreDataManager )
+    public StoreDataManager getStoreDataManager( @Standalone StoreDataManager standaloneStoreDataManager,
+                                                 @Serviced StoreDataManager serviceStoreDataManager )
     {
-        if ( IndyDurableStateConfig.STORAGE_INFINISPAN.equals( durableStateConfig.getStoreStorage() ) )
+        if ( IndyDurableStateConfig.STORAGE_STANDALONE.equals( durableStateConfig.getStoreStorage() ) )
         {
-            return ispnStoreDataManager;
+            return standaloneStoreDataManager;
         }
-        else if ( IndyDurableStateConfig.STORAGE_SERVICE.equals( durableStateConfig.getStoreStorage()) )
+        if ( IndyDurableStateConfig.STORAGE_SERVICE.equals( durableStateConfig.getStoreStorage() ) )
         {
             return serviceStoreDataManager;
         }
         else
         {
             throw new RuntimeException(
-                            "Invalid configuration for store manager:" + durableStateConfig.getStoreStorage() );
+                    "Invalid configuration for store manager:" + durableStateConfig.getStoreStorage() );
         }
     }
 }

--- a/embedder-tests/sonar-report/pom.xml
+++ b/embedder-tests/sonar-report/pom.xml
@@ -98,10 +98,6 @@
       <artifactId>indy-db-memory</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-db-infinispan</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.commonjava.indy.boot</groupId>
       <artifactId>indy-booter-jaxrs</artifactId>
     </dependency>

--- a/embedder/pom.xml
+++ b/embedder/pom.xml
@@ -91,23 +91,9 @@
       <artifactId>indy-db-service</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-db-infinispan</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.commonjava.indy.boot</groupId>
       <artifactId>indy-booter-jaxrs</artifactId>
     </dependency>
-    <!--
-    <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-revisions-jaxrs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.commonjava.indy</groupId>
-      <artifactId>indy-revisions-common</artifactId>
-    </dependency>
-    -->
     <dependency>
       <groupId>org.commonjava.indy</groupId>
       <artifactId>indy-diagnostics-jaxrs</artifactId>

--- a/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
+++ b/ftests/common/src/main/java/org/commonjava/indy/ftest/core/AbstractIndyFunctionalTest.java
@@ -306,7 +306,7 @@ public abstract class AbstractIndyFunctionalTest
                 + "schedule.partition.range=3600000\nschedule.rate.period=3" );
 
         writeConfigFile( "conf.d/durable-state.conf",
-                         "[durable-state]\n" + "folo.storage=infinispan\n" + "store.storage=infinispan\n"
+                         "[durable-state]\n" + "folo.storage=infinispan\n" + "store.storage=standalone\n"
                                  + "schedule.storage=infinispan" );
 
         writeConfigFile( "conf.d/kafka.conf",

--- a/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreReverseMapMigrationTest.java
+++ b/ftests/core/src/main/java/org/commonjava/indy/ftest/core/content/StoreReverseMapMigrationTest.java
@@ -15,15 +15,14 @@
  */
 package org.commonjava.indy.ftest.core.content;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.commonjava.indy.client.core.IndyClientException;
 import org.commonjava.indy.ftest.core.AbstractContentManagementTest;
+import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.Group;
 import org.commonjava.indy.model.core.HostedRepository;
 import org.commonjava.indy.model.core.StoreType;
-import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.indy.test.fixture.core.CoreServerFixture;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Test;
@@ -78,26 +77,32 @@ public class StoreReverseMapMigrationTest
     Group gX = new Group( PKG_TYPE_MAVEN, groupX, hostedA.getKey(), hostedB.getKey() );
     Group gY = new Group( PKG_TYPE_MAVEN,groupY, gX.getKey() );
 
-    @Override
-    protected void initTestData( CoreServerFixture fixture )
-            throws IOException
-    {
-        ObjectMapper mapper = new IndyObjectMapper( true );
-
-        writeDataFile( "indy/maven/hosted/" + repoA + ".json", mapper.writeValueAsString( hostedA ) );
-        writeDataFile( "indy/maven/hosted/" + repoB + ".json", mapper.writeValueAsString( hostedB ) );
-        writeDataFile( "indy/maven/hosted/" + repoC + ".json", mapper.writeValueAsString( hostedC ) );
-
-        writeDataFile( "indy/maven/group/" + groupX + ".json", mapper.writeValueAsString( gX ) );
-        writeDataFile( "indy/maven/group/" + groupY + ".json", mapper.writeValueAsString( gY ) );
-
-        super.initTestData( fixture );
-    }
+//    @Override
+//    protected void initTestData( CoreServerFixture fixture )
+//            throws IOException
+//    {
+//        ObjectMapper mapper = new IndyObjectMapper( true );
+//
+//        writeDataFile( "indy/maven/hosted/" + repoA + ".json", mapper.writeValueAsString( hostedA ) );
+//        writeDataFile( "indy/maven/hosted/" + repoB + ".json", mapper.writeValueAsString( hostedB ) );
+//        writeDataFile( "indy/maven/hosted/" + repoC + ".json", mapper.writeValueAsString( hostedC ) );
+//
+//        writeDataFile( "indy/maven/group/" + groupX + ".json", mapper.writeValueAsString( gX ) );
+//        writeDataFile( "indy/maven/group/" + groupY + ".json", mapper.writeValueAsString( gY ) );
+//
+//        super.initTestData( fixture );
+//    }
 
     @Test
     public void run()
             throws Exception
     {
+        createStore( hostedA );
+        createStore( hostedB );
+        createStore( hostedC );
+
+        createStore( gX );
+        createStore( gY );
         /* @formatter:off */
         final String repoAContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<metadata>\n" +
@@ -227,7 +232,7 @@ public class StoreReverseMapMigrationTest
     private HostedRepository createHostedStorePath( final HostedRepository hosted, final String path, final String content )
             throws Exception
     {
-        if(StringUtils.isNotBlank( content ))
+        if ( StringUtils.isNotBlank( content ) )
         {
             client.content().store( hosted.getKey(), path, new ByteArrayInputStream( content.getBytes() ) );
         }
@@ -253,6 +258,19 @@ public class StoreReverseMapMigrationTest
         {
             logger.error( e.getMessage(), e );
             fail( "Downloaded XML not equal to expected XML" );
+        }
+    }
+
+    private void createStore( ArtifactStore hosted )
+            throws IOException
+    {
+        try
+        {
+            client.stores().create( hosted, "", ArtifactStore.class );
+        }
+        catch ( IndyClientException e )
+        {
+            throw new IOException( e );
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -269,11 +269,6 @@
       </dependency>
       <dependency>
         <groupId>org.commonjava.indy</groupId>
-        <artifactId>indy-db-infinispan</artifactId>
-        <version>3.3.7-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.commonjava.indy</groupId>
         <artifactId>indy-bindings-jaxrs</artifactId>
         <version>3.3.7-SNAPSHOT</version>
       </dependency>

--- a/rest/api/src/test/java/org/commonjava/indy/rest/apigen/SwaggerExportTest.java
+++ b/rest/api/src/test/java/org/commonjava/indy/rest/apigen/SwaggerExportTest.java
@@ -96,7 +96,7 @@ public class SwaggerExportTest
             throws IOException
     {
         writeConfigFile( "main.conf", "standalone=true\n" + "[durable-state]\n" + "folo.storage=infinispan\n"
-                + "store.storage=infinispan\n" );
+                + "store.storage=standalone\n" );
     }
 
 }

--- a/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/TestProvider.java
+++ b/subsys/groovy/src/test/java/org/commonjava/indy/subsys/template/fixture/TestProvider.java
@@ -21,8 +21,14 @@ import org.commonjava.cdi.util.weft.config.WeftConfig;
 import org.commonjava.indy.action.UserLifecycleManager;
 import org.commonjava.indy.action.fixture.AlternativeUserLifecycleManager;
 import org.commonjava.indy.content.IndyPathGenerator;
+import org.commonjava.indy.data.ArtifactStoreValidateData;
+import org.commonjava.indy.data.NoOpStoreEventDispatcher;
 import org.commonjava.indy.data.StoreDataManager;
+import org.commonjava.indy.data.StoreEventDispatcher;
+import org.commonjava.indy.data.StoreValidator;
+import org.commonjava.indy.db.common.inject.Standalone;
 import org.commonjava.indy.mem.data.MemoryStoreDataManager;
+import org.commonjava.indy.model.core.ArtifactStore;
 import org.commonjava.indy.model.core.io.IndyObjectMapper;
 import org.commonjava.maven.galley.cache.FileCacheProvider;
 import org.commonjava.maven.galley.config.TransportManagerConfig;
@@ -41,6 +47,7 @@ import org.junit.rules.TemporaryFolder;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import java.io.IOException;
@@ -78,6 +85,10 @@ public class TestProvider
 
     private UserLifecycleManager userLifecycleManager;
 
+    private StoreEventDispatcher eventDispatcher;
+
+    private StoreValidator storeValidator;
+
     @PostConstruct
     public void setup()
     {
@@ -90,6 +101,8 @@ public class TestProvider
         weftConfig = new DefaultWeftConfig();
         globalHttpConfiguration = new GlobalHttpConfiguration();
         userLifecycleManager = new AlternativeUserLifecycleManager();
+        eventDispatcher = new NoOpStoreEventDispatcher();
+        storeValidator = artifactStore -> null;
 
         temp = new TemporaryFolder();
         try
@@ -123,9 +136,21 @@ public class TestProvider
     }
 
     @Produces
+    @Standalone
+    @Default
     public StoreDataManager getStoreDataManager()
     {
         return storeDataManager;
+    }
+
+    @Produces
+    public StoreValidator getStoreValidator(){
+        return storeValidator;
+    }
+
+    @Produces
+    public StoreEventDispatcher getEventDispatcher(){
+        return eventDispatcher;
     }
 
     @Produces


### PR DESCRIPTION
This indy-db-infinispan module is not used. But ftests still depends on it, so it needs to do some changes to remove dependency in ftests. 