### PR TITLE
Update changelog and clean cache when group is updated

### DIFF
--- a/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
+++ b/db/common/src/main/java/org/commonjava/indy/db/common/AbstractStoreDataManager.java
@@ -46,6 +46,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -493,7 +494,12 @@ public abstract class AbstractStoreDataManager
             return false;
         }
 
-        logger.debug( "Put {} to stores map", k );
+        logger.info( "Put {} to stores, {}", k, summary );
+        if ( summary != null )
+        {
+            store.setMetadata( ArtifactStore.METADATA_CHANGELOG,
+                               String.format( "%s, %s", summary.getSummary(), new Date() ));
+        }
         final ArtifactStore old = putArtifactStoreInternal( store.getKey(), store );
 
         try

--- a/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataManager.java
+++ b/db/service/src/main/java/org/commonjava/indy/db/service/ServiceStoreDataManager.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static org.commonjava.indy.db.common.StoreUpdateAction.STORE;
 import static org.commonjava.indy.model.core.StoreType.hosted;
 
 @SuppressWarnings( "unchecked" )
@@ -413,6 +414,17 @@ public class ServiceStoreDataManager
     protected Indy getIndyClient()
     {
         return this.client;
+    }
+
+    @Override
+    protected void postStore( final ArtifactStore store, final ArtifactStore original, final ChangeSummary summary,
+                              final boolean exists, final boolean fireEvents, final EventMetadata eventMetadata )
+                    throws IndyDataException
+    {
+        super.postStore( store, original, summary, exists, fireEvents, eventMetadata );
+        logger.info( "Remove from store cache, {}", store.getKey() );
+        BasicCacheHandle<StoreKey, ArtifactStore> cache = cacheProducer.getBasicCache( ARTIFACT_STORE );
+        cache.remove( store.getKey() );
     }
 
     private ArtifactStore computeIfAbsent( StoreKey key, Supplier<ArtifactStore> storeProvider, int expirationMins,


### PR DESCRIPTION
This is for [MMENG-4245](https://issues.redhat.com/browse/MMENG-4245) Indy was very slow to add a remote repository from Brew into group brew-proxies

Change 1. clean the ServiceStoreDataManager's store cache when a store is updated
I override the postStore method in ServiceStoreDataManager.

Change 2. update group changelog when the group is updated. For example, the current group brew-proxies still shows the oldest message. 
`{
  "type" : "group",
  "key" : "maven:group:brew-proxies",
  "metadata" : {
    "changelog" : "Create store maven:group:brew-proxies"
  },...`
This pr update the changelog accordingly.