### PR TITLE
Revert "Update o11yphant to 1.9.2-SNAPSHOT"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <cassandraUnitVersion>3.7.1.0</cassandraUnitVersion>
     <datastaxVersion>3.11.3</datastaxVersion>
     <pathmappedStorageVersion>2.6</pathmappedStorageVersion>
-    <o11yphantVersion>1.9.2-SNAPSHOT</o11yphantVersion>
+    <o11yphantVersion>1.9.1</o11yphantVersion>
     <swaggerVersion>1.6.6</swaggerVersion>
     <agroalVersion>1.16</agroalVersion>
     <groovyVersion>3.0.13</groovyVersion>


### PR DESCRIPTION
This reverts commit 7ae38f9a4192d6f45db090391e742d3c926288ff.

To be consistent with indy-client of the o11yphant version.