### PR TITLE
Revert "Add flush after copy during downloads"

### DIFF
--- a/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
+++ b/bindings/jaxrs/src/main/java/org/commonjava/indy/core/bind/jaxrs/util/TransferStreamingOutput.java
@@ -65,7 +65,6 @@ public class TransferStreamingOutput
         {
             CountingOutputStream cout = new CountingOutputStream( out );
             IOUtils.copy( stream, cout );
-            cout.flush(); // ensure any remaining data is written to the output stream
 
             Logger logger = LoggerFactory.getLogger( getClass() );
             logger.trace( "Wrote: {} bytes", cout.getByteCount() );


### PR DESCRIPTION
Reverts Commonjava/indy#2460

which will cause: write transfer error: stream was reset: CANCEL: okhttp3.internal.http2.StreamResetException: stream was reset: CANCEL