### PR TITLE
Fix the path map patterns for brew repos

### DIFF
--- a/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiPathPatternFormatter.java
+++ b/addons/koji/common/src/main/java/org/commonjava/indy/koji/content/KojiPathPatternFormatter.java
@@ -82,17 +82,15 @@ public class KojiPathPatternFormatter
             if ( pattern != null )
             {
                 patterns.add( pattern );
+
+                String meta = getMetaString( ar ); // Add metadata.xml of the koji archive to path mask patterns
+                if ( meta != null )
+                {
+                    patterns.add( meta );
+                }
             }
         }
 
-        if ( !patterns.isEmpty() )
-        {
-            String meta = getMetaString( artifactRef ); // Add metadata.xml to path mask patterns
-            if ( meta != null )
-            {
-                patterns.add( meta );
-            }
-        }
         return patterns;
     }
 


### PR DESCRIPTION
For Issue: https://issues.redhat.com/browse/MMENG-4453

As the brew build may contains multiple archives with different groupId and artifactId, we need to set the path patterns based on the archives not simply on the build itself. 