### PR TITLE
Update Cassandra reconnect policy and default delay value

### DIFF
--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/CassandraClient.java
@@ -18,6 +18,7 @@ package org.commonjava.indy.subsys.cassandra;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.SocketOptions;
+import com.datastax.driver.core.policies.ConstantReconnectionPolicy;
 import org.commonjava.indy.subsys.cassandra.config.CassandraConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +76,8 @@ public class CassandraClient
         socketOptions.setReadTimeoutMillis( config.getReadTimeoutMillis() );
         Cluster.Builder builder = Cluster.builder()
                                          .withoutJMXReporting()
+                                         .withReconnectionPolicy(
+                                                 new ConstantReconnectionPolicy( config.getConstantDelayMs() ) )
                                          .withRetryPolicy( new ConfigurableRetryPolicy( config.getReadRetries(),
                                                                                         config.getWriteRetries() ) )
                                          .addContactPoint( host )

--- a/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/config/CassandraConfig.java
+++ b/subsys/cassandra/src/main/java/org/commonjava/indy/subsys/cassandra/config/CassandraConfig.java
@@ -45,6 +45,8 @@ public class CassandraConfig
 
     private int writeRetries = 3;
 
+    private long constantDelayMs = 60000;
+
     public CassandraConfig()
     {
     }
@@ -150,6 +152,17 @@ public class CassandraConfig
     public void setWriteRetries( int writeRetries )
     {
         this.writeRetries = writeRetries;
+    }
+
+    public long getConstantDelayMs()
+    {
+        return constantDelayMs;
+    }
+
+    @ConfigName( "cassandra.reconnect.delay" )
+    public void setConstantDelayMs( long constantDelayMs )
+    {
+        this.constantDelayMs = constantDelayMs;
     }
 
     @Override


### PR DESCRIPTION
Use ConstantReconnectionPolicy instead of exponential policy, see https://issues.redhat.com/browse/MMENG-4231.