### PR TITLE
Add flush after copy during downloads

### DIFF
--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
@@ -65,6 +65,7 @@ public class TransferStreamingOutput
         {
             CountingOutputStream cout = new CountingOutputStream( out );
             IOUtils.copy( stream, cout );
+            cout.flush(); // ensure any remaining data is written to the output stream
 
             Logger logger = LoggerFactory.getLogger( getClass() );
             logger.trace( "Wrote: {} bytes", cout.getByteCount() );


### PR DESCRIPTION
Trying to fix MMENG-4207 `Inconsistent large downloads`

Adding the flush ensures that all the data is sent to the client after the copy is complete. Without an explicit flush(), some data might remain in the buffer and not be sent until it's full.