### PR TITLE
Add checkMask in maven metadata generator downloadMissing

### DIFF
--- a/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
+++ b/addons/pkg-maven/common/src/main/java/org/commonjava/indy/pkg/maven/content/MavenMetadataGenerator.java
@@ -92,6 +92,7 @@ import static org.apache.commons.io.IOUtils.closeQuietly;
 import static org.commonjava.atlas.maven.ident.util.SnapshotUtils.LOCAL_SNAPSHOT_VERSION_PART;
 import static org.commonjava.atlas.maven.ident.util.SnapshotUtils.generateUpdateTimestamp;
 import static org.commonjava.atlas.maven.ident.util.SnapshotUtils.getCurrentTimestamp;
+import static org.commonjava.indy.core.content.PathMaskChecker.checkMask;
 import static org.commonjava.indy.core.content.PathMaskChecker.checkMavenMetadataMask;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_EXISTS;
 import static org.commonjava.indy.core.content.group.GroupMergeHelper.GROUP_METADATA_GENERATED;
@@ -856,8 +857,13 @@ public class MavenMetadataGenerator
             try
             {
                 logger.trace( "Starting metadata download: {}:{}", store.getKey(), toMergePath );
+                if ( !checkMask( store, toMergePath ) )
+                {
+                    logger.debug( "Transfer {}:{} skipped due to checkMask during maven metadata generator downloadMissing.",
+                                  store.getKey(), toMergePath );
+                    return null;
+                }
                 Transfer memberMetaTxfr = fileManager.retrieveRaw( store, toMergePath, new EventMetadata() );
-
                 if ( exists( memberMetaTxfr ) )
                 {
                     final MetadataXpp3Reader reader = new MetadataXpp3Reader();


### PR DESCRIPTION
Big amount of WARN found as below. 
`[WARN ] [maven-metadata-generator-12] o.c.i.p.m.c.MavenMetadataGenerator$Proxy$_$$_WeldSubclass no 172.40.1.72 - Transfer maven:remote:koji-org.wildfly.common-wildfly-common-1.2.0.Beta1_redhat_1-1:com/test/rest-to-jpa-update/1.0.0-SNAPSHOT/maven-metadata.xml not existed during maven metadata generator downloadMissing.`

This fix reduces the download from stores by checking the pattern mask first (especially for koji remote repos).