### PR TITLE
Clear the metadata cache when setting FORCE_CHECKSUM_AND_WRITE

### DIFF
--- a/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
+++ b/core/src/main/java/org/commonjava/indy/core/content/DefaultContentDigester.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 
+import static org.commonjava.indy.core.content.ContentMetadataGenerator.FORCE_CHECKSUM_AND_WRITE;
 import static org.commonjava.maven.galley.io.ChecksummingTransferDecorator.FORCE_CHECKSUM;
 
 /**
@@ -127,11 +128,18 @@ public class DefaultContentDigester
             return new TransferMetadata( Collections.emptyMap(), 0L );
         }
 
-        TransferMetadata meta = getContentMetadata( transfer );
-        if ( meta != null )
+        if ( Boolean.parseBoolean( String.valueOf( eventMetadata.get( FORCE_CHECKSUM_AND_WRITE ) ) ) )
         {
-            logger.debug( "Get transferMetadata: {}", meta );
-            return meta;
+            removeMetadata( transfer );
+        }
+        else
+        {
+            TransferMetadata meta = getContentMetadata( transfer );
+            if ( meta != null )
+            {
+                logger.debug( "Get transferMetadata: {}", meta );
+                return meta;
+            }
         }
 
         String cacheKey = generateCacheKey( transfer );


### PR DESCRIPTION
Fixing the issue that md5 files not in the static group, ref: https://issues.redhat.com/browse/MMENG-4250

When we publish FileEvent via Kafka, we need to calculate the checksum, but that picks CALCULATE_NO_WRITE, which means there is no checksum files generated at all, and the info is cached. Then when user request the checksum files, it says it exists as the cache value but actually there is no file in storage, which cause the failure as the jira issue mentioned: 

`Message: Path io/dropwizard/metrics/metrics-jmx/4.2.28/metrics-jmx-4.2.28.jar.md5 is not available in store`