### PR TITLE
Revert "Fix github action "verify with maven" to bypass in merged phase"

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -36,7 +36,6 @@ jobs:
   verify:
     name: verify with maven
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'push' }}
     env:
       MAVEN_OPTS: "-Xmx4096m -Xms2048m -XX:MaxMetaspaceSize=4096m -Xss8m"
       SKIP_NPM_CONFIG: false


### PR DESCRIPTION
  Ok, seems the fix is not working as expected. Reverted.

This reverts commit 1462f846f498e662dc3acc4fd52c2ad97fe569f6.